### PR TITLE
prefer %v err over %s err.Erorr()

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -83,22 +83,22 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
-		logger.Fatalf("Error building kubeconfig: %s", err.Error())
+		logger.Fatalf("Error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building kubernetes clientset: %s", err.Error())
+		logger.Fatalf("Error building kubernetes clientset: %v", err)
 	}
 
 	client, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building clientset: %s", err.Error())
+		logger.Fatalf("Error building clientset: %v", err)
 	}
 
 	sharedClient, err := sharedclientset.NewForConfig(cfg)
 	if err != nil {
-		logger.Fatalf("Error building shared clientset: %s", err.Error())
+		logger.Fatalf("Error building shared clientset: %v", err)
 	}
 
 	// TODO: Rip this out from all the controllers since we can get it
@@ -107,7 +107,7 @@ func main() {
 	// Kubernetes. Clients will use the Pod's ServiceAccount principal.
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
-		logger.Fatalf("Error building rest config: %v", err.Error())
+		logger.Fatalf("Error building rest config: %v", err)
 	}
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
@@ -147,7 +147,7 @@ func main() {
 			// We don't expect this to return until stop is called,
 			// but if it does, propagate it back.
 			if err := ctrlr.Run(threadsPerController, stopCh); err != nil {
-				logger.Fatalf("Error running controller: %s", err.Error())
+				logger.Fatalf("Error running controller: %v", err)
 			}
 		}(ctrlr)
 	}

--- a/pkg/buses/gcppubsub/dispatcher/main.go
+++ b/pkg/buses/gcppubsub/dispatcher/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	go func() {
 		if err := monitor.Run(namespace, name, threadsPerMonitor, stopCh); err != nil {
-			glog.Fatalf("Error running monitor: %s", err.Error())
+			glog.Fatalf("Error running monitor: %v", err)
 		}
 	}()
 	messageReceiver.Run(stopCh)

--- a/pkg/buses/gcppubsub/provisioner/main.go
+++ b/pkg/buses/gcppubsub/provisioner/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	if err := monitor.Run(namespace, name, threadsPerMonitor, stopCh); err != nil {
-		glog.Fatalf("Error running monitor: %s", err.Error())
+		glog.Fatalf("Error running monitor: %v", err)
 	}
 }
 

--- a/pkg/buses/kafka/provisioner/provisioner.go
+++ b/pkg/buses/kafka/provisioner/provisioner.go
@@ -68,12 +68,12 @@ func main() {
 
 	clusterAdmin, err := sarama.NewClusterAdmin(brokers, conf)
 	if err != nil {
-		glog.Fatalf("Error building kafka admin client: %s", err.Error())
+		glog.Fatalf("Error building kafka admin client: %v", err)
 	}
 
 	provisioner, err := NewKafkaProvisioner(name, namespace, *masterURL, *kubeconfig, clusterAdmin)
 	if err != nil {
-		glog.Fatalf("Error building kafka provisioner: %s", err.Error())
+		glog.Fatalf("Error building kafka provisioner: %v", err)
 	}
 
 	stopCh := signals.SetupSignalHandler()

--- a/pkg/buses/monitor.go
+++ b/pkg/buses/monitor.go
@@ -240,17 +240,17 @@ func NewMonitor(
 ) *Monitor {
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %s", err.Error())
+		glog.Fatalf("Error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+		glog.Fatalf("Error building kubernetes clientset: %v", err)
 	}
 
 	client, err := clientset.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building clientset: %s", err.Error())
+		glog.Fatalf("Error building clientset: %v", err)
 	}
 
 	informerFactory := informers.NewSharedInformerFactory(client, time.Second*30)
@@ -602,7 +602,7 @@ func (m *Monitor) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the name string of the resource to be synced.
 		if err := m.syncHandler(key); err != nil {
 			m.workqueue.AddRateLimited(obj)
-			return fmt.Errorf("error syncing monitor '%s': %s", key, err.Error())
+			return fmt.Errorf("error syncing monitor '%s': %v", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.

--- a/pkg/buses/stub/main.go
+++ b/pkg/buses/stub/main.go
@@ -64,7 +64,7 @@ func NewStubBus(ref *buses.BusReference, monitor *buses.Monitor) *StubBus {
 func (b *StubBus) Run(stopCh <-chan struct{}) {
 	go func() {
 		if err := b.monitor.Run(b.ref.Namespace, b.ref.Name, 1, stopCh); err != nil {
-			glog.Fatalf("Error running monitor: %s", err.Error())
+			glog.Fatalf("Error running monitor: %v", err)
 		}
 	}()
 	b.monitor.WaitForCacheSync(stopCh)

--- a/pkg/controller/bus/controller.go
+++ b/pkg/controller/bus/controller.go
@@ -269,7 +269,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Bus resource to be synced.
 		if err := c.syncHandler(key); err != nil {
-			return fmt.Errorf("error syncing bus '%s': %s", key, err.Error())
+			return fmt.Errorf("error syncing bus '%s': %v", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.

--- a/pkg/controller/channel/controller.go
+++ b/pkg/controller/channel/controller.go
@@ -258,7 +258,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Channel resource to be synced.
 		if err := c.syncHandler(key); err != nil {
-			return fmt.Errorf("error syncing channel '%s': %s", key, err.Error())
+			return fmt.Errorf("error syncing channel '%s': %v", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.

--- a/pkg/controller/clusterbus/controller.go
+++ b/pkg/controller/clusterbus/controller.go
@@ -245,7 +245,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// ClusterBus resource to be synced.
 		if err := c.syncHandler(key); err != nil {
-			return fmt.Errorf("error syncing clusterbus '%s': %s", key, err.Error())
+			return fmt.Errorf("error syncing clusterbus '%s': %v", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.

--- a/pkg/sources/gcppubsub/gcp_pubsub.go
+++ b/pkg/sources/gcppubsub/gcp_pubsub.go
@@ -238,12 +238,12 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %s", err.Error())
+		glog.Fatalf("Error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+		glog.Fatalf("Error building kubernetes clientset: %v", err)
 	}
 
 	sources.RunEventSource(NewGCPPubSubEventSource(kubeClient, feedNamespace, feedServiceAccountName, p.Image))

--- a/pkg/sources/k8sevents/k8s_events.go
+++ b/pkg/sources/k8sevents/k8s_events.go
@@ -158,12 +158,12 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %v", err.Error())
+		glog.Fatalf("Error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %v", err.Error())
+		glog.Fatalf("Error building kubernetes clientset: %v", err)
 	}
 
 	sources.RunEventSource(NewK8SEventsEventSource(kubeClient, feedNamespace, feedServiceAccountName, p.Image))

--- a/pkg/sources/k8sevents/receive_adapter/receive_adapter.go
+++ b/pkg/sources/k8sevents/receive_adapter/receive_adapter.go
@@ -74,12 +74,12 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		log.Fatalf("Error building kubeconfig: %v", err.Error())
+		log.Fatalf("Error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.Fatalf("Error building kubernetes clientset: %v", err.Error())
+		log.Fatalf("Error building kubernetes clientset: %v", err)
 	}
 
 	log.Printf("Creating a new Event Watcher...")


### PR DESCRIPTION
Fixes #331

## Proposed Changes

  * Refactor error logging and printing to use `"%v", err`

**Release Note**
```release-note
NONE
```