### PR TITLE
Adding  as shortname for the CRD

### DIFF
--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -26,4 +26,6 @@ spec:
     - all
     - knative
     - eventing
+    shortNames:
+    - ccp
   scope: Cluster


### PR DESCRIPTION
Fixes #

I noticed that the other CRDs use the `shortNames`, so adding `ccp` for the **C**luster**C**hannel**Provisioner

Also, saw that `ccp` is used in GO code filez 