### PR TITLE
Enable kubectl get knative || eventing || all to show knative eventing objects

### DIFF
--- a/config/bus.yaml
+++ b/config/bus.yaml
@@ -23,3 +23,7 @@ spec:
     kind: Bus
     plural: buses
     singular: bus
+    categories:
+    - all
+    - knative
+    - eventing

--- a/config/channel.yaml
+++ b/config/channel.yaml
@@ -23,3 +23,7 @@ spec:
     kind: Channel
     plural: channels
     singular: channel
+    categories:
+    - all
+    - knative
+    - eventing

--- a/config/clusterbus.yaml
+++ b/config/clusterbus.yaml
@@ -23,3 +23,7 @@ spec:
     kind: ClusterBus
     plural: clusterbuses
     singular: clusterbus
+    categories:
+    - all
+    - knative
+    - eventing

--- a/config/clustereventsource.yaml
+++ b/config/clustereventsource.yaml
@@ -22,4 +22,8 @@ spec:
     kind: ClusterEventSource
     plural: clustereventsources
     singular: clustereventsource
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Cluster

--- a/config/clustereventtype.yaml
+++ b/config/clustereventtype.yaml
@@ -22,4 +22,8 @@ spec:
     kind: ClusterEventType
     plural: clustereventtypes
     singular: clustereventsource
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Cluster

--- a/config/eventsource.yaml
+++ b/config/eventsource.yaml
@@ -22,4 +22,8 @@ spec:
     kind: EventSource
     plural: eventsources
     singular: eventsource
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Namespaced

--- a/config/eventtype.yaml
+++ b/config/eventtype.yaml
@@ -22,4 +22,8 @@ spec:
     kind: EventType
     plural: eventtypes
     singular: eventtype
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Namespaced

--- a/config/feed.yaml
+++ b/config/feed.yaml
@@ -22,4 +22,8 @@ spec:
     kind: Feed
     plural: feeds
     singular: feed
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Namespaced

--- a/config/flow.yaml
+++ b/config/flow.yaml
@@ -22,4 +22,9 @@ spec:
     kind: Flow
     plural: flows
     singular: flow
+    categories:
+    - all
+    - knative
+    - eventing
   scope: Namespaced
+

--- a/config/subscription.yaml
+++ b/config/subscription.yaml
@@ -23,3 +23,7 @@ spec:
     kind: Subscription
     plural: subscriptions
     singular: subscription
+    categories:
+    - all
+    - knative
+    - eventing


### PR DESCRIPTION
Using [categories](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) (search for Categories).