### PR TITLE
Add gitattributes to note generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+**/zz_generated.*.go linguist-generated=true
+/pkg/client/** linguist-generated=true
+
+# coverage-excluded is an attribute used to explicitly exclude a path from being included in code
+# coverage. If a path is marked as linguist-generated already, it will be implicitly excluded and
+# there is no need to add the coverage-excluded attribute
+#/pkg/controller/testing/** coverage-excluded=true


### PR DESCRIPTION
This marks files as generated so they're hidden in PRs and ignored by the coverage checks.

Copied from knative/serving. :tophat: @mattmoor