### PR TITLE
Reject non-successful (2xx) dispatch responses

### DIFF
--- a/pkg/buses/message_dispatcher.go
+++ b/pkg/buses/message_dispatcher.go
@@ -94,6 +94,10 @@ func (d *MessageDispatcher) executeRequest(url *url.URL, message *Message) (*Mes
 		return nil, err
 	}
 	if res != nil {
+		if res.StatusCode < 200 || res.StatusCode >= 300 {
+			// reject non-successful (2xx) responses
+			return nil, fmt.Errorf("unexpected HTTP response, expected 2xx, got %d", res.StatusCode)
+		}
 		headers := d.fromHTTPHeaders(res.Header)
 		// TODO: add configurable whitelisting of propagated headers/prefixes (configmap?)
 		if correlationID, ok := message.Headers[correlationIDHeaderName]; ok {


### PR DESCRIPTION
If a subscriber or reply request returns a non-2xx status code, the
message dispatcher should treat that response as an error. This allows
the bus to Nack delivery of the message for the subscribtion so that it
can be retried, assuming the bus is durable.

This behavior is important for message durability as right now messages
are dropped if the Subscriber returns an error. It's not uncommon to 
receive an error from Knative Serving when a function is scaling from zero
to one, and a retried request will succeed.

Fixes #432 

## Proposed Changes

* all non HTTP 2xx responses from the message dispatcher will result in error

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```