### PR TITLE
Fix env var len check in gh feedlet

### DIFF
--- a/pkg/sources/github/feedlet/feedlet.go
+++ b/pkg/sources/github/feedlet/feedlet.go
@@ -368,13 +368,13 @@ func main() {
 	}
 
 	feedNamespace := os.Getenv(sources.FeedNamespaceKey)
-	if len(feedNamespace) != 0 {
+	if len(feedNamespace) == 0 {
 		log.Printf("Fatal: feed namespace not provided, expected envvar %q to be set", sources.FeedNamespaceKey)
 		os.Exit(1)
 	}
 
 	feedServiceAccountName := os.Getenv(sources.FeedServiceAccountKey)
-	if len(feedServiceAccountName) != 0 {
+	if len(feedServiceAccountName) == 0 {
 		log.Printf("Fatal: feed service account not provided, expected envvar %q to be set", sources.FeedServiceAccountKey)
 		os.Exit(1)
 	}


### PR DESCRIPTION


## Proposed Changes

The logic is inverted when we are checking for existence of
FEED_NAMESPACE and other env vars in the gihub source feedlet - we are
asserting len != 0 rather than len == 0.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```