### PR TITLE
Nothing to validate with event sources. Removing todos.

### DIFF
--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_defaults.go
@@ -16,11 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-func (ces *ClusterEventSource) SetDefaults() {
-	ces.Spec.SetDefaults()
+func (es *ClusterEventSource) SetDefaults() {
+	es.Spec.SetDefaults()
 }
 
-func (cess *ClusterEventSourceSpec) SetDefaults() {
-	cess.CommonEventSourceSpec.SetDefaults()
-	// TODO anything?
+func (ess *ClusterEventSourceSpec) SetDefaults() {
+	ess.CommonEventSourceSpec.SetDefaults()
 }

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_types.go
@@ -44,7 +44,6 @@ type ClusterEventSource struct {
 // Check that ClusterEventSource can be validated, can be defaulted, and has immutable fields.
 var _ apis.Validatable = (*ClusterEventSource)(nil)
 var _ apis.Defaultable = (*ClusterEventSource)(nil)
-var _ apis.Immutable = (*ClusterEventSource)(nil)
 var _ runtime.Object = (*ClusterEventSource)(nil)
 var _ webhook.GenericCRD = (*ClusterEventSource)(nil)
 

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
@@ -20,11 +20,10 @@ import (
 	"github.com/knative/pkg/apis"
 )
 
-func (ces *ClusterEventSource) Validate() *apis.FieldError {
-	return ces.Spec.Validate().ViaField("spec")
+func (es *ClusterEventSource) Validate() *apis.FieldError {
+	return es.Spec.Validate().ViaField("spec")
 }
 
-func (cess *ClusterEventSourceSpec) Validate() *apis.FieldError {
-	// nothing to validate
-	return cess.CommonEventSourceSpec.Validate()
+func (ess *ClusterEventSourceSpec) Validate() *apis.FieldError {
+	return ess.CommonEventSourceSpec.Validate()
 }

--- a/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/cluster_event_source_validation.go
@@ -25,19 +25,6 @@ func (ces *ClusterEventSource) Validate() *apis.FieldError {
 }
 
 func (cess *ClusterEventSourceSpec) Validate() *apis.FieldError {
+	// nothing to validate
 	return cess.CommonEventSourceSpec.Validate()
-}
-
-func (current *ClusterEventSource) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
-	original, ok := og.(*ClusterEventSource)
-	if !ok {
-		return &apis.FieldError{Message: "The provided original was not a ClusterEventSource"}
-	}
-	if original == nil {
-		return nil
-	}
-
-	// TODO
-
-	return nil
 }

--- a/pkg/apis/feeds/v1alpha1/common_event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_defaults.go
@@ -17,5 +17,5 @@ limitations under the License.
 package v1alpha1
 
 func (cess *CommonEventSourceSpec) SetDefaults() {
-	// TODO anything?
+	// nothing to default
 }

--- a/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/common_event_source_validation.go
@@ -21,6 +21,6 @@ import (
 )
 
 func (cess *CommonEventSourceSpec) Validate() *apis.FieldError {
-	// TODO
+	// nothing to validate
 	return nil
 }

--- a/pkg/apis/feeds/v1alpha1/event_source_defaults.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_defaults.go
@@ -22,5 +22,4 @@ func (es *EventSource) SetDefaults() {
 
 func (ess *EventSourceSpec) SetDefaults() {
 	ess.CommonEventSourceSpec.SetDefaults()
-	// TODO anything?
 }

--- a/pkg/apis/feeds/v1alpha1/event_source_types.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_types.go
@@ -42,7 +42,6 @@ type EventSource struct {
 // Check that EventSource can be validated, can be defaulted, and has immutable fields.
 var _ apis.Validatable = (*EventSource)(nil)
 var _ apis.Defaultable = (*EventSource)(nil)
-var _ apis.Immutable = (*EventSource)(nil)
 var _ runtime.Object = (*EventSource)(nil)
 var _ webhook.GenericCRD = (*EventSource)(nil)
 

--- a/pkg/apis/feeds/v1alpha1/event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_validation.go
@@ -25,6 +25,5 @@ func (es *EventSource) Validate() *apis.FieldError {
 }
 
 func (ess *EventSourceSpec) Validate() *apis.FieldError {
-	// nothing to validate
 	return ess.CommonEventSourceSpec.Validate()
 }

--- a/pkg/apis/feeds/v1alpha1/event_source_validation.go
+++ b/pkg/apis/feeds/v1alpha1/event_source_validation.go
@@ -25,19 +25,6 @@ func (es *EventSource) Validate() *apis.FieldError {
 }
 
 func (ess *EventSourceSpec) Validate() *apis.FieldError {
+	// nothing to validate
 	return ess.CommonEventSourceSpec.Validate()
-}
-
-func (current *EventSource) CheckImmutableFields(og apis.Immutable) *apis.FieldError {
-	original, ok := og.(*EventSource)
-	if !ok {
-		return &apis.FieldError{Message: "The provided original was not a EventSource"}
-	}
-	if original == nil {
-		return nil
-	}
-
-	// TODO
-
-	return nil
 }


### PR DESCRIPTION
Follow-up to: #352

## Proposed Changes

  * Remove TODOs for [Cluster]EventSource validation, nothing to do.

**Release Note**
```release-note
NONE
```