### PR TITLE
Update channel only with subscribers in the same namespace

### DIFF
--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -292,7 +292,15 @@ func (r *reconciler) syncPhysicalChannel(sub *v1alpha1.Subscription, isDeleted b
 	}
 	subscribable := r.createSubscribable(subs)
 
-	return r.patchPhysicalFrom(sub.Namespace, sub.Spec.Channel, subscribable)
+	if patchErr := r.patchPhysicalFrom(sub.Namespace, sub.Spec.Channel, subscribable); patchErr != nil {
+		if isDeleted && errors.IsNotFound(patchErr) {
+			glog.Infof("could not find channel %v\n", sub.Spec.Channel)
+			return nil
+		} else {
+			return patchErr
+		}
+	}
+	return nil
 }
 
 func (r *reconciler) listAllSubscriptionsWithPhysicalChannel(sub *v1alpha1.Subscription) ([]v1alpha1.Subscription, error) {

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -307,6 +307,7 @@ func (r *reconciler) listAllSubscriptionsWithPhysicalChannel(sub *v1alpha1.Subsc
 				Kind:       "Subscription",
 			},
 		},
+		Namespace: sub.Namespace,
 	}
 	ctx := context.TODO()
 	for {

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -296,9 +296,8 @@ func (r *reconciler) syncPhysicalChannel(sub *v1alpha1.Subscription, isDeleted b
 		if isDeleted && errors.IsNotFound(patchErr) {
 			glog.Infof("could not find channel %v\n", sub.Spec.Channel)
 			return nil
-		} else {
-			return patchErr
-		}
+		} 
+		return patchErr
 	}
 	return nil
 }


### PR DESCRIPTION
* Subscription controller should only update the channel with the list of subscribers in the same namespace. 
* Also fixes an issue when a subscription could not be deleted if the channel is already deleted (stumbled upon this while testing the above issue)


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note

```