### PR TITLE
Clear release yaml before appending to it

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -70,7 +70,7 @@ done
 # Assemble the release
 for yaml in "${!RELEASES[@]}"; do
   echo "Assembling Knative Eventing - ${yaml}"
-  touch ${yaml}
+  echo "" > ${yaml}
   for component in ${RELEASES[${yaml}]}; do
     echo "---" >> ${yaml}
     echo "# ${component}" >> ${yaml}


### PR DESCRIPTION
Without this change, running the release multiple times causes the content to be duplicated in the release yaml.

Fixes #612

## Proposed Changes

  * Echo the empty string to each release yaml before appending to it

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```

/cc @matzew @scothis @adrcunha