### PR TITLE
Istio inject ClusterBus pods

### DIFF
--- a/config/a-namespace.yaml
+++ b/config/a-namespace.yaml
@@ -15,3 +15,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-eventing
+  labels:
+    istio-injection: enabled

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -20,6 +20,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: eventing-controller
     spec:

--- a/pkg/controller/bus/controller.go
+++ b/pkg/controller/bus/controller.go
@@ -759,6 +759,9 @@ func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
@@ -866,6 +869,9 @@ func newProvisionerDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/clusterbus/controller.go
+++ b/pkg/controller/clusterbus/controller.go
@@ -582,6 +582,9 @@ func newDispatcherDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.De
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
@@ -635,6 +638,9 @@ func newProvisionerDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.D
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
The cluster bus deployments in the knative-eventing namespace need to be
istio injected in order to put traffic on to the service mesh. Because
of knative/serving#1300, we need to enable the injector for the entire
namespace and then opt-out component that should not be injected.

This change also explicitly enabled the istio injects for bus and
cluster bus deployments, however, the flag will not take effect until
the upstream istio issues are resolved.

Fixes #203

## Proposed Changes

* opt native-eventing namespace into istio injection 
* opt eventing controller and webhook deployments out of istio injection
* opt bus and cluster bus deployments into istio injection (currently redundant, but will take effect after upstream bugs are resolved)

/assign @vaikas-google 