### PR TITLE
Add Knative TOC members as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,6 @@
 approvers:
-- vaikas-google
+- evankanderson
 - inlined
+- mattmoor
 - ultrasaurus
+- vaikas-google


### PR DESCRIPTION
This spreads the approval power around a bit to account for @vaikas-google going on vacation. @mattmoor and @evankanderson are Knative TOC members so they're already trusted as root owners in https://github.com/knative/serving.