### PR TITLE
Move the use of `VerifyType` in tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -268,7 +268,7 @@
   revision = "5c1d8c8469d1ed34b2aecf4c2305b3a57fff2ee3"
 
 [[projects]]
-  digest = "1:15f50d3f3d3a5e0a5bea6b81018a2fc681b400dc2d9d85a84764ed7c91516541"
+  digest = "1:3032bf41e1ec7fe0093c6db659b3cf202ef528c421c26376a7fe209467a9fd74"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -298,7 +298,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "07104dad53e803457a95306e5b1322024bd69af3"
+  revision = "3155feb33006c8e0379a58237a819a36fae98c2d"
 
 [[projects]]
   digest = "1:63f3974f3afe3dc5b6a115c0d53b0897cd01be6880c4bf5d014fc69a95db6ed1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,10 +73,10 @@ required = [
   name = "cloud.google.com/go"
   revision = "90f2606161ee6a14efe2ca79fc05ac2b8efe250b"
 
-[[constraint]]
+[[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2018-09-25
-  revision = "07104dad53e803457a95306e5b1322024bd69af3"
+  # HEAD as of 2018-09-28
+  revision = "3155feb33006c8e0379a58237a819a36fae98c2d"
 
 [[constraint]]
   name = "github.com/knative/serving"

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,12 +51,6 @@ var _ apis.Defaultable = (*Channel)(nil)
 var _ apis.Immutable = (*Channel)(nil)
 var _ runtime.Object = (*Channel)(nil)
 var _ webhook.GenericCRD = (*Channel)(nil)
-
-// Check that Channel implements the Conditions duck type.
-var _ = duck.VerifyType(&Channel{}, &duckv1alpha1.Conditions{})
-var _ = duck.VerifyType(&Channel{}, &duckv1alpha1.Channelable{})
-var _ = duck.VerifyType(&Channel{}, &duckv1alpha1.Subscribable{})
-var _ = duck.VerifyType(&Channel{}, &duckv1alpha1.Sinkable{})
 
 // ChannelSpec specifies the Provisioner backing a channel and the configuration
 // arguments for a Channel.

--- a/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_provisioner_types.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
 )
@@ -51,9 +50,6 @@ var _ apis.Validatable = (*ClusterProvisioner)(nil)
 var _ apis.Defaultable = (*ClusterProvisioner)(nil)
 var _ runtime.Object = (*ClusterProvisioner)(nil)
 var _ webhook.GenericCRD = (*ClusterProvisioner)(nil)
-
-// Check that ClusterProvisioner implements the Conditions duck type.
-var _ = duck.VerifyType(&ClusterProvisioner{}, &duckv1alpha1.Conditions{})
 
 // ClusterProvisionerSpec is the spec for a ClusterProvisioner resource.
 type ClusterProvisionerSpec struct {

--- a/pkg/apis/eventing/v1alpha1/implements_test.go
+++ b/pkg/apis/eventing/v1alpha1/implements_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Knative Authors
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/apis/duck"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+)
+
+func TestTypesImplements(t *testing.T) {
+	var emptyGen duckv1alpha1.Generation
+	testCases := []struct {
+		instance interface{}
+		iface    duck.Implementable
+	}{
+		// Channel
+		{instance: &Channel{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Channel{}, iface: &duckv1alpha1.Channelable{}},
+		{instance: &Channel{}, iface: &duckv1alpha1.Subscribable{}},
+		{instance: &Channel{}, iface: &duckv1alpha1.Sinkable{}},
+		// ClusterProvisioner
+		{instance: &ClusterProvisioner{}, iface: &duckv1alpha1.Conditions{}},
+		// Subscription
+		{instance: &Subscription{}, iface: &duckv1alpha1.Conditions{}},
+		{instance: &Subscription{}, iface: &emptyGen},
+		{instance: &Subscription{}, iface: &duckv1alpha1.Subscribable{}},
+	}
+	for _, tc := range testCases {
+		if err := duck.VerifyType(tc.instance, tc.iface); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
@@ -46,16 +45,6 @@ var _ apis.Defaultable = (*Subscription)(nil)
 var _ apis.Immutable = (*Subscription)(nil)
 var _ runtime.Object = (*Subscription)(nil)
 var _ webhook.GenericCRD = (*Subscription)(nil)
-
-// Check that Subscription implements the Conditions duck type.
-var _ = duck.VerifyType(&Subscription{}, &duckv1alpha1.Conditions{})
-
-// Check that the Subscription implements the Generation duck type.
-var emptyGen duckv1alpha1.Generation
-var _ = duck.VerifyType(&Subscription{}, &emptyGen)
-
-// And it's Subscribable
-var _ = duck.VerifyType(&Subscription{}, &duckv1alpha1.Subscribable{})
 
 // SubscriptionSpec specifies the Channel for incoming events, a Call target for
 // processing those events and where to put the result of the processing. Only

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/channelable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/channelable_types.go
@@ -43,8 +43,6 @@ type ChannelSubscriberSpec struct {
 	SinkableDomain string `json:"sinkableDomain,omitempty"`
 }
 
-// Implementations can verify that they implement Channelable via:
-var _ = duck.VerifyType(&Channel{}, &Channelable{})
 
 // Channelable is an Implementable "duck type".
 var _ duck.Implementable = (*Channelable)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -93,8 +93,6 @@ func (c *Condition) IsUnknown() bool {
 	return c.Status == corev1.ConditionUnknown
 }
 
-// Implementations can verify that they implement Conditions via:
-var _ = duck.VerifyType(&KResource{}, &Conditions{})
 
 // Conditions is an Implementable "duck type".
 var _ duck.Implementable = (*Conditions)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
@@ -27,9 +27,6 @@ import (
 // Generation is the schema for the generational portion of the payload
 type Generation int64
 
-// Implementations can verify that they implement Generation via:
-var emptyGen Generation
-var _ = duck.VerifyType(&Generational{}, &emptyGen)
 
 // Generation is an Implementable "duck type".
 var _ duck.Implementable = (*Generation)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
@@ -41,8 +41,6 @@ type LegacyTargetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-// Implementations can verify that they implement LegacyTargetable via:
-var _ = duck.VerifyType(&LegacyTarget{}, &LegacyTargetable{})
 
 // LegacyTargetable is an Implementable "duck type".
 var _ duck.Implementable = (*LegacyTargetable)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/sinkable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/sinkable_types.go
@@ -33,8 +33,6 @@ type Sinkable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-// Implementations can verify that they implement Sinkable via:
-var _ = duck.VerifyType(&Sink{}, &Sinkable{})
 
 // Sinkable is an Implementable "duck type".
 var _ duck.Implementable = (*Sinkable)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -36,8 +36,6 @@ type Subscribable struct {
 	Channelable corev1.ObjectReference `json:"channelable,omitempty"`
 }
 
-// Implementations can verify that they implement Subscribable via:
-var _ = duck.VerifyType(&Subscription{}, &Subscribable{})
 
 // Subscribable is an Implementable "duck type".
 var _ duck.Implementable = (*Subscribable)(nil)

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/targetable_types.go
@@ -33,8 +33,6 @@ type Targetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-// Implementations can verify that they implement Targetable via:
-var _ = duck.VerifyType(&Target{}, &Targetable{})
 
 // Targetable is an Implementable "duck type".
 var _ duck.Implementable = (*Targetable)(nil)

--- a/vendor/github.com/knative/pkg/webhook/webhook.go
+++ b/vendor/github.com/knative/pkg/webhook/webhook.go
@@ -275,7 +275,9 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) error {
 	for _, crd := range ac.Handlers {
 		cp := crd.DeepCopyObject()
 		var emptyGen duckv1alpha1.Generation
-		duck.VerifyType(cp, &emptyGen)
+		if err := duck.VerifyType(cp, &emptyGen); err != nil {
+			return err
+		}
 	}
 
 	select {


### PR DESCRIPTION
This is part of knative/pkg#97 (not closing it as there will be PRs on `serving`, `eventing` and `build` to follow :wink:)

## Proposed Changes

Those calls to `duck.VerifyType` are done at runtime and thus could be
costly at program startup. Putting them under tests ensure we still
assert those types but during unit testing.

This bumps `knative/pkg` to today's master 

cc @dprotaso @mattmoor 
