### PR TITLE
Source kind should be singular in CRD spec

### DIFF
--- a/config/300-source.yaml
+++ b/config/300-source.yaml
@@ -19,7 +19,7 @@ spec:
   group: eventing.knative.dev
   version: v1alpha1
   names:
-    kind: Sources
+    kind: Source
     plural: sources
     singular: source
     categories:


### PR DESCRIPTION
## Proposed Changes

A typo here makes sources impossible to create because the webhook
expects them to be called Source.

/assign @n3wscott 