### PR TITLE
Rename namespace to knative-eventing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,7 @@ ko apply -f config/
 
 You can see things running with:
 ```shell
-$ kubectl -n knative-eventing-system get pods
+$ kubectl -n knative-eventing get pods
 NAME                               READY     STATUS    RESTARTS   AGE
 bind-controller-59f7969778-4dt7l   1/1       Running   0          2h
 ```
@@ -58,7 +58,7 @@ bind-controller-59f7969778-4dt7l   1/1       Running   0          2h
 You can access the Binding Controller's logs with:
 
 ```shell
-kubectl -n knative-eventing-system logs $(kubectl -n knative-eventing-system get pods -l app=bind-controller -o name)
+kubectl -n knative-eventing logs $(kubectl -n knative-eventing get pods -l app=bind-controller -o name)
 ```
 
 ## Iterating

--- a/config/a-namespace.yaml
+++ b/config/a-namespace.yaml
@@ -14,4 +14,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: knative-eventing-system
+  name: knative-eventing

--- a/config/clusterrolebinding.yaml
+++ b/config/clusterrolebinding.yaml
@@ -18,7 +18,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: bind-controller
-    namespace: knative-eventing-system
+    namespace: knative-eventing
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -15,7 +15,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: bind-controller
-  namespace: knative-eventing-system
+  namespace: knative-eventing
 spec:
   replicas: 1
   template:

--- a/config/serviceaccount.yaml
+++ b/config/serviceaccount.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bind-controller
-  namespace: knative-eventing-system
+  namespace: knative-eventing

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     role: eventing-webhook
   name: eventing-webhook
-  namespace: knative-eventing-system
+  namespace: knative-eventing
 spec:
   ports:
     - port: 443

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: eventing-webhook
-  namespace: knative-eventing-system
+  namespace: knative-eventing
 spec:
   replicas: 1
   template:

--- a/pkg/names.go
+++ b/pkg/names.go
@@ -19,5 +19,5 @@ package pkg
 // GetEventingSystemNamespace returns the namespace where
 // eventing controllers are deployed to.
 func GetEventingSystemNamespace() string {
-	return "knative-eventing-system"
+	return "knative-eventing"
 }

--- a/sample/k8s_events_function/README.md
+++ b/sample/k8s_events_function/README.md
@@ -127,7 +127,7 @@ This will create a receive_adapter that runs in the cluster and receives native 
 and pushes them to the consuming function.
 
 ```shell
-$kubectl -n knative-eventing-system get pods
+$kubectl -n knative-eventing get pods
 
 NAME                                                        READY     STATUS    RESTARTS   AGE
 bind-controller-dddb99dfc-jzp7z                             1/1       Running   0          1d

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -187,7 +187,7 @@ fi
 header "Standing up Knative Binding"
 ko apply -f config/
 exit_if_test_failed
-wait_until_pods_running knative-eventing-system
+wait_until_pods_running knative-eventing
 exit_if_test_failed
 
 # TODO: Add tests.


### PR DESCRIPTION
Fixes Issue #

## Proposed Changes

  *  Rename namespace to `knative-eventing`
  *  using -system suffix makes sense when using a single namespace
  *  since Knative has multiple namespaces, prefer to use `knative-serving` and `knative-eventing`  
