### PR TITLE
Correct fixes comment

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,4 +1,4 @@
-Fixes Issue #
+Fixes #
 
 ## Proposed Changes
 


### PR DESCRIPTION
GitHub recognizes "Fixes #N" as a close comment, but not "Fixes Issue #N".