### PR TITLE
Update test-infra dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -310,11 +310,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d6415e6b744ec877c21fe734067636b9ee149af77276b08a3d33dd8698abf947"
+  digest = "1:36968d4eb1d52090841ae868d7125d8ff10afabdea0d6b622c1f4a662f94be58"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "4a4a682ee1fd31f33e450406393c3553b9ec5c2a"
+  revision = "51872094d69a5b0266fd92a38978819e20ee70c8"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -29,7 +29,7 @@ readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-releases/b
 readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
 
 # Useful environment variables
-[[ -n "${PROW_JOB_ID}" ]] && IS_PROW=1 || IS_PROW=0
+[[ -n "${PROW_JOB_ID:-}" ]] && IS_PROW=1 || IS_PROW=0
 readonly IS_PROW
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -45,7 +45,7 @@ EMIT_METRICS=0
 function exit_if_presubmit_not_required() {
   if [[ -n "${PULL_PULL_SHA}" ]]; then
     # On a presubmit job
-    local changes="$(git diff --name-only ${PULL_PULL_SHA} ${PULL_BASE_SHA})"
+    local changes="$(/workspace/githubhelper -list-changed-files)"
     local no_presubmit_pattern="${NO_PRESUBMIT_FILES[*]}"
     local no_presubmit_pattern="\(${no_presubmit_pattern// /\\|}\)$"
     echo -e "Changed files in commit ${PULL_PULL_SHA}:\n${changes}"


### PR DESCRIPTION
Includes:
* fixes to `library.sh` in order to have some `hack` scripts working again;
* better checking of PRs where presubmit tests are unnecessary;