### PR TITLE
Opt-in to istio sidecar injection

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -15,5 +15,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-eventing
-  labels:
-    istio-injection: enabled

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -20,8 +20,6 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: eventing-controller
     spec:

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -21,8 +21,6 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: eventing-webhook
         role: eventing-webhook

--- a/pkg/controller/feed/reconcile_test.go
+++ b/pkg/controller/feed/reconcile_test.go
@@ -446,9 +446,6 @@ func getNewStartJob() *batchv1.Job {
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"sidecar.istio.io/inject": "false"},
-				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "feedlet",

--- a/pkg/controller/feed/resources/job.go
+++ b/pkg/controller/feed/resources/job.go
@@ -177,11 +177,6 @@ func makePodTemplate(feed *feedsv1alpha1.Feed, source *feedsv1alpha1.EventSource
 	}
 
 	return &corev1.PodTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"sidecar.istio.io/inject": "false",
-			},
-		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: feed.Spec.ServiceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,

--- a/pkg/sources/container_event_source_job.go
+++ b/pkg/sources/container_event_source_job.go
@@ -111,11 +111,6 @@ func makePodTemplate(feed *v1alpha1.Feed, spec *v1alpha1.EventSourceSpec, op Fee
 	}
 
 	return &corev1.PodTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"sidecar.istio.io/inject": "false",
-			},
-		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: feed.Spec.ServiceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,

--- a/test/e2e/k8sevents/e2etestfnnamespace.yaml
+++ b/test/e2e/k8sevents/e2etestfnnamespace.yaml
@@ -15,5 +15,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: e2etestfn
-  labels:
-    istio-injection: enabled

--- a/test/e2e/k8sevents/e2etestnamespace.yaml
+++ b/test/e2e/k8sevents/e2etestnamespace.yaml
@@ -15,5 +15,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: e2etest
-  labels:
-    istio-injection: enabled


### PR DESCRIPTION
Istio 1.0 allows deployments/pods to opt-in to istio sidecar injection
without the namespace being explicity labled to support injection. This
mean that namespace can drop the label and deployments/pod that should
not be istio injected no longer need to explicitly opt-out.

Follow up to #203 and #205. Refs knative/serving#1300

/assign @tcnghia 
/assign @evankanderson 