### PR TITLE
Explicit Istio sidecar injection for the nginx test pod

### DIFF
--- a/test/crd.go
+++ b/test/crd.go
@@ -174,8 +174,9 @@ func Subscription(name string, namespace string, channel *corev1.ObjectReference
 func NGinxPod(namespace string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx",
-			Namespace: namespace,
+			Name:        "nginx",
+			Namespace:   namespace,
+			Annotations: map[string]string{"sidecar.istio.io/inject": "true"},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -67,7 +67,6 @@ function teardown() {
 
 function setup_events_test_resources() {
   kubectl create namespace $E2E_TEST_NAMESPACE
-  kubectl label namespace $E2E_TEST_NAMESPACE istio-injection=enabled --overwrite
   kubectl create namespace $E2E_TEST_FUNCTION_NAMESPACE
 }
 


### PR DESCRIPTION
Fixes Istio sidecar injection into the test pod on OpenShift.

## Proposed Changes

  * Make Istio sidcar injection explicit. Similar to main knative components which declare the annotation.
