### PR TITLE
Adding short names to eventing resources.

### DIFF
--- a/config/300-bus.yaml
+++ b/config/300-bus.yaml
@@ -25,7 +25,6 @@ spec:
     categories:
     - all
     - knative
-    - eventing
-    shortNames:
     - kbus
+    - eventing
   scope: Namespaced

--- a/config/300-bus.yaml
+++ b/config/300-bus.yaml
@@ -27,3 +27,5 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kbus

--- a/config/300-bus.yaml
+++ b/config/300-bus.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: buses.channels.knative.dev
 spec:
-  scope: Namespaced
   group: channels.knative.dev
   version: v1alpha1
   names:
@@ -29,3 +28,4 @@ spec:
     - eventing
     shortNames:
     - kbus
+  scope: Namespaced

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.channels.knative.dev
 spec:
-  scope: Namespaced
   group: channels.knative.dev
   version: v1alpha1
   names:
@@ -30,3 +29,4 @@ spec:
     shortNames:
     - kchan
     - chan
+  scope: Namespaced

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -27,6 +27,5 @@ spec:
     - knative
     - eventing
     shortNames:
-    - kchan
     - chan
   scope: Namespaced

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -27,3 +27,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kchan
+    - chan

--- a/config/300-clusterbus.yaml
+++ b/config/300-clusterbus.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterbuses.channels.knative.dev
 spec:
-  scope: Cluster
   group: channels.knative.dev
   version: v1alpha1
   names:
@@ -30,3 +29,4 @@ spec:
     shortNames:
     - kcbus
     - cbus
+  scope: Cluster

--- a/config/300-clusterbus.yaml
+++ b/config/300-clusterbus.yaml
@@ -27,3 +27,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kcbus
+    - cbus

--- a/config/300-clusterbus.yaml
+++ b/config/300-clusterbus.yaml
@@ -25,8 +25,8 @@ spec:
     categories:
     - all
     - knative
+    - kbus
     - eventing
     shortNames:
-    - kcbus
     - cbus
   scope: Cluster

--- a/config/300-clustereventsource.yaml
+++ b/config/300-clustereventsource.yaml
@@ -25,8 +25,6 @@ spec:
     categories:
     - all
     - knative
+    - keventsource
     - eventing
-    shortNames:
-    - kces
-    - ces
   scope: Cluster

--- a/config/300-clustereventsource.yaml
+++ b/config/300-clustereventsource.yaml
@@ -26,4 +26,7 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kces
+    - ces
   scope: Cluster

--- a/config/300-clustereventtype.yaml
+++ b/config/300-clustereventtype.yaml
@@ -25,7 +25,6 @@ spec:
     categories:
     - all
     - knative
+    - keventtype
     - eventing
-    shortNames:
-    - kcet
   scope: Cluster

--- a/config/300-clustereventtype.yaml
+++ b/config/300-clustereventtype.yaml
@@ -26,4 +26,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kcet
   scope: Cluster

--- a/config/300-eventsource.yaml
+++ b/config/300-eventsource.yaml
@@ -25,8 +25,6 @@ spec:
     categories:
     - all
     - knative
+    - keventsource
     - eventing
-    shortNames:
-    - kes
-    - es
   scope: Namespaced

--- a/config/300-eventsource.yaml
+++ b/config/300-eventsource.yaml
@@ -26,4 +26,7 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kes
+    - es
   scope: Namespaced

--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -25,8 +25,6 @@ spec:
     categories:
     - all
     - knative
+    - keventtype
     - eventing
-    shortNames:
-    - ket
-    - et
   scope: Namespaced

--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -26,4 +26,7 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - ket
+    - et
   scope: Namespaced

--- a/config/300-feed.yaml
+++ b/config/300-feed.yaml
@@ -26,4 +26,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kfeed
   scope: Namespaced

--- a/config/300-feed.yaml
+++ b/config/300-feed.yaml
@@ -26,6 +26,4 @@ spec:
     - all
     - knative
     - eventing
-    shortNames:
-    - kfeed
   scope: Namespaced

--- a/config/300-flow.yaml
+++ b/config/300-flow.yaml
@@ -26,6 +26,4 @@ spec:
     - all
     - knative
     - eventing
-    shortNames:
-    - kflow
   scope: Namespaced

--- a/config/300-flow.yaml
+++ b/config/300-flow.yaml
@@ -26,5 +26,7 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - kflow
   scope: Namespaced
 

--- a/config/300-flow.yaml
+++ b/config/300-flow.yaml
@@ -29,4 +29,3 @@ spec:
     shortNames:
     - kflow
   scope: Namespaced
-

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -27,6 +27,5 @@ spec:
     - knative
     - eventing
     shortNames:
-    - ksub
     - sub
   scope: Namespaced

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.channels.knative.dev
 spec:
-  scope: Namespaced
   group: channels.knative.dev
   version: v1alpha1
   names:
@@ -30,3 +29,4 @@ spec:
     shortNames:
     - ksub
     - sub
+  scope: Namespaced

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -27,3 +27,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - ksub
+    - sub


### PR DESCRIPTION
Relates to https://github.com/knative/serving/pull/1723

### Short Names:

- Channel: `chan`
- ClusterBus: `cbus`
- Subscription: `sub`

### Categories:

- `kbus`: Bus, ClusterBus
- `keventsource`: EventSource, ClusterEventSource
- `keventtype`: EventType, ClusterEventType
