### PR TITLE
Reprovision channels and resubscrube when a bus params are updated

### DIFF
--- a/pkg/buses/cache.go
+++ b/pkg/buses/cache.go
@@ -96,3 +96,19 @@ func (c *Cache) RemoveSubscription(subscription *channelsv1alpha1.Subscription) 
 	ref := NewSubscriptionReference(subscription)
 	delete(c.subscriptions, ref)
 }
+
+func (c *Cache) AllChannels() []*channelsv1alpha1.Channel {
+	chans := []*channelsv1alpha1.Channel{}
+	for _, channel := range c.channels {
+		chans = append(chans, channel)
+	}
+	return chans
+}
+
+func (c *Cache) AllSubscriptions() []*channelsv1alpha1.Subscription {
+	subs := []*channelsv1alpha1.Subscription{}
+	for _, sub := range c.subscriptions {
+		subs = append(subs, sub)
+	}
+	return subs
+}


### PR DESCRIPTION
Fixes #392

## Proposed Changes

  *  When parameters for a bus are updated we need to reprovision and
resubscribe all channels for that bus.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```