### PR TITLE
Update test-infra to include latest features of release.sh

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -375,14 +375,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7a7aea24f67afa5dedb422fb3592d5a5c3af91b4b9d59eddf06767729915b3c4"
+  digest = "1:c30af6878fed9f93bc1ccb3a802720d1e5911c40d8903cd25fe95bcc21f0e31a"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "7ed32409fa2c447a44a4281f0022ab25ce955f51"
+  revision = "8a63be3b3795aa2f7ae9be32d840e096ba877c78"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/hack/release.md
+++ b/hack/release.md
@@ -3,7 +3,8 @@
 The `release.sh` script automates the creation of Knative Eventing releases,
 either nightly or versioned ones.
 
-By default, the script creates a nightly release but does not publish anywhere.
+By default, the script creates a nightly release but does not publish it
+anywhere.
 
 ## Common flags for cutting releases
 
@@ -17,12 +18,16 @@ release.
   either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
   versioned releases. These are docker tags. _For versioned releases, a tag is
   always added._
+- `--release-gcs` Defines the GCS bucket where the manifests will be stored.
+  By default, this is `knative-nightly/eventing`. This flag is ignored if the
+  release is not being published.
+- `--release-gcr` Defines the GCR where the images will be stored. By default,
+  this is `gcr.io/knative-nightly`. This flag is ignored if the release is not
+  being published.
 - `--publish`, `--nopublish` Whether the generated images should be published to
-  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
-  destination GCR is defined by the environment variable `$EVENTING_RELEASE_GCR`
-  (defaults to `gcr.io/knative-nightly`) and the destination GCS bucket is
-  defined by the environment variable `$EVENTING_RELEASE_GCS` (defaults to
-  `knative-nightly/eventing`). If no, the images will be pushed to the
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes,
+  the `--release-gcs` and `--release-gcr` flags can be used to change the
+  default values of the GCR/GCS used. If no, the images will be pushed to the
   `ko.local` registry, and the manifests written to the local disk only (in the
   repository root directory).
 

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -163,8 +163,14 @@ also overrides the value of the `TAG` variable as `v<version>`.
 it's empty and `master` HEAD will be considered the release branch.
     * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
 was passed. The release notes is a simple markdown file.
+    * `RELEASE_GCS_BUCKET`: contains the GCS bucket name to store the manifests if
+`--release-gcs` was passed, otherwise the default value `knative-nightly/<repo>` will be
+used. It is empty if `--publish` was not passed.
+    * `KO_DOCKER_REPO`: contains the GCR to store the images if `--release-gcr` was
+passed, otherwise the default value `gcr.io/knative-nightly` will be used. It is set to
+`ko.local` if `--publish` was not passed.
     * `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically
-by the run_validation_tests() function.
+by the `run_validation_tests()` function.
     * `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
 variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
     * `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
@@ -186,14 +192,12 @@ initialize $@
 run_validation_tests ./test/presubmit-tests.sh
 
 # config/ contains the manifests
-KO_DOCKER_REPO=gcr.io/knative-foo
 ko resolve ${KO_FLAGS} -f config/ > release.yaml
 
-tag_images_in_yaml release.yaml $KO_DOCKER_REPO $TAG
+tag_images_in_yaml release.yaml
 
 if (( PUBLISH_RELEASE )); then
-  # gs://knative-foo hosts the manifest
-  publish_yaml release.yaml knative-foo $TAG
+  publish_yaml release.yaml
 fi
 
 branch_release "Knative Foo" release.yaml

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -100,8 +100,8 @@ function wait_until_object_does_not_exist() {
   fi
   echo -n "Waiting until ${DESCRIPTION} does not exist"
   for i in {1..150}; do  # timeout after 5 minutes
-    if kubectl ${KUBECTL_ARGS} > /dev/null 2>&1; then
-      echo "\n${DESCRIPTION} does not exist"
+    if ! kubectl ${KUBECTL_ARGS} > /dev/null 2>&1; then
+      echo -e "\n${DESCRIPTION} does not exist"
       return 0
     fi
     echo -n "."
@@ -265,10 +265,11 @@ function report_go_test() {
     local field0="${fields[0]}"
     local field1="${fields[1]}"
     local name="${fields[2]}"
-    # Deal with a SIGQUIT log entry (usually a test timeout).
+    # Deal with a SIGQUIT or panic log entry (usually a test timeout).
     # This is a fallback in case there's no kill signal log entry.
     # SIGQUIT: quit
-    if [[ "${field0}" == "SIGQUIT:" ]]; then
+    # panic: test timed out after 5m0s
+    if [[ "${field0}" == "SIGQUIT:" || "${field0}" == "panic:" ]]; then
       name="${last_run}"
       field1="FAIL:"
       error="${fields[@]}"


### PR DESCRIPTION
Major changes:
* use flags instead of environment variables for setting GCR/GCS
* log configuration at the start of the process
* be more verbose when tagging/publishing