### PR TITLE
Move bus deployments to knative-eventing

### DIFF
--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -21,5 +21,5 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: clusterbus-controller
+  name: bus-operator
   namespace: knative-eventing

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -28,10 +28,10 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: clusterbus-controller-manage
+  name: bus-operator-manage
 subjects:
   - kind: ServiceAccount
-    name: clusterbus-controller
+    name: bus-operator
     namespace: knative-eventing
 roleRef:
   kind: ClusterRole

--- a/config/buses/gcppubsub/README.md
+++ b/config/buses/gcppubsub/README.md
@@ -19,5 +19,5 @@ The dispatcher receives events via a Channel's Service from inside the cluster a
 Note: Cloud Pub/Sub does not guarantee exactly once delivery, subscribers must guard against multiple deliveries of the same event.
 
 To view logs:
-- for the dispatcher `kail -d gcppubsub-bus-dispatcher -c dispatcher`
-- for the provisioner `kail -d gcppubsub-bus-provisioner -c provisioner`
+- for the dispatcher `kail -d gcppubsub-[namespace]-bus-dispatcher -c dispatcher`
+- for the provisioner `kail -d gcppubsub-[namespace]-bus-provisioner -c provisioner`

--- a/config/buses/kafka/README.md
+++ b/config/buses/kafka/README.md
@@ -33,5 +33,5 @@ from the subscription's channel and forwards them over HTTP to the
 subscriber.
 
 To view logs:
-- for the dispatcher `kail -d kafka-bus-dispatcher -c dispatcher`
-- for the provisioner `kail -d kafka-bus-provisioner -c provisioner`
+- for the dispatcher `kail -d kafka-[namespace]-bus-dispatcher -c dispatcher`
+- for the provisioner `kail -d kafka-[namespace]-bus-provisioner -c provisioner`

--- a/config/buses/stub/README.md
+++ b/config/buses/stub/README.md
@@ -13,4 +13,4 @@ The dispatcher receives events via a Channel's Service from inside the cluster a
 
 Note: The stub bus does not guarantee delivery, errors will not be reattempted.
 
-To view logs: `kail -d stub-bus-dispatcher -c dispatcher`
+To view logs: `kail -d stub-[namespace]-bus-dispatcher -c dispatcher`

--- a/pkg/controller/bus/controller.go
+++ b/pkg/controller/bus/controller.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/knative/eventing/pkg/controller"
+	"github.com/knative/eventing/pkg/system"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +56,12 @@ import (
 	"github.com/knative/eventing/pkg/controller/util"
 )
 
-const controllerAgentName = "bus-controller"
+const (
+	controllerAgentName = "bus-controller"
+	serviceAccountName  = "bus-operator"
+	provisionerRole     = "provisioner"
+	dispatcherRole      = "dispatcher"
+)
 
 const (
 	// SuccessSynced is used as part of the Event 'reason' when a Bus is synced
@@ -305,35 +310,9 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
-	var serviceAccount *corev1.ServiceAccount
-	var clusterRoleBinding *rbacv1beta1.ClusterRoleBinding
 	var dispatcherService *corev1.Service
 	var dispatcherDeployment, provisionerDeployment *appsv1.Deployment
-	var saErr, clusterRoleBindingErr, dispatcherServiceErr, dispatcherDeplErr, provisionerDeplError error
-
-	// Sync ServiceAccount derived from the Bus
-	serviceAccount, saErr = c.syncBusServiceAccount(bus)
-	if saErr != nil {
-		_ = c.updateBusStatus(bus,
-			dispatcherService, dispatcherServiceErr,
-			dispatcherDeployment, dispatcherDeplErr,
-			provisionerDeployment, provisionerDeplError,
-			serviceAccount, saErr,
-			clusterRoleBinding, clusterRoleBindingErr)
-		return saErr
-	}
-
-	// Sync ClusterRoleBinding derived from the Bus
-	clusterRoleBinding, clusterRoleBindingErr = c.syncBusClusterRoleBinding(bus)
-	if clusterRoleBindingErr != nil {
-		_ = c.updateBusStatus(bus,
-			dispatcherService, dispatcherServiceErr,
-			dispatcherDeployment, dispatcherDeplErr,
-			provisionerDeployment, provisionerDeplError,
-			serviceAccount, saErr,
-			clusterRoleBinding, clusterRoleBindingErr)
-		return clusterRoleBindingErr
-	}
+	var dispatcherServiceErr, dispatcherDeplErr, provisionerDeplError error
 
 	// Sync Service derived from the Bus
 	dispatcherService, dispatcherServiceErr = c.syncBusDispatcherService(bus)
@@ -341,9 +320,7 @@ func (c *Controller) syncHandler(key string) error {
 		_ = c.updateBusStatus(bus,
 			dispatcherService, dispatcherServiceErr,
 			dispatcherDeployment, dispatcherDeplErr,
-			provisionerDeployment, provisionerDeplError,
-			serviceAccount, saErr,
-			clusterRoleBinding, clusterRoleBindingErr)
+			provisionerDeployment, provisionerDeplError)
 		return dispatcherServiceErr
 	}
 
@@ -353,9 +330,7 @@ func (c *Controller) syncHandler(key string) error {
 		_ = c.updateBusStatus(bus,
 			dispatcherService, dispatcherServiceErr,
 			dispatcherDeployment, dispatcherDeplErr,
-			provisionerDeployment, provisionerDeplError,
-			serviceAccount, saErr,
-			clusterRoleBinding, clusterRoleBindingErr)
+			provisionerDeployment, provisionerDeplError)
 		return dispatcherDeplErr
 	}
 
@@ -365,9 +340,7 @@ func (c *Controller) syncHandler(key string) error {
 		_ = c.updateBusStatus(bus,
 			dispatcherService, dispatcherServiceErr,
 			dispatcherDeployment, dispatcherDeplErr,
-			provisionerDeployment, provisionerDeplError,
-			serviceAccount, saErr,
-			clusterRoleBinding, clusterRoleBindingErr)
+			provisionerDeployment, provisionerDeplError)
 		return provisionerDeplError
 	}
 
@@ -376,9 +349,7 @@ func (c *Controller) syncHandler(key string) error {
 	err = c.updateBusStatus(bus,
 		dispatcherService, dispatcherServiceErr,
 		dispatcherDeployment, dispatcherDeplErr,
-		provisionerDeployment, provisionerDeplError,
-		serviceAccount, saErr,
-		clusterRoleBinding, clusterRoleBindingErr)
+		provisionerDeployment, provisionerDeplError)
 	if err != nil {
 		return err
 	}
@@ -389,11 +360,11 @@ func (c *Controller) syncHandler(key string) error {
 
 func (c *Controller) syncBusDispatcherService(bus *channelsv1alpha1.Bus) (*corev1.Service, error) {
 	// Get the service with the specified service name
-	serviceName := controller.BusDispatcherServiceName(bus.ObjectMeta.Name)
-	service, err := c.servicesLister.Services(bus.Namespace).Get(serviceName)
+	serviceName := controller.BusDispatcherServiceName(bus.Name, bus.Namespace)
+	service, err := c.servicesLister.Services(system.Namespace).Get(serviceName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
-		service, err = c.kubeclientset.CoreV1().Services(bus.Namespace).Create(newDispatcherService(bus))
+		service, err = c.kubeclientset.CoreV1().Services(system.Namespace).Create(newDispatcherService(bus))
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can
@@ -416,11 +387,11 @@ func (c *Controller) syncBusDispatcherService(bus *channelsv1alpha1.Bus) (*corev
 
 func (c *Controller) syncBusDispatcherDeployment(bus *channelsv1alpha1.Bus) (*appsv1.Deployment, error) {
 	// Get the deployment with the specified deployment name
-	deploymentName := controller.BusDispatcherDeploymentName(bus.ObjectMeta.Name)
-	deployment, err := c.deploymentsLister.Deployments(bus.Namespace).Get(deploymentName)
+	deploymentName := controller.BusDispatcherDeploymentName(bus.Name, bus.Namespace)
+	deployment, err := c.deploymentsLister.Deployments(system.Namespace).Get(deploymentName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
-		deployment, err = c.kubeclientset.AppsV1().Deployments(bus.Namespace).Create(newDispatcherDeployment(bus))
+		deployment, err = c.kubeclientset.AppsV1().Deployments(system.Namespace).Create(newDispatcherDeployment(bus))
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can
@@ -443,7 +414,7 @@ func (c *Controller) syncBusDispatcherDeployment(bus *channelsv1alpha1.Bus) (*ap
 	proposedDeployment := newDispatcherDeployment(bus)
 	if !reflect.DeepEqual(proposedDeployment.Spec, deployment.Spec) {
 		glog.V(4).Infof("Bus %s dispatcher spec updated", bus.Name)
-		deployment, err = c.kubeclientset.AppsV1().Deployments(bus.Namespace).Update(proposedDeployment)
+		deployment, err = c.kubeclientset.AppsV1().Deployments(system.Namespace).Update(proposedDeployment)
 
 		if err != nil {
 			return nil, err
@@ -453,85 +424,18 @@ func (c *Controller) syncBusDispatcherDeployment(bus *channelsv1alpha1.Bus) (*ap
 	return deployment, nil
 }
 
-func (c *Controller) syncBusServiceAccount(bus *channelsv1alpha1.Bus) (*corev1.ServiceAccount, error) {
-	// Get the serviceAccount with the specified serviceAccount name
-	serviceAccountName := controller.BusServiceAccountName(bus.ObjectMeta.Name)
-	serviceAccount, err := c.serviceAccountsLister.ServiceAccounts(bus.Namespace).Get(serviceAccountName)
-	// If the resource doesn't exist, we'll create it
-	if errors.IsNotFound(err) {
-		serviceAccount, err = c.kubeclientset.CoreV1().ServiceAccounts(bus.Namespace).Create(newServiceAccount(bus))
-	}
-
-	// If an error occurs during Get/Create, we'll requeue the item so we can
-	// attempt processing again later. This could have been caused by a
-	// temporary network failure, or any other transient reason.
-	if err != nil {
-		return nil, err
-	}
-
-	// If the ServiceAccount is not controlled by this Bus resource, we should log
-	// a warning to the event recorder and return
-	if !metav1.IsControlledBy(serviceAccount, bus) {
-		msg := fmt.Sprintf(MessageResourceExists, serviceAccount.Name)
-		c.recorder.Event(bus, corev1.EventTypeWarning, ErrResourceExists, msg)
-		return nil, fmt.Errorf(msg)
-	}
-
-	return serviceAccount, nil
-}
-
-func (c *Controller) syncBusClusterRoleBinding(bus *channelsv1alpha1.Bus) (*rbacv1beta1.ClusterRoleBinding, error) {
-	// Get the clusterRoleBinding with the specified clusterRoleBinding name
-	clusterRoleBindingName := controller.BusClusterRoleBindingName(bus.ObjectMeta.Name)
-	clusterRoleBinding, err := c.clusterRoleBindingsLister.Get(clusterRoleBindingName)
-	// If the resource doesn't exist, we'll create it
-	if errors.IsNotFound(err) {
-		clusterRoleBinding, err = c.kubeclientset.RbacV1beta1().ClusterRoleBindings().Create(newClusterRoleBinding(bus))
-	}
-
-	// If an error occurs during Get/Create, we'll requeue the item so we can
-	// attempt processing again later. This could have been caused by a
-	// temporary network failure, or any other transient reason.
-	if err != nil {
-		return nil, err
-	}
-
-	// If the ClusterRoleBinding is not controlled by this Bus resource, we should log
-	// a warning to the event recorder and return
-	if !metav1.IsControlledBy(clusterRoleBinding, bus) {
-		msg := fmt.Sprintf(MessageResourceExists, clusterRoleBinding.Name)
-		c.recorder.Event(bus, corev1.EventTypeWarning, ErrResourceExists, msg)
-		return nil, fmt.Errorf(msg)
-	}
-
-	// If the ClusterRoleBinding does not match the Bus's proposed ClusterRoleBinding we
-	// should update the ClusterRoleBinding resource.
-	proposedClusterRoleBinding := newClusterRoleBinding(bus)
-	if !reflect.DeepEqual(proposedClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) &&
-		!reflect.DeepEqual(proposedClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
-		glog.V(4).Infof("Bus %s provisioner spec updated", bus.Name)
-		clusterRoleBinding, err = c.kubeclientset.RbacV1beta1().ClusterRoleBindings().Update(proposedClusterRoleBinding)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return clusterRoleBinding, nil
-}
-
 func (c *Controller) syncBusProvisionerDeployment(bus *channelsv1alpha1.Bus) (*appsv1.Deployment, error) {
 	provisioner := bus.Spec.Provisioner
 
 	// Get the deployment with the specified deployment name
-	deploymentName := controller.BusProvisionerDeploymentName(bus.ObjectMeta.Name)
-	deployment, err := c.deploymentsLister.Deployments(bus.Namespace).Get(deploymentName)
+	deploymentName := controller.BusProvisionerDeploymentName(bus.Name, bus.Namespace)
+	deployment, err := c.deploymentsLister.Deployments(system.Namespace).Get(deploymentName)
 
 	// If the resource shouldn't exists
 	if provisioner == nil {
 		// If the resource exists, we'll delete it
 		if deployment != nil {
-			err = c.kubeclientset.AppsV1().Deployments(bus.Namespace).Delete(deploymentName, nil)
+			err = c.kubeclientset.AppsV1().Deployments(system.Namespace).Delete(deploymentName, nil)
 		}
 		if errors.IsNotFound(err) {
 			return nil, nil
@@ -541,7 +445,7 @@ func (c *Controller) syncBusProvisionerDeployment(bus *channelsv1alpha1.Bus) (*a
 
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
-		deployment, err = c.kubeclientset.AppsV1().Deployments(bus.Namespace).Create(newProvisionerDeployment(bus))
+		deployment, err = c.kubeclientset.AppsV1().Deployments(system.Namespace).Create(newProvisionerDeployment(bus))
 	}
 
 	// If an error occurs during Get/Create, we'll requeue the item so we can
@@ -564,7 +468,7 @@ func (c *Controller) syncBusProvisionerDeployment(bus *channelsv1alpha1.Bus) (*a
 	proposedDeployment := newProvisionerDeployment(bus)
 	if !reflect.DeepEqual(proposedDeployment.Spec, deployment.Spec) {
 		glog.V(4).Infof("Bus %s provisioner spec updated", bus.Name)
-		deployment, err = c.kubeclientset.AppsV1().Deployments(bus.Namespace).Update(proposedDeployment)
+		deployment, err = c.kubeclientset.AppsV1().Deployments(system.Namespace).Update(proposedDeployment)
 
 		if err != nil {
 			return nil, err
@@ -579,8 +483,6 @@ func (c *Controller) updateBusStatus(
 	dispatcherService *corev1.Service, dispatcherServiceErr error,
 	dispatcherDeployment *appsv1.Deployment, dispatcherDeploymentErr error,
 	provisionerDeployment *appsv1.Deployment, provisionerDeploymentErr error,
-	serviceAccount *corev1.ServiceAccount, serviceAccountErr error,
-	clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, clusterRoleBindingErr error,
 ) error {
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// You can use DeepCopy() to make a deep copy of original object and modify this copy
@@ -687,13 +589,14 @@ func (c *Controller) handleObject(obj interface{}) {
 // the Bus resource that 'owns' it.
 func newDispatcherService(bus *channelsv1alpha1.Bus) *corev1.Service {
 	labels := map[string]string{
-		"bus":  bus.Name,
-		"role": "dispatcher",
+		"bus":       bus.Name,
+		"namespace": bus.Namespace,
+		"role":      dispatcherRole,
 	}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.BusDispatcherServiceName(bus.ObjectMeta.Name),
-			Namespace: bus.Namespace,
+			Name:      controller.BusDispatcherServiceName(bus.Name, bus.Namespace),
+			Namespace: system.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(bus, schema.GroupVersionKind{
@@ -721,8 +624,9 @@ func newDispatcherService(bus *channelsv1alpha1.Bus) *corev1.Service {
 // the Bus resource that 'owns' it.
 func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 	labels := map[string]string{
-		"bus":  bus.Name,
-		"role": "dispatcher",
+		"bus":       bus.Name,
+		"namespace": bus.Namespace,
+		"role":      dispatcherRole,
 	}
 	one := int32(1)
 	container := bus.Spec.Dispatcher.DeepCopy()
@@ -746,8 +650,8 @@ func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.BusDispatcherDeploymentName(bus.ObjectMeta.Name),
-			Namespace: bus.Namespace,
+			Name:      controller.BusDispatcherDeploymentName(bus.Name, bus.Namespace),
+			Namespace: system.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(bus, schema.GroupVersionKind{
 					Group:   channelsv1alpha1.SchemeGroupVersion.Group,
@@ -769,7 +673,7 @@ func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: controller.BusServiceAccountName(bus.Name),
+					ServiceAccountName: serviceAccountName,
 					Containers: []corev1.Container{
 						*container,
 					},
@@ -780,63 +684,14 @@ func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 	}
 }
 
-// newServiceAccount creates a new ServiceAccount for a Bus resource. It also sets
-// the appropriate OwnerReferences on the resource so handleObject can discover
-// the Bus resource that 'owns' it.
-func newServiceAccount(bus *channelsv1alpha1.Bus) *corev1.ServiceAccount {
-	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.BusServiceAccountName(bus.ObjectMeta.Name),
-			Namespace: bus.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(bus, schema.GroupVersionKind{
-					Group:   channelsv1alpha1.SchemeGroupVersion.Group,
-					Version: channelsv1alpha1.SchemeGroupVersion.Version,
-					Kind:    "Bus",
-				}),
-			},
-		},
-	}
-}
-
-// newClusterRoleBinding creates a new ClusterRoleBinding for a Bus resource. It also sets
-// the appropriate OwnerReferences on the resource so handleObject can discover
-// the Bus resource that 'owns' it.
-func newClusterRoleBinding(bus *channelsv1alpha1.Bus) *rbacv1beta1.ClusterRoleBinding {
-	return &rbacv1beta1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.BusClusterRoleBindingName(bus.ObjectMeta.Name),
-			Namespace: bus.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(bus, schema.GroupVersionKind{
-					Group:   channelsv1alpha1.SchemeGroupVersion.Group,
-					Version: channelsv1alpha1.SchemeGroupVersion.Version,
-					Kind:    "Bus",
-				}),
-			},
-		},
-		Subjects: []rbacv1beta1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      controller.BusServiceAccountName(bus.ObjectMeta.Name),
-				Namespace: bus.Namespace,
-			},
-		},
-		RoleRef: rbacv1beta1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "knative-channels-bus",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
-}
-
 // newProvisionerDeployment creates a new Deployment for a Bus resource. It also sets
 // the appropriate OwnerReferences on the resource so handleObject can discover
 // the Bus resource that 'owns' it.
 func newProvisionerDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 	labels := map[string]string{
-		"bus":  bus.Name,
-		"role": "provisioner",
+		"bus":       bus.Name,
+		"namespace": bus.Namespace,
+		"role":      provisionerRole,
 	}
 	one := int32(1)
 	container := bus.Spec.Provisioner.DeepCopy()
@@ -856,8 +711,8 @@ func newProvisionerDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controller.BusProvisionerDeploymentName(bus.ObjectMeta.Name),
-			Namespace: bus.Namespace,
+			Name:      controller.BusProvisionerDeploymentName(bus.Name, bus.Namespace),
+			Namespace: system.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(bus, schema.GroupVersionKind{
 					Group:   channelsv1alpha1.SchemeGroupVersion.Group,
@@ -879,7 +734,7 @@ func newProvisionerDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: controller.BusServiceAccountName(bus.Name),
+					ServiceAccountName: serviceAccountName,
 					Containers: []corev1.Container{
 						*container,
 					},

--- a/pkg/controller/channel/controller.go
+++ b/pkg/controller/channel/controller.go
@@ -520,7 +520,7 @@ func newVirtualService(channel *channelsv1alpha1.Channel) *istiov1alpha3.Virtual
 	var destinationHost string
 	if len(channel.Spec.Bus) != 0 {
 		labels["bus"] = channel.Spec.Bus
-		destinationHost = controller.ServiceHostName(controller.BusDispatcherServiceName(channel.Spec.Bus), channel.Namespace)
+		destinationHost = controller.ServiceHostName(controller.BusDispatcherServiceName(channel.Spec.Bus, channel.Namespace), system.Namespace)
 	}
 	if len(channel.Spec.ClusterBus) != 0 {
 		labels["clusterBus"] = channel.Spec.ClusterBus

--- a/pkg/controller/clusterbus/controller.go
+++ b/pkg/controller/clusterbus/controller.go
@@ -54,8 +54,10 @@ import (
 )
 
 const (
-	controllerAgentName                    = "clusterbus-controller"
-	clusterBusControllerServiceAccountName = "clusterbus-controller"
+	controllerAgentName = "clusterbus-controller"
+	serviceAccountName  = "bus-operator"
+	provisionerRole     = "provisioner"
+	dispatcherRole      = "dispatcher"
 )
 
 const (
@@ -514,7 +516,7 @@ func (c *Controller) handleObject(obj interface{}) {
 func newDispatcherService(clusterBus *channelsv1alpha1.ClusterBus) *corev1.Service {
 	labels := map[string]string{
 		"clusterBus": clusterBus.Name,
-		"role":       "dispatcher",
+		"role":       dispatcherRole,
 	}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -548,7 +550,7 @@ func newDispatcherService(clusterBus *channelsv1alpha1.ClusterBus) *corev1.Servi
 func newDispatcherDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.Deployment {
 	labels := map[string]string{
 		"clusterBus": clusterBus.Name,
-		"role":       "dispatcher",
+		"role":       dispatcherRole,
 	}
 	one := int32(1)
 	container := clusterBus.Spec.Dispatcher.DeepCopy()
@@ -591,7 +593,7 @@ func newDispatcherDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.De
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: clusterBusControllerServiceAccountName,
+					ServiceAccountName: serviceAccountName,
 					Containers: []corev1.Container{
 						*container,
 					},
@@ -608,7 +610,7 @@ func newDispatcherDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.De
 func newProvisionerDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.Deployment {
 	labels := map[string]string{
 		"clusterBus": clusterBus.Name,
-		"role":       "provisioner",
+		"role":       provisionerRole,
 	}
 	one := int32(1)
 	container := clusterBus.Spec.Provisioner.DeepCopy()
@@ -647,7 +649,7 @@ func newProvisionerDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.D
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: clusterBusControllerServiceAccountName,
+					ServiceAccountName: serviceAccountName,
 					Containers: []corev1.Container{
 						*container,
 					},

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -18,24 +18,16 @@ package controller
 
 import "fmt"
 
-func BusProvisionerDeploymentName(busName string) string {
-	return fmt.Sprintf("%s-bus-provisioner", busName)
+func BusProvisionerDeploymentName(busName, namespace string) string {
+	return fmt.Sprintf("%s-%s-bus-provisioner", busName, namespace)
 }
 
-func BusDispatcherDeploymentName(busName string) string {
-	return fmt.Sprintf("%s-bus-dispatcher", busName)
+func BusDispatcherDeploymentName(busName, namespace string) string {
+	return fmt.Sprintf("%s-%s-bus-dispatcher", busName, namespace)
 }
 
-func BusServiceAccountName(busName string) string {
-	return fmt.Sprintf("%s-bus", busName)
-}
-
-func BusClusterRoleBindingName(busName string) string {
-	return fmt.Sprintf("%s-bus", busName)
-}
-
-func BusDispatcherServiceName(busName string) string {
-	return fmt.Sprintf("%s-bus", busName)
+func BusDispatcherServiceName(busName, namespace string) string {
+	return fmt.Sprintf("%s-%s-bus", busName, namespace)
 }
 
 func ClusterBusProvisionerDeploymentName(clusterBusName string) string {


### PR DESCRIPTION
Buses can create dispatcher and provision deployments. Previously, these
deployments were created in the same namespace as the Bus resource,
which required RBAC rules to be configured to enable the deployments to
read and update Bus, Channel and Subscription resources.

By moving these deployments into the knative-eventing system namespace,
we can use a pre-determined service account and RBAC configuration.
Since the bus-controller no longer needs to create service accounts and
role bindings, the controller can run with reduced privillage (follow
 #207 for that change).

Fixes #349

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Bus provisioner and dispatcher deployments are now created in the knative-eventing namespace instead of the Bus's namespace. ClusterBuses are not impacted as they already run in the native-eventing namespace. The deployment names will now include the namespace of the Bus.
```

/assign @n3wscott for lgtm
/assign @evankanderson for approval