### PR TITLE
Remove mattmoor from eventing OWNERS.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,5 @@ approvers:
 - evankanderson
 - grantr
 - inlined
-- mattmoor
 - scothis
 - vaikas-google


### PR DESCRIPTION
This repo has sufficient OWNERS coverage now that I am generally not needed for `/approve`s.  Trying to reduce the noise :)