### PR TITLE
Removing the -channel from the kafka ccp

### DIFF
--- a/config/provisioners/kafka/README.md
+++ b/config/provisioners/kafka/README.md
@@ -29,9 +29,9 @@ located inside the `config/provisioners/kafka/kafka-channel.yaml` file:
     `my-cluster-kafka-bootstrap.mynamespace:9092`.
 1. Apply the 'Kafka' ClusterChannelProvisioner, Controller, and Dispatcher:
     ```
-    ko apply -f config/provisioners/kafka/kafka-channel.yaml
+    ko apply -f config/provisioners/kafka/kafka.yaml
     ```
-1. Create Channels that reference the 'kafka-channel'.
+1. Create Channels that reference the 'kafka' ClusterChannelProvisioner.
 
     ```yaml
     apiVersion: eventing.knative.dev/v1alpha1
@@ -42,7 +42,7 @@ located inside the `config/provisioners/kafka/kafka-channel.yaml` file:
       provisioner:
         apiVersion: eventing.knative.dev/v1alpha1
         kind: ClusterChannelProvisioner
-        name: kafka-channel
+        name: kafka
     ```
 
 ## Components

--- a/config/provisioners/kafka/kafka.yaml
+++ b/config/provisioners/kafka/kafka.yaml
@@ -15,7 +15,7 @@
 apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
-  name: kafka-channel
+  name: kafka
 spec: {}
 ---
 
@@ -169,7 +169,7 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      clusterChannelProvisioner: kafka-channel
+      clusterChannelProvisioner: kafka
       role: dispatcher
   serviceName: kafka-channel-dispatcher-service
   template:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,7 +27,7 @@ declare -A COMPONENTS
 COMPONENTS=(
   ["eventing.yaml"]="config"
   ["in-memory-channel.yaml"]="config/provisioners/in-memory-channel"
-  ["kafka-channel.yaml"]="config/provisioners/kafka"
+  ["kafka.yaml"]="config/provisioners/kafka"
 )
 readonly COMPONENTS
 

--- a/pkg/provisioners/kafka/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile_test.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	channelName                   = "test-channel"
-	clusterChannelProvisionerName = "kafka-channel"
+	clusterChannelProvisionerName = "kafka"
 	testNS                        = "test-namespace"
 	testUID                       = "test-uid"
 	argumentNumPartitions         = "NumPartitions"

--- a/pkg/provisioners/kafka/controller/reconcile.go
+++ b/pkg/provisioners/kafka/controller/reconcile.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Name is the name of the kafka ClusterChannelProvisioner.
-	Name = "kafka-channel"
+	Name = "kafka"
 )
 
 // Reconcile compares the actual state with the desired, and attempts to

--- a/pkg/provisioners/kafka/controller/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/reconcile_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	clusterChannelProvisionerName = "kafka-channel"
+	clusterChannelProvisionerName = "kafka"
 	testNS                        = ""
 )
 


### PR DESCRIPTION
Fixes not that great naming :-) for Kafka

## Proposed Changes

  * remove the `-channel` part of out the `kafka` ClusterChannelProvisioner, just name it `kafka`

cc @Harwayne @neosab @grantr 

NOTE: Kafka was not released, so a rename here is safe ...