### PR TITLE
Fixes k8s-events demo

### DIFF
--- a/sample/k8s_events_function/feed.yaml
+++ b/sample/k8s_events_function/feed.yaml
@@ -28,4 +28,4 @@ spec:
     parameters:
       namespace: default
   action:
-    routeName: k8s-events-function
+    routeName: k8s-events


### PR DESCRIPTION
The k8s-events demo doesn't work as written. It seems the issue is that `feed.yaml` expects a route with a different name than the one created in `function.yaml`.  As a follow-up, it would be great if the eventing controller also added a status that the route couldn't be resolved.