### PR TITLE
Convert github source to cloud events.

### DIFF
--- a/pkg/sources/github/README.md
+++ b/pkg/sources/github/README.md
@@ -1,0 +1,11 @@
+GitHub
+======
+
+Produces the following eventtypes:
+
+- dev.knative.github.pullrequest
+
+Uses two images, the feedlet and the receive adapter.
+
+### Feedlet
+

--- a/pkg/sources/github/README.md
+++ b/pkg/sources/github/README.md
@@ -1,9 +1,13 @@
-GitHub
-======
+Knative GitHub Source 
+=====================
 
-Produces the following eventtypes:
+This source will enable receiving of GitHub events from within Knative Eventing.
+
+## Events
 
 - dev.knative.github.pullrequest
+
+## Images
 
 Uses two images, the feedlet and the receive adapter.
 
@@ -21,3 +25,75 @@ for the account provided.
 The Receive Adapter is a Service.serving.knative.dev resource that is registered
 to receive GitHub webhook requests. The source will wrap this request in a
 CloudEvent and send it to the action provided. 
+
+## Usage
+
+The GitHub Source expects there to be a secret in the following form:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: githubsecret
+type: Opaque
+stringData:
+  githubCredentials: >
+    {
+      "accessToken": "<YOUR PERSONAL TOKEN FROM GITHUB>",
+      "secretToken": "<YOUR RANDOM STRING>"
+    }
+
+```
+
+The Feedlet requires a ServiceAccount to run as a cluster admin for the targeted namespace: 
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: feed-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: feed-admin
+subjects:
+  - kind: ServiceAccount
+    name: feed-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+```
+
+To create a Receive Adapter (via the Feedlet), a Flow needs to exist:
+
+```yaml
+apiVersion: flows.knative.dev/v1alpha1
+kind: Flow
+metadata:
+  name: my-github-flow
+  namespace: default
+spec:
+  serviceAccountName: feed-sa
+  trigger:
+    eventType: pullrequest
+    resource: <org>/<repo> # TODO: Fill this out
+    service: github
+    parameters:
+      secretName: githubsecret
+      secretKey: githubCredentials
+    parametersFrom:
+      - secretKeyRef:
+          name: githubsecret
+          key: githubCredentials
+  action:
+    target:
+      kind: Service
+      apiVersion: serving.knative.dev/v1alpha1
+      name: my-service
+
+```

--- a/pkg/sources/github/README.md
+++ b/pkg/sources/github/README.md
@@ -9,3 +9,15 @@ Uses two images, the feedlet and the receive adapter.
 
 ### Feedlet
 
+A Feedlet is a container to create or destroy event source bindings.
+
+The Feedlet is run as a Job by the Feed controller.
+
+This Feedlet will create the Receive Adapter and register a webhook in GitHub
+for the account provided.
+
+### Receive Adapter
+
+The Receive Adapter is a Service.serving.knative.dev resource that is registered
+to receive GitHub webhook requests. The source will wrap this request in a
+CloudEvent and send it to the action provided. 

--- a/pkg/sources/github/events.go
+++ b/pkg/sources/github/events.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+const (
+	// Event Names
+	PullrequestEvent = "dev.knative.github.pullrequest"
+)

--- a/pkg/sources/github/events.go
+++ b/pkg/sources/github/events.go
@@ -19,4 +19,14 @@ package github
 const (
 	// Event Names
 	PullrequestEvent = "dev.knative.github.pullrequest"
+	UnsupportedEvent = "dev.knative.github.unsupported"
 )
+
+var CloudEventType = map[string]string{
+	"pull_request": PullrequestEvent,
+	"":             UnsupportedEvent,
+}
+
+var GithubEventType = map[string]string{
+	PullrequestEvent: "pull_request",
+}

--- a/pkg/sources/github/eventsource.yaml
+++ b/pkg/sources/github/eventsource.yaml
@@ -18,8 +18,7 @@ metadata:
   name: github
   namespace: default
 spec:
-  type: github
   source: github
-  image: github.com/knative/eventing/pkg/sources/github
+  image: github.com/knative/eventing/pkg/sources/github/feedlet
   parameters:
     image: github.com/knative/eventing/pkg/sources/github/receive_adapter

--- a/pkg/sources/github/eventtype.yaml
+++ b/pkg/sources/github/eventtype.yaml
@@ -15,7 +15,7 @@
 apiVersion: feeds.knative.dev/v1alpha1
 kind: EventType
 metadata:
-  name: pullrequest
+  name: dev.knative.github.pullrequest
   namespace: default
 spec:
   eventSource: github

--- a/pkg/sources/github/feedlet/feedlet.go
+++ b/pkg/sources/github/feedlet/feedlet.go
@@ -35,6 +35,7 @@ import (
 	"os"
 
 	ghclient "github.com/google/go-github/github"
+	"github.com/knative/eventing/pkg/sources/github"
 	"github.com/knative/eventing/pkg/sources/github/resources"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -66,9 +67,6 @@ const (
 	secretNameKey = "secretName"
 	// secretKeyKey is the name of key inside the secret that contains the GitHub credentials.
 	secretKeyKey = "secretKey"
-
-	// Event Names
-	pullrequestEvent = "dev.knative.github.pullrequest"
 )
 
 type githubEventSource struct {
@@ -454,11 +452,9 @@ func parseEventsFrom(eventType string) ([]string, error) {
 	if len(eventType) == 0 {
 		return []string(nil), fmt.Errorf("event type is empty")
 	}
-	switch eventType {
-	case pullrequestEvent:
-		return []string{"pull_request"}, nil
-	// TODO: Add more supported event types.
-	default:
+	event, ok := github.GithubEventType[eventType]
+	if !ok {
 		return []string(nil), fmt.Errorf("event type is unknown: %s", eventType)
 	}
+	return []string{event}, nil
 }

--- a/pkg/sources/github/feedlet/feedlet.go
+++ b/pkg/sources/github/feedlet/feedlet.go
@@ -66,6 +66,9 @@ const (
 	secretNameKey = "secretName"
 	// secretKeyKey is the name of key inside the secret that contains the GitHub credentials.
 	secretKeyKey = "secretKey"
+
+	// Event Names
+	pullrequestEvent = "dev.knative.github.pullrequest"
 )
 
 type githubEventSource struct {
@@ -452,7 +455,7 @@ func parseEventsFrom(eventType string) ([]string, error) {
 		return []string(nil), fmt.Errorf("event type is empty")
 	}
 	switch eventType {
-	case "pullrequest":
+	case pullrequestEvent:
 		return []string{"pull_request"}, nil
 	// TODO: Add more supported event types.
 	default:


### PR DESCRIPTION
This is a followup to #276. The focus is to migrate the Source and Sample to use the cloudevent naming style and the eventing framework.

Fixes https://github.com/knative/eventing/issues/334

Fixes https://github.com/knative/eventing/issues/332