### PR TITLE
Type is not a field on source. Removed.

### DIFF
--- a/pkg/sources/gcppubsub/eventsource.yaml
+++ b/pkg/sources/gcppubsub/eventsource.yaml
@@ -18,7 +18,6 @@ metadata:
   name: pubsub.googleapis.com
   namespace: default
 spec:
-  type: pubsub.googleapis.com
   source: pubsub.googleapis.com
   image: github.com/knative/eventing/pkg/sources/gcppubsub
   parameters:

--- a/pkg/sources/k8sevents/eventsource.yaml
+++ b/pkg/sources/k8sevents/eventsource.yaml
@@ -18,7 +18,6 @@ metadata:
   name: k8sevents
   namespace: default
 spec:
-  type: k8sevents
   source: k8sevents
   image: github.com/knative/eventing/pkg/sources/k8sevents
   parameters:


### PR DESCRIPTION
The validation webhooks are now doing strict json mapping and the current sources for k8s events and gcp pub/sub have an extra field called "type" on source that does not map into the real resource.

**Release Note**
```release-note
Updated sources k8sevents and gcppubsub to be a valid source yaml.
```