### PR TITLE
Add Channels with no subscribers to config map

### DIFF
--- a/pkg/controller/eventing/inmemory/channel/reconcile.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile.go
@@ -385,16 +385,16 @@ func (r *reconciler) createNewConfigMap(data map[string]string) *corev1.ConfigMa
 func multiChannelFanoutConfig(channels []eventingv1alpha1.Channel) *multichannelfanout.Config {
 	cc := make([]multichannelfanout.ChannelConfig, 0)
 	for _, c := range channels {
-		channelable := c.Spec.Channelable
-		if channelable != nil {
-			cc = append(cc, multichannelfanout.ChannelConfig{
-				Namespace: c.Namespace,
-				Name:      c.Name,
-				FanoutConfig: fanout.Config{
-					Subscriptions: c.Spec.Channelable.Subscribers,
-				},
-			})
+		channelConfig := multichannelfanout.ChannelConfig{
+			Namespace: c.Namespace,
+			Name:      c.Name,
 		}
+		if c.Spec.Channelable != nil {
+			channelConfig.FanoutConfig = fanout.Config{
+				Subscriptions: c.Spec.Channelable.Subscribers,
+			}
+		}
+		cc = append(cc, channelConfig)
 	}
 	return &multichannelfanout.Config{
 		ChannelConfigs: cc,


### PR DESCRIPTION
If a channel has no subscribers, it should still be in the configmap. This allows the dispatcher to respond with a 202 to a publish request (then drop the published event).

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
In-memory channels with no subscribers now respond to publishes with the same status code.
```

/cc @adamharwayne 