### PR TITLE
Enable passing CloudEvents headers ('CE-*')

### DIFF
--- a/pkg/buses/kafka/dispatcher/dispatcher.go
+++ b/pkg/buses/kafka/dispatcher/dispatcher.go
@@ -225,7 +225,7 @@ func initialOffset(parameters buses.ResolvedParameters) (int64, error) {
 func kafka2HttpHeaders(message *sarama.ConsumerMessage) http.Header {
 	result := make(http.Header)
 	for _, h := range message.Headers {
-		result[string(h.Key)] = []string{string(h.Value)}
+		result.Set(string(h.Key), string(h.Value))
 	}
 	return result
 }


### PR DESCRIPTION
Also cleans up some `go vet` warnings.

THIS IS NOT TESTED. Mostly because we don't seem to have any test cases yet for these buses. It seems like it would be useful to have a small test harness that accepts a set of HTTP requests and sends them to the bus then verifies that the correct messages were received by standing up a listening HTTP server and looping back from the bus to the handler.

Works towards #53 

## Proposed Changes

  *  Add `CE-` headers to the whitelist on the two buses that use a whitelist for handling messages. Long term, I'd like to see the buses move towards a blacklist model in terms of header passing, both in light of https://github.com/cloudevents/spec/pull/225 and to enable other development and experimentation without needing to rebuild the controller.
  * Added docstrings wherever they were missing, or made methods which were not used outside the package private in the gcppubsub case.

<--
/assign @scothis 
/assign @ericbottard 
-->