### PR TITLE
don't inject istio sidecar in feed controller job

### DIFF
--- a/pkg/controller/feed/resources/job.go
+++ b/pkg/controller/feed/resources/job.go
@@ -38,6 +38,8 @@ const (
 	OperationStartFeed Operation = "START"
 	// OperationStopFeed specifies a feed should be stopped
 	OperationStopFeed = "STOP"
+	// istio side car injection annotation
+	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
 )
 
 // EnvVar specifies the names of the environment variables passed to the
@@ -183,6 +185,11 @@ func makePodTemplate(feed *feedsv1alpha1.Feed, source *feedsv1alpha1.EventSource
 	}
 
 	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			// don't inject Istio sidecar
+			// so if the feed can to access external services during StartFeed/StopFeed
+			Annotations: map[string]string{sidecarIstioInjectAnnotation: "false"},
+		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: feed.Spec.ServiceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,


### PR DESCRIPTION
Fixes #338 

## Proposed Changes

  *  don't inject istio sidecar, this should help those feed sources that need to initialize by accessing external services (e.g. k8s API server and services)
  * 
  * 
