### PR TITLE
fix typo in the path name

### DIFF
--- a/config/provisioners/in-memory-channel/README.md
+++ b/config/provisioners/in-memory-channel/README.md
@@ -31,10 +31,9 @@ They differ from most Channels in that they have:
       name: foo
     spec:
       provisioner:
-        ref:
-          apiVersion: eventing.knative.dev/v1alpha1
-          kind: ClusterChannelProvisioner
-          name: in-memory-channel
+        apiVersion: eventing.knative.dev/v1alpha1
+        kind: ClusterChannelProvisioner
+        name: in-memory-channel
     ```
 
 ### Components

--- a/config/provisioners/in-memory-channel/README.md
+++ b/config/provisioners/in-memory-channel/README.md
@@ -20,7 +20,7 @@ They differ from most Channels in that they have:
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
 1. Apply the 'in-memory-channel' ClusterChannelProvisioner, Controller, and Dispatcher.
      ```shell
-     ko apply -f config/providers/in-memory-channel/in-memory-channel.yaml
+     ko apply -f config/provisioners/in-memory-channel/in-memory-channel.yaml
      ````
 1. Create Channels that reference the 'in-memory-channel'.
 


### PR DESCRIPTION
s/providers/provisioners/
remove extra ref in the spec in the example.