### PR TITLE
Found panic on missing flag modification. glog no longer used.

### DIFF
--- a/pkg/sources/github/receive_adapter/receive_adapter.go
+++ b/pkg/sources/github/receive_adapter/receive_adapter.go
@@ -81,8 +81,6 @@ func (h *GithubHandler) HandlePullRequest(payload interface{}, header webhooks.H
 
 func main() {
 	flag.Parse()
-	// set the logs to stderr so kube will see them.
-	flag.Lookup("logtostderr").Value.Set("true")
 
 	target := os.Getenv(envTarget)
 


### PR DESCRIPTION
Stop editing the `logtostderr` flag.

**Release Note**
```release-note
NONE
```