### PR TITLE
Remove ultrasaurus from approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,4 @@ approvers:
 - evankanderson
 - inlined
 - mattmoor
-- ultrasaurus
 - vaikas-google


### PR DESCRIPTION
At her request.

EDIT: This change is intended to stop Prow from auto-suggesting her as an approver, rather than imply a lack of approval rights.

/cc @ultrasaurus @evankanderson @vaikas-google @inlined @n3wscott 