### PR TITLE
Fix CCP reconcile issue with owned objects

### DIFF
--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
@@ -61,6 +61,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	ctx := context.TODO()
 	logger := r.logger.With(zap.Any("request", request))
 
+	// Workaround until https://github.com/kubernetes-sigs/controller-runtime/issues/214 is fixed.
 	// The reconcile requests will include a namespace if they are triggered because of changes to the
 	// objects owned by this ClusterChannelProvisioner (e.g k8s service). Since ClusterChannelProvisioner is
 	// cluster-scoped we need to unset the namespace or otherwise the provisioner object cannot be looked up.

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
@@ -61,6 +61,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	ctx := context.TODO()
 	logger := r.logger.With(zap.Any("request", request))
 
+	// The reconcile requests will include a namespace if they are triggered because of changes to the
+	// objects owned by this ClusterChannelProvisioner (e.g k8s service). Since ClusterChannelProvisioner is
+	// cluster-scoped we need to unset the namespace or otherwise the provisioner object cannot be looked up.
+	request.NamespacedName.Namespace = ""
+
 	ccp := &eventingv1alpha1.ClusterChannelProvisioner{}
 	err := r.client.Get(ctx, request.NamespacedName, ccp)
 

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
@@ -42,6 +42,7 @@ import (
 const (
 	ccpUid           = "test-uid"
 	testErrorMessage = "test-induced-error"
+	testNS           = "test-ns"
 )
 
 var (
@@ -211,6 +212,17 @@ func TestReconcile(t *testing.T) {
 				makeReadyClusterChannelProvisioner(),
 				makeK8sService(),
 			},
+		},
+		{
+			Name: "Create dispatcher succeeds - request is namespace-scoped",
+			InitialState: []runtime.Object{
+				makeClusterChannelProvisioner(),
+			},
+			WantPresent: []runtime.Object{
+				makeReadyClusterChannelProvisioner(),
+				makeK8sService(),
+			},
+			ReconcileKey: fmt.Sprintf("%s/%s", testNS, Name),
 		},
 		{
 			Name: "Error getting CCP for updating Status",

--- a/pkg/provisioners/kafka/controller/reconcile.go
+++ b/pkg/provisioners/kafka/controller/reconcile.go
@@ -42,6 +42,12 @@ const (
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.TODO()
 	r.logger.Info("reconciling ClusterChannelProvisioner", zap.Any("request", request))
+
+	// The reconcile requests triggered because of objects owned by this ClusterChannelProvisioner (e.g k8s service)
+	// will contain the namespace of that object. Since ClusterChannelProvisioner is cluster-scoped we need to unset the
+	// namespace or otherwise the provisioner object cannot be found.
+	request.NamespacedName.Namespace = ""
+
 	provisioner := &v1alpha1.ClusterChannelProvisioner{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, provisioner)
 

--- a/pkg/provisioners/kafka/controller/reconcile.go
+++ b/pkg/provisioners/kafka/controller/reconcile.go
@@ -43,6 +43,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	ctx := context.TODO()
 	r.logger.Info("reconciling ClusterChannelProvisioner", zap.Any("request", request))
 
+	// Workaround until https://github.com/kubernetes-sigs/controller-runtime/issues/214 is fixed.
 	// The reconcile requests triggered because of objects owned by this ClusterChannelProvisioner (e.g k8s service)
 	// will contain the namespace of that object. Since ClusterChannelProvisioner is cluster-scoped we need to unset the
 	// namespace or otherwise the provisioner object cannot be found.

--- a/pkg/provisioners/kafka/controller/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/reconcile_test.go
@@ -37,6 +37,7 @@ import (
 const (
 	clusterChannelProvisionerName = "kafka"
 	testNS                        = ""
+	otherTestNS                   = "testing"
 )
 
 func init() {
@@ -85,6 +86,18 @@ var testCases = []controllertesting.TestCase{
 		WantPresent: []runtime.Object{
 			GetNewChannelClusterChannelProvisioner("not-default-provisioner"),
 		},
+	},
+	{
+		Name: "reconciles even when request is namespace-scoped",
+		InitialState: []runtime.Object{
+			GetNewChannelClusterChannelProvisioner(clusterChannelProvisionerName),
+		},
+		ReconcileKey: fmt.Sprintf("%s/%s", otherTestNS, clusterChannelProvisionerName),
+		WantResult:   reconcile.Result{},
+		WantPresent: []runtime.Object{
+			GetNewChannelClusterChannelProvisionerReady(clusterChannelProvisionerName),
+		},
+		IgnoreTimes: true,
 	},
 	{
 		Name:         "clusterChannelProvisioner not found",


### PR DESCRIPTION
Fixes #649

## Proposed Changes

* Sets the reconcile request's namespace to an empty string as in a certain case it contains the namespace of the owned object. More details in the issue #649.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```