### PR TITLE
Fix github source to use valid webhook name

### DIFF
--- a/pkg/sources/github/feedlet/feedlet.go
+++ b/pkg/sources/github/feedlet/feedlet.go
@@ -327,8 +327,11 @@ func (t *githubEventSource) createWebhook(trigger sources.EventTrigger, name, do
 	config["url"] = fmt.Sprintf("http://%s", domain)
 	config["content_type"] = "json"
 	config["secret"] = secretToken
+
+	// GitHub hook names are required to be named "web" or the name of a GitHub service
+	hookname := "web"
 	hook := ghclient.Hook{
-		Name:   &name,
+		Name:   &hookname,
 		URL:    &domain,
 		Events: events,
 		Active: &active,


### PR DESCRIPTION
## Proposed Changes

Github webhooks are requires to be named "web" or the name of a valid
service:
https://developer.github.com/v3/repos/hooks/#create-a-hook

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```