### PR TITLE
Strict channels subscription

### DIFF
--- a/pkg/apis/eventing/v1alpha1/subscribable_channelable_validation.go
+++ b/pkg/apis/eventing/v1alpha1/subscribable_channelable_validation.go
@@ -30,16 +30,16 @@ func isSubscribableEmpty(f corev1.ObjectReference) bool {
 }
 
 // Valid from only contains the following fields:
-// - Kind       == 'Channel' || 'Source'
+// - Kind       == 'Channel'
 // - APIVersion == 'eventing.knative.dev/v1alpha1'
 // - Name       == not empty
 func isValidSubscribable(f corev1.ObjectReference) *apis.FieldError {
 	errs := isValidObjectReference(f)
 
-	if f.Kind != "Channel" && f.Kind != "Source" {
+	if f.Kind != "Channel" {
 		fe := apis.ErrInvalidValue(f.Kind, "kind")
 		fe.Paths = []string{"kind"}
-		fe.Details = "only 'Channel' or 'Source' kind is allowed"
+		fe.Details = "only 'Channel' kind is allowed"
 		errs = errs.Also(fe)
 	}
 	if f.APIVersion != "eventing.knative.dev/v1alpha1" {

--- a/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
@@ -431,7 +431,7 @@ func TestValidFrom(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := apis.ErrInvalidValue("", "kind")
-			fe.Details = "only 'Channel' or 'Source' kind is allowed"
+			fe.Details = "only 'Channel' kind is allowed"
 			return apis.ErrMissingField("kind").Also(fe)
 		}(),
 	}, {
@@ -443,7 +443,7 @@ func TestValidFrom(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			fe := apis.ErrInvalidValue("subscription", "kind")
-			fe.Details = "only 'Channel' or 'Source' kind is allowed"
+			fe.Details = "only 'Channel' kind is allowed"
 			return fe
 		}(),
 	}, {

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -453,9 +453,9 @@ var testCases = []controllertesting.TestCase{
 				}},
 		},
 	}, {
-		Name: "new subscription with source: adds status, all targets resolved, subscribers modified",
+		Name: "new subscription with from channel: adds status, all targets resolved, subscribers modified",
 		InitialState: []runtime.Object{
-			getNewSubscriptionWithSource(),
+			getNewSubscriptionWithFromChannel(),
 		},
 		ReconcileKey: fmt.Sprintf("%s/%s", testNS, subscriptionName),
 		// TODO: JSON patch is not working on the fake, see
@@ -636,14 +636,14 @@ func getNewSubscriptionToK8sService() *eventingv1alpha1.Subscription {
 	return sub
 }
 
-func getNewSubscriptionWithSource() *eventingv1alpha1.Subscription {
+func getNewSubscriptionWithFromChannel() *eventingv1alpha1.Subscription {
 	subscription := &eventingv1alpha1.Subscription{
 		TypeMeta:   subscriptionType(),
 		ObjectMeta: om(testNS, subscriptionName),
 		Spec: eventingv1alpha1.SubscriptionSpec{
 			From: corev1.ObjectReference{
-				Name:       sourceName,
-				Kind:       sourceKind,
+				Name:       fromChannelName,
+				Kind:       channelKind,
 				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
 			},
 			Call: &eventingv1alpha1.Callable{


### PR DESCRIPTION


## Proposed Changes

  * Do not allow Source in Subscription.From

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Disallow Source references in Subscription.From, as per meeting today to move forward with the Strict Channels model.
```