### PR TITLE
GCP Pub/Sub Knative Bus

### DIFF
--- a/config/buses/gcppubsub.yaml
+++ b/config/buses/gcppubsub.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google, Inc. All rights reserved.
+# Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/buses/gcppubsub/bus.go
+++ b/pkg/buses/gcppubsub/bus.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018 The Knative Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/buses/gcppubsub/dispatcher/main.go
+++ b/pkg/buses/gcppubsub/dispatcher/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018 The Knative Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/buses/gcppubsub/provisioner/main.go
+++ b/pkg/buses/gcppubsub/provisioner/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018 The Knative Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
A Knative Bus implementation backed by GCP Cloud Pub/Sub.

Deployment steps:
1. Setup Knative Eventing
2. [Create a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/project) with the 'Pub/Sub Editor' role, and download a new JSON private key.
3. Create a secret for the downloaded key `kubectl create secret generic gcppubsub-bus-key --from-file=key.json=PATH-TO-KEY-FILE.json`
4. Replace `$PROJECT_ID` in `config/buses/gcppubsub.yaml` with your GCP Project ID
5. Apply the 'gcppubsub' Bus `ko apply -f config/buses/gcppubsub.yaml`
6. Create Channels that reference the 'gcppubsub' Bus

The bus has an independent provisioner and dispatcher.

The provisioner will create GCP Pub/Sub Topics and Subscriptions for each Knative Channel and Subscription (respectively) targeting the Bus. Clients should avoid interacting with topics and subscriptions provisioned by the Bus.

The dispatcher can receive events via the Channel Ingress from outside the cluster, or the Channel Service from inside the cluster. Events on the Pub/Sub topic for an active subscription are forwarded via HTTP to the subscriber. HTTP responses with a 2xx status code are acknowledge while all other status code will have delivery reattempted.

Note: Cloud Pub/Sub does not guarantee exactly once delivery, subscribers must guard against multiple deliveries of the same event.

To view logs:
- for the dispatcher `kail -d gcppubsub-bus -c dispatcher`
- for the provisioner `kail -d gcppubsub-bus-provisioner -c provisioner`

Resolves #80

This PR is effectively adds a [single commit](https://github.com/knative/eventing/commit/7c843721fd98560bc2ebb9f20dc19113c18b92e0) on top of #88, and will be rebased after it merges.

<!--
/assign @ericbottard @markfisher @vaikas-google 
-->