### PR TITLE
Remove `glog` dependency from pkg/events.

### DIFF
--- a/pkg/event/encoding_binary.go
+++ b/pkg/event/encoding_binary.go
@@ -23,12 +23,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/golang/glog"
 )
 
 const (
@@ -87,7 +86,7 @@ func (binary) FromRequest(data interface{}, r *http.Request) (*EventContext, err
 	ctx.EventTypeVersion = r.Header.Get(HeaderEventTypeVersion)
 	ctx.SchemaURL = r.Header.Get(HeaderSchemaURL)
 	if ctx.CloudEventsVersion != CloudEventsVersion {
-		glog.Warningf("Received CloudEvent version %q; parsing as version %q",
+		log.Printf("Received CloudEvent version %q; parsing as version %q",
 			ctx.CloudEventsVersion, CloudEventsVersion)
 	}
 


### PR DESCRIPTION
The `glog` library defines a `log_dir` flag. Incautiously including multiple versions of `glog` (e.g. through two dependencies without using `dep`) causes a startup-time panic on multiple definitions of `log_dir`.

It turns out that the kubernetes client libraries depend on `glog`, which means that samples like the `k8sevents` sample which try to include both need to use `dep`. This is a bit painful, so let's make life easy for future library users.

## Proposed Changes

  *  Removes `glog`, as it is hostile to naive vendoring/multiple inclusion