### PR TITLE
Enforce all code dirs have tests

### DIFF
--- a/cmd/controller/stub_test.go
+++ b/cmd/controller/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/cmd/sendevent/stub_test.go
+++ b/cmd/sendevent/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/cmd/webhook/stub_test.go
+++ b/cmd/webhook/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/channels/logkey/stub_test.go
+++ b/pkg/apis/channels/logkey/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logkey
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/channels/stub_test.go
+++ b/pkg/apis/channels/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channels
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/eventing/logkey/stub_test.go
+++ b/pkg/apis/eventing/logkey/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logkey
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/eventing/stub_test.go
+++ b/pkg/apis/eventing/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventing
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/feeds/logkey/stub_test.go
+++ b/pkg/apis/feeds/logkey/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logkey
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/feeds/stub_test.go
+++ b/pkg/apis/feeds/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feeds
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/flows/logkey/stub_test.go
+++ b/pkg/apis/flows/logkey/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logkey
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/apis/flows/stub_test.go
+++ b/pkg/apis/flows/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flows
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/gcppubsub/dispatcher/stub_test.go
+++ b/pkg/buses/gcppubsub/dispatcher/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/gcppubsub/provisioner/stub_test.go
+++ b/pkg/buses/gcppubsub/provisioner/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/kafka/dispatcher/stub_test.go
+++ b/pkg/buses/kafka/dispatcher/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/kafka/provisioner/stub_test.go
+++ b/pkg/buses/kafka/provisioner/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/buses/stub/dispatcher/stub_test.go
+++ b/pkg/buses/stub/dispatcher/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/controller/testing/stub_test.go
+++ b/pkg/controller/testing/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/logconfig/stub_test.go
+++ b/pkg/logconfig/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logconfig
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}

--- a/pkg/system/stub_test.go
+++ b/pkg/system/stub_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import "testing"
+
+func TestStub(t *testing.T) {
+	// TODO: Implement tests in this directory, please.
+	// This file is used to make code coverage on this directly count.
+}


### PR DESCRIPTION
## Proposed Changes

  * In order to get accurate coverage results we attempt to always have a
_test.go file in directories with code. Add a test to enfoce this in CI
and add stub_tests.go to dirs which fail this test.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```