### PR TITLE
Add '-dispatcher' suffix to bus dispatcher deployment

### DIFF
--- a/config/buses/gcppubsub/README.md
+++ b/config/buses/gcppubsub/README.md
@@ -19,5 +19,5 @@ The dispatcher receives events via a Channel's Service from inside the cluster a
 Note: Cloud Pub/Sub does not guarantee exactly once delivery, subscribers must guard against multiple deliveries of the same event.
 
 To view logs:
-- for the dispatcher `kail -d gcppubsub-bus -c dispatcher`
+- for the dispatcher `kail -d gcppubsub-bus-dispatcher -c dispatcher`
 - for the provisioner `kail -d gcppubsub-bus-provisioner -c provisioner`

--- a/config/buses/kafka/README.md
+++ b/config/buses/kafka/README.md
@@ -33,5 +33,5 @@ from the subscription's channel and forwards them over HTTP to the
 subscriber.
 
 To view logs:
-- for the dispatcher `kail -d kafka-bus -c dispatcher`
+- for the dispatcher `kail -d kafka-bus-dispatcher -c dispatcher`
 - for the provisioner `kail -d kafka-bus-provisioner -c provisioner`

--- a/config/buses/stub/README.md
+++ b/config/buses/stub/README.md
@@ -13,4 +13,4 @@ The dispatcher receives events via a Channel's Service from inside the cluster a
 
 Note: The stub bus does not guarantee delivery, errors will not be reattempted.
 
-To view logs: `kail -d stub-bus -c dispatcher`
+To view logs: `kail -d stub-bus-dispatcher -c dispatcher`

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -23,7 +23,7 @@ func BusProvisionerDeploymentName(busName string) string {
 }
 
 func BusDispatcherDeploymentName(busName string) string {
-	return fmt.Sprintf("%s-bus", busName)
+	return fmt.Sprintf("%s-bus-dispatcher", busName)
 }
 
 func BusServiceAccountName(busName string) string {
@@ -43,7 +43,7 @@ func ClusterBusProvisionerDeploymentName(clusterBusName string) string {
 }
 
 func ClusterBusDispatcherDeploymentName(clusterBusName string) string {
-	return fmt.Sprintf("%s-clusterbus", clusterBusName)
+	return fmt.Sprintf("%s-clusterbus-dispatcher", clusterBusName)
 }
 
 func ClusterBusDispatcherServiceName(clusterBusName string) string {


### PR DESCRIPTION
Fixes #283

## Proposed Changes

* Add '-dispatcher' suffix to bus dispatcher deployment creating symmetry with the provisioner deployment, which uses the '-provisioner' suffix

<!--
/cc @sslavic 
-->