### PR TITLE
Fix e2e test after removal of controller manager.

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -44,5 +44,4 @@ data:
   # Log level overrides
   # For all components changes are be picked up immediately.
   loglevel.controller: "info"
-  loglevel.controller-manager: "info"
   loglevel.webhook: "info"

--- a/pkg/logconfig/config.go
+++ b/pkg/logconfig/config.go
@@ -23,14 +23,10 @@ const (
 	// Named Loggers are used to override the default log level. config-logging.yaml will use the follow:
 	//
 	// loglevel.controller: "info"
-	// loglevel.controller-manager: "info"
 	// loglevel.webhook: "info"
 
 	// Controller is the name of the override key used inside of the logging config for Controller.
 	Controller = "controller"
-
-	// ControllerManager is the name of the override key used inside of the logging config for Controller Manager.
-	ControllerManager = "controller-manager"
 
 	// Webhook is the name of the override key used inside of the logging config for Webhook Controller.
 	Webhook = "webhook"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -72,10 +72,8 @@ function wait_until_flow_ready() {
   kubectl get -n $NAMESPACE flows $NAME -oyaml
   kubectl get -n $NAMESPACE jobs $NAME-start -oyaml
   kubectl get -n $NAMESPACE feeds $NAME -oyaml
-  echo -e "Dumping controller manager logs"
-  kubectl -n knative-eventing logs `kubectl -n knative-eventing get pods -oname | grep controller-manager` controller-manager
-  echo -e "Dumping controller logs"
-  kubectl -n knative-eventing logs `kubectl -n knative-eventing get pods -oname | grep eventing-controller`
+  echo -e "Dumping eventing controller logs"
+  kubectl -n knative-eventing logs `kubectl -n knative-eventing get pods -oname | grep eventing-controller` eventing-controller
   return 1
 }
 


### PR DESCRIPTION
I saw an issue in the e2e test run where the script fails because it can't find the pod with the "controller-manager" name. We removed that in https://github.com/knative/eventing/pull/313