### PR TITLE
Kafka provisioner persists its finalizer before manipulating Kafka

### DIFF
--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -2,7 +2,6 @@ package provisioners
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
@@ -32,12 +31,6 @@ const (
 	FinalizerAlreadyPresent AddFinalizerResult = false
 	FinalizerAdded          AddFinalizerResult = true
 )
-
-// FinalizerAddedError is the error that the reconcile loop should return when a finalizer has been
-// added and needs to be persisted to the API server before other portions of the reconcile loop can
-// run. Returning an error will cause the reconcile loop to run again. This error is named to make
-// it easy to see that this is an 'expected' error.
-var FinalizerAddedError = errors.New("finalizer-added")
 
 // AddFinalizer adds finalizerName to the Channel.
 func AddFinalizer(c *eventingv1alpha1.Channel, finalizerName string) AddFinalizerResult {

--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -24,10 +24,23 @@ const (
 	PortNumber = 80
 )
 
-func AddFinalizer(c *eventingv1alpha1.Channel, finalizerName string) {
+// AddFinalizerResult is used indicate whether a finalizer was added or already present.
+type AddFinalizerResult bool
+
+const (
+	FinalizerAlreadyPresent AddFinalizerResult = false
+	FinalizerAdded          AddFinalizerResult = true
+)
+
+// AddFinalizer adds finalizerName to the Channel.
+func AddFinalizer(c *eventingv1alpha1.Channel, finalizerName string) AddFinalizerResult {
 	finalizers := sets.NewString(c.Finalizers...)
+	if finalizers.Has(finalizerName) {
+		return FinalizerAlreadyPresent
+	}
 	finalizers.Insert(finalizerName)
 	c.Finalizers = finalizers.List()
+	return FinalizerAdded
 }
 
 func RemoveFinalizer(c *eventingv1alpha1.Channel, finalizerName string) {

--- a/pkg/provisioners/channel_util_test.go
+++ b/pkg/provisioners/channel_util_test.go
@@ -118,6 +118,36 @@ func TestChannelUtils(t *testing.T) {
 	}
 }
 
+func TestAddFinalizer(t *testing.T) {
+	testCases := map[string]struct {
+		alreadyPresent bool
+	}{
+		"not present": {
+			alreadyPresent: false,
+		},
+		"already present": {
+			alreadyPresent: true,
+		},
+	}
+	finalizer := "test-finalizer"
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			c := getNewChannel()
+			if tc.alreadyPresent {
+				c.Finalizers = []string{finalizer}
+			} else {
+				c.Finalizers = []string{}
+			}
+			addFinalizerResult := AddFinalizer(c, finalizer)
+			if tc.alreadyPresent && addFinalizerResult != FinalizerAlreadyPresent {
+				t.Errorf("Finalizer already present, expected FinalizerAlreadyPresent. Actual %v", addFinalizerResult)
+			} else if !tc.alreadyPresent && addFinalizerResult != FinalizerAdded {
+				t.Errorf("Finalizer not already present, expected FinalizerAdded. Actual %v", addFinalizerResult)
+			}
+		})
+	}
+}
+
 func TestChannelNames(t *testing.T) {
 	testCases := []struct {
 		Name string

--- a/pkg/provisioners/kafka/controller/channel/reconcile.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile.go
@@ -92,10 +92,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	newChannel.Status.InitializeConditions()
 
+	var requeue = false
 	if clusterChannelProvisioner.Status.IsReady() {
 		// Reconcile this copy of the Channel and then write back any status
 		// updates regardless of whether the reconcile error out.
-		err = r.reconcile(ctx, newChannel)
+		requeue, err = r.reconcile(ctx, newChannel)
 	} else {
 		newChannel.Status.MarkNotProvisioned("NotProvisioned", "ClusterChannelProvisioner %s is not ready", clusterChannelProvisioner.Name)
 		err = fmt.Errorf("ClusterChannelProvisioner %s is not ready", clusterChannelProvisioner.Name)
@@ -107,15 +108,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Requeue if the resource is not ready:
-	return reconcile.Result{}, err
+	return reconcile.Result{
+		Requeue: requeue,
+	}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Channel) error {
+func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Channel) (bool, error) {
 
 	// We always need to sync the Channel config, so do it first.
 	if err := r.syncChannelConfig(ctx); err != nil {
 		r.logger.Info("error updating syncing the Channel config", zap.Error(err))
-		return err
+		return false, err
 	}
 
 	// We don't currently initialize r.kafkaClusterAdmin, hence we end up creating the cluster admin client every time.
@@ -128,7 +131,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 		kafkaClusterAdmin, err = createKafkaAdminClient(r.config)
 		if err != nil {
 			r.logger.Fatal("unable to build kafka admin client", zap.Error(err))
-			return err
+			return false, err
 		}
 	}
 
@@ -136,35 +139,35 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	accessor, err := meta.Accessor(channel)
 	if err != nil {
 		r.logger.Info("failed to get metadata", zap.Error(err))
-		return err
+		return false, err
 	}
 	deletionTimestamp := accessor.GetDeletionTimestamp()
 	if deletionTimestamp != nil {
 		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", deletionTimestamp))
 		if err := r.deprovisionChannel(channel, kafkaClusterAdmin); err != nil {
-			return err
+			return false, err
 		}
 		util.RemoveFinalizer(channel, finalizerName)
-		return nil
+		return false, nil
 	}
 
 	// If we are adding the finalizer for the first time, then ensure that finalizer is persisted
 	// before manipulating Kafka, which will not be automatically garbage collected by K8s if this
 	// Channel is deleted.
 	if addFinalizerResult := util.AddFinalizer(channel, finalizerName); addFinalizerResult == util.FinalizerAdded {
-		return util.FinalizerAddedError
+		return true, nil
 	}
 
 	if err := r.provisionChannel(channel, kafkaClusterAdmin); err != nil {
 		channel.Status.MarkNotProvisioned("NotProvisioned", "error while provisioning: %s", err)
-		return err
+		return false, err
 	}
 
 	svc, err := util.CreateK8sService(ctx, r.client, channel)
 
 	if err != nil {
 		r.logger.Info("error creating the Channel's K8s Service", zap.Error(err))
-		return err
+		return false, err
 	}
 
 	// Check if this Channel is the owner of the K8s service.
@@ -178,7 +181,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 
 	if err != nil {
 		r.logger.Info("error creating the Virtual Service for the Channel", zap.Error(err))
-		return err
+		return false, err
 	}
 
 	// If the Virtual Service is not controlled by this Channel, we should log a warning, but don't
@@ -192,7 +195,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	// close the connection
 	kafkaClusterAdmin.Close()
 
-	return nil
+	return false, nil
 }
 
 func (r *reconciler) shouldReconcile(channel *eventingv1alpha1.Channel, clusterChannelProvisioner *eventingv1alpha1.ClusterChannelProvisioner) bool {

--- a/pkg/provisioners/kafka/controller/channel/reconcile.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile.go
@@ -113,6 +113,9 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}, err
 }
 
+// reconcile reconciles this Channel so that the real world matches the intended state. The returned
+// boolean indicates if this Channel should be immediately requeued for another reconcile loop. The
+// returned error indicates an error during reconciliation.
 func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Channel) (bool, error) {
 
 	// We always need to sync the Channel config, so do it first.

--- a/pkg/provisioners/kafka/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	"github.com/Shopify/sarama"
 	"github.com/google/go-cmp/cmp"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
@@ -131,7 +133,9 @@ var testCases = []controllertesting.TestCase{
 			getNewChannel(channelName, clusterChannelProvisionerName),
 			makeVirtualService(),
 		},
-		WantErrMsg: util.FinalizerAddedError.Error(),
+		WantResult: reconcile.Result{
+			Requeue: true,
+		},
 		WantPresent: []runtime.Object{
 			getNewChannelWithStatusAndFinalizer(channelName, clusterChannelProvisionerName),
 		},

--- a/pkg/provisioners/kafka/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/kafka/controller/channel/reconcile_test.go
@@ -24,6 +24,11 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/google/go-cmp/cmp"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	controllertesting "github.com/knative/eventing/pkg/controller/testing"
+	"github.com/knative/eventing/pkg/provisioners"
+	util "github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
@@ -32,13 +37,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/controller/testing"
-	"github.com/knative/eventing/pkg/provisioners"
-	util "github.com/knative/eventing/pkg/provisioners"
-	"github.com/knative/eventing/pkg/provisioners/kafka/controller"
 )
 
 const (
@@ -127,18 +125,27 @@ func (ca *mockClusterAdmin) DeleteACL(filter sarama.AclFilter, validateOnly bool
 
 var testCases = []controllertesting.TestCase{
 	{
-		Name: "new channel with valid provisioner: adds provisioned status",
+		Name: "new channel with valid provisioner: adds finalizer",
 		InitialState: []runtime.Object{
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
 			getNewChannel(channelName, clusterChannelProvisionerName),
 			makeVirtualService(),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
+		WantErrMsg: util.FinalizerAddedError.Error(),
+		WantPresent: []runtime.Object{
+			getNewChannelWithStatusAndFinalizer(channelName, clusterChannelProvisionerName),
+		},
+	},
+	{
+		Name: "new channel with valid provisioner and finalizer: adds provisioned status",
+		InitialState: []runtime.Object{
+			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
+			getNewChannelWithStatusAndFinalizer(channelName, clusterChannelProvisionerName),
+			makeVirtualService(),
+		},
 		WantPresent: []runtime.Object{
 			getNewChannelProvisionedStatus(channelName, clusterChannelProvisionerName),
 		},
-		IgnoreTimes: true,
 	},
 	{
 		Name: "new channel with provisioner not ready: error",
@@ -146,24 +153,18 @@ var testCases = []controllertesting.TestCase{
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, false),
 			getNewChannel(channelName, clusterChannelProvisionerName),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
-		WantErrMsg:   "ClusterChannelProvisioner " + clusterChannelProvisionerName + " is not ready",
+		WantErrMsg: "ClusterChannelProvisioner " + clusterChannelProvisionerName + " is not ready",
 		WantPresent: []runtime.Object{
 			getNewChannelNotProvisionedStatus(channelName, clusterChannelProvisionerName,
 				"ClusterChannelProvisioner "+clusterChannelProvisionerName+" is not ready"),
 		},
-		IgnoreTimes: true,
 	},
 	{
 		Name: "new channel with missing provisioner: error",
 		InitialState: []runtime.Object{
 			getNewChannel(channelName, clusterChannelProvisionerName),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
-		WantErrMsg:   "clusterchannelprovisioners.eventing.knative.dev \"" + clusterChannelProvisionerName + "\" not found",
-		IgnoreTimes:  true,
+		WantErrMsg: "clusterchannelprovisioners.eventing.knative.dev \"" + clusterChannelProvisionerName + "\" not found",
 	},
 	{
 		Name: "new channel with provisioner not managed by this controller: skips channel",
@@ -172,32 +173,23 @@ var testCases = []controllertesting.TestCase{
 			getNewClusterChannelProvisioner("not-our-provisioner", true),
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
 		WantPresent: []runtime.Object{
 			getNewChannel(channelName, "not-our-provisioner"),
 		},
-		IgnoreTimes: true,
 	},
 	{
 		Name: "new channel with missing provisioner reference: skips channel",
 		InitialState: []runtime.Object{
 			getNewChannelNoProvisioner(channelName),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
 		WantPresent: []runtime.Object{
 			getNewChannelNoProvisioner(channelName),
 		},
-		IgnoreTimes: true,
 	},
 	{
 		Name:         "channel not found",
 		InitialState: []runtime.Object{},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
 		WantPresent:  []runtime.Object{},
-		IgnoreTimes:  true,
 	},
 	{
 		Name: "error fetching channel",
@@ -205,9 +197,8 @@ var testCases = []controllertesting.TestCase{
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
 			getNewChannel(channelName, clusterChannelProvisionerName),
 		},
-		Mocks:        mockFetchError,
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantErrMsg:   "error fetching",
+		Mocks:      mockFetchError,
+		WantErrMsg: "error fetching",
 		WantPresent: []runtime.Object{
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
 			getNewChannel(channelName, clusterChannelProvisionerName),
@@ -219,10 +210,7 @@ var testCases = []controllertesting.TestCase{
 			getNewClusterChannelProvisioner(clusterChannelProvisionerName, true),
 			getNewChannelDeleted(channelName, clusterChannelProvisionerName),
 		},
-		ReconcileKey: fmt.Sprintf("%s/%s", testNS, channelName),
-		WantResult:   reconcile.Result{},
-		WantPresent:  []runtime.Object{},
-		IgnoreTimes:  true,
+		WantPresent: []runtime.Object{},
 	},
 }
 
@@ -230,6 +218,9 @@ func TestAllCases(t *testing.T) {
 	recorder := record.NewBroadcaster().NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	for _, tc := range testCases {
+		tc.ReconcileKey = fmt.Sprintf("%s/%s", testNS, channelName)
+		tc.IgnoreTimes = true
+
 		c := tc.GetClient()
 		logger := provisioners.NewProvisionerLoggerFromConfig(provisioners.NewLoggingConfig())
 		r := &reconciler{
@@ -424,6 +415,18 @@ func getNewChannel(name, provisioner string) *eventingv1alpha1.Channel {
 	// selflink is not filled in when we create the object, so clear it
 	channel.ObjectMeta.SelfLink = ""
 	return channel
+}
+
+func getNewChannelWithFinalizer(name, provisioner string) *eventingv1alpha1.Channel {
+	c := getNewChannel(name, provisioner)
+	util.AddFinalizer(c, finalizerName)
+	return c
+}
+
+func getNewChannelWithStatusAndFinalizer(name, provisioner string) *eventingv1alpha1.Channel {
+	c := getNewChannelWithFinalizer(name, provisioner)
+	c.Status.InitializeConditions()
+	return c
 }
 
 func getNewChannelWithArgs(name string, args map[string]interface{}) *eventingv1alpha1.Channel {


### PR DESCRIPTION
A possible fix for #643 (for the Kafka provisioner anyway).

## Proposed Changes

  * util.AddFinalizer returns whether or not a finalizer was added.
  * The Kafka provisioner's first reconcile loop will only add the finalizer, _not_ manipulate Kafka. It returns result with `Requeue: true`, which causes the next reconcile to occur immediately and that reconcile manipulates Kafka.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```