### PR TITLE
Fix passing yamls to hub tool

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -93,6 +93,6 @@ for yaml in ${all_yamls[@]}; do
   publish_yaml ${yaml} ${EVENTING_RELEASE_GCS} ${TAG}
 done
 
-branch_release "Knative Eventing" "${all_yamls[@]}"
+branch_release "Knative Eventing" "${all_yamls[*]}"
 
 echo "New release published successfully"


### PR DESCRIPTION
Expand the array of yaml files into a single string, not separate strings.

Fixes #610