### PR TITLE
Convert buses from glog to zap

### DIFF
--- a/pkg/buses/gcppubsub/provisioner/main.go
+++ b/pkg/buses/gcppubsub/provisioner/main.go
@@ -20,10 +20,10 @@ import (
 	"flag"
 	"os"
 
-	"github.com/golang/glog"
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/buses/gcppubsub"
 	"github.com/knative/pkg/signals"
+	"go.uber.org/zap"
 )
 
 const (
@@ -31,19 +31,27 @@ const (
 )
 
 func main() {
-	defer glog.Flush()
-
 	busRef := buses.NewBusReferenceFromNames(
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
 
+	config := buses.NewLoggingConfig()
+	logger := buses.NewBusLoggerFromConfig(config)
+	defer logger.Sync()
+	logger = logger.With(
+		zap.String("channels.knative.dev/bus", busRef.String()),
+		zap.String("channels.knative.dev/busType", gcppubsub.BusType),
+		zap.String("channels.knative.dev/busComponent", buses.Provisioner),
+	)
+
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if projectID == "" {
-		glog.Fatalf("GOOGLE_CLOUD_PROJECT environment variable must be set")
+		logger.Fatalf("GOOGLE_CLOUD_PROJECT environment variable must be set")
 	}
 
-	opts := &buses.BusOpts{}
+	opts := &buses.BusOpts{
+		Logger: logger}
 
 	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -51,7 +59,7 @@ func main() {
 
 	bus, err := gcppubsub.NewCloudPubSubBusProvisioner(busRef, projectID, opts)
 	if err != nil {
-		glog.Fatalf("Error starting pub/sub bus provisioner: %v", err)
+		logger.Fatalf("Error starting pub/sub bus provisioner: %v", err)
 	}
 
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/buses/kafka/dispatcher/main.go
+++ b/pkg/buses/kafka/dispatcher/main.go
@@ -18,15 +18,14 @@ package main
 
 import (
 	"flag"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/Shopify/sarama"
-	"github.com/golang/glog"
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/buses/kafka"
 	"github.com/knative/pkg/signals"
+	"go.uber.org/zap"
 )
 
 const (
@@ -34,20 +33,29 @@ const (
 )
 
 func main() {
-	defer glog.Flush()
-	sarama.Logger = log.New(os.Stderr, "[Sarama] ", log.LstdFlags)
-
 	busRef := buses.NewBusReferenceFromNames(
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
 
+	config := buses.NewLoggingConfig()
+	logger := buses.NewBusLoggerFromConfig(config)
+	defer logger.Sync()
+	logger = logger.With(
+		zap.String("channels.knative.dev/bus", busRef.String()),
+		zap.String("channels.knative.dev/busType", kafka.BusType),
+		zap.String("channels.knative.dev/busComponent", buses.Dispatcher),
+	)
+	sarama.Logger = zap.NewStdLog(logger.With(zap.Namespace("Sarama")).Desugar())
+
 	brokers := strings.Split(os.Getenv("KAFKA_BROKERS"), ",")
 	if len(brokers) == 0 {
-		log.Fatalf("Environment variable KAFKA_BROKERS not set")
+		logger.Fatalf("Environment variable KAFKA_BROKERS not set")
 	}
 
-	opts := &buses.BusOpts{}
+	opts := &buses.BusOpts{
+		Logger: logger,
+	}
 
 	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -55,7 +63,7 @@ func main() {
 
 	bus, err := kafka.NewKafkaBusDispatcher(busRef, brokers, opts)
 	if err != nil {
-		glog.Fatalf("Error starting kafka bus dispatcher: %v", err)
+		logger.Fatalf("Error starting kafka bus dispatcher: %v", err)
 	}
 
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/buses/kafka/provisioner/main.go
+++ b/pkg/buses/kafka/provisioner/main.go
@@ -18,15 +18,14 @@ package main
 
 import (
 	"flag"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/Shopify/sarama"
-	"github.com/golang/glog"
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/buses/kafka"
 	"github.com/knative/pkg/signals"
+	"go.uber.org/zap"
 )
 
 const (
@@ -34,20 +33,29 @@ const (
 )
 
 func main() {
-	defer glog.Flush()
-	sarama.Logger = log.New(os.Stderr, "[Sarama] ", log.LstdFlags)
-
 	busRef := buses.NewBusReferenceFromNames(
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
 
-	brokers := strings.Split(os.Getenv("KAFKA_BROKERS"), ",")
-	if len(brokers) == 0 {
-		log.Fatalf("Environment variable KAFKA_BROKERS not set")
+	config := buses.NewLoggingConfig()
+	logger := buses.NewBusLoggerFromConfig(config)
+	defer logger.Sync()
+	logger = logger.With(
+		zap.String("channels.knative.dev/bus", busRef.String()),
+		zap.String("channels.knative.dev/busType", kafka.BusType),
+		zap.String("channels.knative.dev/busComponent", buses.Provisioner),
+	)
+	sarama.Logger = zap.NewStdLog(logger.With(zap.Namespace("Sarama")).Desugar())
+
+	opts := &buses.BusOpts{
+		Logger: logger,
 	}
 
-	opts := &buses.BusOpts{}
+	brokers := strings.Split(os.Getenv("KAFKA_BROKERS"), ",")
+	if len(brokers) == 0 {
+		logger.Fatalf("Environment variable KAFKA_BROKERS not set")
+	}
 
 	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -55,7 +63,7 @@ func main() {
 
 	bus, err := kafka.NewKafkaBusProvisioner(busRef, brokers, opts)
 	if err != nil {
-		glog.Fatalf("Error starting kafka bus provisioner: %v", err)
+		logger.Fatalf("Error starting kafka bus provisioner: %v", err)
 	}
 
 	// set up signals so we handle the first shutdown signal gracefully

--- a/pkg/buses/logger.go
+++ b/pkg/buses/logger.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package buses
+
+import (
+	"github.com/knative/pkg/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	busLoggingComponent        = "bus"
+	reconcilerLoggingComponent = "reconciler"
+	handlerLoggingComponent    = "handler"
+	dispatcherLoggingComponent = "dispatcher"
+	receiverLoggingComponent   = "receiver"
+)
+
+// NewLoggingConfig creates a static logging configuration appropriate for a
+// bus. All logging levels are set to Info.
+func NewLoggingConfig() *logging.Config {
+	lc := &logging.Config{}
+	lc.LoggingConfig = `{
+		"level": "info",
+		"development": false,
+		"outputPaths": ["stdout"],
+		"errorOutputPaths": ["stderr"],
+		"encoding": "json",
+		"encoderConfig": {
+			"timeKey": "ts",
+			"levelKey": "level",
+			"nameKey": "logger",
+			"callerKey": "caller",
+			"messageKey": "msg",
+			"stacktraceKey": "stacktrace",
+			"lineEnding": "",
+			"levelEncoder": "",
+			"timeEncoder": "iso8601",
+			"durationEncoder": "",
+			"callerEncoder": ""
+		}
+	}`
+	lc.LoggingLevel = make(map[string]zapcore.Level)
+	lc.LoggingLevel[busLoggingComponent] = zapcore.InfoLevel
+	lc.LoggingLevel[reconcilerLoggingComponent] = zapcore.InfoLevel
+	lc.LoggingLevel[handlerLoggingComponent] = zapcore.InfoLevel
+	lc.LoggingLevel[dispatcherLoggingComponent] = zapcore.InfoLevel
+	lc.LoggingLevel[receiverLoggingComponent] = zapcore.InfoLevel
+	return lc
+}
+
+// NewBusLoggerFromConfig creates a new zap logger for the bus component based
+// on the provided configuration
+func NewBusLoggerFromConfig(config *logging.Config) *zap.SugaredLogger {
+	logger, _ := logging.NewLoggerFromConfig(config, busLoggingComponent)
+	return logger
+}

--- a/pkg/buses/stub/dispatcher/main.go
+++ b/pkg/buses/stub/dispatcher/main.go
@@ -20,11 +20,10 @@ import (
 	"flag"
 	"os"
 
-	"github.com/golang/glog"
-
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/buses/stub"
 	"github.com/knative/pkg/signals"
+	"go.uber.org/zap"
 )
 
 const (
@@ -32,14 +31,23 @@ const (
 )
 
 func main() {
-	defer glog.Flush()
-
 	busRef := buses.NewBusReferenceFromNames(
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
 
-	opts := &buses.BusOpts{}
+	config := buses.NewLoggingConfig()
+	logger := buses.NewBusLoggerFromConfig(config)
+	defer logger.Sync()
+	logger = logger.With(
+		zap.String("channels.knative.dev/bus", busRef.String()),
+		zap.String("channels.knative.dev/busType", stub.BusType),
+		zap.String("channels.knative.dev/busComponent", buses.Dispatcher),
+	)
+
+	opts := &buses.BusOpts{
+		Logger: logger,
+	}
 
 	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")


### PR DESCRIPTION
Unlike the controller, the configuration is not being pulled from a
ConfigMap and instead using a static config. This is to make it easier
to deploy new buses into any arbitrary namespace. We can add dynamic
configuration down the road.

Fixes #393

## Proposed Changes

* switch from glog to zap for logging

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```

/assign @n3wscott 
/assign @vaikas-google 