### PR TITLE
Remove images deletion step from e2e test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -357,14 +357,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a8f096af01ca3ef74546e412d0ffc5ad526bd17ae88495c04e6042200fc7fabc"
+  digest = "1:7a7aea24f67afa5dedb422fb3592d5a5c3af91b4b9d59eddf06767729915b3c4"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "f710a703baf3ac7e5e9005693fb1c8d61c4eccbb"
+  revision = "7ed32409fa2c447a44a4281f0022ab25ce955f51"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -101,6 +101,9 @@ project `$PROJECT_ID` and run the tests against it.
 `K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
 tests against the cluster.
 
+1. You can force running the tests against a specific GKE cluster version by using
+the `--cluster-version` flag and passing a X.Y.Z version as the flag value.
+
 ### Sample end-to-end test script
 
 This script will test that the latest Knative Serving nightly release works. It

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -45,6 +45,9 @@ readonly E2E_CLUSTER_NODES=3
 readonly E2E_CLUSTER_MACHINE=n1-standard-4
 readonly TEST_RESULT_FILE=/tmp/${E2E_BASE_NAME}-e2e-result
 
+# Flag whether test is using a boskos GCP project
+IS_BOSKOS=0
+
 # Tear down the test resources.
 function teardown_test_resources() {
   header "Tearing down test environment"
@@ -53,15 +56,8 @@ function teardown_test_resources() {
     teardown
   fi
 
-  # Delete Knative Serving images when using prow.
-  if (( IS_PROW )); then
-    echo "Images in ${DOCKER_REPO_OVERRIDE}:"
-    gcloud container images list --repository=${DOCKER_REPO_OVERRIDE}
-    delete_gcr_images ${DOCKER_REPO_OVERRIDE}
-  else
-    # Delete the kubernetes source downloaded by kubetest
-    rm -fr kubernetes kubernetes.tar.gz
-  fi
+  # Delete the kubernetes source downloaded by kubetest
+  rm -fr kubernetes kubernetes.tar.gz
 }
 
 # Exit test, dumping current state info.
@@ -83,21 +79,25 @@ function go_test_e2e() {
 }
 
 # Download the k8s binaries required by kubetest.
+# Parameters: $1 - GCP project that will host the test cluster.
 function download_k8s() {
-  local version=${SERVING_GKE_VERSION}
+  local version=${E2E_CLUSTER_VERSION}
+  # Fetch valid versions
+  local versions="$(gcloud container get-server-config \
+      --project=$1 \
+      --format='value(validMasterVersions)' \
+      --region=${E2E_CLUSTER_REGION})"
+  local gke_versions=(`echo -n ${versions//;/ /}`)
+  echo "Valid GKE versions are [${versions//;/, }]"
   if [[ "${version}" == "latest" ]]; then
-    # Fetch latest valid version
-    local versions="$(gcloud container get-server-config \
-        --project=${GCP_PROJECT} \
-        --format='value(validMasterVersions)' \
-        --region=${E2E_CLUSTER_REGION})"
-    local gke_versions=(`echo -n ${versions//;/ /}`)
     # Get first (latest) version, excluding the "-gke.#" suffix
     version="${gke_versions[0]%-*}"
-    echo "Latest GKE is ${version}, from [${versions//;/, }]"
+    echo "Using latest version, ${version}"
   elif [[ "${version}" == "default" ]]; then
     echo "ERROR: `default` GKE version is not supported yet"
     return 1
+  else
+    echo "Using command-line supplied version ${version}"
   fi
   # Download k8s to staging dir
   version=v${version}
@@ -115,6 +115,7 @@ function download_k8s() {
     mv kubernetes/client/kubernetes-client-*.tar.gz .
     rm -fr kubernetes
     # Create an empty kubernetes test tarball; we don't use it but kubetest will fetch it
+    # As of August 21 2018 this means avoiding a useless 1.2GB download
     tar -czf kubernetes-test.tar.gz -T /dev/null
   fi
   popd
@@ -125,7 +126,7 @@ function download_k8s() {
 # This is intended to be called when a test fails to provide debugging information.
 function dump_cluster_state() {
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***    Start of information dump    ***"
   echo "***************************************"
   echo ">>> All resources:"
@@ -136,7 +137,7 @@ function dump_cluster_state() {
   kubectl get events --all-namespaces
   function_exists dump_extra_cluster_state && dump_extra_cluster_state
   echo "***************************************"
-  echo "***           TEST FAILED           ***"
+  echo "***         E2E TEST FAILED         ***"
   echo "***     End of information dump     ***"
   echo "***************************************"
 }
@@ -159,10 +160,10 @@ function create_test_cluster() {
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment=prod
   )
-  if (( ! IS_PROW )); then
-    CLUSTER_CREATION_ARGS+=(--gcp-project=${PROJECT_ID:?"PROJECT_ID must be set to the GCP project where the tests are run."})
-  else
+  if (( IS_BOSKOS )); then
     CLUSTER_CREATION_ARGS+=(--gcp-service-account=/etc/service-account/service-account.json)
+  else
+    CLUSTER_CREATION_ARGS+=(--gcp-project=${GCP_PROJECT})
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
@@ -174,15 +175,19 @@ function create_test_cluster() {
   # be a writeable docker repo.
   export K8S_USER_OVERRIDE=
   export K8S_CLUSTER_OVERRIDE=
-  # Get the current GCP project
-  export GCP_PROJECT=${PROJECT_ID}
-  [[ -z ${GCP_PROJECT} ]] && export GCP_PROJECT=$(gcloud config get-value project)
   # Assume test failed (see more details at the end of this script).
   echo -n "1"> ${TEST_RESULT_FILE}
   local test_cmd_args="--run-tests"
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
+  [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
+  # Get the current GCP project for downloading kubernetes
+  local gcloud_project="${GCP_PROJECT}"
+  [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
+  echo "gcloud project is ${gcloud_project}"
+  (( IS_BOSKOS )) && echo "Using boskos for the test cluster"
+  [[ -n "${GCP_PROJECT}" ]] && echo "GCP project for test cluster is ${GCP_PROJECT}"
   echo "Test script is ${E2E_SCRIPT}"
-  download_k8s || return 1
+  download_k8s ${gcloud_project} || return 1
   # Don't fail test for kubetest, as it might incorrectly report test failure
   # if teardown fails (for details, see success() below)
   set +o errexit
@@ -191,29 +196,31 @@ function create_test_cluster() {
     --up \
     --down \
     --extract local \
-    --gcp-node-image ${SERVING_GKE_IMAGE} \
+    --gcp-node-image "${SERVING_GKE_IMAGE}" \
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
+  # Ensure we're using the GCP project used by kubetest
+  gcloud_project="$(gcloud config get-value project)"
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.
   local http_health_checks="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     grep httpHealthChecks | tr '\n' ' ')"
   local target_pools="$(gcloud compute target-pools list \
-    --project=${GCP_PROJECT} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
     tr '\n' ' ')"
   if [[ -n "${target_pools}" ]]; then
     echo "Found leaked target pools, deleting"
-    gcloud compute forwarding-rules delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
-    gcloud compute target-pools delete -q --project=${GCP_PROJECT} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
   fi
   if [[ -n "${http_health_checks}" ]]; then
     echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${GCP_PROJECT} ${http_health_checks}
+    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
   fi
   local result="$(cat ${TEST_RESULT_FILE})"
   echo "Test result code is $result"
@@ -249,6 +256,8 @@ function setup_test_cluster() {
   echo "- User is ${K8S_USER_OVERRIDE}"
   echo "- Docker is ${DOCKER_REPO_OVERRIDE}"
 
+  export KO_DOCKER_REPO="${DOCKER_REPO_OVERRIDE}"
+
   trap teardown_test_resources EXIT
 
   if (( USING_EXISTING_CLUSTER )) && function_exists teardown; then
@@ -273,7 +282,7 @@ function success() {
   # TODO(adrcunha): Get rid of this workaround.
   echo -n "0"> ${TEST_RESULT_FILE}
   echo "**************************************"
-  echo "***        ALL TESTS PASSED        ***"
+  echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
   exit 0
 }
@@ -281,7 +290,14 @@ function success() {
 RUN_TESTS=0
 EMIT_METRICS=0
 USING_EXISTING_CLUSTER=1
+GCP_PROJECT=""
 E2E_SCRIPT=""
+E2E_CLUSTER_VERSION=""
+
+function abort() {
+  echo "error: $@"
+  exit 1
+}
 
 # Parse flags and initialize the test cluster.
 function initialize() {
@@ -290,6 +306,8 @@ function initialize() {
   [[ ${E2E_SCRIPT} =~ ^[\./].* ]] || E2E_SCRIPT="./$0"
   E2E_SCRIPT="$(cd ${E2E_SCRIPT%/*} && echo $PWD/${E2E_SCRIPT##*/})"
   readonly E2E_SCRIPT
+
+  E2E_CLUSTER_VERSION="${SERVING_GKE_VERSION}"
 
   cd ${REPO_ROOT_DIR}
   while [[ $# -ne 0 ]]; do
@@ -308,16 +326,47 @@ function initialize() {
     case $parameter in
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
+      --gcp-project)
+        shift
+        [[ $# -ge 1 ]] || abort "missing project name after --gcp-project"
+        GCP_PROJECT=$1
+        ;;
+      --cluster-version)
+        shift
+        [[ $# -ge 1 ]] || abort "missing version after --cluster-version"
+        [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "kubernetes version must be 'X.Y.Z'"
+        E2E_CLUSTER_VERSION=$1
+        ;;
       *)
-        echo "error: unknown option ${parameter}"
-        echo "usage: $0 [--run-tests][--emit-metrics]"
-        exit 1
+        echo "usage: $0 [--run-tests][--emit-metrics][--cluster-version X.Y.Z][--gcp-project name]"
+        abort "unknown option ${parameter}"
         ;;
     esac
     shift
   done
+
+  # Use PROJECT_ID if set, unless --gcp-project was used.
+  if [[ -n "${PROJECT_ID:-}" && -z "${GCP_PROJECT}" ]]; then
+    echo "\$PROJECT_ID is set to '${PROJECT_ID}', using it to run the tests"
+    GCP_PROJECT="${PROJECT_ID}"
+  fi
+  if (( ! IS_PROW )) && [[ -z "${GCP_PROJECT}" ]]; then
+    abort "set \$PROJECT_ID or use --gcp-project to select the GCP project where the tests are run"
+  fi
+
+  (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
+
+  # Safety checks
+
+  if [[ "${DOCKER_REPO_OVERRIDE}" =~ ^gcr.io/knative-(releases|nightly)/?$ ]]; then
+    abort "\$DOCKER_REPO_OVERRIDE is set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
+  fi
+
   readonly RUN_TESTS
   readonly EMIT_METRICS
+  readonly E2E_CLUSTER_VERSION
+  readonly GCP_PROJECT
+  readonly IS_BOSKOS
 
   if (( ! RUN_TESTS )); then
     create_test_cluster

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -22,12 +22,12 @@
 readonly SERVING_GKE_VERSION=latest
 readonly SERVING_GKE_IMAGE=cos
 
-# Public images and yaml files.
-readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio-crds.yaml
-readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
-readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
-readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-releases/build/latest/release.yaml
-readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
+# Public latest stable nightly images and yaml files.
+readonly KNATIVE_ISTIO_CRD_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio-crds.yaml
+readonly KNATIVE_ISTIO_YAML=https://storage.googleapis.com/knative-nightly/serving/latest/istio.yaml
+readonly KNATIVE_SERVING_RELEASE=https://storage.googleapis.com/knative-nightly/serving/latest/release.yaml
+readonly KNATIVE_BUILD_RELEASE=https://storage.googleapis.com/knative-nightly/build/latest/release.yaml
+readonly KNATIVE_EVENTING_RELEASE=https://storage.googleapis.com/knative-nightly/eventing/latest/release.yaml
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then
@@ -47,7 +47,7 @@ readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 #             $2 - banner message.
 function make_banner() {
     local msg="$1$1$1$1 $2 $1$1$1$1"
-    local border="${msg//[-0-9A-Za-z _.,]/$1}"
+    local border="${msg//[-0-9A-Za-z _.,\/]/$1}"
     echo -e "${border}\n${msg}\n${border}"
 }
 
@@ -100,7 +100,10 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    kubectl ${KUBECTL_ARGS} > /dev/null 2>&1 || return 0
+    if kubectl ${KUBECTL_ARGS} > /dev/null 2>&1; then
+      echo "\n${DESCRIPTION} does not exist"
+      return 0
+    fi
     echo -n "."
     sleep 2
   done
@@ -182,9 +185,8 @@ function wait_until_routable() {
 # Parameters: $1 - app name.
 #             $2 - namespace (optional).
 function get_app_pod() {
-  local namespace=""
-  [[ -n $2 ]] && namespace="-n $2"
-  kubectl get pods ${namespace} --selector=app=$1 --output=jsonpath="{.items[0].metadata.name}"
+  local pods=($(get_app_pods $1 $2))
+  echo "${pods[0]}"
 }
 
 # Returns the name of all pods of the given app.
@@ -235,8 +237,8 @@ function acquire_cluster_admin_role() {
 function report_go_test() {
   # Run tests in verbose mode to capture details.
   # go doesn't like repeating -v, so remove if passed.
-  local args=("${@/-v}")
-  local go_test="go test -race -v ${args[@]}"
+  local args=" $@ "
+  local go_test="go test -race -v ${args/ -v / }"
   # Just run regular go tests if not on Prow.
   if (( ! IS_PROW )); then
     ${go_test}
@@ -246,6 +248,7 @@ function report_go_test() {
   local report=$(mktemp)
   local failed=0
   local test_count=0
+  local tests_failed=0
   ${go_test} > ${report} || failed=$?
   echo "Finished run, return code is ${failed}"
   # Tests didn't run.
@@ -298,6 +301,7 @@ function report_go_test() {
         local src="${name}.sh"
         echo "exit 0" > ${src}
         if [[ "${field1}" == "FAIL:" ]]; then
+          tests_failed=$(( tests_failed + 1 ))
           [[ -z "${error}" ]] && read error
           echo "cat <<ERROR-EOF" > ${src}
           echo "${error}" >> ${src}
@@ -324,13 +328,13 @@ function report_go_test() {
       fi
     fi
   done < ${report}
-  echo "Done parsing ${test_count} tests"
+  echo "Done parsing ${test_count} tests, ${tests_failed} tests failed"
   # If any test failed, show the detailed report.
   # Otherwise, we already shown the summary.
   # Exception: when emitting metrics, dump the full report.
   if (( failed )) || [[ "$@" == *" -emitmetrics"* ]]; then
     if (( failed )); then
-      echo "At least one test failed, full log:"
+      echo "There were ${tests_failed} test failures, full log:"
     else
       echo "Dumping full log as metrics were requested:"
     fi

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -20,7 +20,7 @@
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Extensions or file patterns that don't require presubmit tests.
-readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)
+readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS ^OWNERS_ALIASES)
 
 # Options set by command-line flags.
 RUN_BUILD_TESTS=0
@@ -48,6 +48,11 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
+function abort() {
+  echo "error: $@"
+  exit 1
+}
+
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
@@ -63,52 +68,55 @@ function main() {
     kubectl version
     echo ">> go version"
     go version
+    echo ">> git version"
+    git version
   fi
 
-  local all_parameters=$@
-  [[ -z $1 ]] && all_parameters="--all-tests"
+  [[ -z $1 ]] && set -- "--all-tests"
 
-  for parameter in ${all_parameters}; do
+  local TEST_TO_RUN=""
+
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case ${parameter} in
+      --build-tests) RUN_BUILD_TESTS=1 ;;
+      --unit-tests) RUN_UNIT_TESTS=1 ;;
+      --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
         RUN_INTEGRATION_TESTS=1
+        ;;
+      --run-test)
         shift
+        [[ $# -ge 1 ]] || abort "missing executable after --run-test"
+        TEST_TO_RUN=$1
         ;;
-      --build-tests)
-        RUN_BUILD_TESTS=1
-        shift
-        ;;
-      --unit-tests)
-        RUN_UNIT_TESTS=1
-        shift
-        ;;
-      --integration-tests)
-        RUN_INTEGRATION_TESTS=1
-        shift
-        ;;
-      --emit-metrics)
-        EMIT_METRICS=1
-        shift
-        ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
-        ;;
+      *) abort "error: unknown option ${parameter}" ;;
     esac
+    shift
   done
 
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
   readonly EMIT_METRICS
+  readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
   # Tests to be performed, in the right order if --all-tests is passed.
 
   local failed=0
+
+  if [[ -n "${TEST_TO_RUN}" ]]; then
+    if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
+      abort "--run-test must be used alone"
+    fi
+    ${TEST_TO_RUN} || failed=1
+  fi
+
   if (( RUN_BUILD_TESTS )); then
     build_tests || failed=1
   fi
@@ -116,21 +124,38 @@ function main() {
     unit_tests || failed=1
   fi
   if (( RUN_INTEGRATION_TESTS )); then
+    local e2e_failed=0
+    # Run pre-integration tests, if any
     if function_exists pre_integration_tests; then
-      pre_integration_tests || failed=1
+      if ! pre_integration_tests; then
+        failed=1
+        e2e_failed=1
+      fi
     fi
-    if (( ! failed )); then
+    # Don't run integration tests if pre-integration tests failed
+    if (( ! e2e_failed )); then
       if function_exists integration_tests; then
-        integration_tests || failed=1
+        if ! integration_tests; then
+          failed=1
+          e2e_failed=1
+        fi
       else
        local options=""
        (( EMIT_METRICS )) && options="--emit-metrics"
-       ./test/e2e-tests.sh ${options} || failed=1
+       for e2e_test in ./test/e2e-*tests.sh; do
+         echo "Running integration test ${e2e_test}"
+         if ! ${e2e_test} ${options}; then
+           failed=1
+           e2e_failed=1
+         fi
+       done
       fi
     fi
-    if (( ! failed )) && function_exists post_integration_tests; then
+    # Don't run post-integration
+    if (( ! e2e_failed )) && function_exists post_integration_tests; then
       post_integration_tests || failed=1
     fi
   fi
+
   exit ${failed}
 }

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -31,8 +31,10 @@ function banner() {
 #             $3 - tag to apply (optional).
 function tag_images_in_yaml() {
   [[ -z $3 ]] && return 0
-  echo "Tagging images with $3"
-  for image in $(grep -o "$2/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
+  local src_dir="${GOPATH}/src/"
+  local BASE_PATH="${REPO_ROOT_DIR/$src_dir}"
+  echo "Tagging images under '${BASE_PATH}' with $3"
+  for image in $(grep -o "$2/${BASE_PATH}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
     gcloud -q container images add-tag ${image} ${image%%@*}:$3
   done
 }
@@ -108,8 +110,9 @@ function parse_flags() {
   fi
 
   if (( TAG_RELEASE )); then
-    # Currently we're not considering the tags in refs/tags namespace.
-    commit=$(git describe --always --dirty)
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi

--- a/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
+++ b/vendor/github.com/knative/test-infra/tools/dep-collector/imports.go
@@ -62,7 +62,7 @@ func CollectTransitiveImports(binaries []string) ([]string, error) {
 func qualifyLocalImport(ip string) (string, error) {
 	gopathsrc := filepath.Join(gb.Default.GOPATH, "src")
 	if !strings.HasPrefix(WorkingDir, gopathsrc) {
-		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = ", gopathsrc)
+		return "", fmt.Errorf("working directory must be on ${GOPATH}/src = %s", gopathsrc)
 	}
 	return filepath.Join(strings.TrimPrefix(WorkingDir, gopathsrc+string(filepath.Separator)), ip), nil
 }


### PR DESCRIPTION
Old images cleanup is no longer part of e2e test, this functionality will be moved to a separate job runs periodically.

## Proposed Changes

  * This part is done in knative/test-infra, updating dependencies in this repo to include this update.

Link to the issue in test-infra: knative/test-infra#276