### PR TITLE
Format markdown

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -21,4 +21,5 @@ Docs in this directory:
 See the
 [Knative Eventing Docs Architecture](https://github.com/knative/docs/blob/master/eventing/README.md#architecture)
 for more high level details.
+
 <!-- TODO(#498): Update the docs/Architecture page. -->


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`