### PR TITLE
Format markdown

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,4 @@
 # Contributor Covenant Code of Conduct
 
-Please see the Knative Community [Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/community/CODE-OF-CONDUCT.md).
+Please see the Knative Community
+[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/community/CODE-OF-CONDUCT.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,16 +1,17 @@
 # Development
 
 This doc explains how to setup a development environment so you can get started
-[contributing](./CONTRIBUTING.md) to Knative Eventing. Also take a look at [the
-development workflow](./CONTRIBUTING.md#workflow) and [the test
-docs](./test/README.md).
+[contributing](./CONTRIBUTING.md) to Knative Eventing. Also take a look at
+[the development workflow](./CONTRIBUTING.md#workflow) and
+[the test docs](./test/README.md).
 
 ## Getting started
 
 1. Setup [Knative Serving](http://github.com/knative/serving)
 1. [Create and checkout a repo fork](#checkout-your-fork)
 
-Once you meet these requirements, you can [start the eventing-controller](#starting-eventing-controller)!
+Once you meet these requirements, you can
+[start the eventing-controller](#starting-eventing-controller)!
 
 Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -20,7 +21,8 @@ You must have the core of [Knative](http://github.com/knative/serving) running
 on your cluster.
 
 You must have
-[ko](https://github.com/google/go-containerregistry/blob/master/cmd/ko/README.md) installed.
+[ko](https://github.com/google/go-containerregistry/blob/master/cmd/ko/README.md)
+installed.
 
 ### Checkout your fork
 
@@ -30,7 +32,8 @@ The Go tools require that you clone the repository to the
 
 To check out this repository:
 
-1. Create your own [fork of this repo](https://help.github.com/articles/fork-a-repo/)
+1. Create your own
+   [fork of this repo](https://help.github.com/articles/fork-a-repo/)
 2. Clone it to your machine:
 
 ```shell
@@ -42,10 +45,11 @@ git remote add upstream git@github.com:knative/eventing.git
 git remote set-url --push upstream no_push
 ```
 
-_Adding the `upstream` remote sets you up nicely for regularly [syncing your
-fork](https://help.github.com/articles/syncing-a-fork/)._
+_Adding the `upstream` remote sets you up nicely for regularly
+[syncing your fork](https://help.github.com/articles/syncing-a-fork/)._
 
-Once you reach this point you are ready to do a full build and deploy as follows.
+Once you reach this point you are ready to do a full build and deploy as
+follows.
 
 ## Starting Eventing Controller
 
@@ -72,15 +76,16 @@ kubectl -n knative-eventing logs $(kubectl -n knative-eventing get pods -l app=e
 
 ## Iterating
 
-As you make changes to the code-base, there are two special cases to be aware of:
+As you make changes to the code-base, there are two special cases to be aware
+of:
 
-- **If you change a type definition ([pkg/apis/](./pkg/apis/.)),** then you must run
-  [`./hack/update-codegen.sh`](./hack/update-codegen.sh).
-- **If you change a package's deps** (including adding external dep), then you must run
-  [`./hack/update-deps.sh`](./hack/update-deps.sh).
+- **If you change a type definition ([pkg/apis/](./pkg/apis/.)),** then you must
+  run [`./hack/update-codegen.sh`](./hack/update-codegen.sh).
+- **If you change a package's deps** (including adding external dep), then you
+  must run [`./hack/update-deps.sh`](./hack/update-deps.sh).
 
-These are both idempotent, and we expect that running these at `HEAD` to have
-no diffs.
+These are both idempotent, and we expect that running these at `HEAD` to have no
+diffs.
 
 Once the codegen and dependency information is correct, redeploying the
 controller is simply:
@@ -93,8 +98,8 @@ Or you can [clean it up completely](#clean-up) and start again.
 
 ## Tests
 
-Running tests as you make changes to the code-base is pretty simple. See [the
-test docs](./test/README.md).
+Running tests as you make changes to the code-base is pretty simple. See
+[the test docs](./test/README.md).
 
 ## Clean up
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ For complete Knative Eventing documentation, see
 [Knative eventing](https://github.com/knative/docs/tree/master/eventing) or
 [Knative docs](https://github.com/knative/docs/) to learn about Knative.
 
-If you are interested in contributing, see
-[CONTRIBUTING.md](./CONTRIBUTING.md), [DEVELOPMENT.md](./DEVELOPMENT.md) and
+If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
+[DEVELOPMENT.md](./DEVELOPMENT.md) and
 [Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#events).

--- a/config/provisioners/gcppubsub/README.md
+++ b/config/provisioners/gcppubsub/README.md
@@ -4,36 +4,42 @@ GCP PubSub channels are production-quality Channels that are backed by
 [GCP PubSub](https://cloud.google.com/pubsub/).
 
 They offer:
-* Persistence
-    - If the Channel's Pod goes down, all events already ACKed by the Channel will persist and be
-      retransmitted when the Pod restarts.
-* Redelivery attempts
-    - If downstream rejects an event, that request is attempted again.
- 
+
+- Persistence
+  - If the Channel's Pod goes down, all events already ACKed by the Channel will
+    persist and be retransmitted when the Pod restarts.
+- Redelivery attempts
+  - If downstream rejects an event, that request is attempted again.
+
 They do not offer:
-* Ordering guarantees
-    - Events seen downstream may not occur in the same order they were inserted into the Channel.
-    
+
+- Ordering guarantees
+  - Events seen downstream may not occur in the same order they were inserted
+    into the Channel.
+
 ### Deployment Steps
 
 #### Prerequisites
 
-1. Create a [Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+1. Create a
+   [Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 1. Enable the 'Cloud Pub/Sub API' on that project.
 
-    ```shell
-    gcloud services enable pubsub.googleapis.com
-    ```
+   ```shell
+   gcloud services enable pubsub.googleapis.com
+   ```
 
-1. Create a GCP [Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project).
-    1. Determine the Service Account to use, or create a new one.
-    1. Give that Service Account the 'Pub/Sub Editor' role on your GCP project.
-    1. Download a new JSON private key for that Service Account.
-    1. Create a secret for the downloaded key:
-        
-        ```shell
-        kubectl -n knative-sources create secret generic gcppubsub-channel-key --from-file=key.json=PATH_TO_KEY_FILE.json
-        ```
+1. Create a GCP
+   [Service Account](https://console.cloud.google.com/iam-admin/serviceaccounts/project).
+
+   1. Determine the Service Account to use, or create a new one.
+   1. Give that Service Account the 'Pub/Sub Editor' role on your GCP project.
+   1. Download a new JSON private key for that Service Account.
+   1. Create a secret for the downloaded key:
+
+      ```shell
+      kubectl -n knative-sources create secret generic gcppubsub-channel-key --from-file=key.json=PATH_TO_KEY_FILE.json
+      ```
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
 
@@ -41,50 +47,52 @@ They do not offer:
 
 1. Set the shell variable with the correct value:
 
-    ```shell
-    export GCP_PROJECT=REPLACE_ME
-    ```
+   ```shell
+   export GCP_PROJECT=REPLACE_ME
+   ```
 
 1. Apply `gcppubsub.yaml`.
 
-    ```shell
-    sed "s/REPLACE_WITH_GCP_PROJECT/$GCP_PROJECT/" config/provisioners/gcppubsub/gcppubsub.yaml | ko apply -f -
-    ```
+   ```shell
+   sed "s/REPLACE_WITH_GCP_PROJECT/$GCP_PROJECT/" config/provisioners/gcppubsub/gcppubsub.yaml | ko apply -f -
+   ```
 
 1. Create Channels that reference the `gcp-pubsub` Channel.
 
-    ```yaml
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    metadata:
-      name: foo
-    spec:
-      provisioner:
-        apiVersion: eventing.knative.dev/v1alpha1
-        kind: ClusterChannelProvisioner
-        name: gcp-pubsub
-    ```
+   ```yaml
+   apiVersion: eventing.knative.dev/v1alpha1
+   kind: Channel
+   metadata:
+     name: foo
+   spec:
+     provisioner:
+       apiVersion: eventing.knative.dev/v1alpha1
+       kind: ClusterChannelProvisioner
+       name: gcp-pubsub
+   ```
 
 ### Components
 
 The major components are:
-* [Channel Controller](../../../pkg/provisioners/gcppubsub/controller)
-    - [ClusterChannelProvisioner Controller](../../../pkg/provisioners/gcppubsub/clusterchannelprovisioner)
-    - [Channel Controller](../../../pkg/provisioners/gcppubsub/channel)
-* [Channel Dispatcher](../../../pkg/provisioners/gcppubsub/dispatcher/cmd)
-    - [Dispatcher](../../../pkg/provisioners/gcppubsub/dispatcher/dispatcher)
-    - [Receiver](../../../pkg/provisioners/gcppubsub/dispatcher/receiver)
-    
-The `Channel Controller` controls all the Kubernetes resources and creates `Topic`s and
-`Subscription`s in GCP PubSub. It runs in the Deployment:
+
+- [Channel Controller](../../../pkg/provisioners/gcppubsub/controller)
+  - [ClusterChannelProvisioner Controller](../../../pkg/provisioners/gcppubsub/clusterchannelprovisioner)
+  - [Channel Controller](../../../pkg/provisioners/gcppubsub/channel)
+- [Channel Dispatcher](../../../pkg/provisioners/gcppubsub/dispatcher/cmd)
+  - [Dispatcher](../../../pkg/provisioners/gcppubsub/dispatcher/dispatcher)
+  - [Receiver](../../../pkg/provisioners/gcppubsub/dispatcher/receiver)
+
+The `Channel Controller` controls all the Kubernetes resources and creates
+`Topic`s and `Subscription`s in GCP PubSub. It runs in the Deployment:
 
 ```shell
 kubectl get deployment -n knative-eventing gcp-pubsub-channel-controller
 ```
 
-The `Channel Dispatcher` handles all the data plane portions of the `Channel`. It receives events
-from the cluster and writes them to GCP PubSub `Topic`s. It also polls `Subscriptions`s and sends
-events back into the cluster. It runs in the Deployment:
+The `Channel Dispatcher` handles all the data plane portions of the `Channel`.
+It receives events from the cluster and writes them to GCP PubSub `Topic`s. It
+also polls `Subscriptions`s and sends events back into the cluster. It runs in
+the Deployment:
 
 ```shell
 kubectl get deployment -n knative-eventing gcp-pubsub-channel-dispatcher

--- a/config/provisioners/in-memory-channel/README.md
+++ b/config/provisioners/in-memory-channel/README.md
@@ -1,24 +1,25 @@
 # In-Memory Channels
 
-In-memory channels are a best effort Channel. They should **NOT** be used in Production. They are
-useful for development.
+In-memory channels are a best effort Channel. They should **NOT** be used in
+Production. They are useful for development.
 
 They differ from most Channels in that they have:
 
 - No persistence.
   - If a Pod goes down, messages go with it.
 - No ordering guarantee.
-  - There is nothing enforcing an ordering, so two messages that arrive at the same time may
-    go downstream in any order.
+  - There is nothing enforcing an ordering, so two messages that arrive at the
+    same time may go downstream in any order.
   - Different downstream subscribers may see different orders.
 - No redelivery attempts.
-  - If downstream rejects a request, a log message is written, but that request is never sent
-    again.
+  - If downstream rejects a request, a log message is written, but that request
+    is never sent again.
 
 ### Deployment steps:
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
-1. Apply the 'in-memory-channel' ClusterChannelProvisioner, Controller, and Dispatcher.
+1. Apply the 'in-memory-channel' ClusterChannelProvisioner, Controller, and
+   Dispatcher.
    ```shell
    ko apply -f config/provisioners/in-memory-channel/in-memory-channel.yaml
    ```
@@ -45,21 +46,22 @@ The major components are:
 - Channel Dispatcher
 - Channel Dispatcher Config Map.
 
-The ClusterChannelProvisioner Controller and the Channel Controller are colocated in one Pod.
+The ClusterChannelProvisioner Controller and the Channel Controller are
+colocated in one Pod.
 
 ```shell
 kubectl get deployment -n knative-eventing in-memory-channel-controller
 ```
 
-The Channel Dispatcher receives and distributes all events. There is a single Dispatcher for all
-in-memory Channels.
+The Channel Dispatcher receives and distributes all events. There is a single
+Dispatcher for all in-memory Channels.
 
 ```shell
 kubectl get deployment -n knative-eventing in-memory-channel-dispatcher
 ```
 
-The Channel Dispatcher Config Map is used to send information about Channels and Subscriptions from
-the Channel Controller to the Channel Dispatcher.
+The Channel Dispatcher Config Map is used to send information about Channels and
+Subscriptions from the Channel Controller to the Channel Dispatcher.
 
 ```shell
 kubectl get configmap -n knative-eventing in-memory-channel-dispatcher-config-map

--- a/config/provisioners/kafka/README.md
+++ b/config/provisioners/kafka/README.md
@@ -6,16 +6,18 @@ Deployment steps:
 1. If not done already, install an Apache Kafka cluster. There are two choices:
 
    - Simple installation of [Apache Kafka](broker).
-   - A production grade installation using the [Strimzi Kafka Operator](strimzi).
-     Installation [guides](http://strimzi.io/quickstarts/) are provided for
-     kubernetes and Openshift.
+   - A production grade installation using the
+     [Strimzi Kafka Operator](strimzi). Installation
+     [guides](http://strimzi.io/quickstarts/) are provided for kubernetes and
+     Openshift.
 
 1. Now that Apache Kafka is installed, you need to configure the
    `bootstrap_servers` value in the `kafka-channel-controller-config` ConfigMap,
    located inside the `config/provisioners/kafka/kafka-channel.yaml` file:
-   `... apiVersion: v1 kind: ConfigMap metadata: name: kafka-channel-controller-config namespace: knative-eventing data: # Broker URL's for the provisioner bootstrap_servers: kafkabroker.kafka:9092 ...` > Note: The `bootstrap_servers` needs to contain the address of at least
-   one broker of your Apache Kafka cluster. If you are using Strimzi, you need
-   to update the `bootstrap_servers` value to
+   `... apiVersion: v1 kind: ConfigMap metadata: name: kafka-channel-controller-config namespace: knative-eventing data: # Broker URL's for the provisioner bootstrap_servers: kafkabroker.kafka:9092 ...` >
+   Note: The `bootstrap_servers` needs to contain the address of at least one
+   broker of your Apache Kafka cluster. If you are using Strimzi, you need to
+   update the `bootstrap_servers` value to
    `my-cluster-kafka-bootstrap.mynamespace:9092`.
 1. Apply the 'Kafka' ClusterChannelProvisioner, Controller, and Dispatcher:
    ```
@@ -45,8 +47,8 @@ The major components are:
 - Channel Dispatcher
 - Channel Dispatcher Config Map.
 
-The ClusterChannelProvisioner Controller and the Channel Controller are colocated
-in one Pod:
+The ClusterChannelProvisioner Controller and the Channel Controller are
+colocated in one Pod:
 
 ```shell
 kubectl get deployment -n knative-eventing kafka-channel-controller

--- a/config/provisioners/kafka/broker/README.md
+++ b/config/provisioners/kafka/broker/README.md
@@ -1,11 +1,13 @@
 # Apache Kafka - simple installation
 
-1. For an installation of a simple (**non production**) Apache Kafka cluster, a setup is provided:
+1. For an installation of a simple (**non production**) Apache Kafka cluster, a
+   setup is provided:
    ```
    kubectl create namespace kafka
    kubectl apply -n kafka -f kafka-broker.yaml
    ```
-   > Note: If you are running Knative on OpenShift you will need to run the following command first to allow the Kafka broker to run as root:
+   > Note: If you are running Knative on OpenShift you will need to run the
+   > following command first to allow the Kafka broker to run as root:
    ```
    oc adm policy add-scc-to-user anyuid -z default -n kafka
    ```

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,20 +1,19 @@
 # Knative Personas
 
-When discussing user actions, it is often helpful to [define specific
-user roles](<https://en.wikipedia.org/wiki/Persona_(user_experience)>) who
-might want to do the action.
+When discussing user actions, it is often helpful to
+[define specific user roles](<https://en.wikipedia.org/wiki/Persona_(user_experience)>)
+who might want to do the action.
 
 ## Knative Events
 
-Event generation and consumption is a core part of the serverless
-(particularly function as a service) computing model. Event generation
-and dispatch enables decoupling of event producers from consumers.
+Event generation and consumption is a core part of the serverless (particularly
+function as a service) computing model. Event generation and dispatch enables
+decoupling of event producers from consumers.
 
 ### Event consumer (developer)
 
-An event consumer may be a software developer, or may be an integrator
-which is reusing existing packaged functions to build a workflow
-without writing code.
+An event consumer may be a software developer, or may be an integrator which is
+reusing existing packaged functions to build a workflow without writing code.
 
 User stories:
 
@@ -24,8 +23,8 @@ User stories:
 
 ### Event producer
 
-An event producer owns a data source or system which produces events
-which can be acted on by event consumers.
+An event producer owns a data source or system which produces events which can
+be acted on by event consumers.
 
 User stories:
 
@@ -34,9 +33,9 @@ User stories:
 
 ## Contributors
 
-Contributors are an important part of the Knative project. As such, we
-will also consider how various infrastructure encourages and enables
-contributors to the project, as well as the impact on end-users.
+Contributors are an important part of the Knative project. As such, we will also
+consider how various infrastructure encourages and enables contributors to the
+project, as well as the impact on end-users.
 
 - Hobbyist or newcomer
 - Motivated user

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -5,8 +5,8 @@ implemented in [`eventing.knative.dev`](/pkg/apis/eventing/v1alpha1) and
 verified via [the e2e test](/test/e2e).
 
 **Updates to this spec should include a corresponding change to the API
-implementation for [eventing](/pkg/apis/eventing/v1alpha1) and [the e2e
-test](/test/e2e).**
+implementation for [eventing](/pkg/apis/eventing/v1alpha1) and
+[the e2e test](/test/e2e).**
 
 Docs in this directory:
 
@@ -18,6 +18,7 @@ Docs in this directory:
 <!-- TODO(n3wscott): * [Error conditions and reporting](errors.md) -->
 <!-- TODO(n3wscott): * [Sample API usage](normative_examples.md) -->
 
-See the [Knative Eventing Docs
-Architecture](https://github.com/knative/docs/blob/master/eventing/README.md#architecture)
-for more high level details. <!-- TODO(#498): Update the docs/Architecture page. -->
+See the
+[Knative Eventing Docs Architecture](https://github.com/knative/docs/blob/master/eventing/README.md#architecture)
+for more high level details.
+<!-- TODO(#498): Update the docs/Architecture page. -->

--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -2,27 +2,27 @@
 
 ## Addressable
 
-An **Addressable** resource receives events over a network transport
-(currently only HTTP is supported). The _Addressable_ returns success when it
-has successfully handled the event (for example, by committing it to stable
-storage). When used as an _Addressable_, only the acknowledgement or return
-code is used to determine whether the event was handled successfully. One
-example of an _Addressable_ is a _Channel_.
+An **Addressable** resource receives events over a network transport (currently
+only HTTP is supported). The _Addressable_ returns success when it has
+successfully handled the event (for example, by committing it to stable
+storage). When used as an _Addressable_, only the acknowledgement or return code
+is used to determine whether the event was handled successfully. One example of
+an _Addressable_ is a _Channel_.
 
 ### Control Plane
 
-An **Addressable** resource MUST expose a `status.address.hostname` field.
-The _hostname_ value is a cluster-resolvable DNS name which is capable of
-receiving event deliveries. _Addressable_ resources may be referenced in the
-`reply` section of a _Subscription_, and also by other custom resources acting
-as an event Source.
+An **Addressable** resource MUST expose a `status.address.hostname` field. The
+_hostname_ value is a cluster-resolvable DNS name which is capable of receiving
+event deliveries. _Addressable_ resources may be referenced in the `reply`
+section of a _Subscription_, and also by other custom resources acting as an
+event Source.
 
 ### Data Plane
 
 An **Addressable** resource will only respond to requests with success or
-failure. Any payload (including a valid CloudEvent) returned to the sender
-will be ignored. An _Addressable_ may receive the same event multiple times
-even if it previously indicated success.
+failure. Any payload (including a valid CloudEvent) returned to the sender will
+be ignored. An _Addressable_ may receive the same event multiple times even if
+it previously indicated success.
 
 ---
 
@@ -39,8 +39,8 @@ _Addressable_ resources are _Callable_.
 A **Callable** resource MUST expose a `status.address.hostname` field (like
 _Addressable_). The _hostname_ value is a cluster-resolvable DNS name which is
 capable of receiving event deliveries and returning a resulting event in the
-reply.. _Callable_ resources may be referenced in the `subscriber` section of
-a _Subscription_.
+reply.. _Callable_ resources may be referenced in the `subscriber` section of a
+_Subscription_.
 
 <!-- TODO(evankanderson):
 
@@ -52,14 +52,14 @@ represent the return type of the _Callable_.
 
 ### Data Plane
 
-The **Callable** resource receives one event and returns zero or more events
-in response. The returned events are not required to be related to the received
+The **Callable** resource receives one event and returns zero or more events in
+response. The returned events are not required to be related to the received
 event. The _Callable_ should return a successful response if the event was
 processed successfully.
 
 The _Callable_ is not responsible for ensuring successful delivery of any
-received or returned event. It may receive the same event multiple times even
-if it previously indicated success.
+received or returned event. It may receive the same event multiple times even if
+it previously indicated success.
 
 ---
 

--- a/docs/spec/motivation.md
+++ b/docs/spec/motivation.md
@@ -7,12 +7,12 @@ enable late-binding event sources and event consumers.
 
 Knative Eventing has following principles:
 
-1. Services are loosely coupled during development and deployed independently
-   on a variety of platforms (Kubernetes, VMs, SaaS or FaaS).
+1. Services are loosely coupled during development and deployed independently on
+   a variety of platforms (Kubernetes, VMs, SaaS or FaaS).
 
-1. A producer can generate events before a consumer is listening, and a
-   consumer can express an interest in an event or class of events that is not
-   yet being produced.
+1. A producer can generate events before a consumer is listening, and a consumer
+   can express an interest in an event or class of events that is not yet being
+   produced.
 
 1. Services can be connected to create new applications
    - without modifying producer or consumer.
@@ -20,8 +20,8 @@ Knative Eventing has following principles:
      producer
 
 These primitives enable producing and consuming events adhering to the
-[CloudEvents Specification](https://github.com/cloudevents/spec), in a
-decoupled way.
+[CloudEvents Specification](https://github.com/cloudevents/spec), in a decoupled
+way.
 
 Kubernetes has no primitives related to event processing, yet this is an
 essential component in serverless workloads. Eventing introduces high-level
@@ -36,8 +36,8 @@ event transport, and declarative binding of events (generated either by storage
 services or earlier computation) to further event processing and persistence.
 
 The Knative Eventing API is intended to operate independently, and interoperate
-well with the [Serving API](https://github.com/knative/serving) and [Build
-API](https://github.com/knative/build).
+well with the [Serving API](https://github.com/knative/serving) and
+[Build API](https://github.com/knative/build).
 
 ---
 

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -1,20 +1,19 @@
 # Resource Types
 
 The API defines and provides a complete implementation for
-[Subscription](spec.md#kind-subscription) and abstract resource definitions
-for [Channels](spec.md#kind-channel) and
-[ClusterChannelProvisioners](spec.md#kind-clusterchannelprovisioner) which
-may be fulfilled by multiple backing implementations (much like the
-Kubernetes Ingress resource).
+[Subscription](spec.md#kind-subscription) and abstract resource definitions for
+[Channels](spec.md#kind-channel) and
+[ClusterChannelProvisioners](spec.md#kind-clusterchannelprovisioner) which may
+be fulfilled by multiple backing implementations (much like the Kubernetes
+Ingress resource).
 
-With extensibility and composability as a goal of Knative Eventing, the
-eventing API defines several resources that can be reduced down to well
-understood contracts. These eventing resource interfaces may be fulfilled by
-other Kubernetes objects and then composed in the same way as the concrete
-objects. The interfaces are ([Addressable](interfaces.md#addressable),
-[Subscribable](interfaces.md#Subscribable),
-[Callable](interfaces.md#callable)). For more details, see
-[Interface Contracts](interfaces.md).
+With extensibility and composability as a goal of Knative Eventing, the eventing
+API defines several resources that can be reduced down to well understood
+contracts. These eventing resource interfaces may be fulfilled by other
+Kubernetes objects and then composed in the same way as the concrete objects.
+The interfaces are ([Addressable](interfaces.md#addressable),
+[Subscribable](interfaces.md#Subscribable), [Callable](interfaces.md#callable)).
+For more details, see [Interface Contracts](interfaces.md).
 
 - A **Subscription** describes the transformation of an event and optional
   forwarding of a returned event.
@@ -26,17 +25,17 @@ objects. The interfaces are ([Addressable](interfaces.md#addressable),
 
 ![Resource Types Overview](images/resource-types-overview.svg)
 
-- **ClusterChannelProvisioners** implement strategies for realizing backing resources
-  for different implementations of _Channels_ currently active in the eventing
-  system.
+- **ClusterChannelProvisioners** implement strategies for realizing backing
+  resources for different implementations of _Channels_ currently active in the
+  eventing system.
 
 <!-- This image is sourced from https://drive.google.com/open?id=1o_0Xh5VjwpQ7Px08h_Q4qnaOdMjt4yCEPixRFwJQjh8 -->
 
 <img alt="Resource Types ClusterChannelProvisioners" src="images/resource-types-provisioner.svg" width="200">
 
 Sources are defined by independent CRDs that can be installed into a cluster.
-For more information see [Knative Eventing
-Sources](https://github.com/knative/eventing-sources).
+For more information see
+[Knative Eventing Sources](https://github.com/knative/eventing-sources).
 
 ## Subscription
 
@@ -79,8 +78,8 @@ provide cluster wide defaults for the _Channels_ they provision.
 _ClusterChannelProvisioners_ do not directly handle events. They are 1:N with
 _Channels_.
 
-For more details, see [Kind:
-ClusterChannelProvisioner](spec.md#kind-clusterchannelprovisioner).
+For more details, see
+[Kind: ClusterChannelProvisioner](spec.md#kind-clusterchannelprovisioner).
 
 ---
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -36,8 +36,8 @@ its subscribers._
 
 ##### Owner References
 
-- Owned (non-controlling) by the ClusterChannelProvisioner used to provision
-  the Channel.
+- Owned (non-controlling) by the ClusterChannelProvisioner used to provision the
+  Channel.
 
 #### Status
 
@@ -70,7 +70,8 @@ its subscribers._
 
 ### group: eventing.knative.dev/v1alpha1
 
-_Describes a linkage between a Channel and a Callable and/or Addressable channel._
+_Describes a linkage between a Channel and a Callable and/or Addressable
+channel._
 
 ### Object Schema
 
@@ -97,7 +98,8 @@ _Describes a linkage between a Channel and a Callable and/or Addressable channel
 
 - **Ready.**
 - **FromReady.**
-- **Resolved.** True if `channel`, `subscriber`, and `reply` all resolve into valid object references which implement the appropriate spec.
+- **Resolved.** True if `channel`, `subscriber`, and `reply` all resolve into
+  valid object references which implement the appropriate spec.
 
 #### Events
 
@@ -118,8 +120,8 @@ _Describes a linkage between a Channel and a Callable and/or Addressable channel
 
 ### group: eventing.knative.dev/v1alpha1
 
-_Describes an abstract configuration of a Source system which produces events
-or a Channel system that receives and delivers events._
+_Describes an abstract configuration of a Source system which produces events or
+a Channel system that receives and delivers events._
 
 ### Object Schema
 

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,9 +1,12 @@
 # Assorted scripts for development
 
-This directory contains several scripts useful in the development process of Knative Eventing.
+This directory contains several scripts useful in the development process of
+Knative Eventing.
 
-- `boilerplate/add-boilerplate.sh` Adds license boilerplate to _txt_ or _go_ files in a directory, recursively.
+- `boilerplate/add-boilerplate.sh` Adds license boilerplate to _txt_ or _go_
+  files in a directory, recursively.
 - `release.sh` Creates a new [release](release.md) of Knative Eventing.
 - `update-codegen.sh` Updates auto-generated client libraries.
 - `update-deps.sh` Updates Go dependencies.
-- `verify-codegen.sh` Verifies that auto-generated client libraries are up-to-date.
+- `verify-codegen.sh` Verifies that auto-generated client libraries are
+  up-to-date.

--- a/hack/release.md
+++ b/hack/release.md
@@ -7,30 +7,30 @@ By default, the script creates a nightly release but does not publish anywhere.
 
 ## Common flags for cutting releases
 
-The following flags affect the behavior of the script, no matter the type of
-the release.
+The following flags affect the behavior of the script, no matter the type of the
+release.
 
-- `--skip-tests` Do not run tests before building the release. Otherwise,
-  build, unit and end-to-end tests are run and they all must pass for the
-  release to be built.
-- `--tag-release`, `--notag-release` Tag (or not) the generated images
-  with either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or
-  `vX.Y.Z` for versioned releases. These are docker tags. _For versioned
-  releases, a tag is always added._
-- `--publish`, `--nopublish` Whether the generated images should be published
-  to a GCR, and the generated manifests written to a GCS bucket or not. If yes,
-  the destination GCR is defined by the environment variable
-  `$EVENTING_RELEASE_GCR` (defaults to `gcr.io/knative-nightly`) and
-  the destination GCS bucket is defined by the environment variable
-  `$EVENTING_RELEASE_GCS` (defaults to `knative-nightly/eventing`). If no, the
-  images will be pushed to the `ko.local` registry, and the manifests written to
-  the local disk only (in the repository root directory).
+- `--skip-tests` Do not run tests before building the release. Otherwise, build,
+  unit and end-to-end tests are run and they all must pass for the release to be
+  built.
+- `--tag-release`, `--notag-release` Tag (or not) the generated images with
+  either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
+  versioned releases. These are docker tags. _For versioned releases, a tag is
+  always added._
+- `--publish`, `--nopublish` Whether the generated images should be published to
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
+  destination GCR is defined by the environment variable `$EVENTING_RELEASE_GCR`
+  (defaults to `gcr.io/knative-nightly`) and the destination GCS bucket is
+  defined by the environment variable `$EVENTING_RELEASE_GCS` (defaults to
+  `knative-nightly/eventing`). If no, the images will be pushed to the
+  `ko.local` registry, and the manifests written to the local disk only (in the
+  repository root directory).
 
 ## Creating nightly releases
 
 Nightly releases are built against the current git tree. The behavior of the
-script is defined by the common flags. You must have write access to the GCR
-and GCS bucket the release will be pushed to, unless `--nopublish` is used.
+script is defined by the common flags. You must have write access to the GCR and
+GCS bucket the release will be pushed to, unless `--nopublish` is used.
 
 Examples:
 
@@ -53,11 +53,11 @@ repository, specified by the `--branch` flag.
 - `--version` Defines the version of the release, and must be in the form
   `X.Y.Z`, where X, Y and Z are numbers.
 - `--branch` Defines the branch in Knative Eventing repository from which the
-  release will be built. If not passed, the `master` branch at HEAD will be used.
-  This branch must be created before the script is executed, and must be in the
-  form `release-X.Y`, where X and Y must match the numbers used in the version
-  passed in the `--version` flag. This flag has no effect unless `--version` is
-  also passed.
+  release will be built. If not passed, the `master` branch at HEAD will be
+  used. This branch must be created before the script is executed, and must be
+  in the form `release-X.Y`, where X and Y must match the numbers used in the
+  version passed in the `--version` flag. This flag has no effect unless
+  `--version` is also passed.
 - `--release-notes` Points to a markdown file containing a description of the
   release. This is optional but highly recommended. It has no effect unless
   `--version` is also passed.

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,24 +12,25 @@ the [README](README.md).
    specific action
 1. Example source generating an event
 1. Example action
-1. Events conform to [CloudEvents](https://github.com/cloudevents/spec)
-   0.1 specification
+1. Events conform to [CloudEvents](https://github.com/cloudevents/spec) 0.1
+   specification
 
 ## 0.2 Friendly Repo
 
 1. Easy installation [issue#51](https://github.com/knative/eventing/issues/51)
 1. We have clear guidelines for how we use Prow
-1. All the contributing info is tested and someone new to the repo has made a
-   PR by following the directions
+1. All the contributing info is tested and someone new to the repo has made a PR
+   by following the directions
 
 ## 0.3 Functions
 
-1. An event can trigger Knative function [issue#52](https://github.com/knative/eventing/issues/52)
+1. An event can trigger Knative function
+   [issue#52](https://github.com/knative/eventing/issues/52)
 1. A local event can trigger a Google Cloud Function
 1. A Google source can trigger an action local within the Knative cluster.
    Likely this will use some scaffolding on the Google side to validate the
-   interaction between systems, such as deploying a Cloud Function that
-   forwards the Google Event to the Knative cluster.
+   interaction between systems, such as deploying a Cloud Function that forwards
+   the Google Event to the Knative cluster.
 
 ## 0.4 Event Persistence
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,3 +1,4 @@
 # Samples
 
-_Knative eventing_ samples have moved to [the docs repository](https://github.com/knative/docs/tree/master/eventing/samples).
+_Knative eventing_ samples have moved to
+[the docs repository](https://github.com/knative/docs/tree/master/eventing/samples).

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,8 @@
 
 This directory contains tests and testing docs for `Knative Eventing`.
 
-- [Unit tests](#running-unit-tests) reside in the codebase alongside the code they test
+- [Unit tests](#running-unit-tests) reside in the codebase alongside the code
+  they test
 - [End-to-end tests](#running-end-to-end-tests) reside in [`/test/e2e`](./e2e)
 
 ## Running unit tests
@@ -13,25 +14,30 @@ Use `go test`:
 go test -v ./pkg/...
 ```
 
-_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests),
+which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
 ## Presubmit tests
 
-[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the [end-to-end tests](/test/e2e).
+[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the
+[end-to-end tests](/test/e2e).
 
-This script, and consequently, the e2e tests will be run before every code submission. You can run these tests manually with:
+This script, and consequently, the e2e tests will be run before every code
+submission. You can run these tests manually with:
 
 ```shell
 test/presubmit-tests.sh
 ```
 
-_Note that to run `presubmit-tests.sh` or `e2e-tests.sh` scripts, you need to have a running environment that meets
+_Note that to run `presubmit-tests.sh` or `e2e-tests.sh` scripts, you need to
+have a running environment that meets
 [the e2e test environment requirements](#environment-requirements)_
 
 ## Running end-to-end tests
 
 To run [the e2e tests](./e2e), you need to have a running environment that meets
-[the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
+[the e2e test environment requirements](#environment-requirements), and you need
+to specify the build tag `e2e`.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e
@@ -39,7 +45,8 @@ go test -v -tags=e2e -count=1 ./test/e2e
 
 ### One test case
 
-To run one e2e test case, e.g. TestKubernetesEvents, use [the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
+To run one e2e test case, e.g. TestKubernetesEvents, use
+[the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e -run ^TestKubernetesEvents$
@@ -56,23 +63,36 @@ There's couple of things you need to install before running e2e tests locally.
 2. [A running `Knative Serving` cluster.]
 3. A docker repo containing [the test images](#test-images)
 
-Simply run the `./test/e2e-tests.sh` script. It will create a GKE cluster, install Knative Serving stack with Istio, upload test images to your Docker repo and run the end-to-end tests against the Knative Eventing built from source.
+Simply run the `./test/e2e-tests.sh` script. It will create a GKE cluster,
+install Knative Serving stack with Istio, upload test images to your Docker repo
+and run the end-to-end tests against the Knative Eventing built from source.
 
-If you already have the `*_OVERRIDE` environment variables set, call the script with the `--run-tests` argument and it will use the cluster and run the tests. Note that this requires you to have Serving and Istio installed and configured to your particular configuration setup. Knative Eventing will still built and deployed from source.
+If you already have the `*_OVERRIDE` environment variables set, call the script
+with the `--run-tests` argument and it will use the cluster and run the tests.
+Note that this requires you to have Serving and Istio installed and configured
+to your particular configuration setup. Knative Eventing will still built and
+deployed from source.
 
-Otherwise, calling this script without arguments will create a new cluster in project `$PROJECT_ID`, start Knative Serving and the eventing system, upload test images, run the tests and delete the cluster. In this case, it's required that `$DOCKER_REPO_OVERRIDE` points to a valid writable docker repo.
+Otherwise, calling this script without arguments will create a new cluster in
+project `$PROJECT_ID`, start Knative Serving and the eventing system, upload
+test images, run the tests and delete the cluster. In this case, it's required
+that `$DOCKER_REPO_OVERRIDE` points to a valid writable docker repo.
 
 ## Test images
 
 ### Building the test images
 
-Note: this is only required when you run e2e tests locally with `go test` commands. Running tests throught e2e-tests.sh will publish the images automatically.
+Note: this is only required when you run e2e tests locally with `go test`
+commands. Running tests throught e2e-tests.sh will publish the images
+automatically.
 
-The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to build and push the test images used by the e2e tests. It requires:
+The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to
+build and push the test images used by the e2e tests. It requires:
 
-- [`DOCKER_REPO_OVERRIDE`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup) to be set
-- You to be [authenticated with your
-  `DOCKER_REPO_OVERRIDE`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
+- [`DOCKER_REPO_OVERRIDE`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
+  to be set
+- You to be
+  [authenticated with your `DOCKER_REPO_OVERRIDE`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
 - [`docker`](https://docs.docker.com/install/) to be installed
 
 To run the script for all end to end test images:
@@ -81,15 +101,18 @@ To run the script for all end to end test images:
 ./test/upload-test-images.sh e2e
 ```
 
-A docker tag is mandatory to avoid issues with using `latest` tag for images deployed in GCR.
+A docker tag is mandatory to avoid issues with using `latest` tag for images
+deployed in GCR.
 
 ### Adding new test images
 
-New test images should be placed in `./test/test_images`. For each image create a new sub-folder
-and include a Go file that will be an entry point to the application. This Go file should use the
-package "main" and include the function main(). It is a good practice to include a readme file as well.
-When uploading test images, `ko` will build an image from this folder.
+New test images should be placed in `./test/test_images`. For each image create
+a new sub-folder and include a Go file that will be an entry point to the
+application. This Go file should use the package "main" and include the function
+main(). It is a good practice to include a readme file as well. When uploading
+test images, `ko` will build an image from this folder.
 
 ## Flags
 
-Flags are similar to those in [`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)
+Flags are similar to those in
+[`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,13 +4,17 @@
 
 ## Adding end to end tests
 
-Knative Eventing e2e tests [test the end to end functionality of the Knative Eventing API](#requirements) to verify the behavior of this specific implementation.
+Knative Eventing e2e tests
+[test the end to end functionality of the Knative Eventing API](#requirements)
+to verify the behavior of this specific implementation.
 
 ### Requirements
 
-The e2e tests are used to test whether the flow of Knative Eventing is performing as designed from start to finish.
+The e2e tests are used to test whether the flow of Knative Eventing is
+performing as designed from start to finish.
 
 The e2e tests **MUST**:
 
-1. Provide frequent output describing what actions they are undertaking, especially before performing long running operations.
+1. Provide frequent output describing what actions they are undertaking,
+   especially before performing long running operations.
 2. Follow Golang best practices.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`