### PR TITLE
golang format tools

### DIFF
--- a/pkg/provisioners/natss/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/natss/controller/channel/reconcile_test.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (

--- a/pkg/provisioners/natss/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/provisioners/natss/dispatcher/dispatcher/dispatcher.go
@@ -88,7 +88,7 @@ func (s *SubscriptionsSupervisor) UpdateSubscriptions(channel *eventingv1alpha1.
 
 	cRef := provisioners.ChannelReference{Namespace: channel.Namespace, Name: channel.Name}
 
-	if (channel.Spec.Subscribable == nil || isFinalizer) {
+	if channel.Spec.Subscribable == nil || isFinalizer {
 		s.logger.Sugar().Infof("Empty subscriptions for channel Ref: %v; unsubscribe all active subscriptions, if any", cRef)
 		chMap, ok := s.subscriptions[cRef]
 		if !ok {

--- a/pkg/provisioners/natss/dispatcher/main.go
+++ b/pkg/provisioners/natss/dispatcher/main.go
@@ -17,15 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"log"
+	"time"
+
 	"github.com/knative/eventing/pkg/provisioners/natss/dispatcher/channel"
 	"github.com/knative/eventing/pkg/provisioners/natss/dispatcher/dispatcher"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"log"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"time"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners/natss/controller/clusterchannelprovisioner"

--- a/pkg/provisioners/natss/stanutil/stanutil.go
+++ b/pkg/provisioners/natss/stanutil/stanutil.go
@@ -48,7 +48,7 @@ func Connect(clusterId string, clientId string, natsUrl string, logger *zap.Suga
 
 // Close must be the last call to close the connection
 func Close(sc *stan.Conn, logger *zap.SugaredLogger) (err error) {
-	defer func() {  // the NATSS client could panic if the underlying connectivity is damaged
+	defer func() { // the NATSS client could panic if the underlying connectivity is damaged
 		if r := recover(); r != nil {
 			err = fmt.Errorf("recovered from: %v", r)
 			logger.Errorf("Close(): %v", err.Error())


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
