### PR TITLE
Added instructions for setting default cluster-bus

### DIFF
--- a/config/buses/gcppubsub/README.md
+++ b/config/buses/gcppubsub/README.md
@@ -7,6 +7,12 @@ Deployment steps:
 1. Configure the bus, replacing `$PROJECT_ID` with your GCP Project ID, `kubectl -n knative-eventing create configmap gcppubsub-bus-config --from-literal=GOOGLE_CLOUD_PROJECT=$PROJECT_ID`
 1. For cluster wide deployment, change the kind in `config/buses/gcppubsub/gcppubsub-bus.yaml` from `Bus` to `ClusterBus`.
 1. Apply the 'gcppubsub' Bus `ko apply -f config/buses/gcppubsub/`
+1. If you want to set the default Knative Bus to GCP Cloud Pub/Sub run the following command to edit the Knative Eventing configuration (requires the above change in kind from `Bus` to `ClusterBus`):
+    ```shell
+    kubectl get cm flow-controller-config -n knative-eventing -oyaml  \
+    | sed -e 's/default-cluster-bus: stub/  default-cluster-bus: gcppubsub/' \
+    | kubectl replace -f -
+    ```
 1. Create Channels that reference the 'gcppubsub' Bus
 1. (Optional) Install [Kail](https://github.com/boz/kail) - Kubernetes tail
 

--- a/config/buses/kafka/README.md
+++ b/config/buses/kafka/README.md
@@ -2,12 +2,6 @@
 
 Deployment steps:
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md)
-1. If you want to set the default Knative Bus to Kafka run the following command to edit the Knative Eventing configuration:
-    ```shell
-    kubectl get cm flow-controller-config -n knative-eventing -oyaml  \
-    | sed -e 's/stub/kafka/' \
-    | kubectl replace -f -
-    ```
 1. Install a Kafka broker. A simple setup is provided:
     ```
     kubectl create namespace kafka
@@ -21,6 +15,12 @@ Deployment steps:
 1. Apply the Kafka Bus:
     ```
     ko apply -f config/buses/kafka/
+    ```
+1. If you want to set the default Knative Bus to Kafka run the following command to edit the Knative Eventing configuration (requires the above change in kind from `Bus` to `ClusterBus`):
+    ```shell
+    kubectl get cm flow-controller-config -n knative-eventing -oyaml  \
+    | sed -e 's/default-cluster-bus: stub/  default-cluster-bus: kafka/' \
+    | kubectl replace -f -
     ```
 1. Create Channels that reference the 'kafka' Bus
 1. (Optional) Install [Kail](https://github.com/boz/kail) - Kubernetes tail

--- a/config/buses/kafka/README.md
+++ b/config/buses/kafka/README.md
@@ -2,6 +2,12 @@
 
 Deployment steps:
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md)
+1. If you want to set the default Knative Bus to Kafka run the following command to edit the Knative Eventing configuration:
+    ```shell
+    kubectl get cm flow-controller-config -n knative-eventing -oyaml  \
+    | sed -e 's/stub/kafka/' \
+    | kubectl replace -f -
+    ```
 1. Install a Kafka broker. A simple setup is provided:
     ```
     kubectl create namespace kafka


### PR DESCRIPTION
## Proposed Changes

  * Minor fix to instructions for installing Kafka Cluster Bus. Edits ConfigMap to set default Cluster Bus to Kafka

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```