### PR TITLE
Adding GetCondition and patch merge to ClusterProvisionerStatus

### DIFF
--- a/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
@@ -75,7 +75,7 @@ var cProvCondSet = duck.NewLivingConditionSet()
 // ClusterProvisionerStatus is the status for a ClusterProvisioner resource
 type ClusterProvisionerStatus struct {
 	// Conditions holds the state of a cluster provisioner at a point in time.
-	Conditions duck.Conditions `json:"conditions,omitempty"`
+	Conditions duck.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// ObservedGeneration is the 'Generation' of the ClusterProvisioner that
 	// was last reconciled by the controller.
@@ -88,14 +88,9 @@ func (p *ClusterProvisioner) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(p.Spec)
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// ClusterProvisionerList is a list of ClusterProvisioner resources
-type ClusterProvisionerList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-
-	Items []ClusterProvisioner `json:"items"`
+// GetCondition returns the condition currently associated with the given type, or nil.
+func (p *ClusterProvisionerStatus) GetCondition(t duck.ConditionType) *duck.Condition {
+	return cProvCondSet.Manage(p).GetCondition(t)
 }
 
 // GetConditions returns the Conditions array. This enables generic handling of
@@ -108,4 +103,14 @@ func (ps *ClusterProvisionerStatus) GetConditions() duck.Conditions {
 // conditions by implementing the duck.Conditions interface.
 func (ps *ClusterProvisionerStatus) SetConditions(conditions duck.Conditions) {
 	ps.Conditions = conditions
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// ClusterProvisionerList is a list of ClusterProvisioner resources
+type ClusterProvisionerList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []ClusterProvisioner `json:"items"`
 }

--- a/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
@@ -22,7 +22,8 @@ import (
 
 	"encoding/json"
 	"github.com/knative/pkg/apis"
-	duck "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
 )
 
@@ -53,7 +54,10 @@ var _ runtime.Object = (*ClusterProvisioner)(nil)
 var _ webhook.GenericCRD = (*ClusterProvisioner)(nil)
 
 // Check that ConfigurationStatus may have its conditions managed.
-var _ duck.ConditionsAccessor = (*ClusterProvisionerStatus)(nil)
+var _ duckv1alpha1.ConditionsAccessor = (*ClusterProvisionerStatus)(nil)
+
+// Check that ClusterProvisioner implements the Conditions duck type.
+var _ = duck.VerifyType(&ClusterProvisioner{}, &duckv1alpha1.Conditions{})
 
 // ClusterProvisionerSpec is the spec for a ClusterProvisioner resource.
 type ClusterProvisionerSpec struct {
@@ -70,12 +74,12 @@ type ClusterProvisionerSpec struct {
 	Reconciles metav1.GroupKind `json:"reconciles"`
 }
 
-var cProvCondSet = duck.NewLivingConditionSet()
+var cProvCondSet = duckv1alpha1.NewLivingConditionSet()
 
 // ClusterProvisionerStatus is the status for a ClusterProvisioner resource
 type ClusterProvisionerStatus struct {
 	// Conditions holds the state of a cluster provisioner at a point in time.
-	Conditions duck.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// ObservedGeneration is the 'Generation' of the ClusterProvisioner that
 	// was last reconciled by the controller.
@@ -89,19 +93,19 @@ func (p *ClusterProvisioner) GetSpecJSON() ([]byte, error) {
 }
 
 // GetCondition returns the condition currently associated with the given type, or nil.
-func (p *ClusterProvisionerStatus) GetCondition(t duck.ConditionType) *duck.Condition {
+func (p *ClusterProvisionerStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {
 	return cProvCondSet.Manage(p).GetCondition(t)
 }
 
 // GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duck.Conditions interface.
-func (ps *ClusterProvisionerStatus) GetConditions() duck.Conditions {
+// conditions by implementing the duckv1alpha1.Conditions interface.
+func (ps *ClusterProvisionerStatus) GetConditions() duckv1alpha1.Conditions {
 	return ps.Conditions
 }
 
 // SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duck.Conditions interface.
-func (ps *ClusterProvisionerStatus) SetConditions(conditions duck.Conditions) {
+// conditions by implementing the duckv1alpha1.Conditions interface.
+func (ps *ClusterProvisionerStatus) SetConditions(conditions duckv1alpha1.Conditions) {
 	ps.Conditions = conditions
 }
 

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -20,7 +20,8 @@ import (
 	"encoding/json"
 
 	"github.com/knative/pkg/apis"
-	duck "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +50,10 @@ var _ runtime.Object = (*Subscription)(nil)
 var _ webhook.GenericCRD = (*Subscription)(nil)
 
 // Check that ConfigurationStatus may have its conditions managed.
-var _ duck.ConditionsAccessor = (*SubscriptionStatus)(nil)
+var _ duckv1alpha1.ConditionsAccessor = (*SubscriptionStatus)(nil)
+
+// Check that Subscription implements the Conditions duck type.
+var _ = duck.VerifyType(&Subscription{}, &duckv1alpha1.Conditions{})
 
 // SubscriptionSpec specifies the Channel for incoming events, a Call target for
 // processing those events and where to put the result of the processing. Only
@@ -163,14 +167,14 @@ type ResultStrategy struct {
 	Target *corev1.ObjectReference `json:"target,omitempty"`
 }
 
-var subCondSet = duck.NewLivingConditionSet()
+var subCondSet = duckv1alpha1.NewLivingConditionSet()
 
 // SubscriptionStatus (computed) for a subscription
 type SubscriptionStatus struct {
 	// Represents the latest available observations of a subscription's current state.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	Conditions duck.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // GetSpecJSON returns spec as json
@@ -179,19 +183,19 @@ func (s *Subscription) GetSpecJSON() ([]byte, error) {
 }
 
 // GetCondition returns the condition currently associated with the given type, or nil.
-func (ss *SubscriptionStatus) GetCondition(t duck.ConditionType) *duck.Condition {
+func (ss *SubscriptionStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {
 	return subCondSet.Manage(ss).GetCondition(t)
 }
 
 // GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duck.Conditions interface.
-func (ss *SubscriptionStatus) GetConditions() duck.Conditions {
+// conditions by implementing the duckv1alpha1.Conditions interface.
+func (ss *SubscriptionStatus) GetConditions() duckv1alpha1.Conditions {
 	return ss.Conditions
 }
 
 // SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duck.Conditions interface.
-func (ss *SubscriptionStatus) SetConditions(conditions duck.Conditions) {
+// conditions by implementing the duckv1alpha1.Conditions interface.
+func (ss *SubscriptionStatus) SetConditions(conditions duckv1alpha1.Conditions) {
 	ss.Conditions = conditions
 }
 

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -173,21 +173,14 @@ type SubscriptionStatus struct {
 	Conditions duck.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
-func (ss *SubscriptionStatus) GetCondition(t duck.ConditionType) *duck.Condition {
-	return subCondSet.Manage(ss).GetCondition(t)
-}
-
+// GetSpecJSON returns spec as json
 func (s *Subscription) GetSpecJSON() ([]byte, error) {
 	return json.Marshal(s.Spec)
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// SubscriptionList returned in list operations
-type SubscriptionList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
-	Items           []Subscription `json:"items"`
+// GetCondition returns the condition currently associated with the given type, or nil.
+func (ss *SubscriptionStatus) GetCondition(t duck.ConditionType) *duck.Condition {
+	return subCondSet.Manage(ss).GetCondition(t)
 }
 
 // GetConditions returns the Conditions array. This enables generic handling of
@@ -200,4 +193,13 @@ func (ss *SubscriptionStatus) GetConditions() duck.Conditions {
 // conditions by implementing the duck.Conditions interface.
 func (ss *SubscriptionStatus) SetConditions(conditions duck.Conditions) {
 	ss.Conditions = conditions
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// SubscriptionList returned in list operations
+type SubscriptionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []Subscription `json:"items"`
 }


### PR DESCRIPTION
Relates to https://github.com/knative/eventing/pull/434

## Proposed Changes

  * Adding GetCondition on ClusterProvisionerStatus
  * Adding `patchStrategy:"merge"` to `ClusterProvisionerStatus.Conditions`

**Release Note**
```release-note
None
```