### PR TITLE
Only update the Feed object once per reconcile

### DIFF
--- a/pkg/controller/feed/reconcile.go
+++ b/pkg/controller/feed/reconcile.go
@@ -74,9 +74,9 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		}
 	}
 
-	if err := r.updateFeed(feed); err != nil {
-		glog.Errorf("failed to update Feed status: %v", err)
-		return reconcile.Result{}, err
+	if updateErr := r.updateFeed(feed); updateErr != nil {
+		glog.Errorf("failed to update Feed status: %v", updateErr)
+		return reconcile.Result{}, updateErr
 	}
 	return reconcile.Result{}, err
 }


### PR DESCRIPTION
Updating the Feed multiple times in a single reconcile causes a race condition for updates after the first. The controller-runtime client always serves Get requests from cache (informers) and the cache may
not have been synced with the N-1 update when update N happens, causing a resourceVersion mismatch.

To avoid this race, update finalizers, object references, and status all in the same request. This should be the same behavior as before because all code paths execute the update once the Feed object has been modified.

This should fix resourceVersion mismatch errors in the controller logs when creating and deleting a feed.