### PR TITLE
add support for Subsciption.replyTo property

### DIFF
--- a/pkg/apis/channels/v1alpha1/subscription_types.go
+++ b/pkg/apis/channels/v1alpha1/subscription_types.go
@@ -47,7 +47,7 @@ type SubscriptionSpec struct {
 	Subscriber string `json:"subscriber"`
 
 	// Target service DNS name for replies returned by the subscriber.
-	ReplyTo string `json:"replyTo"`
+	ReplyTo string `json:"replyTo,omitempty"`
 
 	// Arguments is a list of configuration arguments for the Subscription. The
 	// Arguments for a channel must contain values for each of the Parameters

--- a/pkg/apis/channels/v1alpha1/subscription_types.go
+++ b/pkg/apis/channels/v1alpha1/subscription_types.go
@@ -46,6 +46,9 @@ type SubscriptionSpec struct {
 	// Subscriber is the name of the subscriber service DNS name.
 	Subscriber string `json:"subscriber"`
 
+	// Target service DNS name for replies returned by the subscriber.
+	ReplyTo string `json:"replyTo"`
+
 	// Arguments is a list of configuration arguments for the Subscription. The
 	// Arguments for a channel must contain values for each of the Parameters
 	// specified by the Bus' spec.parameters.Subscriptions field except the

--- a/pkg/buses/gcppubsub/bus.go
+++ b/pkg/buses/gcppubsub/bus.go
@@ -167,12 +167,13 @@ func (b *PubSubBus) ReceiveEvents(sub *channelsv1alpha1.Subscription, parameters
 		glog.Infof("Start receiving events for subscription %q\n", subscriptionID)
 		err := subscription.Receive(cctx, func(ctx context.Context, pubsubMessage *pubsub.Message) {
 			subscriber := sub.Spec.Subscriber
+			replyTo := sub.Spec.ReplyTo
 			namespace := sub.Namespace
 			message := &buses.Message{
 				Headers: pubsubMessage.Attributes,
 				Payload: pubsubMessage.Data,
 			}
-			err := b.messageDispatcher.DispatchMessage(subscriber, namespace, message)
+			err := b.messageDispatcher.DispatchMessage(subscriber, replyTo, namespace, message)
 			if err != nil {
 				glog.Warningf("Unable to dispatch event %q to %q", pubsubMessage.ID, subscriber)
 				pubsubMessage.Nack()

--- a/pkg/buses/gcppubsub/bus.go
+++ b/pkg/buses/gcppubsub/bus.go
@@ -167,13 +167,15 @@ func (b *PubSubBus) ReceiveEvents(sub *channelsv1alpha1.Subscription, parameters
 		glog.Infof("Start receiving events for subscription %q\n", subscriptionID)
 		err := subscription.Receive(cctx, func(ctx context.Context, pubsubMessage *pubsub.Message) {
 			subscriber := sub.Spec.Subscriber
-			replyTo := sub.Spec.ReplyTo
-			namespace := sub.Namespace
 			message := &buses.Message{
 				Headers: pubsubMessage.Attributes,
 				Payload: pubsubMessage.Data,
 			}
-			err := b.messageDispatcher.DispatchMessage(subscriber, replyTo, namespace, message)
+			defaults := buses.DispatchDefaults{
+				Namespace: sub.Namespace,
+				ReplyTo:   sub.Spec.ReplyTo,
+			}
+			err := b.messageDispatcher.DispatchMessage(message, subscriber, defaults)
 			if err != nil {
 				glog.Warningf("Unable to dispatch event %q to %q", pubsubMessage.ID, subscriber)
 				pubsubMessage.Nack()

--- a/pkg/buses/kafka/dispatcher/dispatcher.go
+++ b/pkg/buses/kafka/dispatcher/dispatcher.go
@@ -167,7 +167,7 @@ func (d *dispatcher) subscribe(subscription *channelsv1alpha1.Subscription, para
 				glog.Infof("Dispatching a message for subscription %s/%s: %s -> %s", subscription.Namespace,
 					subscription.Name, subscription.Spec.Channel, subscription.Spec.Subscriber)
 				message := fromKafkaMessage(msg)
-				err := d.messageDispatcher.DispatchMessage(subscription.Spec.Subscriber, subscription.Namespace, message)
+				err := d.messageDispatcher.DispatchMessage(subscription.Spec.Subscriber, subscription.Spec.ReplyTo, subscription.Namespace, message)
 				if err != nil {
 					glog.Warningf("Got error trying to dispatch message: %v", err)
 				}

--- a/pkg/buses/kafka/dispatcher/dispatcher.go
+++ b/pkg/buses/kafka/dispatcher/dispatcher.go
@@ -167,7 +167,11 @@ func (d *dispatcher) subscribe(subscription *channelsv1alpha1.Subscription, para
 				glog.Infof("Dispatching a message for subscription %s/%s: %s -> %s", subscription.Namespace,
 					subscription.Name, subscription.Spec.Channel, subscription.Spec.Subscriber)
 				message := fromKafkaMessage(msg)
-				err := d.messageDispatcher.DispatchMessage(subscription.Spec.Subscriber, subscription.Spec.ReplyTo, subscription.Namespace, message)
+				defaults := buses.DispatchDefaults{
+					Namespace: subscription.Namespace,
+					ReplyTo:   subscription.Spec.ReplyTo,
+				}
+				err := d.messageDispatcher.DispatchMessage(message, subscription.Spec.Subscriber, defaults)
 				if err != nil {
 					glog.Warningf("Got error trying to dispatch message: %v", err)
 				}

--- a/pkg/buses/message.go
+++ b/pkg/buses/message.go
@@ -28,7 +28,7 @@ var forwardHeaders = []string{
 
 var forwardPrefixes = []string{
 	// knative
-	"x-knative-",
+	"knative-",
 	// cloud events
 	"ce-",
 	// tracing

--- a/pkg/buses/message.go
+++ b/pkg/buses/message.go
@@ -27,6 +27,8 @@ var forwardHeaders = []string{
 }
 
 var forwardPrefixes = []string{
+	// knative
+	"x-knative-",
 	// cloud events
 	"ce-",
 	// tracing

--- a/pkg/buses/stub/main.go
+++ b/pkg/buses/stub/main.go
@@ -88,8 +88,9 @@ func (b *StubBus) receiveMessage(channel *buses.ChannelReference, message *buses
 // dispatchMessage dispatches messages for the bus to a channel's subscriber.
 func (b *StubBus) dispatchMessage(subscription channelsv1alpha1.SubscriptionSpec, channel *buses.ChannelReference, message *buses.Message) {
 	subscriber := subscription.Subscriber
-	glog.Infof("Sending to %q for %q", subscriber, channel)
-	b.dispatcher.DispatchMessage(subscriber, channel.Namespace, message)
+	replyTo := subscription.ReplyTo
+	glog.Infof("Sending to %q for %q and replying to %q", subscriber, channel, replyTo)
+	b.dispatcher.DispatchMessage(subscriber, replyTo, channel.Namespace, message)
 }
 
 func main() {

--- a/pkg/buses/stub/main.go
+++ b/pkg/buses/stub/main.go
@@ -88,9 +88,9 @@ func (b *StubBus) receiveMessage(channel *buses.ChannelReference, message *buses
 // dispatchMessage dispatches messages for the bus to a channel's subscriber.
 func (b *StubBus) dispatchMessage(subscription channelsv1alpha1.SubscriptionSpec, channel *buses.ChannelReference, message *buses.Message) {
 	subscriber := subscription.Subscriber
-	replyTo := subscription.ReplyTo
-	glog.Infof("Sending to %q for %q and replying to %q", subscriber, channel, replyTo)
-	b.dispatcher.DispatchMessage(subscriber, replyTo, channel.Namespace, message)
+	defaults := buses.DispatchDefaults{Namespace: channel.Namespace, ReplyTo: subscription.ReplyTo}
+	glog.Infof("Sending to %q for %q with defaults %+v", subscriber, channel, defaults)
+	b.dispatcher.DispatchMessage(message, subscriber, defaults)
 }
 
 func main() {


### PR DESCRIPTION
Fixes #216

## Proposed Changes

  * Subscription now accepts an optional "replyTo" property
  * Bus implementations pass the Subscription's replyTo property when delegating to the common dispatcher
  * the dispatcher will forward a non-empty response body as a new request to the destination specified by the replyTo if present
* headers will be propagated, including a correlation ID header if provided in the request
