### PR TITLE
Make the subscription controller resilient to empty subscriber and reply fields

### DIFF
--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -96,7 +96,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	}
 
 	subscriberURI := ""
-	if subscription.Spec.Subscriber != nil {
+	if !isNilOrEmptySubscriber(subscription.Spec.Subscriber) {
 		subscriberURI, err = r.resolveSubscriberSpec(subscription.Namespace, *subscription.Spec.Subscriber)
 		if err != nil {
 			glog.Warningf("Failed to resolve Subscriber %+v : %s", *subscription.Spec.Subscriber, err)
@@ -110,7 +110,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	}
 
 	replyURI := ""
-	if subscription.Spec.Reply != nil {
+	if !isNilOrEmptyReply(subscription.Spec.Reply) {
 		replyURI, err = r.resolveResult(subscription.Namespace, *subscription.Spec.Reply)
 		if err != nil {
 			glog.Warningf("Failed to resolve Result %v : %v", subscription.Spec.Reply, err)
@@ -137,6 +137,14 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	// Everything went well, set the fact that subscriptions have been modified
 	subscription.Status.MarkFromReady()
 	return nil
+}
+
+func isNilOrEmptySubscriber(sub *v1alpha1.SubscriberSpec) bool {
+	return sub == nil || equality.Semantic.DeepEqual(sub, &v1alpha1.SubscriberSpec{})
+}
+
+func isNilOrEmptyReply(reply *v1alpha1.ReplyStrategy) bool {
+	return reply == nil || equality.Semantic.DeepEqual(reply, &v1alpha1.ReplyStrategy{})
 }
 
 func (r *reconciler) updateStatus(subscription *v1alpha1.Subscription) (*v1alpha1.Subscription, error) {


### PR DESCRIPTION
## Proposed Changes

  * Only operate on non-nil _and_ _non-empty_ `subscriber` and `reply` fields.
    - Only checking non-nil allows panics (which is how I found #574).

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```