### PR TITLE
Grep for function pods in e2e test

### DIFF
--- a/test/library.sh
+++ b/test/library.sh
@@ -159,7 +159,7 @@ function wait_until_feed_ready() {
 
 function validate_function_logs() {
   local NAMESPACE=$1
-  local podname="$(kubectl -n $NAMESPACE get pods --no-headers -oname | grep e2e-k8s-events-)"
+  local podname="$(kubectl -n $NAMESPACE get pods --no-headers -oname | grep e2e-k8s-events-function)"
   echo "$podname"
   local logs="$(kubectl -n $NAMESPACE logs $podname user-container)"
   echo "${logs}" | grep "Started container" || return 1


### PR DESCRIPTION
Now that job start pods are prefixed with the name of the bind (see #213), we need
to be more specific in our name match when looking for function pods.

Without this change the grep was often returning two pod names:

```
e2e-k8s-events-example-start-ffjt2
e2e-k8s-events-function-00001-deployment-7786db587-tjnvc
```

In this case, only the second is the function pod. The first is the completed start job pod.