### PR TITLE
GCP PubSub controller persists its finalizer before manipulating anything outside of the cluster

### DIFF
--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sync"
 	"testing"
 	"time"
@@ -172,10 +173,22 @@ func TestReconcile(t *testing.T) {
 				makeDeletingChannelWithoutFinalizer(),
 			},
 		},
+				{
+			Name: "Finalizer added",
+			InitialState: []runtime.Object{
+				makeChannelWithSubscribers(),
+			},
+			WantResult: reconcile.Result{
+				Requeue:true,
+			},
+			WantPresent: []runtime.Object{
+				makeChannelWithSubscribersAndFinalizer(),
+			},
+		},
 		{
 			Name: "GetCredential fails",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribers(),
+				makeChannelWithSubscribersAndFinalizer(),
 				testcreds.MakeSecretWithInvalidCreds(),
 			},
 			WantPresent: []runtime.Object{
@@ -186,7 +199,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel update fails - cannot create PubSub client",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribers(),
+				makeChannelWithSubscribersAndFinalizer(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			OtherTestData: map[string]interface{}{
@@ -199,7 +212,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Receive errors",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribers(),
+				makeChannelWithSubscribersAndFinalizer(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			OtherTestData: map[string]interface{}{
@@ -231,7 +244,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "PubSub Subscription.Receive already running",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribers(),
+				makeChannelWithSubscribersAndFinalizer(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			OtherTestData: map[string]interface{}{
@@ -253,7 +266,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Delete old Subscriptions",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribers(),
+				makeChannelWithSubscribersAndFinalizer(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			OtherTestData: map[string]interface{}{


### PR DESCRIPTION
Working on #643.

## Proposed Changes

- Persist the finalizer before manipulating GCP PubSub.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
