### PR TITLE
extracting TopicName as util function

### DIFF
--- a/pkg/provisioners/kafka/controller/channel/reconcile.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile.go
@@ -33,8 +33,8 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingController "github.com/knative/eventing/pkg/controller"
 	util "github.com/knative/eventing/pkg/provisioners"
-	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
+	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	"github.com/knative/eventing/pkg/sidecar/configmap"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
@@ -195,7 +195,7 @@ func (r *reconciler) shouldReconcile(channel *eventingv1alpha1.Channel, clusterC
 }
 
 func (r *reconciler) provisionChannel(channel *eventingv1alpha1.Channel, kafkaClusterAdmin sarama.ClusterAdmin) error {
-	topicName := topicUtils.TopicName(channel.Namespace, channel.Name)
+	topicName := topicUtils.TopicName(controller.KafkaChannelSeparator, channel.Namespace, channel.Name)
 	r.logger.Info("creating topic on kafka cluster", zap.String("topic", topicName))
 
 	var arguments channelArgs
@@ -227,7 +227,7 @@ func (r *reconciler) provisionChannel(channel *eventingv1alpha1.Channel, kafkaCl
 }
 
 func (r *reconciler) deprovisionChannel(channel *eventingv1alpha1.Channel, kafkaClusterAdmin sarama.ClusterAdmin) error {
-	topicName := topicUtils.TopicName(channel.Namespace, channel.Name)
+	topicName := topicUtils.TopicName(controller.KafkaChannelSeparator, channel.Namespace, channel.Name)
 	r.logger.Info("deleting topic on kafka cluster", zap.String("topic", topicName))
 
 	err := kafkaClusterAdmin.DeleteTopic(topicName)

--- a/pkg/provisioners/kafka/controller/channel/reconcile.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile.go
@@ -33,6 +33,7 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingController "github.com/knative/eventing/pkg/controller"
 	util "github.com/knative/eventing/pkg/provisioners"
+	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
 	"github.com/knative/eventing/pkg/sidecar/configmap"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
@@ -194,7 +195,7 @@ func (r *reconciler) shouldReconcile(channel *eventingv1alpha1.Channel, clusterC
 }
 
 func (r *reconciler) provisionChannel(channel *eventingv1alpha1.Channel, kafkaClusterAdmin sarama.ClusterAdmin) error {
-	topicName := topicName(channel)
+	topicName := topicUtils.TopicName(channel.Namespace, channel.Name)
 	r.logger.Info("creating topic on kafka cluster", zap.String("topic", topicName))
 
 	var arguments channelArgs
@@ -226,7 +227,7 @@ func (r *reconciler) provisionChannel(channel *eventingv1alpha1.Channel, kafkaCl
 }
 
 func (r *reconciler) deprovisionChannel(channel *eventingv1alpha1.Channel, kafkaClusterAdmin sarama.ClusterAdmin) error {
-	topicName := topicName(channel)
+	topicName := topicUtils.TopicName(channel.Namespace, channel.Name)
 	r.logger.Info("deleting topic on kafka cluster", zap.String("topic", topicName))
 
 	err := kafkaClusterAdmin.DeleteTopic(topicName)
@@ -365,10 +366,6 @@ func createKafkaAdminClient(config *controller.KafkaProvisionerConfig) (sarama.C
 	saramaConf.Version = sarama.V1_1_0_0
 	saramaConf.ClientID = controllerAgentName
 	return sarama.NewClusterAdmin(config.Brokers, saramaConf)
-}
-
-func topicName(channel *eventingv1alpha1.Channel) string {
-	return fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)
 }
 
 // unmarshalArguments unmarshal's a json/yaml serialized input and returns channelArgs

--- a/pkg/provisioners/kafka/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile_test.go
@@ -256,7 +256,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with no channel arguments - uses default",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     1,
@@ -265,7 +265,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with unknown channel arguments - uses default",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{"testing": "testing"}),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     1,
@@ -274,6 +274,11 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:      "provision with invalid channel arguments - errors",
 			c:         getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: "invalid"}),
+			wantError: fmt.Sprintf("error unmarshalling arguments: json: cannot unmarshal string into Go struct field channelArgs.%s of type int32", argumentNumPartitions),
+		},
+		{
+			name:      "provision with nil channel arguments - errors",
+			c:         getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: "nil"}),
 			wantError: fmt.Sprintf("error unmarshalling arguments: json: cannot unmarshal string into Go struct field channelArgs.%s of type int32", argumentNumPartitions),
 		},
 		{
@@ -290,7 +295,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with valid channel arguments",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -299,7 +304,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision but topic already exists - no error",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -309,7 +314,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision but error creating topic",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -353,20 +358,20 @@ func TestDeprovisionChannel(t *testing.T) {
 		{
 			name:          "deprovision channel - unknown error",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			mockError:     fmt.Errorf("unknown sarama error"),
 			wantError:     "unknown sarama error",
 		},
 		{
 			name:          "deprovision channel - topic already deleted",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 			mockError:     sarama.ErrUnknownTopicOrPartition,
 		},
 		{
 			name:          "deprovision channel - success",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s.%s.%s", topicPrefix, testNS, channelName),
 		}}
 
 	for _, tc := range deprovisionTestCases {

--- a/pkg/provisioners/kafka/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile_test.go
@@ -45,6 +45,7 @@ const (
 	channelName                   = "test-channel"
 	clusterChannelProvisionerName = "kafka-channel"
 	testNS                        = "test-namespace"
+	topicPrefix                   = "knative-eventing-channel"
 	testUID                       = "test-uid"
 	argumentNumPartitions         = "NumPartitions"
 )
@@ -255,7 +256,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with no channel arguments - uses default",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     1,
@@ -264,7 +265,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with unknown channel arguments - uses default",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{"testing": "testing"}),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     1,
@@ -289,7 +290,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision with valid channel arguments",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -298,7 +299,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision but topic already exists - no error",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -308,7 +309,7 @@ func TestProvisionChannel(t *testing.T) {
 		{
 			name:          "provision but error creating topic",
 			c:             getNewChannelWithArgs(channelName, map[string]interface{}{argumentNumPartitions: 2}),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			wantTopicDetail: &sarama.TopicDetail{
 				ReplicationFactor: 1,
 				NumPartitions:     2,
@@ -352,20 +353,20 @@ func TestDeprovisionChannel(t *testing.T) {
 		{
 			name:          "deprovision channel - unknown error",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			mockError:     fmt.Errorf("unknown sarama error"),
 			wantError:     "unknown sarama error",
 		},
 		{
 			name:          "deprovision channel - topic already deleted",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 			mockError:     sarama.ErrUnknownTopicOrPartition,
 		},
 		{
 			name:          "deprovision channel - success",
 			c:             getNewChannel(channelName, clusterChannelProvisionerName),
-			wantTopicName: fmt.Sprintf("%s.%s", testNS, channelName),
+			wantTopicName: fmt.Sprintf("%s_%s.%s", topicPrefix, testNS, channelName),
 		}}
 
 	for _, tc := range deprovisionTestCases {

--- a/pkg/provisioners/kafka/controller/util.go
+++ b/pkg/provisioners/kafka/controller/util.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	BrokerConfigMapKey = "bootstrap_servers"
+	BrokerConfigMapKey    = "bootstrap_servers"
+	KafkaChannelSeparator = "."
 )
 
 // GetProvisionerConfig returns the details of the associated ClusterChannelProvisioner object

--- a/pkg/provisioners/kafka/dispatcher/dispatcher.go
+++ b/pkg/provisioners/kafka/dispatcher/dispatcher.go
@@ -26,10 +26,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 
-	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
+	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
 )
 
@@ -165,7 +165,7 @@ func (d *KafkaDispatcher) subscribe(channelRef buses.ChannelReference, sub subsc
 
 	d.logger.Info("Subscribing", zap.Any("channelRef", channelRef), zap.Any("subscription", sub))
 
-	topicName := topicUtils.TopicName(channelRef.Namespace, channelRef.Name)
+	topicName := topicUtils.TopicName(controller.KafkaChannelSeparator, channelRef.Namespace, channelRef.Name)
 
 	group := fmt.Sprintf("%s.%s.%s", controller.Name, sub.Namespace, sub.Name)
 	consumer, err := d.kafkaCluster.NewConsumer(group, []string{topicName})
@@ -275,7 +275,7 @@ func fromKafkaMessage(kafkaMessage *sarama.ConsumerMessage) *buses.Message {
 
 func toKafkaMessage(channel buses.ChannelReference, message *buses.Message) *sarama.ProducerMessage {
 	kafkaMessage := sarama.ProducerMessage{
-		Topic: topicUtils.TopicName(channel.Namespace, channel.Name),
+		Topic: topicUtils.TopicName(controller.KafkaChannelSeparator, channel.Namespace, channel.Name),
 		Value: sarama.ByteEncoder(message.Payload),
 	}
 	for h, v := range message.Headers {

--- a/pkg/provisioners/kafka/dispatcher/dispatcher.go
+++ b/pkg/provisioners/kafka/dispatcher/dispatcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 
+	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/buses"
 	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
@@ -164,7 +165,7 @@ func (d *KafkaDispatcher) subscribe(channelRef buses.ChannelReference, sub subsc
 
 	d.logger.Info("Subscribing", zap.Any("channelRef", channelRef), zap.Any("subscription", sub))
 
-	topicName := topicName(channelRef)
+	topicName := topicUtils.TopicName(channelRef.Namespace, channelRef.Name)
 
 	group := fmt.Sprintf("%s.%s.%s", controller.Name, sub.Namespace, sub.Name)
 	consumer, err := d.kafkaCluster.NewConsumer(group, []string{topicName})
@@ -274,7 +275,7 @@ func fromKafkaMessage(kafkaMessage *sarama.ConsumerMessage) *buses.Message {
 
 func toKafkaMessage(channel buses.ChannelReference, message *buses.Message) *sarama.ProducerMessage {
 	kafkaMessage := sarama.ProducerMessage{
-		Topic: topicName(channel),
+		Topic: topicUtils.TopicName(channel.Namespace, channel.Name),
 		Value: sarama.ByteEncoder(message.Payload),
 	}
 	for h, v := range message.Headers {
@@ -284,10 +285,6 @@ func toKafkaMessage(channel buses.ChannelReference, message *buses.Message) *sar
 		})
 	}
 	return &kafkaMessage
-}
-
-func topicName(channel buses.ChannelReference) string {
-	return fmt.Sprintf("%s.%s", channel.Namespace, channel.Name)
 }
 
 func newSubscription(spec eventingduck.ChannelSubscriberSpec) subscription {

--- a/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
+++ b/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
@@ -326,7 +326,7 @@ func TestToKafkaMessage(t *testing.T) {
 		Payload: data,
 	}
 	want := &sarama.ProducerMessage{
-		Topic: "knative-eventing-channel_test-ns.test-channel",
+		Topic: "knative-eventing-channel.test-ns.test-channel",
 		Headers: []sarama.RecordHeader{
 			{
 				Key:   []byte("k1"),

--- a/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
+++ b/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
@@ -326,7 +326,7 @@ func TestToKafkaMessage(t *testing.T) {
 		Payload: data,
 	}
 	want := &sarama.ProducerMessage{
-		Topic: "test-ns.test-channel",
+		Topic: "knative-eventing-channel_test-ns.test-channel",
 		Headers: []sarama.RecordHeader{
 			{
 				Key:   []byte("k1"),

--- a/pkg/provisioners/provisioner_util.go
+++ b/pkg/provisioners/provisioner_util.go
@@ -90,6 +90,6 @@ func newDispatcherService(ccp *eventingv1alpha1.ClusterChannelProvisioner) *core
 func DispatcherLabels(ccpName string) map[string]string {
 	return map[string]string{
 		"clusterChannelProvisioner": ccpName,
-		"role":                      "dispatcher",
+		"role": "dispatcher",
 	}
 }

--- a/pkg/provisioners/utils/topic_names.go
+++ b/pkg/provisioners/utils/topic_names.go
@@ -1,0 +1,9 @@
+package utils
+
+import (
+	"fmt"
+)
+
+func TopicName(channelNamespace, channelName string) string {
+	return fmt.Sprintf("knative-eventing-channel_%s.%s", channelNamespace, channelName)
+}

--- a/pkg/provisioners/utils/topic_names.go
+++ b/pkg/provisioners/utils/topic_names.go
@@ -4,6 +4,6 @@ import (
 	"fmt"
 )
 
-func TopicName(channelNamespace, channelName string) string {
-	return fmt.Sprintf("knative-eventing-channel_%s.%s", channelNamespace, channelName)
+func TopicName(channelSeparator, channelNamespace, channelName string) string {
+	return fmt.Sprintf("knative-eventing-channel%s%s%s%s", channelSeparator, channelNamespace, channelSeparator, channelName)
 }

--- a/pkg/provisioners/utils/topic_names_test.go
+++ b/pkg/provisioners/utils/topic_names_test.go
@@ -4,9 +4,17 @@ import (
 	"testing"
 )
 
-func TestGenerateTopicName(t *testing.T) {
-	expected := "knative-eventing-channel_channel-namespace.channel-name"
-	actual := TopicName("channel-namespace", "channel-name")
+func TestGenerateTopicNameWithDot(t *testing.T) {
+	expected := "knative-eventing-channel.channel-namespace.channel-name"
+	actual := TopicName(".", "channel-namespace", "channel-name")
+	if expected != actual {
+		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
+	}
+}
+
+func TestGenerateTopicNameWithHyphen(t *testing.T) {
+	expected := "knative-eventing-channel-channel-namespace-channel-name"
+	actual := TopicName("-", "channel-namespace", "channel-name")
 	if expected != actual {
 		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
 	}

--- a/pkg/provisioners/utils/topic_names_test.go
+++ b/pkg/provisioners/utils/topic_names_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGenerateTopicName(t *testing.T) {
+	expected := "knative-eventing-channel_channel-namespace.channel-name"
+	actual := TopicName("channel-namespace", "channel-name")
+	if expected != actual {
+		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
+	}
+}


### PR DESCRIPTION

## Proposed Changes

  * create `TopicName` util and remove duplicated code
  * adding some better prefix of the actual kafka topics

//cc @Harwayne @neosab 

This is a bit inspired by a discussion on the GCP PUB/SUB PR:
* https://github.com/knative/eventing/pull/618/files#r235173725
* https://github.com/knative/eventing/pull/618/files#r235173995

This also adds better, identified topic names, IMO.

Also, if merged , I think the PR on PUB/SUB from @Harwayne can reuse this
