### PR TITLE
Add DomainInternal property to ChannelStatus

### DIFF
--- a/pkg/apis/channels/v1alpha1/channel_types.go
+++ b/pkg/apis/channels/v1alpha1/channel_types.go
@@ -104,6 +104,12 @@ type ChannelStatus struct {
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	Conditions []ChannelCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// DomainInternal holds the top-level domain that will distribute traffic
+	// over the provided targets from inside the cluster. It generally has the
+	// form {channel}.{namespace}.svc.cluster.local
+	// +optional
+	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
 func (c *Channel) GetSpecJSON() ([]byte, error) {

--- a/pkg/apis/flows/v1alpha1/flow_types.go
+++ b/pkg/apis/flows/v1alpha1/flow_types.go
@@ -266,16 +266,14 @@ func (fs *FlowStatus) removeCondition(t FlowConditionType) {
 }
 
 func (fs *FlowStatus) PropagateChannelStatus(cs channelsv1alpha1.ChannelStatus) {
-	// TODO update after https://github.com/knative/eventing/pull/130 merges
-	// if cs.ServiceName != "" {
-	// 	fs.ChannelTarget = cs.ServiceName
-	// 	fs.setCondition(&FlowCondition{
-	// 		Type:   FlowConditionChannelReady,
-	// 		Status: corev1.ConditionTrue,
-	// 	})
-	// 	fs.checkAndMarkReady()
-	// }
-
+	if cs.DomainInternal != "" {
+		fs.ChannelTarget = cs.DomainInternal
+		fs.setCondition(&FlowCondition{
+			Type:   FlowConditionChannelReady,
+			Status: corev1.ConditionTrue,
+		})
+		fs.checkAndMarkReady()
+	}
 }
 
 func (fs *FlowStatus) PropagateSubscriptionStatus(ss channelsv1alpha1.SubscriptionStatus) {

--- a/pkg/apis/flows/v1alpha1/flow_types_test.go
+++ b/pkg/apis/flows/v1alpha1/flow_types_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	channelsv1alpha1 "github.com/knative/eventing/pkg/apis/channels/v1alpha1"
+	feedsv1alpha1 "github.com/knative/eventing/pkg/apis/feeds/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -183,64 +185,63 @@ func TestFlowCondition_IsReady(t *testing.T) {
 	}
 }
 
-// TODO restore test after https://github.com/knative/eventing/pull/130 merges
-// func TestFlowCondition_PropagateStatus(t *testing.T) {
-// 	testcases := []struct {
-// 		name            string
-// 		feedStatuses    []feedsv1alpha1.FeedStatus
-// 		channelStatuses []channelsv1alpha1.ChannelStatus
-// 		want            bool
-// 	}{
-// 		{"FeedReady",
-// 			[]feedsv1alpha1.FeedStatus{
-// 				feedsv1alpha1.FeedStatus{
-// 					Conditions: []feedsv1alpha1.FeedCondition{
-// 						feedsv1alpha1.FeedCondition{
-// 							Type:   feedsv1alpha1.FeedConditionReady,
-// 							Status: corev1.ConditionTrue,
-// 						},
-// 					},
-// 				}},
-// 			[]channelsv1alpha1.ChannelStatus{},
-// 			false},
-// 		{"ChannelReady",
-// 			[]feedsv1alpha1.FeedStatus{},
-// 			[]channelsv1alpha1.ChannelStatus{
-// 				channelsv1alpha1.ChannelStatus{
-// 					ServiceName: "foobar",
-// 				},
-// 			},
-// 			false},
-// 		{"BothReady",
-// 			[]feedsv1alpha1.FeedStatus{
-// 				feedsv1alpha1.FeedStatus{
-// 					Conditions: []feedsv1alpha1.FeedCondition{
-// 						feedsv1alpha1.FeedCondition{
-// 							Type:   feedsv1alpha1.FeedConditionReady,
-// 							Status: corev1.ConditionTrue,
-// 						},
-// 					},
-// 				}},
-// 			[]channelsv1alpha1.ChannelStatus{
-// 				channelsv1alpha1.ChannelStatus{
-// 					ServiceName: "foobar",
-// 				},
-// 			},
-// 			true},
-// 	}
-// 	for _, tc := range testcases {
-// 		testName := fmt.Sprintf("%s - %s", "Flow", tc.name)
-// 		t.Run(testName, func(t *testing.T) {
-// 			flow := Flow{}
-// 			for _, fs := range tc.feedStatuses {
-// 				flow.Status.PropagateFeedStatus(fs)
-// 			}
-// 			for _, cs := range tc.channelStatuses {
-// 				flow.Status.PropagateChannelStatus(cs)
-// 			}
-// 			if want, got := tc.want, flow.Status.IsReady(); want != got {
-// 				t.Fatalf("Failed IsReady check : \nwant:\t%#v\ngot:\t%#v", want, got)
-// 			}
-// 		})
-// 	}
-// }
+func TestFlowCondition_PropagateStatus(t *testing.T) {
+	testcases := []struct {
+		name            string
+		feedStatuses    []feedsv1alpha1.FeedStatus
+		channelStatuses []channelsv1alpha1.ChannelStatus
+		want            bool
+	}{
+		{"FeedReady",
+			[]feedsv1alpha1.FeedStatus{
+				feedsv1alpha1.FeedStatus{
+					Conditions: []feedsv1alpha1.FeedCondition{
+						feedsv1alpha1.FeedCondition{
+							Type:   feedsv1alpha1.FeedConditionReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				}},
+			[]channelsv1alpha1.ChannelStatus{},
+			false},
+		{"ChannelReady",
+			[]feedsv1alpha1.FeedStatus{},
+			[]channelsv1alpha1.ChannelStatus{
+				channelsv1alpha1.ChannelStatus{
+					DomainInternal: "foobar-channel.default.svc.cluster.local",
+				},
+			},
+			false},
+		{"BothReady",
+			[]feedsv1alpha1.FeedStatus{
+				feedsv1alpha1.FeedStatus{
+					Conditions: []feedsv1alpha1.FeedCondition{
+						feedsv1alpha1.FeedCondition{
+							Type:   feedsv1alpha1.FeedConditionReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				}},
+			[]channelsv1alpha1.ChannelStatus{
+				channelsv1alpha1.ChannelStatus{
+					DomainInternal: "foobar-channel.default.svc.cluster.local",
+				},
+			},
+			true},
+	}
+	for _, tc := range testcases {
+		testName := fmt.Sprintf("%s - %s", "Flow", tc.name)
+		t.Run(testName, func(t *testing.T) {
+			flow := Flow{}
+			for _, fs := range tc.feedStatuses {
+				flow.Status.PropagateFeedStatus(fs)
+			}
+			for _, cs := range tc.channelStatuses {
+				flow.Status.PropagateChannelStatus(cs)
+			}
+			if want, got := tc.want, flow.Status.IsReady(); want != got {
+				t.Fatalf("Failed IsReady check : \nwant:\t%#v\ngot:\t%#v", want, got)
+			}
+		})
+	}
+}

--- a/pkg/controller/channel/controller.go
+++ b/pkg/controller/channel/controller.go
@@ -390,6 +390,8 @@ func (c *Controller) updateChannelStatus(channel *channelsv1alpha1.Channel,
 	// Or create a copy manually for better performance
 	channelCopy := channel.DeepCopy()
 
+	// Update ChannelStatus
+
 	if service != nil {
 		channelCopy.Status.Service = &corev1.LocalObjectReference{Name: service.Name}
 		serviceCondition := util.NewChannelCondition(channelsv1alpha1.ChannelServiceable, corev1.ConditionTrue, ServiceSynced, "service successfully synced")
@@ -411,6 +413,8 @@ func (c *Controller) updateChannelStatus(channel *channelsv1alpha1.Channel,
 	}
 
 	util.ConsolidateChannelCondition(&channelCopy.Status)
+
+	channelCopy.Status.DomainInternal = controller.ServiceHostName(service.Name, service.Namespace)
 
 	// If the CustomResourceSubresources feature gate is not enabled,
 	// we must use Update instead of UpdateStatus to update the Status block of the Channel resource.


### PR DESCRIPTION
The DomainInternal status property allows the channel resource to be targeted from within the cluster.

Also reverting changes from #199 since #130 merged.

/assign @vaikas-google 