### PR TITLE
Fix in-memory channel RBAC role

### DIFF
--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -44,6 +44,12 @@ rules:
       - watch
       - update
   - apiGroups:
+    - eventing.knative.dev
+    resources:
+    - channels/finalizers
+    verbs:
+    - update
+  - apiGroups:
       - "" # Core API group.
     resources:
       - configmaps


### PR DESCRIPTION
The in-memory channel controller is not able to provision a channel without this role:

```
{"level":"info","ts":"2018-11-09T08:08:58.209Z","logger":"bus","caller":"channel/reconcile.go:142","msg":"Error creating the Channel's K8s Service","eventing.knative.dev/clusterChannelProvisioner":"in-memory-channel","eventing.knative.dev/clusterChannelProvisionerComponent":"Controller","channel":{"metadata":{"name":"foo","namespace":"myproject","selfLink":"/apis/eventing.knative.dev/v1alpha1/namespaces/myproject/channels/foo","uid":"a516c9c5-e3f6-11e8-a78f-52540061a142","resourceVersion":"140036","generation":1,"creationTimestamp":"2018-11-09T08:08:30Z","finalizers":["in-memory-channel-controller"]},"spec":{"generation":1,"provisioner":{"kind":"ClusterChannelProvisioner","name":"in-memory-channel","apiVersion":"eventing.knative.dev/v1alpha1"}},"status":{"address":{},"conditions":[{"type":"Addressable","status":"Unknown","lastTransitionTime":"2018-11-09T08:08:30Z"},{"type":"Provisioned","status":"Unknown","lastTransitionTime":"2018-11-09T08:08:30Z"},{"type":"Ready","status":"Unknown","lastTransitionTime":"2018-11-09T08:08:30Z"}]}},"error":"services \"foo-channel\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>"}
{"level":"info","ts":"2018-11-09T08:08:58.209Z","logger":"bus","caller":"channel/reconcile.go:93","msg":"Error reconciling Channel","eventing.knative.dev/clusterChannelProvisioner":"in-memory-channel","eventing.knative.dev/clusterChannelProvisionerComponent":"Controller","request":"myproject/foo","error":"services \"foo-channel\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>"}
```