### PR TITLE
Generate unique, stable pubsub topic and subscription IDs

### DIFF
--- a/pkg/buses/gcppubsub/dispatcher/main.go
+++ b/pkg/buses/gcppubsub/dispatcher/main.go
@@ -35,6 +35,7 @@ func main() {
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
+	busUID := os.Getenv("BUS_UID")
 
 	config := buses.NewLoggingConfig()
 	logger := buses.NewBusLoggerFromConfig(config)
@@ -58,7 +59,7 @@ func main() {
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.Parse()
 
-	bus, err := gcppubsub.NewCloudPubSubBusDispatcher(ref, projectID, opts)
+	bus, err := gcppubsub.NewCloudPubSubBusDispatcher(ref, busUID, projectID, opts)
 	if err != nil {
 		logger.Fatalf("Error starting pub/sub bus dispatcher: %v", err)
 	}

--- a/pkg/buses/gcppubsub/provisioner/main.go
+++ b/pkg/buses/gcppubsub/provisioner/main.go
@@ -35,6 +35,7 @@ func main() {
 		os.Getenv("BUS_NAME"),
 		os.Getenv("BUS_NAMESPACE"),
 	)
+	busUID := os.Getenv("BUS_UID")
 
 	config := buses.NewLoggingConfig()
 	logger := buses.NewBusLoggerFromConfig(config)
@@ -51,13 +52,14 @@ func main() {
 	}
 
 	opts := &buses.BusOpts{
-		Logger: logger}
+		Logger: logger,
+	}
 
 	flag.StringVar(&opts.KubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&opts.MasterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.Parse()
 
-	bus, err := gcppubsub.NewCloudPubSubBusProvisioner(ref, projectID, opts)
+	bus, err := gcppubsub.NewCloudPubSubBusProvisioner(ref, busUID, projectID, opts)
 	if err != nil {
 		logger.Fatalf("Error starting pub/sub bus provisioner: %v", err)
 	}

--- a/pkg/controller/bus/controller.go
+++ b/pkg/controller/bus/controller.go
@@ -634,6 +634,10 @@ func newDispatcherDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 			Name:  "BUS_NAME",
 			Value: bus.Name,
 		},
+		corev1.EnvVar{
+			Name:  "BUS_UID",
+			Value: string(bus.UID),
+		},
 	)
 	volumes := []corev1.Volume{}
 	if bus.Spec.Volumes != nil {
@@ -690,6 +694,10 @@ func newProvisionerDeployment(bus *channelsv1alpha1.Bus) *appsv1.Deployment {
 		corev1.EnvVar{
 			Name:  "BUS_NAME",
 			Value: bus.Name,
+		},
+		corev1.EnvVar{
+			Name:  "BUS_UID",
+			Value: string(bus.UID),
 		},
 	)
 	volumes := []corev1.Volume{}

--- a/pkg/controller/clusterbus/controller.go
+++ b/pkg/controller/clusterbus/controller.go
@@ -556,6 +556,10 @@ func newDispatcherDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.De
 			Name:  "BUS_NAME",
 			Value: clusterBus.Name,
 		},
+		corev1.EnvVar{
+			Name:  "BUS_UID",
+			Value: string(clusterBus.UID),
+		},
 	)
 	volumes := []corev1.Volume{}
 	if clusterBus.Spec.Volumes != nil {
@@ -608,6 +612,10 @@ func newProvisionerDeployment(clusterBus *channelsv1alpha1.ClusterBus) *appsv1.D
 		corev1.EnvVar{
 			Name:  "BUS_NAME",
 			Value: clusterBus.Name,
+		},
+		corev1.EnvVar{
+			Name:  "BUS_UID",
+			Value: string(clusterBus.UID),
 		},
 	)
 	volumes := []corev1.Volume{}


### PR DESCRIPTION
With the gcppubsub bus it was possible to create conflicting topics and
subscription if two (or more) clusters used the same Bus, Channel and
Subscription names. This would result in the misdelivery of messages
between the clusters.

Now the UID of the Bus/ClusterBus that owns the topic/subscription is a
factor in the identifier. The Bus UID will be stable durring The
lifetime of the Bus, but unique between individual resources.

Fixes #253

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```