### PR TITLE
Just point to the docs repo for being the best sample source

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -1,24 +1,8 @@
 # Samples
 
-This directory contains sample services which demonstrate `Feed`
-functionality.
+This location is a staging ground for _Knative eventing_ samples, which are being moved to [the docs repository](https://github.com/knative/docs/tree/master/eventing/samples).
 
-## Prerequisites
-
-1. [Setup your development environment](../DEVELOPMENT.md#getting-started)
-2. [Start Eventing](../DEVELOPMENT.md#starting-eventing-controller)
-
-## Tools
-
-- [Kail](https://github.com/boz/kail) - Kubernetes tail. Streams logs from all
-  containers of all matched pods. Match pods by service, replicaset,
-  deployment, and others. Adjusts to a changing cluster - pods are added and
-  removed from logging as they fall in or out of the selection.
-
-
-## Samples
-
-See [the docs repo](https://github.com/knative/docs/tree/master/eventing/samples) for the best-maintained samples:
+The `docs` repo contains the following best-maintained samples:
 
 * [Handling Kubernetes events](https://github.com/knative/docs/tree/master/eventing/samples/k8s-events) -
   A simple handler for processing k8s events from the local cluster.


### PR DESCRIPTION
Fixes #506

## Proposed Changes

  * remove unneeded instructions for samples, those have been moved out
  * just link to the actual sample on the `docs` repo
