### PR TITLE
Adding provisioner category for the ccp

### DIFF
--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -26,6 +26,7 @@ spec:
     - all
     - knative
     - eventing
+    - provisioner
     shortNames:
     - ccp
   scope: Cluster


### PR DESCRIPTION
Minor change
## Proposed Changes

  * adding a `provisioner` category for the ClustrChannelProvisioners (see #571) 

/cc @scothis 