### PR TITLE
Update Bus README's with correct namespace

### DIFF
--- a/config/buses/gcppubsub/README.md
+++ b/config/buses/gcppubsub/README.md
@@ -3,8 +3,8 @@
 Deployment steps:
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md)
 1. [Create a service account](https://console.cloud.google.com/iam-admin/serviceaccounts/project) with the 'Pub/Sub Editor' role, and download a new JSON private key.
-1. Create a secret for the downloaded key `kubectl create secret generic gcppubsub-bus-key --from-file=key.json=PATH-TO-KEY-FILE.json`
-1. Configure the bus, replacing `$PROJECT_ID` with your GCP Project ID, `kubectl create configmap gcppubsub-bus-config --from-literal=GOOGLE_CLOUD_PROJECT=$PROJECT_ID`
+1. Create a secret for the downloaded key `kubectl -n knative-eventing create secret generic gcppubsub-bus-key --from-file=key.json=PATH-TO-KEY-FILE.json`
+1. Configure the bus, replacing `$PROJECT_ID` with your GCP Project ID, `kubectl -n knative-eventing create configmap gcppubsub-bus-config --from-literal=GOOGLE_CLOUD_PROJECT=$PROJECT_ID`
 1. For cluster wide deployment, change the kind in `config/buses/gcppubsub/gcppubsub-bus.yaml` from `Bus` to `ClusterBus`.
 1. Apply the 'gcppubsub' Bus `ko apply -f config/buses/gcppubsub/`
 1. Create Channels that reference the 'gcppubsub' Bus

--- a/config/buses/kafka/README.md
+++ b/config/buses/kafka/README.md
@@ -9,7 +9,7 @@ Deployment steps:
     ```
 1. Configure the bus to use the Kafka broker, replace the broker URL if not using the provided broker:
     ```
-    kubectl create configmap kafka-bus-config --from-literal=KAFKA_BROKERS=kafkabroker.kafka:9092
+    kubectl -n knative-eventing create configmap kafka-bus-config --from-literal=KAFKA_BROKERS=kafkabroker.kafka:9092
     ```
 1. For cluster wide deployment, change the kind in `config/buses/kafka/kafka-bus.yaml` from `Bus` to `ClusterBus`.
 1. Apply the Kafka Bus:


### PR DESCRIPTION
Addresses concern in #424 but this warrants a better fix as mentioned in the issue.

## Proposed Changes

  * Update Kafka/GCP PubSub docs to create config-map/secrets in the knative-eventing namespace


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```