### PR TITLE
Only update the feed in one place

### DIFF
--- a/pkg/controller/feed/reconcile.go
+++ b/pkg/controller/feed/reconcile.go
@@ -112,6 +112,10 @@ func (r *reconciler) reconcile(feed *feedsv1alpha1.Feed) error {
 				Reason:  t.Reason,
 				Message: t.Message,
 			})
+		default:
+			// This is unreachable unless getFeedSource is refactored.
+			// Assume this is a non-terminal state and return the error.
+			return fmt.Errorf("Error getting feed source: %v", err)
 		}
 		// This is a terminal state, and we've noted it in the status, so return
 		// nil to signal that no further reconciling is required.


### PR DESCRIPTION
When there are multiple places a Feed can be updated, resourceVersion conflicts become more likely. This PR splits `Reconcile` into two functions:
- an inner function `reconcile` that reconciles the state of a Feed without updating it
- an outer function `Reconcile` that loads the Feed, calls the inner function if the
  Feed exists, then updates the Feed.

This separation of responsibilities reduces the likelihood that a Feed will be updated more than once per reconcile.

@adamharwayne this might fix the problem you were having yesterday with Feeds not getting a status when EventSource and/or EventType were missing.