### PR TITLE
Set propagation policy when deleting Job

### DIFF
--- a/pkg/sources/container_event_source.go
+++ b/pkg/sources/container_event_source.go
@@ -149,7 +149,10 @@ func (t *ContainerEventSource) run(job *batchv1.Job, parseLogs bool) (*BindConte
 
 func (t *ContainerEventSource) delete(job *batchv1.Job) error {
 	jobClient := t.kubeclientset.BatchV1().Jobs(job.Namespace)
-	err := jobClient.Delete(job.Name, &metav1.DeleteOptions{})
+	backgroundPolicy := metav1.DeletePropagationBackground
+	err := jobClient.Delete(job.Name, &metav1.DeleteOptions{
+		PropagationPolicy: &backgroundPolicy,
+	})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			glog.Infof("Job has already been deleted")


### PR DESCRIPTION
The default propagation policy for Job seems to be `orphan`, but we want to clean up all Job pods when a Job is deleted. Setting PropagationPolicy to Background does that without blocking the Job deletion.

Fixes #105.