### PR TITLE
Fixture builders for Subscription reconcile tests

### DIFF
--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -75,13 +75,13 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "subscription but From channel does not exist",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		WantErrMsg: `channels.eventing.knative.dev "fromchannel" not found`,
 	}, {
 		Name: "subscription, but From is not subscribable",
 		InitialState: []runtime.Object{
-			getNewSourceSubscription(),
+			Subscription().FromSource(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
@@ -141,11 +141,11 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "Valid channel, subscriber does not exist",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		WantErrMsg: `routes.serving.knative.dev "subscriberroute" not found`,
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithUnknownConditions(),
+			Subscription().UnknownConditions(),
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -167,10 +167,10 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "Valid channel, subscriber is not callable",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithUnknownConditions(),
+			Subscription().UnknownConditions(),
 		},
 		WantErrMsg: "status does not contain address",
 		Scheme:     scheme.Scheme,
@@ -207,10 +207,10 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "Valid channel and subscriber, result does not exist",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithUnknownConditionsAndPhysicalSubscriber(),
+			Subscription().UnknownConditions().PhysicalSubscriber(targetDNS),
 		},
 		WantErrMsg: `channels.eventing.knative.dev "resultchannel" not found`,
 		Scheme:     scheme.Scheme,
@@ -249,14 +249,14 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "valid channel, subscriber, result is not addressable",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		WantErrMsg: "status does not contain address",
 		WantPresent: []runtime.Object{
 			// TODO: Again this works on gke cluster, but I need to set
 			// something else up here. later...
-			// getNewSubscriptionWithReferencesResolvedStatus(),
-			getNewSubscriptionWithUnknownConditionsAndPhysicalSubscriber(),
+			// Subscription().ReferencesResolved(),
+			Subscription().UnknownConditions().PhysicalSubscriber(targetDNS),
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -308,14 +308,14 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription: adds status, all targets resolved, subscribers modified",
 		InitialState: []runtime.Object{
-			getNewSubscription(),
+			Subscription(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
 		// failure for now, until upstream is fixed.
 		WantResult: reconcile.Result{},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberReply(),
+			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
 		Scheme:     scheme.Scheme,
@@ -373,14 +373,14 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription: adds status, all targets resolved, subscribers modified -- empty but non-nil reply",
 		InitialState: []runtime.Object{
-			getNewSubscriptionWithEmptyNonNilReply(),
+			Subscription().EmptyNonNilReply(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
 		// failure for now, until upstream is fixed.
 		WantResult: reconcile.Result{},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberAndNoReply(),
+			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).EmptyNonNilReply(),
 		},
 		WantErrMsg: "invalid JSON document",
 		Scheme:     scheme.Scheme,
@@ -419,14 +419,14 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription: adds status, all targets resolved, subscribers modified -- empty but non-nil subscriber",
 		InitialState: []runtime.Object{
-			getNewSubscriptionWithEmptyNonNilSubscriber(),
+			Subscription().EmptyNonNilSubscriber(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
 		// failure for now, until upstream is fixed.
 		WantResult: reconcile.Result{},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithReferencesResolvedAndPhysicalReplyAndNoSubscriber(),
+			Subscription().EmptyNonNilSubscriber().ReferencesResolved().Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
 		Scheme:     scheme.Scheme,
@@ -468,11 +468,11 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription to non-existent K8s Service: fails with no service found",
 		InitialState: []runtime.Object{
-			getNewSubscriptionToK8sService(),
+			Subscription().ToK8sService(),
 		},
 		WantResult: reconcile.Result{},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionToK8sServiceWithUnknownConditions(),
+			Subscription().ToK8sService().UnknownConditions(),
 		},
 		WantErrMsg: "services \"testk8sservice\" not found",
 		Scheme:     scheme.Scheme,
@@ -495,7 +495,7 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription to K8s Service: adds status, all targets resolved, subscribers modified",
 		InitialState: []runtime.Object{
-			getNewSubscriptionToK8sService(),
+			Subscription().ToK8sService(),
 			getK8sService(),
 		},
 		// TODO: JSON patch is not working on the fake, see
@@ -503,7 +503,7 @@ var testCases = []controllertesting.TestCase{
 		// failure for now, until upstream is fixed.
 		WantResult: reconcile.Result{},
 		WantPresent: []runtime.Object{
-			getNewSubscriptionToK8sServiceWithReferencesResolvedAndPhysicalFromSubscriberReply(),
+			Subscription().ToK8sService().ReferencesResolved().PhysicalSubscriber(k8sServiceDNS).Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
 		Scheme:     scheme.Scheme,
@@ -556,7 +556,7 @@ var testCases = []controllertesting.TestCase{
 	}, {
 		Name: "new subscription with from channel: adds status, all targets resolved, subscribers modified",
 		InitialState: []runtime.Object{
-			getNewSubscriptionWithFromChannel(),
+			Subscription(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
@@ -564,7 +564,7 @@ var testCases = []controllertesting.TestCase{
 		WantResult: reconcile.Result{},
 		WantErrMsg: "invalid JSON document",
 		WantPresent: []runtime.Object{
-			getNewSubscriptionWithSourceWithReferencesResolvedAndPhysicalFromSubscriberReply(),
+			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -638,11 +638,11 @@ var testCases = []controllertesting.TestCase{
 		InitialState: []runtime.Object{
 			// The first two Subscriptions both have the same physical From, so we should see that
 			// Channel updated with both Subscriptions.
-			getNewSubscriptionWithFromChannel(),
-			rename(getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberReply()),
+			Subscription(),
+			Subscription().Renamed().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 			// This subscription has a different physical From, so we should not see it in the same
 			// Channel as the first two.
-			getSubscriptionWithDifferentChannel(),
+			Subscription().DifferentChannel(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
@@ -656,10 +656,10 @@ var testCases = []controllertesting.TestCase{
 			// a Strategic Merge Patch, whereas we are doing a JSON Patch). so for now, comment it
 			// out.
 			//getChannelWithMultipleSubscriptions(),
-			getNewSubscriptionWithSourceWithReferencesResolvedAndPhysicalFromSubscriberReply(),
+			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 			// Unaltered because this Subscription was not reconciled.
-			rename(getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberReply()),
-			getSubscriptionWithDifferentChannel(),
+			Subscription().Renamed().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
+			Subscription().DifferentChannel(),
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -731,7 +731,7 @@ var testCases = []controllertesting.TestCase{
 	{
 		Name: "delete subscription with from channel: subscribers modified",
 		InitialState: []runtime.Object{
-			getNewDeletedSubscriptionWithChannelReady(),
+			Subscription().Deleted().ChannelReady(),
 		},
 		// TODO: JSON patch is not working on the fake, see
 		// https://github.com/kubernetes/client-go/issues/478. Marking this as expecting a specific
@@ -739,20 +739,20 @@ var testCases = []controllertesting.TestCase{
 		WantResult: reconcile.Result{},
 		WantErrMsg: "invalid JSON document",
 		WantAbsent: []runtime.Object{
-			// TODO: JSON patch is not working on the fake, see
-			// https://github.com/kubernetes/client-go/issues/478. The entire test is really to
-			// verify the following, but can't be done because the call to Patch fails (it assumes
-			// a Strategic Merge Patch, whereas we are doing a JSON Patch). so for now, comment it
-			// out.
-			//getNewDeletedSubscriptionWithChannelReady(),
+		// TODO: JSON patch is not working on the fake, see
+		// https://github.com/kubernetes/client-go/issues/478. The entire test is really to
+		// verify the following, but can't be done because the call to Patch fails (it assumes
+		// a Strategic Merge Patch, whereas we are doing a JSON Patch). so for now, comment it
+		// out.
+		//getNewDeletedSubscriptionWithChannelReady(),
 		},
 		WantPresent: []runtime.Object{
-			// TODO: JSON patch is not working on the fake, see
-			// https://github.com/kubernetes/client-go/issues/478. The entire test is really to
-			// verify the following, but can't be done because the call to Patch fails (it assumes
-			// a Strategic Merge Patch, whereas we are doing a JSON Patch). so for now, comment it
-			// out.
-			//getChannelWithOtherSubscription(),
+		// TODO: JSON patch is not working on the fake, see
+		// https://github.com/kubernetes/client-go/issues/478. The entire test is really to
+		// verify the following, but can't be done because the call to Patch fails (it assumes
+		// a Strategic Merge Patch, whereas we are doing a JSON Patch). so for now, comment it
+		// out.
+		//getChannelWithOtherSubscription(),
 		},
 		Objects: []runtime.Object{
 			// Source channel
@@ -878,203 +878,6 @@ func getNewChannel(name string) *eventingv1alpha1.Channel {
 	// selflink is not filled in when we create the object, so clear it
 	channel.ObjectMeta.SelfLink = ""
 	return channel
-}
-
-// rename renames the subscription. It is intended to be used in tests that create multiple
-// Subscriptions, so that there are no naming conflicts.
-func rename(sub *eventingv1alpha1.Subscription) *eventingv1alpha1.Subscription {
-	sub.Name = "renamed"
-	sub.UID = "renamed-UID"
-	sub.Status.PhysicalSubscription.SubscriberURI = ""
-	sub.Status.PhysicalSubscription.ReplyURI = otherAddressableDNS
-	return sub
-}
-
-func getNewSubscription() *eventingv1alpha1.Subscription {
-	subscription := &eventingv1alpha1.Subscription{
-		TypeMeta:   subscriptionType(),
-		ObjectMeta: om(testNS, subscriptionName),
-		Spec: eventingv1alpha1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
-				Name:       fromChannelName,
-				Kind:       channelKind,
-				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-			},
-			Subscriber: &eventingv1alpha1.SubscriberSpec{
-				Ref: &corev1.ObjectReference{
-					Name:       routeName,
-					Kind:       routeKind,
-					APIVersion: "serving.knative.dev/v1alpha1",
-				},
-			},
-			Reply: &eventingv1alpha1.ReplyStrategy{
-				Channel: &corev1.ObjectReference{
-					Name:       resultChannelName,
-					Kind:       channelKind,
-					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-				},
-			},
-		},
-	}
-	subscription.ObjectMeta.OwnerReferences = append(subscription.ObjectMeta.OwnerReferences, getOwnerReference(false))
-
-	// selflink is not filled in when we create the object, so clear it
-	subscription.ObjectMeta.SelfLink = ""
-	return subscription
-}
-
-func getNewSubscriptionWithEmptyNonNilReply() *eventingv1alpha1.Subscription {
-	sub := getNewSubscription()
-	sub.Spec.Reply = &eventingv1alpha1.ReplyStrategy{}
-	return sub
-}
-
-func getNewSubscriptionWithEmptyNonNilSubscriber() *eventingv1alpha1.Subscription {
-	sub := getNewSubscription()
-	sub.Spec.Subscriber = &eventingv1alpha1.SubscriberSpec{}
-	return sub
-}
-
-func getNewSourceSubscription() *eventingv1alpha1.Subscription {
-	sub := getNewSubscription()
-	sub.Spec.Channel = corev1.ObjectReference{
-		APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-		Kind:       sourceKind,
-		Name:       sourceName,
-	}
-	return sub
-}
-
-func getNewSubscriptionToK8sService() *eventingv1alpha1.Subscription {
-	sub := getNewSubscription()
-	sub.Spec.Subscriber = &eventingv1alpha1.SubscriberSpec{
-		Ref: &corev1.ObjectReference{
-			Name:       k8sServiceName,
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-	}
-	return sub
-}
-
-func getNewSubscriptionToK8sServiceWithUnknownConditions() *eventingv1alpha1.Subscription {
-	sub := getNewSubscriptionToK8sService()
-	sub.Status.InitializeConditions()
-	return sub
-}
-
-func getNewSubscriptionWithFromChannel() *eventingv1alpha1.Subscription {
-	subscription := &eventingv1alpha1.Subscription{
-		TypeMeta:   subscriptionType(),
-		ObjectMeta: om(testNS, subscriptionName),
-		Spec: eventingv1alpha1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
-				Name:       fromChannelName,
-				Kind:       channelKind,
-				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-			},
-			Subscriber: &eventingv1alpha1.SubscriberSpec{
-				Ref: &corev1.ObjectReference{
-					Name:       routeName,
-					Kind:       routeKind,
-					APIVersion: "serving.knative.dev/v1alpha1",
-				},
-			},
-			Reply: &eventingv1alpha1.ReplyStrategy{
-				Channel: &corev1.ObjectReference{
-					Name:       resultChannelName,
-					Kind:       channelKind,
-					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-				},
-			},
-		},
-	}
-	subscription.ObjectMeta.OwnerReferences = append(subscription.ObjectMeta.OwnerReferences, getOwnerReference(false))
-
-	// selflink is not filled in when we create the object, so clear it
-	subscription.ObjectMeta.SelfLink = ""
-	return subscription
-}
-
-func getNewSubscriptionWithUnknownConditions() *eventingv1alpha1.Subscription {
-	s := getNewSubscription()
-	s.Status.InitializeConditions()
-	return s
-}
-func getNewSubscriptionWithUnknownConditionsAndPhysicalSubscriber() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithUnknownConditions()
-	s.Status.PhysicalSubscription.SubscriberURI = domainToURL(targetDNS)
-	return s
-}
-
-func getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberAndNoReply() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithEmptyNonNilReply()
-	s.Status.InitializeConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription.SubscriberURI = domainToURL(targetDNS)
-	return s
-}
-
-func getNewSubscriptionWithReferencesResolvedAndPhysicalReplyAndNoSubscriber() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithEmptyNonNilSubscriber()
-	s.Status.InitializeConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription.ReplyURI = domainToURL(sinkableDNS)
-	return s
-}
-
-func getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberReply() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithUnknownConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription.SubscriberURI = domainToURL(targetDNS)
-	s.Status.PhysicalSubscription.ReplyURI = domainToURL(sinkableDNS)
-	return s
-}
-
-func getNewSubscriptionToK8sServiceWithReferencesResolvedAndPhysicalFromSubscriberReply() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionToK8sService()
-	s.Status.InitializeConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription = eventingv1alpha1.SubscriptionStatusPhysicalSubscription{
-		SubscriberURI: domainToURL(k8sServiceDNS),
-		ReplyURI:      domainToURL(sinkableDNS),
-	}
-	return s
-}
-
-func getNewSubscriptionWithSourceWithReferencesResolvedAndPhysicalFromSubscriberReply() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithFromChannel()
-	s.Status.InitializeConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription = eventingv1alpha1.SubscriptionStatusPhysicalSubscription{
-		SubscriberURI: domainToURL(targetDNS),
-		ReplyURI:      domainToURL(sinkableDNS),
-	}
-	return s
-}
-
-func getNewSubscriptionWithReferencesResolvedStatus() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithUnknownConditions()
-	s.Status.MarkReferencesResolved()
-	return s
-}
-
-func getSubscriptionWithDifferentChannel() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithSourceWithReferencesResolvedAndPhysicalFromSubscriberReply()
-	s.Name = "different-channel"
-	s.UID = "different-channel-UID"
-	s.Status.PhysicalSubscription.SubscriberURI = "some-other-domain"
-	return s
-}
-
-func getNewDeletedSubscriptionWithChannelReady() *eventingv1alpha1.Subscription {
-	s := getNewSubscriptionWithUnknownConditions()
-	s.Status.MarkReferencesResolved()
-	s.Status.PhysicalSubscription.SubscriberURI = domainToURL(targetDNS)
-	s.Status.PhysicalSubscription.ReplyURI = domainToURL(sinkableDNS)
-	s.Status.MarkChannelReady()
-	s.ObjectMeta.DeletionTimestamp = &deletionTime
-	return s
 }
 
 type SubscriptionBuilder struct {

--- a/pkg/controller/testing/builder.go
+++ b/pkg/controller/testing/builder.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// Buildable allows test fixtures to use the builder pattern. The table
+// test runner will call Build() on any Buildable objects and use the result
+// as the test fixture.
+type Buildable interface {
+	Build() runtime.Object
+}


### PR DESCRIPTION
The existing fixture builders in the Subscription reconciler tests aren't terrible, but they don't compose well. Every case needs its own fixture method like `getNewSubscriptionWithReferencesResolvedAndPhysicalReplyAndNoSubscriber`.

@dprotaso experimented with builders in https://github.com/knative/serving/pull/1762 and https://github.com/knative/serving/pull/1924, but apparently moved on to other things before getting to a satisfactory state.

This is my attempt at a builder interface satisfying the following:
- minimal code for both framework and test authors to write and understand
- Flexible for test authors to define their own builder function signatures
- No runtime typing (more than what's already used by the controller-runtime client)
- As clear (or clearer) to read as the existing fixtures

I chose the Subscription reconcile tests for this PoC because they use more complex combinations. The diffstats are probably a best case scenario for this kind of refactor.

Here's the diff for the above fixture invocation:

```diff
   WantPresent: []runtime.Object{
-    getNewSubscriptionWithReferencesResolvedAndPhysicalSubscriberAndNoReply(),
+    Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).EmptyNonNilReply(),
   },
```

And an example of one of the builder methods:

```go
func (s *SubscriptionBuilder) EmptyNonNilSubscriber() *SubscriptionBuilder {
	s.Spec.Subscriber = &eventingv1alpha1.SubscriberSpec{}
	return s
}
```

@mattmoor

