### PR TITLE
Fix logging typo in e2e-tests.sh

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -77,7 +77,7 @@ function publish_test_images() {
       ko publish -P $IMAGE
       local IMAGE=$KO_DOCKER_REPO/$IMAGE
       local DIGEST=$(gcloud container images list-tags --filter="tags:latest" --format='get(digest)' $IMAGE)
-      echo "Tagging $IMAGE:$DIGEST with $DOCKER_TAG"
+      echo "Tagging $IMAGE@$DIGEST with $DOCKER_TAG"
       gcloud -q container images add-tag $IMAGE@$DIGEST $IMAGE:$DOCKER_TAG
     fi
   done < "$IMAGE_PATHS_FILE"


### PR DESCRIPTION

## Proposed Changes

  * Log `Tagging my-image:tag@sha256:xxx` instead of `Tagging my-image:tag:sha256:xxx` (which is invalid)

The test does the right thing, it just logs that it's doing a wrong thing.

**Release Note**
```release-note
NONE
```