### PR TITLE
Unbreak integration tests

### DIFF
--- a/pkg/controller/util/channel_util.go
+++ b/pkg/controller/util/channel_util.go
@@ -69,7 +69,8 @@ func RemoveChannelCondition(status *v1alpha1.ChannelStatus, condType v1alpha1.Ch
 // given all other sub-conditions.
 func ConsolidateChannelCondition(status *v1alpha1.ChannelStatus) {
 	subConditionsTypes := []v1alpha1.ChannelConditionType{
-		v1alpha1.ChannelProvisioned,
+		// TODO restore ChannelProvisioned condition with issue #285
+		// v1alpha1.ChannelProvisioned,
 		v1alpha1.ChannelRoutable,
 		v1alpha1.ChannelServiceable,
 	}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -72,6 +72,8 @@ function wait_until_flow_ready() {
   kubectl get -n $NAMESPACE flows $NAME -oyaml
   kubectl get -n $NAMESPACE jobs $NAME-start -oyaml
   kubectl get -n $NAMESPACE feeds $NAME -oyaml
+  kubectl get -n $NAMESPACE channels $NAME -oyaml
+  kubectl get -n $NAMESPACE subscriptions $NAME -oyaml
   echo -e "Dumping controller manager logs"
   kubectl -n knative-eventing logs `kubectl -n knative-eventing get pods -oname | grep controller-manager` controller-manager
   echo -e "Dumping controller logs"


### PR DESCRIPTION
The Channel Ready condition is an aggregation of ChannelProvisioned,
ChannelRoutable and ChannelServiceable. However, ChannelProvisioned is
not reliably set by the bus provisioner. Until it is reliable, it should
not be used to indicate the Channel is ready as it also propagates into
the Flow Ready condition.

This change will be reverted as part of issue #285. Until then, the
integration test suite will be unblocked.

<!--
/hold
-->