### PR TITLE
golang format tools

### DIFF
--- a/pkg/channeldefaulter/channel_defaulter_test.go
+++ b/pkg/channeldefaulter/channel_defaulter_test.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
@@ -28,7 +28,7 @@ import (
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"

--- a/pkg/provisioners/gcppubsub/controller/cmd/main.go
+++ b/pkg/provisioners/gcppubsub/controller/cmd/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"github.com/knative/eventing/pkg/provisioners"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/controller/channel"

--- a/pkg/provisioners/gcppubsub/dispatcher/cmd/main.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/cmd/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"github.com/knative/eventing/pkg/provisioners"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/dispatcher"
 

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/knative/eventing/pkg/provisioners"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"

--- a/pkg/provisioners/gcppubsub/util/creds.go
+++ b/pkg/provisioners/gcppubsub/util/creds.go
@@ -26,7 +26,7 @@ import (
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/pkg/provisioners/gcppubsub/util/creds_test.go
+++ b/pkg/provisioners/gcppubsub/util/creds_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/testcreds"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/pkg/provisioners/gcppubsub/util/names_test.go
+++ b/pkg/provisioners/gcppubsub/util/names_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // These tests are here so that any changes made to the generation algorithm are noticed. Because

--- a/pkg/provisioners/gcppubsub/util/testcreds/helper.go
+++ b/pkg/provisioners/gcppubsub/util/testcreds/helper.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testcreds
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
+++ b/pkg/provisioners/kafka/dispatcher/dispatcher_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"

--- a/pkg/provisioners/natss/dispatcher/dispatcher/dispatcher.go
+++ b/pkg/provisioners/natss/dispatcher/dispatcher/dispatcher.go
@@ -23,7 +23,7 @@ import (
 	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/pkg/provisioners/natss/controller/clusterchannelprovisioner"
 	"github.com/knative/eventing/pkg/provisioners/natss/stanutil"
-	"github.com/nats-io/go-nats-streaming"
+	stan "github.com/nats-io/go-nats-streaming"
 	"go.uber.org/zap"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"

--- a/pkg/provisioners/natss/stanutil/stanutil.go
+++ b/pkg/provisioners/natss/stanutil/stanutil.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nats-io/go-nats-streaming"
+	stan "github.com/nats-io/go-nats-streaming"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
