### PR TITLE
Pull feedlet image only if not present

### DIFF
--- a/pkg/controller/feed/reconcile_test.go
+++ b/pkg/controller/feed/reconcile_test.go
@@ -490,7 +490,7 @@ func getNewStartJob() *batchv1.Job {
 								},
 							},
 						}},
-						ImagePullPolicy: corev1.PullAlways,
+						ImagePullPolicy: corev1.PullIfNotPresent,
 					}},
 					RestartPolicy: corev1.RestartPolicyNever,
 				},

--- a/pkg/controller/feed/resources/job.go
+++ b/pkg/controller/feed/resources/job.go
@@ -189,7 +189,7 @@ func makePodTemplate(feed *feedsv1alpha1.Feed, source *feedsv1alpha1.EventSource
 				corev1.Container{
 					Name:            "feedlet",
 					Image:           source.Spec.Image,
-					ImagePullPolicy: "Always",
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Env: []corev1.EnvVar{
 						{
 							Name:  string(EnvVarOperation),


### PR DESCRIPTION
This allows local images to be used, e.g. for minikube.

Fixes #284.

## Proposed Changes

  *  Change feedlet pod PullPolicy to `IfNotPresent`.