### PR TITLE
Add a test for creating a subscription to a Source that resolves then…

### DIFF
--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -96,7 +96,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		return fmt.Errorf("from is not subscribable %s %s/%s", subscription.Spec.From.Kind, subscription.Namespace, subscription.Spec.From.Name)
 	}
 
-	glog.Infof("Resolved from subscricable to: %+v", from.Status.Subscribable.Channelable)
+	glog.Infof("Resolved from subscribable to: %+v", from.Status.Subscribable.Channelable)
 
 	callDomain := ""
 	if subscription.Spec.Call != nil {

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -96,6 +96,8 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		return fmt.Errorf("from is not subscribable %s %s/%s", subscription.Spec.From.Kind, subscription.Namespace, subscription.Spec.From.Name)
 	}
 
+	glog.Infof("Resolved from subscricable to: %+v", from.Status.Subscribable.Channelable)
+
 	callDomain := ""
 	if subscription.Spec.Call != nil {
 		callDomain, err = r.resolveCall(subscription.Namespace, *subscription.Spec.Call)

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -41,9 +41,11 @@ var (
 const (
 	fromChannelName   = "fromchannel"
 	resultChannelName = "resultchannel"
+	sourceName        = "source"
 	routeName         = "callroute"
-	ChannelKind       = "Channel"
+	channelKind       = "Channel"
 	routeKind         = "Route"
+	sourceKind        = "Source"
 	targetDNS         = "myfunction.mynamespace.svc.cluster.local"
 	sinkableDNS       = "myresultchannel.mynamespace.svc.cluster.local"
 	eventType         = "myeventtype"
@@ -82,7 +84,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -93,7 +95,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"notsubscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -114,7 +116,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -125,7 +127,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -146,7 +148,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -157,7 +159,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -191,7 +193,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -202,7 +204,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -245,7 +247,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -256,7 +258,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -282,7 +284,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      resultChannelName,
@@ -293,7 +295,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -319,7 +321,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      fromChannelName,
@@ -330,7 +332,7 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -356,7 +358,7 @@ var testCases = []controllertesting.TestCase{
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
-					"kind":       ChannelKind,
+					"kind":       channelKind,
 					"metadata": map[string]interface{}{
 						"namespace": testNS,
 						"name":      resultChannelName,
@@ -367,7 +369,104 @@ var testCases = []controllertesting.TestCase{
 					"status": map[string]interface{}{
 						"subscribable": map[string]interface{}{
 							"channelable": map[string]interface{}{
-								"kind":       ChannelKind,
+								"kind":       channelKind,
+								"name":       fromChannelName,
+								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+							},
+						},
+						"sinkable": map[string]interface{}{
+							"domainInternal": sinkableDNS,
+						},
+					},
+				}},
+		},
+	}, {
+		Name: "new subscription with source: adds status, all targets resolved, subscribers modified",
+		InitialState: []runtime.Object{
+			getNewSubscriptionWithSource(),
+		},
+		ReconcileKey: fmt.Sprintf("%s/%s", testNS, subscriptionName),
+		// TODO: JSON patch is not working for some reason. Is this the array vs. non-array, or
+		// k8s accepting something the fake doesn't, or is there a real bug somewhere?
+		// it works correctly on the k8s cluster. so need to figure this out
+		// Marking this as expecting a failure. Needs to be fixed obviously.
+		WantResult: reconcile.Result{},
+		WantErrMsg: "invalid JSON document",
+		Scheme:     scheme.Scheme,
+		Objects: []runtime.Object{
+			// Source with a reference to the From Channel
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+					"kind":       sourceKind,
+					"metadata": map[string]interface{}{
+						"namespace": testNS,
+						"name":      sourceName,
+					},
+					"spec": map[string]interface{}{
+						"channelable": map[string]interface{}{},
+					},
+					"status": map[string]interface{}{
+						"subscribable": map[string]interface{}{
+							"channelable": map[string]interface{}{
+								"kind":       channelKind,
+								"name":       fromChannelName,
+								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+							},
+						},
+					},
+				}},
+			// Source channel
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+					"kind":       channelKind,
+					"metadata": map[string]interface{}{
+						"namespace": testNS,
+						"name":      fromChannelName,
+					},
+					"spec": map[string]interface{}{
+						"channelable": map[string]interface{}{},
+					},
+					"status": map[string]interface{}{
+						"subscribable": map[string]interface{}{
+							"channelable": map[string]interface{}{
+								"kind":       channelKind,
+								"name":       fromChannelName,
+								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+							},
+						},
+					},
+				}},
+			// Call (using knative route)
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "serving.knative.dev/v1alpha1",
+					"kind":       routeKind,
+					"metadata": map[string]interface{}{
+						"namespace": testNS,
+						"name":      routeName,
+					},
+					"status": map[string]interface{}{
+						"domainInternal": targetDNS,
+					},
+				}},
+			// Result channel
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
+					"kind":       channelKind,
+					"metadata": map[string]interface{}{
+						"namespace": testNS,
+						"name":      resultChannelName,
+					},
+					"spec": map[string]interface{}{
+						"channelable": map[string]interface{}{},
+					},
+					"status": map[string]interface{}{
+						"subscribable": map[string]interface{}{
+							"channelable": map[string]interface{}{
+								"kind":       channelKind,
 								"name":       fromChannelName,
 								"apiVersion": eventingv1alpha1.SchemeGroupVersion.String(),
 							},
@@ -426,7 +525,7 @@ func getNewSubscription() *eventingv1alpha1.Subscription {
 		Spec: eventingv1alpha1.SubscriptionSpec{
 			From: corev1.ObjectReference{
 				Name:       fromChannelName,
-				Kind:       ChannelKind,
+				Kind:       channelKind,
 				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
 			},
 			Call: &eventingv1alpha1.Callable{
@@ -439,7 +538,40 @@ func getNewSubscription() *eventingv1alpha1.Subscription {
 			Result: &eventingv1alpha1.ResultStrategy{
 				Target: &corev1.ObjectReference{
 					Name:       resultChannelName,
-					Kind:       ChannelKind,
+					Kind:       channelKind,
+					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+				},
+			},
+		},
+	}
+	subscription.ObjectMeta.OwnerReferences = append(subscription.ObjectMeta.OwnerReferences, getOwnerReference(false))
+
+	// selflink is not filled in when we create the object, so clear it
+	subscription.ObjectMeta.SelfLink = ""
+	return subscription
+}
+
+func getNewSubscriptionWithSource() *eventingv1alpha1.Subscription {
+	subscription := &eventingv1alpha1.Subscription{
+		TypeMeta:   subscriptionType(),
+		ObjectMeta: om(testNS, subscriptionName),
+		Spec: eventingv1alpha1.SubscriptionSpec{
+			From: corev1.ObjectReference{
+				Name:       sourceName,
+				Kind:       sourceKind,
+				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+			},
+			Call: &eventingv1alpha1.Callable{
+				Target: &corev1.ObjectReference{
+					Name:       routeName,
+					Kind:       routeKind,
+					APIVersion: "serving.knative.dev/v1alpha1",
+				},
+			},
+			Result: &eventingv1alpha1.ResultStrategy{
+				Target: &corev1.ObjectReference{
+					Name:       resultChannelName,
+					Kind:       channelKind,
 					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
 				},
 			},

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -448,7 +448,9 @@ var testCases = []controllertesting.TestCase{
 						"name":      routeName,
 					},
 					"status": map[string]interface{}{
-						"domainInternal": targetDNS,
+						"targetable": map[string]interface{}{
+							"domainInternal": targetDNS,
+						},
 					},
 				}},
 			// Result channel


### PR DESCRIPTION
… into a channel backing it

Fixes #

## Proposed Changes

  * Add a test case where the Subscription is using Source as From demonstrating expected behaviour there.
  * change const ChannelKind to channelKind for consistency with other consts.
  *
