### PR TITLE
Change json tag for condition.Type to "type"

### DIFF
--- a/pkg/apis/feeds/v1alpha1/common_event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_types.go
@@ -59,7 +59,7 @@ const (
 // CommonEventSourceCondition defines a readiness condition for a EventSource.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 type CommonEventSourceCondition struct {
-	Type CommonEventSourceConditionType `json:"state"`
+	Type CommonEventSourceConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 

--- a/pkg/apis/feeds/v1alpha1/common_event_type_types.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_type_types.go
@@ -54,7 +54,7 @@ const (
 // EventTypeCondition defines a readiness condition for a EventType.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 type CommonEventTypeCondition struct {
-	Type CommonEventTypeConditionType `json:"state"`
+	Type CommonEventTypeConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 

--- a/pkg/apis/feeds/v1alpha1/feed_types.go
+++ b/pkg/apis/feeds/v1alpha1/feed_types.go
@@ -179,7 +179,7 @@ const (
 // FeedCondition defines a readiness condition for a Feed.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 type FeedCondition struct {
-	Type FeedConditionType `json:"state"`
+	Type FeedConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 	// +optional

--- a/pkg/apis/flows/v1alpha1/flow_types.go
+++ b/pkg/apis/flows/v1alpha1/flow_types.go
@@ -204,7 +204,7 @@ const (
 // FlowCondition defines a readiness condition for a Flow.
 // See: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties
 type FlowCondition struct {
-	Type FlowConditionType `json:"state"`
+	Type FlowConditionType `json:"type"`
 
 	Status corev1.ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown"`
 	// +optional


### PR DESCRIPTION
Makes json tags for *Condition.Type to be `type` instead of `state`.