### PR TITLE
Create OWNERS in //hack

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,9 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- adrcunha
+- evankanderson
+- inlined
+- mattmoor
+- ultrasaurus
+- vaikas-google


### PR DESCRIPTION
This is a copy of OWNERS in the repo root dir, plus adrcunha.