### PR TITLE
check the VENDOR-LICENSE, Gopkg.lock and vendor as part of verification

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -35,24 +35,24 @@ mkdir -p "${TMP_DIFFROOT}"
 cp -aR \
   "${REPO_ROOT_DIR}/Gopkg.lock" \
   "${REPO_ROOT_DIR}/pkg" \
-  "${REPO_ROOT_DIR}/vendor" \
   "${REPO_ROOT_DIR}/third_party" \
+  "${REPO_ROOT_DIR}/vendor" \
   "${TMP_DIFFROOT}"
 
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 diff -Naupr "${REPO_ROOT_DIR}/Gopkg.lock" "${TMP_DIFFROOT}/Gopkg.lock" || ret=1
-diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
 diff -Naupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
 diff -Naupr "${REPO_ROOT_DIR}/third_party" "${TMP_DIFFROOT}/third_party" || ret=1
+diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
 
 # Restore working tree state
 rm -fr \
   "${REPO_ROOT_DIR}/Gopkg.lock" \
   "${REPO_ROOT_DIR}/pkg" \
-  "${REPO_ROOT_DIR}/vendor" \
-  "${REPO_ROOT_DIR}/third_party"
+  "${REPO_ROOT_DIR}/third_party" \
+  "${REPO_ROOT_DIR}/vendor"
 
 cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
 

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -32,6 +32,7 @@ cleanup
 
 # Save working tree state
 mkdir -p "${TMP_DIFFROOT}"
+
 cp -aR \
   "${REPO_ROOT_DIR}/Gopkg.lock" \
   "${REPO_ROOT_DIR}/pkg" \
@@ -42,10 +43,18 @@ cp -aR \
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
-diff -Naupr "${REPO_ROOT_DIR}/Gopkg.lock" "${TMP_DIFFROOT}/Gopkg.lock" || ret=1
-diff -Naupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
-diff -Naupr "${REPO_ROOT_DIR}/third_party" "${TMP_DIFFROOT}/third_party" || ret=1
-diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+
+diff -Naupr --no-dereference \
+  "${REPO_ROOT_DIR}/Gopkg.lock" "${TMP_DIFFROOT}/Gopkg.lock" || ret=1
+
+diff -Naupr --no-dereference \
+  "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
+
+diff -Naupr --no-dereference \
+  "${REPO_ROOT_DIR}/third_party" "${TMP_DIFFROOT}/third_party" || ret=1
+
+diff -Naupr --no-dereference \
+  "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
 
 # Restore working tree state
 rm -fr \

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -32,15 +32,26 @@ cleanup
 
 # Save working tree state
 mkdir -p "${TMP_DIFFROOT}"
-cp -aR "${REPO_ROOT_DIR}/Gopkg.lock" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
+cp -aR \
+  "${REPO_ROOT_DIR}/Gopkg.lock" \
+  "${REPO_ROOT_DIR}/pkg" \
+  "${REPO_ROOT_DIR}/vendor" \
+  "${REPO_ROOT_DIR}/third_party" \
+  "${TMP_DIFFROOT}"
 
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 diff -Naupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
+diff -Naupr "${REPO_ROOT_DIR}/third_party" "${TMP_DIFFROOT}/third_party" || ret=1
 
 # Restore working tree state
-rm -fr "${REPO_ROOT_DIR}/Gopkg.lock" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor"
+rm -fr \
+  "${REPO_ROOT_DIR}/Gopkg.lock" \
+  "${REPO_ROOT_DIR}/pkg" \
+  "${REPO_ROOT_DIR}/vendor" \
+  "${REPO_ROOT_DIR}/third_party"
+
 cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
 
 if [[ $ret -eq 0 ]]

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -42,6 +42,8 @@ cp -aR \
 "${REPO_ROOT_DIR}/hack/update-codegen.sh"
 echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
+diff -Naupr "${REPO_ROOT_DIR}/Gopkg.lock" "${TMP_DIFFROOT}/Gopkg.lock" || ret=1
+diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
 diff -Naupr "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
 diff -Naupr "${REPO_ROOT_DIR}/third_party" "${TMP_DIFFROOT}/third_party" || ret=1
 


### PR DESCRIPTION
`verify-codegen.sh` now ensures `third_party/VENDOR-LICENSE`, `Gopkg.lock` and the `/vendor` folder don't change