### PR TITLE
We never used the err from uuid.NewRandom.

### DIFF
--- a/pkg/sources/gcppubsub/gcp_pubsub.go
+++ b/pkg/sources/gcppubsub/gcp_pubsub.go
@@ -129,6 +129,10 @@ func (t *GCPPubSubEventSource) StartFeed(trigger sources.EventTrigger, route str
 
 	// Just generate a random UUID as a subscriptionName
 	uuid, err := uuid.NewRandom()
+	if err != nil {
+		glog.Infof("Failed to get create random uuid: %v", err)
+		return nil, err
+	}
 	subscriptionName := fmt.Sprintf("sub-%s", uuid.String())
 
 	glog.Infof("ProjectID: %q Topic: %q SubscriptionName: %q Route: %s", projectID, topicID, subscriptionName, route)

--- a/pkg/sources/k8sevents/k8s_events.go
+++ b/pkg/sources/k8sevents/k8s_events.go
@@ -76,6 +76,10 @@ func (t *K8SEventsEventSource) StartFeed(trigger sources.EventTrigger, route str
 
 	// Just generate a random UUID as a subscriptionName
 	uuid, err := uuid.NewRandom()
+	if err != nil {
+		glog.Infof("Failed to create new random uuid: %v", err)
+		return nil, err
+	}
 	subscriptionName := fmt.Sprintf("sub-%s", uuid.String())
 
 	glog.Infof("Namespace: %q Route: %s", namespace, route)


### PR DESCRIPTION
Cleaning up based on https://goreportcard.com/report/github.com/knative/eventing#ineffassign

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```