### PR TITLE
Exclude test and vendor from coverage. now matches serving

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@
 # coverage. If a path is marked as linguist-generated already, it will be implicitly excluded and
 # there is no need to add the coverage-excluded attribute
 #/pkg/controller/testing/** coverage-excluded=true
+/vendor/** coverage-excluded=true
+/test/** coverage-excluded=true


### PR DESCRIPTION
Fixes #587 

## Proposed Changes

  * Exclude /test and /vendor from test coverage
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Exclude /test and /vendor from test coverage.
```