### PR TITLE
Capture the Channel's Service name as status

### DIFF
--- a/pkg/apis/channels/v1alpha1/channel_types.go
+++ b/pkg/apis/channels/v1alpha1/channel_types.go
@@ -59,6 +59,10 @@ type ChannelSpec struct {
 
 // ChannelStatus (computed) for a channel
 type ChannelStatus struct {
+	// ServiceName holds the name of a core Kubernetes Service resource that
+	// load balances over the pods backing the Channel's Bus.
+	// +optional
+	ServiceName string `json:"serviceName,omitempty"`
 }
 
 func (c *Channel) GetSpecJSON() ([]byte, error) {

--- a/pkg/controller/channel/controller.go
+++ b/pkg/controller/channel/controller.go
@@ -367,6 +367,10 @@ func (c *Controller) updateChannelStatus(channel *channelsv1alpha1.Channel, serv
 	// You can use DeepCopy() to make a deep copy of original object and modify this copy
 	// Or create a copy manually for better performance
 	channelCopy := channel.DeepCopy()
+
+	// Update ChannelStatus
+	channelCopy.Status.ServiceName = service.Name
+
 	// If the CustomResourceSubresources feature gate is not enabled,
 	// we must use Update instead of UpdateStatus to update the Status block of the Channel resource.
 	// UpdateStatus will not allow changes to the Spec of the resource,


### PR DESCRIPTION
In order to facilitate in cluster communication, resources that can be
sent traffic via a service should include the name of the service that
fronts that resource in it's status.

## Proposed Changes

* channels now contain `.status.serviceName`

/assign @vaikas-google 