### PR TITLE
Do not specify node port number for kafka broker

### DIFF
--- a/config/buses/kafka/broker/kafka-broker.yaml
+++ b/config/buses/kafka/broker/kafka-broker.yaml
@@ -49,8 +49,6 @@ spec:
   - port: 9092
     name: kafka
     protocol: TCP
-    nodePort: 31349
-
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
## Proposed Changes

  * Removes the node port number specified in the `kafka-broker.yaml`

Specifying the node port number can result in port collisions.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```