### PR TITLE
Adding shell _default and _validation files for event type and source.

### DIFF
--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (ces *ClusterEventSource) SetDefaults() {
+	ces.Spec.SetDefaults()
+}
+
+func (cess *ClusterEventSourceSpec) SetDefaults() {
+	cess.CommonEventSourceSpec.SetDefaults()
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
+	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,6 +38,11 @@ type ClusterEventSource struct {
 	Spec   ClusterEventSourceSpec   `json:"spec"`
 	Status ClusterEventSourceStatus `json:"status"`
 }
+
+// Check that ClusterEventSource can be validated, can be defaulted, and has immutable fields.
+var _ apis.Validatable = (*ClusterEventSource)(nil)
+var _ apis.Defaultable = (*ClusterEventSource)(nil)
+var _ apis.Immutable = (*ClusterEventSource)(nil)
 
 // ClusterEventSourceSpec describes the type and source of an event, a container image
 // to run for feed lifecycle operations, and configuration options for the

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
@@ -17,11 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func (ces *ClusterEventSource) Validate() *apis.FieldError {

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/apis"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func (ces *ClusterEventSource) Validate() *apis.FieldError {
+	return ces.Spec.Validate().ViaField("spec")
+}
+
+func (cess *ClusterEventSourceSpec) Validate() *apis.FieldError {
+	return cess.CommonEventSourceSpec.Validate()
+}
+
+func (current *ClusterEventSource) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	original, ok := og.(*ClusterEventSource)
+	if !ok {
+		return &apis.FieldError{Message: "The provided original was not a ClusterEventSource"}
+	}
+	if original == nil {
+		return nil
+	}
+
+	// TODO
+
+	return nil
+}

--- a/pkg/apis/feeds/v1alpha1/cluster_event_type_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_type_defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (cet *ClusterEventType) SetDefaults() {
+	cet.Spec.SetDefaults()
+}
+
+func (cets *ClusterEventTypeSpec) SetDefaults() {
+	cets.CommonEventTypeSpec.SetDefaults()
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/cluster_event_type_types.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_type_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,6 +35,11 @@ type ClusterEventType struct {
 	Spec   ClusterEventTypeSpec   `json:"spec"`
 	Status ClusterEventTypeStatus `json:"status"`
 }
+
+// Check that ClusterEventType can be validated, can be defaulted, and has immutable fields.
+var _ apis.Validatable = (*ClusterEventType)(nil)
+var _ apis.Defaultable = (*ClusterEventType)(nil)
+var _ apis.Immutable = (*ClusterEventType)(nil)
 
 // ClusterEventTypeSpec specifies information about the ClusterEventType, including a schema
 // for the event and information about the parameters needed to create a Feed to

--- a/pkg/apis/feeds/v1alpha1/cluster_event_type_validation.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_type_validation.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/knative/pkg/apis"
+)
+
+func (cet *ClusterEventType) Validate() *apis.FieldError {
+	return cet.Spec.Validate().ViaField("spec")
+}
+
+func (cess *ClusterEventTypeSpec) Validate() *apis.FieldError {
+	return cess.CommonEventTypeSpec.Validate()
+}
+
+func (current *ClusterEventType) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	original, ok := og.(*ClusterEventType)
+	if !ok {
+		return &apis.FieldError{Message: "The provided original was not a ClusterEventType"}
+	}
+	if original == nil {
+		return nil
+	}
+
+	// TODO
+
+	return nil
+}

--- a/pkg/apis/feeds/v1alpha1/common_event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_defaults.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (cess *CommonEventSourceSpec) SetDefaults() {
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/common_event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/knative/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -39,6 +40,10 @@ type CommonEventSourceSpec struct {
 	// on the event sources containers.
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
 }
+
+// Check that CommonEventSourceSpec can be validated and can be defaulted
+var _ apis.Validatable = (*CommonEventSourceSpec)(nil)
+var _ apis.Defaultable = (*CommonEventSourceSpec)(nil)
 
 // EventSourceStatus is the status for a EventSource resource
 type CommonEventSourceStatus struct {

--- a/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/apis"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func (cess *CommonEventSourceSpec) Validate() *apis.FieldError {
+	// TODO
+	return nil
+}

--- a/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
@@ -17,11 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func (cess *CommonEventSourceSpec) Validate() *apis.FieldError {

--- a/pkg/apis/feeds/v1alpha1/common_event_type_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_type_defaults.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (cets *CommonEventTypeSpec) SetDefaults() {
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/common_event_type_types.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_type_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/knative/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -34,6 +35,10 @@ type CommonEventTypeSpec struct {
 	// Describe the schema for the events emitted by this EventType.
 	EventSchema *runtime.RawExtension `json:"eventSchema,omitempty"`
 }
+
+// Check that CommonEventTypeSpec can be validated and can be defaulted
+var _ apis.Validatable = (*CommonEventTypeSpec)(nil)
+var _ apis.Defaultable = (*CommonEventTypeSpec)(nil)
 
 // CommonEventTypeStatus is the status for a EventType resource
 type CommonEventTypeStatus struct {

--- a/pkg/apis/feeds/v1alpha1/common_event_type_validation.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_type_validation.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/knative/pkg/apis"
+)
+
+func (cess *CommonEventTypeSpec) Validate() *apis.FieldError {
+	return nil
+}

--- a/pkg/apis/feeds/v1alpha1/event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (es *EventSource) SetDefaults() {
+	es.Spec.SetDefaults()
+}
+
+func (ess *EventSourceSpec) SetDefaults() {
+	ess.CommonEventSourceSpec.SetDefaults()
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,6 +35,11 @@ type EventSource struct {
 	Spec   EventSourceSpec   `json:"spec"`
 	Status EventSourceStatus `json:"status"`
 }
+
+// Check that EventSource can be validated, can be defaulted, and has immutable fields.
+var _ apis.Validatable = (*EventSource)(nil)
+var _ apis.Defaultable = (*EventSource)(nil)
+var _ apis.Immutable = (*EventSource)(nil)
 
 // EventSourceSpec describes the type and source of an event, a container image
 // to run for feed lifecycle operations, and configuration options for the

--- a/pkg/apis/feeds/v1alpha1/event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_validation.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/knative/pkg/apis"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func (es *EventSource) Validate() *apis.FieldError {
+	return es.Spec.Validate().ViaField("spec")
+}
+
+func (ess *EventSourceSpec) Validate() *apis.FieldError {
+	return ess.CommonEventSourceSpec.Validate()
+}
+
+func (current *EventSource) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	original, ok := og.(*EventSource)
+	if !ok {
+		return &apis.FieldError{Message: "The provided original was not a EventSource"}
+	}
+	if original == nil {
+		return nil
+	}
+
+	// TODO
+
+	return nil
+}

--- a/pkg/apis/feeds/v1alpha1/event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_validation.go
@@ -17,11 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func (es *EventSource) Validate() *apis.FieldError {

--- a/pkg/apis/feeds/v1alpha1/event_type_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/event_type_defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func (et *EventType) SetDefaults() {
+	et.Spec.SetDefaults()
+}
+
+func (ets *EventTypeSpec) SetDefaults() {
+	ets.CommonEventTypeSpec.SetDefaults()
+	// TODO anything?
+}

--- a/pkg/apis/feeds/v1alpha1/event_type_types.go
+++ b/pkg/apis/feeds/v1alpha1/event_type_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
+	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,6 +36,11 @@ type EventType struct {
 	Spec   EventTypeSpec   `json:"spec"`
 	Status EventTypeStatus `json:"status"`
 }
+
+// Check that EventType can be validated, can be defaulted, and has immutable fields.
+var _ apis.Validatable = (*EventType)(nil)
+var _ apis.Defaultable = (*EventType)(nil)
+var _ apis.Immutable = (*EventType)(nil)
 
 // EventTypeSpec specifies information about the EventType, including a schema
 // for the event and information about the parameters needed to create a Feed to

--- a/pkg/apis/feeds/v1alpha1/event_type_validation.go
+++ b/pkg/apis/feeds/v1alpha1/event_type_validation.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/knative/pkg/apis"
+)
+
+func (et *EventType) Validate() *apis.FieldError {
+	return et.Spec.Validate().ViaField("spec")
+}
+
+func (ets *EventTypeSpec) Validate() *apis.FieldError {
+	return ets.CommonEventTypeSpec.Validate()
+}
+
+func (current *EventType) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
+	original, ok := og.(*EventType)
+	if !ok {
+		return &apis.FieldError{Message: "The provided original was not a EventType"}
+	}
+	if original == nil {
+		return nil
+	}
+
+	// TODO
+
+	return nil
+}


### PR DESCRIPTION
This is the continued effort to stage the required methods for integration with pkg/webhook.

Note all these are REALLY just shells, there was no impl to copy over from the original webhook side.