### PR TITLE
Rename fromReady to channelReady, to reflect the change in field name in #563

### DIFF
--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -159,8 +159,8 @@ type ReplyStrategy struct {
 }
 
 // subCondSet is a condition set with Ready as the happy condition and
-// ReferencesResolved and FromReady as the dependent conditions.
-var subCondSet = duckv1alpha1.NewLivingConditionSet(SubscriptionConditionReferencesResolved, SubscriptionConditionFromReady)
+// ReferencesResolved and ChannelReady as the dependent conditions.
+var subCondSet = duckv1alpha1.NewLivingConditionSet(SubscriptionConditionReferencesResolved, SubscriptionConditionChannelReady)
 
 // SubscriptionStatus (computed) for a subscription
 type SubscriptionStatus struct {
@@ -191,9 +191,9 @@ const (
 	// resolved.
 	SubscriptionConditionReferencesResolved duckv1alpha1.ConditionType = "Resolved"
 
-	// SubscriptionConditionFromReady has status True when controller has successfully added a subscription to From
-	// resource.
-	SubscriptionConditionFromReady duckv1alpha1.ConditionType = "FromReady"
+	// SubscriptionConditionChannelReady has status True when controller has successfully added a
+	// subscription to the spec.channel resource.
+	SubscriptionConditionChannelReady duckv1alpha1.ConditionType = "ChannelReady"
 )
 
 // GetCondition returns the condition currently associated with the given type, or nil.
@@ -216,9 +216,9 @@ func (ss *SubscriptionStatus) MarkReferencesResolved() {
 	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionReferencesResolved)
 }
 
-// MarkFromReady sets the FromReady condition to True state.
-func (ss *SubscriptionStatus) MarkFromReady() {
-	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionFromReady)
+// MarkChannelReady sets the ChannelReady condition to True state.
+func (ss *SubscriptionStatus) MarkChannelReady() {
+	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionChannelReady)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/eventing/v1alpha1/subscription_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types_test.go
@@ -35,8 +35,8 @@ var subscriptionConditionReferencesResolved = duckv1alpha1.Condition{
 	Status: corev1.ConditionFalse,
 }
 
-var subscriptionConditionFromReady = duckv1alpha1.Condition{
-	Type:   SubscriptionConditionFromReady,
+var subscriptionConditionChannelReady = duckv1alpha1.Condition{
+	Type:   SubscriptionConditionChannelReady,
 	Status: corev1.ConditionTrue,
 }
 
@@ -70,11 +70,11 @@ func TestSubscriptionGetCondition(t *testing.T) {
 		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{
 				subscriptionConditionReady,
-				subscriptionConditionFromReady,
+				subscriptionConditionChannelReady,
 			},
 		},
-		condQuery: SubscriptionConditionFromReady,
-		want:      &subscriptionConditionFromReady,
+		condQuery: SubscriptionConditionChannelReady,
+		want:      &subscriptionConditionChannelReady,
 	}, {
 		name: "unknown condition",
 		ss: &SubscriptionStatus{
@@ -107,7 +107,7 @@ func TestSubscriptionInitializeConditions(t *testing.T) {
 		ss:   &SubscriptionStatus{},
 		want: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{{
-				Type:   SubscriptionConditionFromReady,
+				Type:   SubscriptionConditionChannelReady,
 				Status: corev1.ConditionUnknown,
 			}, {
 				Type:   SubscriptionConditionReady,
@@ -121,13 +121,13 @@ func TestSubscriptionInitializeConditions(t *testing.T) {
 		name: "one false",
 		ss: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{{
-				Type:   SubscriptionConditionFromReady,
+				Type:   SubscriptionConditionChannelReady,
 				Status: corev1.ConditionFalse,
 			}},
 		},
 		want: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{{
-				Type:   SubscriptionConditionFromReady,
+				Type:   SubscriptionConditionChannelReady,
 				Status: corev1.ConditionFalse,
 			}, {
 				Type:   SubscriptionConditionReady,
@@ -147,7 +147,7 @@ func TestSubscriptionInitializeConditions(t *testing.T) {
 		},
 		want: &SubscriptionStatus{
 			Conditions: []duckv1alpha1.Condition{{
-				Type:   SubscriptionConditionFromReady,
+				Type:   SubscriptionConditionChannelReady,
 				Status: corev1.ConditionUnknown,
 			}, {
 				Type:   SubscriptionConditionReady,
@@ -172,30 +172,30 @@ func TestSubscriptionInitializeConditions(t *testing.T) {
 
 func TestSubscriptionIsReady(t *testing.T) {
 	tests := []struct {
-		name          string
-		markResolved  bool
-		markFromReady bool
-		wantReady     bool
+		name             string
+		markResolved     bool
+		markChannelReady bool
+		wantReady        bool
 	}{{
-		name:          "all happy",
-		markResolved:  true,
-		markFromReady: true,
-		wantReady:     true,
+		name:             "all happy",
+		markResolved:     true,
+		markChannelReady: true,
+		wantReady:        true,
 	}, {
-		name:          "one sad",
-		markResolved:  false,
-		markFromReady: true,
-		wantReady:     false,
+		name:             "one sad",
+		markResolved:     false,
+		markChannelReady: true,
+		wantReady:        false,
 	}, {
-		name:          "other sad",
-		markResolved:  true,
-		markFromReady: false,
-		wantReady:     false,
+		name:             "other sad",
+		markResolved:     true,
+		markChannelReady: false,
+		wantReady:        false,
 	}, {
-		name:          "both sad",
-		markResolved:  false,
-		markFromReady: false,
-		wantReady:     false,
+		name:             "both sad",
+		markResolved:     false,
+		markChannelReady: false,
+		wantReady:        false,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -203,8 +203,8 @@ func TestSubscriptionIsReady(t *testing.T) {
 			if test.markResolved {
 				ss.MarkReferencesResolved()
 			}
-			if test.markFromReady {
-				ss.MarkFromReady()
+			if test.markChannelReady {
+				ss.MarkChannelReady()
 			}
 			got := ss.IsReady()
 			if test.wantReady != got {

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -135,7 +135,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		return err
 	}
 	// Everything went well, set the fact that subscriptions have been modified
-	subscription.Status.MarkFromReady()
+	subscription.Status.MarkChannelReady()
 	return nil
 }
 


### PR DESCRIPTION
## Proposed Changes

  * Rename `Subscription`'s `fromReady` status condition to `channelReady`, to reflect the change in field name in #563.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```