### PR TITLE
Add pointer to k8s events to sample readme

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -12,3 +12,4 @@ functionality.
 
 * [Github Pull Request Handler](./github) - A simple handler for Github Pull Requests
 * [GCP PubSub Receiver Handler](./gcp_pubsub_function) - A simple handler for processing GCP PubSub events
+* [K8S events Handler](./k8s_events_function) - A simple handler for processing k8s events in the cluster

--- a/sample/k8s_events_function/README.md
+++ b/sample/k8s_events_function/README.md
@@ -127,7 +127,7 @@ $ kubectl logs k8s-events-function user-container
 
 ## Removing a binding
 
-Remove the binding and things get cleaned up (including removing the subscription to GCP PubSub)
+Remove the binding and things get cleaned up (including removing the receive adapter to k8s events)
 
 ```shell
 kubectl delete binds k8s-events-example


### PR DESCRIPTION
fix a left over cut&paste issue with GCP
add pointer to k8s events into main sample/README.md 