### PR TITLE
switch from legacytarget to target

### DIFF
--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -172,7 +172,7 @@ func (r *reconciler) resolveCall(namespace string, callable v1alpha1.Callable) (
 		glog.Warningf("Failed to fetch Callable target %+v: %s", callable.Target, err)
 		return "", err
 	}
-	t := duckv1alpha1.LegacyTarget{}
+	t := duckv1alpha1.Target{}
 	// Once Knative services support Targetable, switch to using this.
 	//t := duckv1alpha1.Target{}
 	err = duck.FromUnstructured(obj, &t)
@@ -181,12 +181,10 @@ func (r *reconciler) resolveCall(namespace string, callable v1alpha1.Callable) (
 		return "", err
 	}
 
-	return t.Status.DomainInternal, nil
-	// Once Knative services support Targetable, switch to using this
-	// 	if t.Status.Targetable != nil {
-	//		return t.Status.Targetable.DomainInternal, nil
-	//	}
-	//return "", fmt.Errorf("status does not contain targetable")
+	if t.Status.Targetable != nil {
+		return t.Status.Targetable.DomainInternal, nil
+	}
+	return "", fmt.Errorf("status does not contain targetable")
 }
 
 // resolveResult resolves the Spec.Result object.

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -139,7 +139,7 @@ var testCases = []controllertesting.TestCase{
 			getNewSubscription(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, subscriptionName),
-		WantErrMsg:   "could not get domain from call (is it not targetable?)",
+		WantErrMsg:   "status does not contain targetable",
 		Scheme:       scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
@@ -219,7 +219,9 @@ var testCases = []controllertesting.TestCase{
 						"name":      routeName,
 					},
 					"status": map[string]interface{}{
-						"domainInternal": targetDNS,
+						"targetable": map[string]interface{}{
+							"domainInternal": targetDNS,
+						},
 					},
 				}},
 		},
@@ -271,7 +273,9 @@ var testCases = []controllertesting.TestCase{
 						"name":      routeName,
 					},
 					"status": map[string]interface{}{
-						"domainInternal": targetDNS,
+						"targetable": map[string]interface{}{
+							"domainInternal": targetDNS,
+						},
 					},
 				}},
 			// Result channel
@@ -343,7 +347,9 @@ var testCases = []controllertesting.TestCase{
 						"name":      routeName,
 					},
 					"status": map[string]interface{}{
-						"domainInternal": targetDNS,
+						"targetable": map[string]interface{}{
+							"domainInternal": targetDNS,
+						},
 					},
 				}},
 			// Result channel


### PR DESCRIPTION

## Proposed Changes

  * Use Target instead of LegacyTarget since serving now supports it as per:
https://github.com/knative/serving/pull/2068
