### PR TITLE
Add standard elafros CoC to root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -54,18 +54,17 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by contacting the project team at
-elafros-maintainers@groups.google.com. All complaints will be reviewed
-and investigated and will result in a response that is deemed
-necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of
-an incident.  Further details of specific enforcement policies may be
-posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the Technical Oversight Committee at
+elafros-tech-oversight@groups.google.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+TOC members who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the
+project's leadership.
 
 ## Attribution
 


### PR DESCRIPTION
Fixes Issue #15 

## Proposed Changes:

This PR adds the standard Elafros Code of Conduct to the root of the `elafros/eventing` repository.
