### PR TITLE
Add cluster scoped feed webhooks.

### DIFF
--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,4 +58,8 @@ type ClusterEventSourceList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []ClusterEventSource `json:"items"`
+}
+
+func (et *ClusterEventType) GetSpecJSON() ([]byte, error) {
+	return json.Marshal(et.Spec)
 }

--- a/pkg/apis/feeds/v1alpha1/event_type_types.go
+++ b/pkg/apis/feeds/v1alpha1/event_type_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,4 +58,8 @@ type EventTypeList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []EventType `json:"items"`
+}
+
+func (et *EventType) GetSpecJSON() ([]byte, error) {
+	return json.Marshal(et.Spec)
 }

--- a/pkg/apis/feeds/v1alpha1/feed_types.go
+++ b/pkg/apis/feeds/v1alpha1/feed_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -68,9 +70,10 @@ type FeedAction struct {
 // EventTrigger specifies the intention that a particular event type and
 // resource should be consumed.
 type EventTrigger struct {
-	// Required. The type of event to observe. For example:
-	// `google.storage.object.finalize` and
-	// `google.firebase.analytics.event.log`.
+	// EventType or ClusterEventType Required. The type of event to observe.
+	// For example:
+	//   `google.storage.object.finalize` and
+	//   `google.firebase.analytics.event.log`.
 	//
 	// Event type consists of three parts:
 	//  1. namespace: The domain name of the organization in reverse-domain
@@ -86,6 +89,10 @@ type EventTrigger struct {
 	//     a Google Cloud Storage Object include 'finalize' and 'delete'.
 	// These parts are lower case and joined by '.'.
 	EventType string `json:"eventType"`
+
+	// EventType or ClusterEventType Required. ClusterEventType is the same as
+	// EventType but Cluster scoped.
+	ClusterEventType string `json:"clusterEventType"`
 
 	// Required. The resource(s) from which to observe events, for example,
 	// `projects/_/buckets/myBucket/objects/{objectPath=**}`.
@@ -300,4 +307,8 @@ func (f *Feed) SetOwnerReference(or *metav1.OwnerReference) {
 	}
 	refs = append(refs, *or)
 	f.SetOwnerReferences(refs)
+}
+
+func (f *Feed) GetSpecJSON() ([]byte, error) {
+	return json.Marshal(f.Spec)
 }

--- a/pkg/controller/feed/reconcile.go
+++ b/pkg/controller/feed/reconcile.go
@@ -445,18 +445,6 @@ func (r *reconciler) createJob(feed *feedsv1alpha1.Feed, es *feedsv1alpha1.Event
 		return nil, err
 	}
 
-	// TODO(nicholss): this needs to be an EventType of ClusterEventType
-	et := &feedsv1alpha1.EventType{}
-	if err = r.client.Get(context.TODO(), client.ObjectKey{Namespace: feed.Namespace, Name: feed.Spec.Trigger.EventType}, et); err != nil {
-		return nil, err
-	}
-
-	// TODO(nicholss): this needs to be an EventSource or ClusterEventSource
-	source := &feedsv1alpha1.EventSource{}
-	if err = r.client.Get(context.TODO(), client.ObjectKey{Namespace: feed.Namespace, Name: et.Spec.EventSource}, source); err != nil {
-		return nil, err
-	}
-
 	trigger, err := r.resolveTrigger(feed)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/feed/reconcile.go
+++ b/pkg/controller/feed/reconcile.go
@@ -103,7 +103,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// TODO: Remove this and use finalizers in the EventTypes / EventSources
 	// to do this properly.
 	// TODO: Add issue link here. can't look up right now, no wifi
-	r.setEventTypeOwnerReference(feed, eventType)
+	r.setEventTypeOwnerReference(feed)
 	if err := r.updateOwnerReferences(feed); err != nil {
 		glog.Errorf("failed to update Feed owner references: %v", err)
 		return reconcile.Result{}, err

--- a/pkg/webhook/cluster_event_type.go
+++ b/pkg/webhook/cluster_event_type.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/glog"
+	"github.com/knative/eventing/pkg/apis/feeds/v1alpha1"
+	"github.com/mattbaird/jsonpatch"
+)
+
+var (
+	errInvalidClusterEventTypeInput = errors.New("failed to convert input into ClusterEventType")
+)
+
+// Test the type for interface compliance
+var _ GenericCRD = &v1alpha1.ClusterEventType{}
+
+// ValidateClusterEventType is the event type for a Feed
+func ValidateClusterClusterEventType(ctx context.Context) ResourceCallback {
+	return func(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
+		oldSubscription, newSubscription, err := unmarshalClusterEventTypes(ctx, old, new, "ValidateClusterEventType")
+		if err != nil {
+			return err
+		}
+
+		return validateClusterEventType(oldSubscription, newSubscription)
+	}
+}
+
+func validateClusterEventType(old, new *v1alpha1.ClusterEventType) error {
+	// TODO(nicholss): write this.
+	return nil
+}
+
+func unmarshalClusterEventTypes(
+	ctx context.Context, old, new GenericCRD, fnName string) (*v1alpha1.ClusterEventType, *v1alpha1.ClusterEventType, error) {
+	var oldClusterEventType *v1alpha1.ClusterEventType
+	if old != nil {
+		var ok bool
+		oldClusterEventType, ok = old.(*v1alpha1.ClusterEventType)
+		if !ok {
+			return nil, nil, errInvalidSubscriptionInput
+		}
+	}
+	glog.Infof("%s: OLD ClusterEventType is\n%+v", fnName, oldClusterEventType)
+
+	newClusterEventType, ok := new.(*v1alpha1.ClusterEventType)
+	if !ok {
+		return nil, nil, errInvalidClusterEventTypeInput
+	}
+	glog.Infof("%s: NEW ClusterEventType is\n%+v", fnName, newClusterEventType)
+
+	return oldClusterEventType, newClusterEventType, nil
+}

--- a/pkg/webhook/event_type.go
+++ b/pkg/webhook/event_type.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/glog"
+	"github.com/knative/eventing/pkg/apis/feeds/v1alpha1"
+	"github.com/mattbaird/jsonpatch"
+)
+
+var (
+	errInvalidEventTypeInput = errors.New("failed to convert input into EventType")
+)
+
+// Test the type for interface compliance
+var _ GenericCRD = &v1alpha1.EventType{}
+
+// ValidateEventType is the event type for a Feed
+func ValidateEventType(ctx context.Context) ResourceCallback {
+	return func(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
+		oldSubscription, newSubscription, err := unmarshalEventTypes(ctx, old, new, "ValidateEventType")
+		if err != nil {
+			return err
+		}
+
+		return validateEventType(oldSubscription, newSubscription)
+	}
+}
+
+func validateEventType(old, new *v1alpha1.EventType) error {
+	// TODO(nicholss): write this.
+	return nil
+}
+
+func unmarshalEventTypes(
+	ctx context.Context, old, new GenericCRD, fnName string) (*v1alpha1.EventType, *v1alpha1.EventType, error) {
+	var oldEventType *v1alpha1.EventType
+	if old != nil {
+		var ok bool
+		oldEventType, ok = old.(*v1alpha1.EventType)
+		if !ok {
+			return nil, nil, errInvalidSubscriptionInput
+		}
+	}
+	glog.Infof("%s: OLD EventType is\n%+v", fnName, oldEventType)
+
+	newEventType, ok := new.(*v1alpha1.EventType)
+	if !ok {
+		return nil, nil, errInvalidEventTypeInput
+	}
+	glog.Infof("%s: NEW EventType is\n%+v", fnName, newEventType)
+
+	return oldEventType, newEventType, nil
+}

--- a/pkg/webhook/feed.go
+++ b/pkg/webhook/feed.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/glog"
+	"github.com/knative/eventing/pkg/apis/feeds/v1alpha1"
+	"github.com/mattbaird/jsonpatch"
+)
+
+var (
+	errInvalidFeedInput                = errors.New("failed to convert input into Feed")
+	errInvalidFeedEventTypeMissing     = errors.New("the Feed must reference a EventType or ClusterEventType")
+	errInvalidFeedEventTypeExclusivity = errors.New("the Feed must reference either a EventType or ClusterEventType, not both")
+)
+
+// Test the type for interface compliance
+var _ GenericCRD = &v1alpha1.Feed{}
+
+// ValidateFeed is the event type for a Feed
+func ValidateFeed(ctx context.Context) ResourceCallback {
+	return func(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
+		oldSubscription, newSubscription, err := unmarshalFeeds(ctx, old, new, "ValidateFeed")
+		if err != nil {
+			return err
+		}
+
+		return validateFeed(oldSubscription, newSubscription)
+	}
+}
+
+func validateFeed(old, new *v1alpha1.Feed) error {
+	refsEventType := len(new.Spec.Trigger.EventType) != 0
+	refsClusterEventType := len(new.Spec.Trigger.ClusterEventType) != 0
+	if !refsEventType && !refsClusterEventType {
+		return errInvalidFeedEventTypeMissing
+	} else if refsEventType && refsClusterEventType {
+		return errInvalidFeedEventTypeExclusivity
+	}
+	// TODO(nicholss): write this.
+	return nil
+}
+
+func unmarshalFeeds(
+	ctx context.Context, old, new GenericCRD, fnName string) (*v1alpha1.Feed, *v1alpha1.Feed, error) {
+	var oldFeed *v1alpha1.Feed
+	if old != nil {
+		var ok bool
+		oldFeed, ok = old.(*v1alpha1.Feed)
+		if !ok {
+			return nil, nil, errInvalidSubscriptionInput
+		}
+	}
+	glog.Infof("%s: OLD Feed is\n%+v", fnName, oldFeed)
+
+	newFeed, ok := new.(*v1alpha1.Feed)
+	if !ok {
+		return nil, nil, errInvalidFeedInput
+	}
+	glog.Infof("%s: NEW Feed is\n%+v", fnName, newFeed)
+
+	return oldFeed, newFeed, nil
+}

--- a/pkg/webhook/feed_test.go
+++ b/pkg/webhook/feed_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Knative Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+)
+
+func TestNewFeedNSEventType(t *testing.T) {
+	c := createFeed(testFeedName, testEventTypeName, "")
+	if err := ValidateFeed(testCtx)(nil, nil, &c); err != nil {
+		t.Errorf("Expected success, but failed with: %s", err)
+	}
+}
+
+func TestNewFeedClusterEventType(t *testing.T) {
+	c := createFeed(testFeedName, "", testClusterEventTypeName)
+	if err := ValidateFeed(testCtx)(nil, nil, &c); err != nil {
+		t.Errorf("Expected success, but failed with: %s", err)
+	}
+}
+
+func TestNewEmptyFeed(t *testing.T) {
+	c := createFeed(testFeedName, "", "")
+	err := ValidateFeed(testCtx)(nil, nil, &c)
+	if err == nil {
+		t.Errorf("Expected failure, but succeeded with: %+v", c)
+	}
+	if e, a := errInvalidFeedEventTypeMissing, err; e != a {
+		t.Errorf("Expected %s got %s", e, a)
+	}
+}
+
+func TestNewExclusiveFeed(t *testing.T) {
+	c := createFeed(testFeedName, testEventTypeName, testClusterEventTypeName)
+	err := ValidateFeed(testCtx)(nil, nil, &c)
+	if err == nil {
+		t.Errorf("Expected failure, but succeeded with: %+v", c)
+	}
+	if e, a := errInvalidFeedEventTypeExclusivity, err; e != a {
+		t.Errorf("Expected %s got %s", e, a)
+	}
+}

--- a/pkg/webhook/webhook_channels_test.go
+++ b/pkg/webhook/webhook_channels_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/knative/eventing/pkg/apis/channels/v1alpha1"
+	"github.com/mattbaird/jsonpatch"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testBusName          = "test-bus"
+	testClusterBusName   = "test-clusterbus"
+	testChannelName      = "test-channel"
+	testSubscriptionName = "test-subscription"
+)
+
+func TestValidBusParameterNamePasses(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Bus"},
+	}
+	validName := "ok_param.name"
+	bus := createBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: validName}}
+	marshaled, err := json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectAllowed(t, ac.admit(testCtx, req))
+
+	validName = "simple-name"
+	bus = createBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: validName}}
+	marshaled, err = json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectAllowed(t, ac.admit(testCtx, req))
+}
+
+func TestInvalidBusParameterNameFails(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Bus"},
+	}
+	invalidName := "paramètre"
+	bus := createBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: invalidName}}
+	marshaled, err := json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Subscription.paramètre")
+
+	invalidName = "param/name"
+	bus = createBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: invalidName}}
+	marshaled, err = json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Channel.param/name")
+}
+
+func TestInvalidClusterBusParameterNameFails(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "ClusterBus"},
+	}
+	invalidName := "paramètre"
+	bus := createClusterBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: invalidName}}
+	marshaled, err := json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Subscription.paramètre")
+
+	invalidName = "param/name"
+	bus = createClusterBus(testBusName, "foobar/dispatcher")
+	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: invalidName}}
+	marshaled, err = json.Marshal(bus)
+	if err != nil {
+		t.Fatalf("Failed to marshal bus: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Channel.param/name")
+}
+
+func TestInvalidNewChannelNameFails(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
+	}
+	invalidName := "channel.example"
+	channel := createChannel(invalidName, testBusName, "")
+	marshaled, err := json.Marshal(channel)
+	if err != nil {
+		t.Fatalf("Failed to marshal channel: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
+
+	invalidName = strings.Repeat("a", 64)
+	channel = createChannel(invalidName, testBusName, "")
+	marshaled, err = json.Marshal(channel)
+	if err != nil {
+		t.Fatalf("Failed to marshal channel: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
+}
+
+func TestValidNewChannelObject(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	resp := ac.admit(testCtx, createValidCreateChannel())
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
+}
+
+func TestValidChannelNSBusNoChanges(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	old := createChannel(testChannelName, testBusName, "")
+	new := createChannel(testChannelName, testBusName, "")
+	resp := ac.admit(testCtx, createUpdateChannel(&old, &new))
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
+}
+
+func TestValidChannelClusterBusNoChanges(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	old := createChannel(testChannelName, "", testClusterBusName)
+	new := createChannel(testChannelName, "", testClusterBusName)
+	resp := ac.admit(testCtx, createUpdateChannel(&old, &new))
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
+}
+
+func TestInvalidNewSubscriptionNameFails(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
+	}
+	invalidName := "subscription.example"
+	subscription := createSubscription(invalidName, "channel-name")
+	marshaled, err := json.Marshal(subscription)
+	if err != nil {
+		t.Fatalf("Failed to marshal subscription: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
+
+	invalidName = strings.Repeat("a", 64)
+	subscription = createSubscription(invalidName, "channel-name")
+	marshaled, err = json.Marshal(subscription)
+	if err != nil {
+		t.Fatalf("Failed to marshal subscription: %s", err)
+	}
+	req.Object.Raw = marshaled
+	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
+}
+
+func TestValidNewSubscriptionObject(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	resp := ac.admit(testCtx, createValidCreateSubscription())
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
+}
+
+func TestValidSubscriptionNoChanges(t *testing.T) {
+	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
+	old := createSubscription(testSubscriptionName, testChannelName)
+	new := createSubscription(testSubscriptionName, testChannelName)
+	resp := ac.admit(testCtx, createUpdateSubscription(&old, &new))
+	expectAllowed(t, resp)
+	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
+}
+
+func createBus(busName string, dispatcherImage string) v1alpha1.Bus {
+	return v1alpha1.Bus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      busName,
+		},
+		Spec: v1alpha1.BusSpec{
+			Dispatcher: v1.Container{
+				Image: dispatcherImage,
+			},
+			Parameters: &v1alpha1.BusParameters{
+				Channel:      &[]v1alpha1.Parameter{},
+				Subscription: &[]v1alpha1.Parameter{},
+			},
+		},
+	}
+}
+
+func createClusterBus(busName string, dispatcherImage string) v1alpha1.ClusterBus {
+	return v1alpha1.ClusterBus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      busName,
+		},
+		Spec: v1alpha1.BusSpec{
+			Dispatcher: v1.Container{
+				Image: dispatcherImage,
+			},
+			Parameters: &v1alpha1.BusParameters{
+				Channel:      &[]v1alpha1.Parameter{},
+				Subscription: &[]v1alpha1.Parameter{},
+			},
+		},
+	}
+}
+
+func createBaseUpdateChannel() *admissionv1beta1.AdmissionRequest {
+	return &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Update,
+		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
+	}
+}
+
+func createUpdateChannel(old, new *v1alpha1.Channel) *admissionv1beta1.AdmissionRequest {
+	req := createBaseUpdateChannel()
+	marshaled, err := json.Marshal(old)
+	if err != nil {
+		panic("failed to marshal channel")
+	}
+	req.Object.Raw = marshaled
+	marshaledOld, err := json.Marshal(new)
+	if err != nil {
+		panic("failed to marshal channel")
+	}
+	req.OldObject.Raw = marshaledOld
+	return req
+}
+
+func createCreateChannel(channel v1alpha1.Channel) *admissionv1beta1.AdmissionRequest {
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
+	}
+	marshaled, err := json.Marshal(channel)
+	if err != nil {
+		panic("failed to marshal channel")
+	}
+	req.Object.Raw = marshaled
+	return req
+}
+
+func createValidCreateChannel() *admissionv1beta1.AdmissionRequest {
+	return createCreateChannel(createChannel(testChannelName, testBusName, ""))
+}
+
+func createChannel(channelName string, busName, clusterBusName string) v1alpha1.Channel {
+	return v1alpha1.Channel{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      channelName,
+		},
+		Spec: v1alpha1.ChannelSpec{
+			Bus:        busName,
+			ClusterBus: clusterBusName,
+		},
+	}
+}
+
+func createBaseUpdateSubscription() *admissionv1beta1.AdmissionRequest {
+	return &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Update,
+		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
+	}
+}
+
+func createUpdateSubscription(old, new *v1alpha1.Subscription) *admissionv1beta1.AdmissionRequest {
+	req := createBaseUpdateSubscription()
+	marshaled, err := json.Marshal(old)
+	if err != nil {
+		panic("failed to marshal subscription")
+	}
+	req.Object.Raw = marshaled
+	marshaledOld, err := json.Marshal(new)
+	if err != nil {
+		panic("failed to marshal subscription")
+	}
+	req.OldObject.Raw = marshaledOld
+	return req
+}
+
+func createCreateSubscription(subscription v1alpha1.Subscription) *admissionv1beta1.AdmissionRequest {
+	req := &admissionv1beta1.AdmissionRequest{
+		Operation: admissionv1beta1.Create,
+		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
+	}
+	marshaled, err := json.Marshal(subscription)
+	if err != nil {
+		panic("failed to marshal subscription")
+	}
+	req.Object.Raw = marshaled
+	return req
+}
+
+func createValidCreateSubscription() *admissionv1beta1.AdmissionRequest {
+	return createCreateSubscription(createSubscription(testSubscriptionName, testChannelName))
+}
+
+func createSubscription(subscriptionName string, channelName string) v1alpha1.Subscription {
+	return v1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      subscriptionName,
+		},
+		Spec: v1alpha1.SubscriptionSpec{
+			Channel: channelName,
+		},
+	}
+}

--- a/pkg/webhook/webhook_feeds_test.go
+++ b/pkg/webhook/webhook_feeds_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"github.com/knative/eventing/pkg/apis/feeds/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testFeedName             = "test-feed"
+	testClusterEventTypeName = "test-clustereventtype"
+	testEventTypeName        = "test-eventtype"
+)
+
+func createFeed(feedName, eventTypeName, clusterEventTypeName string) v1alpha1.Feed {
+	return v1alpha1.Feed{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      feedName,
+		},
+		Spec: v1alpha1.FeedSpec{
+			Trigger: v1alpha1.EventTrigger{
+				EventType:        eventTypeName,
+				ClusterEventType: clusterEventTypeName,
+			},
+			// TODO(nicholss): Fill this out more?
+		},
+	}
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -25,14 +25,16 @@ import (
 
 	"github.com/knative/eventing/pkg"
 
-	"github.com/knative/eventing/pkg/apis/channels/v1alpha1"
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "test-namespace"
 )
 
 func newDefaultOptions() ControllerOptions {
@@ -44,14 +46,6 @@ func newDefaultOptions() ControllerOptions {
 		WebhookName:      "webhook.eventing.knative.dev",
 	}
 }
-
-const (
-	testNamespace        = "test-namespace"
-	testBusName          = "test-bus"
-	testClusterBusName   = "test-clusterbus"
-	testChannelName      = "test-channel"
-	testSubscriptionName = "test-subscription"
-)
 
 var (
 	testCtx = context.TODO()
@@ -126,178 +120,6 @@ func TestUnknownKindFails(t *testing.T) {
 	}
 
 	expectFailsWith(t, ac.admit(testCtx, &req), "unhandled kind")
-}
-
-func TestValidBusParameterNamePasses(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Bus"},
-	}
-	validName := "ok_param.name"
-	bus := createBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: validName}}
-	marshaled, err := json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectAllowed(t, ac.admit(testCtx, req))
-
-	validName = "simple-name"
-	bus = createBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: validName}}
-	marshaled, err = json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectAllowed(t, ac.admit(testCtx, req))
-}
-
-func TestInvalidBusParameterNameFails(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Bus"},
-	}
-	invalidName := "paramètre"
-	bus := createBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: invalidName}}
-	marshaled, err := json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Subscription.paramètre")
-
-	invalidName = "param/name"
-	bus = createBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: invalidName}}
-	marshaled, err = json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Channel.param/name")
-}
-
-func TestInvalidClusterBusParameterNameFails(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "ClusterBus"},
-	}
-	invalidName := "paramètre"
-	bus := createClusterBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Subscription = &[]v1alpha1.Parameter{{Name: invalidName}}
-	marshaled, err := json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Subscription.paramètre")
-
-	invalidName = "param/name"
-	bus = createClusterBus(testBusName, "foobar/dispatcher")
-	bus.Spec.Parameters.Channel = &[]v1alpha1.Parameter{{Name: invalidName}}
-	marshaled, err = json.Marshal(bus)
-	if err != nil {
-		t.Fatalf("Failed to marshal bus: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "invalid parameter name Spec.Parameters.Channel.param/name")
-}
-
-func TestInvalidNewChannelNameFails(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
-	}
-	invalidName := "channel.example"
-	channel := createChannel(invalidName, testBusName, "")
-	marshaled, err := json.Marshal(channel)
-	if err != nil {
-		t.Fatalf("Failed to marshal channel: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
-
-	invalidName = strings.Repeat("a", 64)
-	channel = createChannel(invalidName, testBusName, "")
-	marshaled, err = json.Marshal(channel)
-	if err != nil {
-		t.Fatalf("Failed to marshal channel: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
-}
-
-func TestValidNewChannelObject(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	resp := ac.admit(testCtx, createValidCreateChannel())
-	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
-}
-
-func TestValidChannelNSBusNoChanges(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	old := createChannel(testChannelName, testBusName, "")
-	new := createChannel(testChannelName, testBusName, "")
-	resp := ac.admit(testCtx, createUpdateChannel(&old, &new))
-	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
-}
-
-func TestValidChannelClusterBusNoChanges(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	old := createChannel(testChannelName, "", testClusterBusName)
-	new := createChannel(testChannelName, "", testClusterBusName)
-	resp := ac.admit(testCtx, createUpdateChannel(&old, &new))
-	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
-}
-
-func TestInvalidNewSubscriptionNameFails(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
-	}
-	invalidName := "subscription.example"
-	subscription := createSubscription(invalidName, "channel-name")
-	marshaled, err := json.Marshal(subscription)
-	if err != nil {
-		t.Fatalf("Failed to marshal subscription: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
-
-	invalidName = strings.Repeat("a", 64)
-	subscription = createSubscription(invalidName, "channel-name")
-	marshaled, err = json.Marshal(subscription)
-	if err != nil {
-		t.Fatalf("Failed to marshal subscription: %s", err)
-	}
-	req.Object.Raw = marshaled
-	expectFailsWith(t, ac.admit(testCtx, req), "Invalid resource name")
-}
-
-func TestValidNewSubscriptionObject(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	resp := ac.admit(testCtx, createValidCreateSubscription())
-	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
-}
-
-func TestValidSubscriptionNoChanges(t *testing.T) {
-	_, ac := newNonRunningTestAdmissionController(t, newDefaultOptions())
-	old := createSubscription(testSubscriptionName, testChannelName)
-	new := createSubscription(testSubscriptionName, testChannelName)
-	resp := ac.admit(testCtx, createUpdateSubscription(&old, &new))
-	expectAllowed(t, resp)
-	expectPatches(t, resp.Patch, []jsonpatch.JsonPatchOperation{})
 }
 
 func TestValidWebhook(t *testing.T) {
@@ -398,144 +220,5 @@ func expectPatches(t *testing.T, a []byte, e []jsonpatch.JsonPatchOperation) {
 		if !f {
 			t.Errorf("Extra patch found %+v in expected patches: %q", a[i], e)
 		}
-	}
-}
-
-func createBus(busName string, dispatcherImage string) v1alpha1.Bus {
-	return v1alpha1.Bus{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      busName,
-		},
-		Spec: v1alpha1.BusSpec{
-			Dispatcher: v1.Container{
-				Image: dispatcherImage,
-			},
-			Parameters: &v1alpha1.BusParameters{
-				Channel:      &[]v1alpha1.Parameter{},
-				Subscription: &[]v1alpha1.Parameter{},
-			},
-		},
-	}
-}
-
-func createClusterBus(busName string, dispatcherImage string) v1alpha1.ClusterBus {
-	return v1alpha1.ClusterBus{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      busName,
-		},
-		Spec: v1alpha1.BusSpec{
-			Dispatcher: v1.Container{
-				Image: dispatcherImage,
-			},
-			Parameters: &v1alpha1.BusParameters{
-				Channel:      &[]v1alpha1.Parameter{},
-				Subscription: &[]v1alpha1.Parameter{},
-			},
-		},
-	}
-}
-
-func createBaseUpdateChannel() *admissionv1beta1.AdmissionRequest {
-	return &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Update,
-		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
-	}
-}
-
-func createUpdateChannel(old, new *v1alpha1.Channel) *admissionv1beta1.AdmissionRequest {
-	req := createBaseUpdateChannel()
-	marshaled, err := json.Marshal(old)
-	if err != nil {
-		panic("failed to marshal channel")
-	}
-	req.Object.Raw = marshaled
-	marshaledOld, err := json.Marshal(new)
-	if err != nil {
-		panic("failed to marshal channel")
-	}
-	req.OldObject.Raw = marshaledOld
-	return req
-}
-
-func createCreateChannel(channel v1alpha1.Channel) *admissionv1beta1.AdmissionRequest {
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Channel"},
-	}
-	marshaled, err := json.Marshal(channel)
-	if err != nil {
-		panic("failed to marshal channel")
-	}
-	req.Object.Raw = marshaled
-	return req
-}
-
-func createValidCreateChannel() *admissionv1beta1.AdmissionRequest {
-	return createCreateChannel(createChannel(testChannelName, testBusName, ""))
-}
-
-func createChannel(channelName string, busName, clusterBusName string) v1alpha1.Channel {
-	return v1alpha1.Channel{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      channelName,
-		},
-		Spec: v1alpha1.ChannelSpec{
-			Bus:        busName,
-			ClusterBus: clusterBusName,
-		},
-	}
-}
-
-func createBaseUpdateSubscription() *admissionv1beta1.AdmissionRequest {
-	return &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Update,
-		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
-	}
-}
-
-func createUpdateSubscription(old, new *v1alpha1.Subscription) *admissionv1beta1.AdmissionRequest {
-	req := createBaseUpdateSubscription()
-	marshaled, err := json.Marshal(old)
-	if err != nil {
-		panic("failed to marshal subscription")
-	}
-	req.Object.Raw = marshaled
-	marshaledOld, err := json.Marshal(new)
-	if err != nil {
-		panic("failed to marshal subscription")
-	}
-	req.OldObject.Raw = marshaledOld
-	return req
-}
-
-func createCreateSubscription(subscription v1alpha1.Subscription) *admissionv1beta1.AdmissionRequest {
-	req := &admissionv1beta1.AdmissionRequest{
-		Operation: admissionv1beta1.Create,
-		Kind:      metav1.GroupVersionKind{Kind: "Subscription"},
-	}
-	marshaled, err := json.Marshal(subscription)
-	if err != nil {
-		panic("failed to marshal subscription")
-	}
-	req.Object.Raw = marshaled
-	return req
-}
-
-func createValidCreateSubscription() *admissionv1beta1.AdmissionRequest {
-	return createCreateSubscription(createSubscription(testSubscriptionName, testChannelName))
-}
-
-func createSubscription(subscriptionName string, channelName string) v1alpha1.Subscription {
-	return v1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
-			Name:      subscriptionName,
-		},
-		Spec: v1alpha1.SubscriptionSpec{
-			Channel: channelName,
-		},
 	}
 }


### PR DESCRIPTION
Replaces https://github.com/knative/eventing/pull/230

This adds the field `ClusterEventType` to the trigger on a `Feed`. 
Then adds the webhook for `Feeds` to test to see if a `ClusterEventType` or `EventType` are set.