### PR TITLE
Subscription controller tweaks

### DIFF
--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -157,6 +157,8 @@ type Callable struct {
 	TargetURI *string `json:"targetURI,omitempty"`
 }
 
+// ResultStrategy specifies the handling of the Callable's returned result. If
+// no Callable is specified, the identity function is assumed.
 type ResultStrategy struct {
 	// This object must fulfill the Sinkable contract.
 	//
@@ -188,7 +190,7 @@ const (
 	// SubscriptionConditionReady has status True when all subconditions below have been set to True.
 	SubscriptionConditionReady = duckv1alpha1.ConditionReady
 
-	// SubscriptionReferencesResolved has status True when all the specified references have been successfully
+	// SubscriptionConditionReferencesResolved has status True when all the specified references have been successfully
 	// resolved.
 	SubscriptionConditionReferencesResolved duckv1alpha1.ConditionType = "Resolved"
 

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -172,7 +172,9 @@ type ResultStrategy struct {
 	Target *corev1.ObjectReference `json:"target,omitempty"`
 }
 
-var subCondSet = duckv1alpha1.NewLivingConditionSet()
+// subCondSet is a condition set with Ready as the happy condition and
+// ReferencesResolved and FromReady as the dependent conditions.
+var subCondSet = duckv1alpha1.NewLivingConditionSet(SubscriptionConditionReferencesResolved, SubscriptionConditionFromReady)
 
 // SubscriptionStatus (computed) for a subscription
 type SubscriptionStatus struct {
@@ -213,6 +215,26 @@ func (ss *SubscriptionStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1
 // conditions by implementing the duckv1alpha1.Conditions interface.
 func (ss *SubscriptionStatus) GetConditions() duckv1alpha1.Conditions {
 	return ss.Conditions
+}
+
+// IsReady returns true if the resource is ready overall.
+func (ss *SubscriptionStatus) IsReady() bool {
+	return subCondSet.Manage(ss).IsHappy()
+}
+
+// InitializeConditions sets relevant unset conditions to Unknown state.
+func (ss *SubscriptionStatus) InitializeConditions() {
+	subCondSet.Manage(ss).InitializeConditions()
+}
+
+// MarkReferencesResolved sets the ReferencesResolved condition to True state.
+func (ss *SubscriptionStatus) MarkReferencesResolved() {
+	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionReferencesResolved)
+}
+
+// MarkFromReady sets the FromReady condition to True state.
+func (ss *SubscriptionStatus) MarkFromReady() {
+	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionFromReady)
 }
 
 // SetConditions sets the Conditions array. This enables generic handling of

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -17,8 +17,6 @@
 package v1alpha1
 
 import (
-	"encoding/json"
-
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -54,6 +52,10 @@ var _ duckv1alpha1.ConditionsAccessor = (*SubscriptionStatus)(nil)
 
 // Check that Subscription implements the Conditions duck type.
 var _ = duck.VerifyType(&Subscription{}, &duckv1alpha1.Conditions{})
+
+// Check that the Subscription implements the Generation duck type.
+var emptyGen duckv1alpha1.Generation
+var _ = duck.VerifyType(&Subscription{}, &emptyGen)
 
 // And it's Subscribable
 var _ = duck.VerifyType(&Subscription{}, &duckv1alpha1.Subscribable{})
@@ -200,11 +202,6 @@ const (
 	// resource.
 	SubscriptionConditionFromReady duckv1alpha1.ConditionType = "FromReady"
 )
-
-// GetSpecJSON returns spec as json
-func (s *Subscription) GetSpecJSON() ([]byte, error) {
-	return json.Marshal(s.Spec)
-}
 
 // GetCondition returns the condition currently associated with the given type, or nil.
 func (ss *SubscriptionStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {

--- a/pkg/apis/eventing/v1alpha1/subscription_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types_test.go
@@ -225,32 +225,3 @@ func TestSubscriptionSetConditions(t *testing.T) {
 		t.Errorf("unexpected conditions (-want, +got) = %v", diff)
 	}
 }
-
-func TestSubscriptionGetSpecJSON(t *testing.T) {
-	targetURI := "http://example.com"
-	c := &Subscription{
-		Spec: SubscriptionSpec{
-			From: corev1.ObjectReference{
-				Name: "foo",
-			},
-			Call: &Callable{
-				TargetURI: &targetURI,
-			},
-			Result: &ResultStrategy{
-				Target: &corev1.ObjectReference{
-					Name: "result",
-				},
-			},
-		},
-	}
-
-	want := `{"from":{"name":"foo"},"call":{"targetURI":"http://example.com"},"result":{"target":{"name":"result"}}}`
-	got, err := c.GetSpecJSON()
-	if err != nil {
-		t.Fatalf("unexpected spec JSON error: %v", err)
-	}
-
-	if diff := cmp.Diff(want, string(got)); diff != "" {
-		t.Errorf("unexpected spec JSON (-want, +got) = %v", diff)
-	}
-}

--- a/pkg/apis/eventing/v1alpha1/subscription_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types_test.go
@@ -42,12 +42,12 @@ var subscriptionConditionFromReady = duckv1alpha1.Condition{
 func TestSubscriptionGetCondition(t *testing.T) {
 	tests := []struct {
 		name      string
-		cs        *SubscriptionStatus
+		ss        *SubscriptionStatus
 		condQuery duckv1alpha1.ConditionType
 		want      *duckv1alpha1.Condition
 	}{{
 		name: "single condition",
-		cs: &SubscriptionStatus{
+		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{
 				subscriptionConditionReady,
 			},
@@ -56,7 +56,7 @@ func TestSubscriptionGetCondition(t *testing.T) {
 		want:      &subscriptionConditionReady,
 	}, {
 		name: "multiple conditions",
-		cs: &SubscriptionStatus{
+		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{
 				subscriptionConditionReady,
 				subscriptionConditionReferencesResolved,
@@ -66,7 +66,7 @@ func TestSubscriptionGetCondition(t *testing.T) {
 		want:      &subscriptionConditionReferencesResolved,
 	}, {
 		name: "multiple conditions, condition true",
-		cs: &SubscriptionStatus{
+		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{
 				subscriptionConditionReady,
 				subscriptionConditionFromReady,
@@ -76,7 +76,7 @@ func TestSubscriptionGetCondition(t *testing.T) {
 		want:      &subscriptionConditionFromReady,
 	}, {
 		name: "unknown condition",
-		cs: &SubscriptionStatus{
+		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{
 				subscriptionConditionReady,
 				subscriptionConditionReferencesResolved,
@@ -88,7 +88,7 @@ func TestSubscriptionGetCondition(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.cs.GetCondition(test.condQuery)
+			got := test.ss.GetCondition(test.condQuery)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("unexpected condition (-want, +got) = %v", diff)
 			}

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -78,9 +78,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 }
 
 func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
-	// TODO: Should this just also set up a defer call for subscription.SetConditions.
-	// No time right now as I'm turning into a pumpking but seems reasonable.
-	conditions := []duckv1alpha1.Condition{}
+	subscription.Status.InitializeConditions()
 
 	// See if the subscription has been deleted
 	accessor, err := meta.Accessor(subscription)
@@ -130,10 +128,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	}
 
 	// Everything that was supposed to be resolved was, so flip the status bit on that.
-	conditions = append(conditions, duckv1alpha1.Condition{
-		Type:   v1alpha1.SubscriptionConditionReferencesResolved,
-		Status: corev1.ConditionTrue,
-	})
+	subscription.Status.MarkReferencesResolved()
 
 	// Ok, now that we have the From and at least one of the Call/Result, let's reconcile
 	// the From with this information.
@@ -143,11 +138,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		return err
 	}
 	// Everything went well, set the fact that subscriptions have been modified
-	conditions = append(conditions, duckv1alpha1.Condition{
-		Type:   duckv1alpha1.ConditionReady,
-		Status: corev1.ConditionTrue,
-	})
-	subscription.Status.SetConditions(conditions)
+	subscription.Status.MarkFromReady()
 	return nil
 }
 

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -234,9 +234,10 @@ var testCases = []controllertesting.TestCase{
 			// TODO: Again this works on gke cluster, but I need to set
 			// something else up here. later...
 			// getNewSubscriptionWithReferencesResolvedStatus(),
-			getNewSubscription(),
+			getNewSubscriptionWithUnknownConditions(),
 		},
-		Scheme: scheme.Scheme,
+		IgnoreTimes: true,
+		Scheme:      scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -412,15 +413,6 @@ func getNewChannel(name string) *eventingv1alpha1.Channel {
 	return channel
 }
 
-func getNewSubscriptionWithReferencesResolvedStatus() *eventingv1alpha1.Subscription {
-	s := getNewSubscription()
-	s.Status.SetConditions([]duckv1alpha1.Condition{{
-		Type:   eventingv1alpha1.SubscriptionConditionReferencesResolved,
-		Status: corev1.ConditionTrue,
-	}})
-	return s
-}
-
 func getNewSubscription() *eventingv1alpha1.Subscription {
 	subscription := &eventingv1alpha1.Subscription{
 		TypeMeta:   subscriptionType(),
@@ -452,6 +444,18 @@ func getNewSubscription() *eventingv1alpha1.Subscription {
 	// selflink is not filled in when we create the object, so clear it
 	subscription.ObjectMeta.SelfLink = ""
 	return subscription
+}
+
+func getNewSubscriptionWithUnknownConditions() *eventingv1alpha1.Subscription {
+	s := getNewSubscription()
+	s.Status.InitializeConditions()
+	return s
+}
+
+func getNewSubscriptionWithReferencesResolvedStatus() *eventingv1alpha1.Subscription {
+	s := getNewSubscriptionWithUnknownConditions()
+	s.Status.MarkReferencesResolved()
+	return s
 }
 
 func channelType() metav1.TypeMeta {

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -113,9 +113,8 @@ func (tc *TestCase) Runner(t *testing.T, r reconcile.Reconciler, c *MockClient) 
 func (tc *TestCase) GetDynamicClient() dynamic.Interface {
 	if tc.Scheme == nil {
 		return dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), tc.Objects...)
-	} else {
-		return dynamicfake.NewSimpleDynamicClient(tc.Scheme, tc.Objects...)
 	}
+	return dynamicfake.NewSimpleDynamicClient(tc.Scheme, tc.Objects...)
 }
 
 // GetClient returns the mockClient to use for this test case.


### PR DESCRIPTION
Followup tweaks to #437 as suggested by @n3wscott:

- Add `IsReady` and `Mark*` functions to manage conditions easily
- Remove `GetSpecJSON` and use `duck.Generation` instead
