### PR TITLE
Kafka bus: fix bus params parse issue

### DIFF
--- a/pkg/buses/kafka/bus.go
+++ b/pkg/buses/kafka/bus.go
@@ -207,9 +207,11 @@ func (b *KafkaBus) provision(channel buses.ChannelReference, parameters buses.Re
 	partitions := 1
 	if p, ok := parameters[numPartitions]; ok {
 		var err error
-		partitions, err = strconv.Atoi(p)
+		intPartitions, err := strconv.Atoi(p)
 		if err != nil {
 			b.logger.Warnf("Could not parse partition count for %q: %s", channel.String(), p)
+		} else {
+			partitions = intPartitions
 		}
 	}
 


### PR DESCRIPTION
If we are unable to parse `NumPartitions` from bus params, we expect to use the default. Unfortunately, we set `partitions` to 0 instead (since `strconv.Atoi` returns 0 if there is an error).
