### PR TITLE
Add missing -f for ko apply in gh sample

### DIFF
--- a/sample/github/README.md
+++ b/sample/github/README.md
@@ -78,7 +78,7 @@ In response to a pull request event, the _legit_ Service will add `(looks pretty
 Deploy the _legit_ service via:
 
 ```shell
-ko apply sample/github/legit-service.yaml
+ko apply -f sample/github/legit-service.yaml
 ```
 
 Once deployed, you can inspect the created resources with `kubectl` commands:


### PR DESCRIPTION
## Proposed Changes

  * ko apply <file> needs to be ko apply -f <file>


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```