### PR TITLE
Handle github webhook missing

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -76,8 +76,15 @@ func (t *GithubEventSource) StopFeed(trigger sources.EventTrigger, feedContext s
 		log.Printf("Failed to convert webhook %q to int64 : %s", webhookID, err)
 		return err
 	}
-	r, err := client.Repositories.DeleteHook(ctx, owner, repo, id)
+	_, err = client.Repositories.DeleteHook(ctx, owner, repo, id)
 	if err != nil {
+		if errResp, ok := err.(*ghclient.ErrorResponse); ok {
+			// If the webhook doesn't exist, nothing to do
+			if errResp.Message == "Not Found" {
+				log.Printf("Webhook doesn't exist, nothing to delete.")
+				return nil
+			}
+		}
 		log.Printf("Failed to delete the webhook: %#v", err)
 		return err
 	}


### PR DESCRIPTION
Related to #246

## Proposed Changes

  *  Github feedlet container now considers a 404 when deleting a webhook to be success instead of failure.
  * GitHub feedlet now uses `log.Printf` instead of `glog`. `glog` was not correctly configured to emit to stdout/stderr, so its logs were being lost.

This fixes the issue @n3wscott ran into with a missing webhook causing feed delete to hang indefinitely.
