### PR TITLE
Folllow-up to change wording of contrib text.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-# How to contribute
+# Contribution guidelines
 
-Please see the Knative Community
-[how to contribute](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
-document.
+So you want to hack on Knative Eventing? Yay! Please refer to Knative's overall
+[contribution guidelines](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
+to find out how you can help.


### PR DESCRIPTION
`/hold` did not work because of the text after.

