### PR TITLE
Adding empty tests to make code coverage more correct (lower).

### DIFF
--- a/pkg/buses/kafka/dispatcher/stub_test.go
+++ b/pkg/buses/kafka/dispatcher/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/kafka/provisioner/stub_test.go
+++ b/pkg/buses/kafka/provisioner/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/stub/stub_test.go
+++ b/pkg/buses/stub/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stub
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/stub_test.go
+++ b/pkg/buses/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buses
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/bus/stub_test.go
+++ b/pkg/controller/bus/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bus
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/channel/stub_test.go
+++ b/pkg/controller/channel/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/clusterbus/stub_test.go
+++ b/pkg/controller/clusterbus/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterbus
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/feed/resources/stub_test.go
+++ b/pkg/controller/feed/resources/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/flow/resources/stub_test.go
+++ b/pkg/controller/flow/resources/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/stub_test.go
+++ b/pkg/controller/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/util/stub_test.go
+++ b/pkg/controller/util/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/gcppubsub/receive_adapter/stub_test.go
+++ b/pkg/sources/gcppubsub/receive_adapter/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/gcppubsub/stub_test.go
+++ b/pkg/sources/gcppubsub/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/github/feedlet/stub_test.go
+++ b/pkg/sources/github/feedlet/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/github/receive_adapter/stub_test.go
+++ b/pkg/sources/github/receive_adapter/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/github/resources/stub_test.go
+++ b/pkg/sources/github/resources/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/github/stub_test.go
+++ b/pkg/sources/github/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/k8sevents/receive_adapter/stub_test.go
+++ b/pkg/sources/k8sevents/receive_adapter/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/k8sevents/stub_test.go
+++ b/pkg/sources/k8sevents/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/sources/stub_test.go
+++ b/pkg/sources/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sources
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}


### PR DESCRIPTION
It was requested that we add stub tests to signal to the code coverage tracker to count each directly we have source toward our coverage totals. This is that PR.