### PR TITLE
Adding standard isReady method to Channel.

### DIFF
--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -117,6 +117,16 @@ func (cs *ChannelStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha
 	return chanCondSet.Manage(cs).GetCondition(t)
 }
 
+// IsReady returns true if the resource is ready overall.
+func (cs *ChannelStatus) IsReady() bool {
+	return chanCondSet.Manage(cs).IsHappy()
+}
+
+// InitializeConditions sets relevant unset conditions to Unknown state.
+func (cs *ChannelStatus) InitializeConditions() {
+	chanCondSet.Manage(cs).InitializeConditions()
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ChannelList is a collection of Channels.


### PR DESCRIPTION
## Proposed Changes

  * All other eventing objects have a `IsReady` helper except Channel, adding that and `InitializeConditions`

**Release Note**
```release-note
NONE
```