### PR TITLE
Format markdown

### DIFF
--- a/config/provisioners/natss/README.md
+++ b/config/provisioners/natss/README.md
@@ -1,44 +1,46 @@
 # NATS Streaming Channels
 
-
 ### Deployment steps:
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
-1. If not done already, install a [NATS Streaming](natss)  
+1. If not done already, install a [NATS Streaming](natss)
 1. Apply the 'natss' ClusterChannelProvisioner, Controller, and Dispatcher.
-     ```shell
-     ko apply -f config/provisioners/natss/provisioner.yaml
-     ````
+   ```shell
+   ko apply -f config/provisioners/natss/provisioner.yaml
+   ```
 1. Create Channels that reference the 'natss'.
 
-    ```yaml
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    metadata:
-      name: foo
-    spec:
-      provisioner:
-        apiVersion: eventing.knative.dev/v1alpha1
-        kind: ClusterChannelProvisioner
-        name: natss
-    ```
+   ```yaml
+   apiVersion: eventing.knative.dev/v1alpha1
+   kind: Channel
+   metadata:
+     name: foo
+   spec:
+     provisioner:
+       apiVersion: eventing.knative.dev/v1alpha1
+       kind: ClusterChannelProvisioner
+       name: natss
+   ```
 
 ### Components
 
 The major components are:
-* NATS Streaming
-* ClusterChannelProvisioner Controller
-* Channel Controller
-* Channel Dispatcher
 
-The ClusterChannelProvisioner Controller and the Channel Controller are colocated in one Pod.
+- NATS Streaming
+- ClusterChannelProvisioner Controller
+- Channel Controller
+- Channel Dispatcher
+
+The ClusterChannelProvisioner Controller and the Channel Controller are
+colocated in one Pod.
+
 ```shell
 kubectl get deployment -n knative-eventing natss-controller
 ```
 
-The Channel Dispatcher receives and distributes all events. There is a single Dispatcher for all
-natss Channels.
+The Channel Dispatcher receives and distributes all events. There is a single
+Dispatcher for all natss Channels.
+
 ```shell
 kubectl get deployment -n knative-eventing natss-dispatcher
 ```
-

--- a/config/provisioners/natss/natss/README.md
+++ b/config/provisioners/natss/natss/README.md
@@ -6,7 +6,8 @@
    kubectl label namespace natss istio-injection=enabled
    kubectl apply -n natss -f config/provisioners/natss/natss/natss.yaml
    ```
-NATS Streaming is deployed as a StatefulSet, using "nats-streaming" ConfigMap in the namespace "natss". 
- 
+   NATS Streaming is deployed as a StatefulSet, using "nats-streaming" ConfigMap
+   in the namespace "natss".
+
 For tuning NATS Streaming, see:
 https://github.com/nats-io/nats-streaming-server#configuring

--- a/hack/release.md
+++ b/hack/release.md
@@ -18,18 +18,18 @@ release.
   either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
   versioned releases. These are docker tags. _For versioned releases, a tag is
   always added._
-- `--release-gcs` Defines the GCS bucket where the manifests will be stored.
-  By default, this is `knative-nightly/eventing`. This flag is ignored if the
+- `--release-gcs` Defines the GCS bucket where the manifests will be stored. By
+  default, this is `knative-nightly/eventing`. This flag is ignored if the
   release is not being published.
 - `--release-gcr` Defines the GCR where the images will be stored. By default,
   this is `gcr.io/knative-nightly`. This flag is ignored if the release is not
   being published.
 - `--publish`, `--nopublish` Whether the generated images should be published to
-  a GCR, and the generated manifests written to a GCS bucket or not. If yes,
-  the `--release-gcs` and `--release-gcr` flags can be used to change the
-  default values of the GCR/GCS used. If no, the images will be pushed to the
-  `ko.local` registry, and the manifests written to the local disk only (in the
-  repository root directory).
+  a GCR, and the generated manifests written to a GCS bucket or not. If yes, the
+  `--release-gcs` and `--release-gcr` flags can be used to change the default
+  values of the GCR/GCS used. If no, the images will be pushed to the `ko.local`
+  registry, and the manifests written to the local disk only (in the repository
+  root directory).
 
 ## Creating nightly releases
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`