### PR TITLE
Allow Kafka bus to run as a ClusterBus

### DIFF
--- a/pkg/buses/kafka/dispatcher/dispatcher.go
+++ b/pkg/buses/kafka/dispatcher/dispatcher.go
@@ -68,13 +68,7 @@ func main() {
 	flag.Parse()
 
 	name := os.Getenv("BUS_NAME")
-	if name == "" {
-		log.Fatalf("Environment variable BUS_NAME not set")
-	}
 	namespace := os.Getenv("BUS_NAMESPACE")
-	if namespace == "" {
-		log.Fatalf("Environment variable BUS_NAMESPACE not set")
-	}
 
 	brokers := strings.Split(os.Getenv("KAFKA_BROKERS"), ",")
 	if len(brokers) == 0 {

--- a/pkg/buses/kafka/provisioner/provisioner.go
+++ b/pkg/buses/kafka/provisioner/provisioner.go
@@ -55,13 +55,7 @@ func main() {
 	flag.Parse()
 
 	name := os.Getenv("BUS_NAME")
-	if name == "" {
-		log.Fatalf("Environment variable BUS_NAME not set")
-	}
 	namespace := os.Getenv("BUS_NAMESPACE")
-	if namespace == "" {
-		log.Fatalf("Environment variable BUS_NAMESPACE not set")
-	}
 
 	brokers := strings.Split(os.Getenv("KAFKA_BROKERS"), ",")
 	if len(brokers) == 0 {


### PR DESCRIPTION
Cluster buses no not have a namespaces, therefore we cannot require the `BUS_NAMESPACE` env var to be set.

Fixes #187

## Proposed Changes

  *  Remove validation for variable that should not be set when running as a ClusterBus
