### PR TITLE
Update e2e-test.sh to be portable

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,7 +29,10 @@
 [ -f /workspace/e2e-tests.sh ] \
   && source /workspace/e2e-tests.sh \
   || eval "$(docker run --entrypoint sh gcr.io/knative-tests/test-infra/prow-tests -c 'cat e2e-tests.sh')"
-[ -v KNATIVE_TEST_INFRA ] || exit 1
+
+if [ -z "${KNATIVE_TEST_INFRA}" ]; then
+  exit 1
+fi
 
 # Names of the Resources used in the tests.
 readonly E2E_TEST_NAMESPACE=e2etest


### PR DESCRIPTION
The changes will allow it to run on MacOS X which has an older bash
