### PR TITLE
Fix #638: add message history into header

### DIFF
--- a/pkg/provisioners/message.go
+++ b/pkg/provisioners/message.go
@@ -90,16 +90,11 @@ func (m *Message) AppendToHistory(host string) {
 	if host == "" {
 		return
 	}
-	history := m.History()
-	if history == nil {
-		history = make([]string, 0)
-	}
-	newHistory := append(history, host)
-	m.SetHistory(newHistory)
+	m.setHistory(append(m.History(), host))
 }
 
-// SetHistory sets the message history to the given value
-func (m *Message) SetHistory(history []string) {
+// setHistory sets the message history to the given value
+func (m *Message) setHistory(history []string) {
 	historyStr := encodeMessageHistory(history)
 	if m.Headers == nil {
 		m.Headers = make(map[string]string)

--- a/pkg/provisioners/message_receiver.go
+++ b/pkg/provisioners/message_receiver.go
@@ -126,6 +126,10 @@ func (r *MessageReceiver) HandleRequest(res http.ResponseWriter, req *http.Reque
 		res.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	// setting common channel information in the request
+	if err := message.AppendToHistory(channel, true); err != nil {
+		r.logger.Warn("Could not append channel to message history", zap.Error(err))
+	}
 
 	err = r.receiverFunc(channel, message)
 	if err != nil {

--- a/pkg/provisioners/message_receiver.go
+++ b/pkg/provisioners/message_receiver.go
@@ -127,9 +127,7 @@ func (r *MessageReceiver) HandleRequest(res http.ResponseWriter, req *http.Reque
 		return
 	}
 	// setting common channel information in the request
-	if err := message.AppendToHistory(channel, true); err != nil {
-		r.logger.Warn("Could not append channel to message history", zap.Error(err))
-	}
+	message.AppendToHistory(host)
 
 	err = r.receiverFunc(channel, message)
 	if err != nil {

--- a/pkg/provisioners/message_receiver_test.go
+++ b/pkg/provisioners/message_receiver_test.go
@@ -100,6 +100,7 @@ func TestMessageReceiver_HandleRequest(t *testing.T) {
 					"cE-pass-through":           "true",
 					"x-B3-pass":                 "true",
 					"x-ot-pass":                 "true",
+					"ce-knativehistory":         "test-name.test-namespace.svc.cluster.local",
 				}
 				if diff := cmp.Diff(expectedHeaders, m.Headers); diff != "" {
 					return fmt.Errorf("test receiver func -- bad headers (-want, +got): %s", diff)

--- a/pkg/provisioners/message_test.go
+++ b/pkg/provisioners/message_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioners
+
+import (
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestMessageHistoryEmpty(t *testing.T) {
+	m := Message{}
+	history := getHistoryOrFail(t, &m)
+	if len(history) != 0 {
+		t.Error("history not empty")
+	}
+}
+
+func TestMessageHistoryAppendSet(t *testing.T) {
+	m := Message{}
+	m.AppendToHistory(ChannelReference{
+		Namespace: "namespace1",
+		Name:      "name1",
+	}, true)
+	history := getHistoryOrFail(t, &m)
+	if len(history) != 1 {
+		t.Error("history does not contain first element")
+	}
+	m.AppendToHistory(ChannelReference{
+		Namespace: "namespace2",
+		Name:      "name2",
+	}, true)
+	history = getHistoryOrFail(t, &m)
+	if len(history) != 2 {
+		t.Error("history does not contain all elements")
+	}
+	if history[0].Name != "name1" {
+		t.Error("wrong name")
+	}
+	if history[0].Namespace != "namespace1" {
+		t.Error("wrong namespace")
+	}
+	if history[1].Name != "name2" {
+		t.Error("wrong name")
+	}
+	if history[1].Namespace != "namespace2" {
+		t.Error("wrong namespace")
+	}
+	newHistory := []v1.ObjectReference{
+		{
+			Namespace: "namespace3",
+			Name:      "name3",
+		},
+	}
+	m.SetHistory(newHistory)
+	history = getHistoryOrFail(t, &m)
+	if len(history) != 1 {
+		t.Error("history does not contain the new element")
+	}
+	if history[0] != newHistory[0] {
+		t.Error("wrong history element")
+	}
+}
+
+func TestMessageHistoryAppendOverwrite(t *testing.T) {
+	m := Message{}
+	m.Headers = make(map[string]string)
+	m.Headers[messageHistoryHeader] = "-unparsable-"
+	if _, err := m.History(); err == nil {
+		t.Error("read error not thrown")
+	}
+	ch := ChannelReference{
+		Name: "err",
+	}
+	if err := m.AppendToHistory(ch, false); err == nil {
+		t.Error("append error not thrown")
+	}
+	ch.Name = "name"
+	if err := m.AppendToHistory(ch, true); err != nil {
+		t.Error("unexpected error thrown")
+	}
+	history := getHistoryOrFail(t, &m)
+	if len(history) != 1 || history[0].Name != "name" {
+		t.Error("wrong history")
+	}
+}
+
+func getHistoryOrFail(t *testing.T, m *Message) []v1.ObjectReference {
+	history, err := m.History()
+	if err != nil {
+		t.Errorf("got %v when getting history", err)
+	}
+	return history
+}

--- a/pkg/provisioners/message_test.go
+++ b/pkg/provisioners/message_test.go
@@ -73,7 +73,7 @@ func TestMessageHistory(t *testing.T) {
 		},
 		{
 			start:    "  ",
-			append:   []string{" ", "name.multispace.service.local", "  ", "   "},
+			append:   []string{" ", "name.multispace.service.local", "  "},
 			expected: "name.multispace.service.local",
 			len:      1,
 		},
@@ -87,7 +87,7 @@ func TestMessageHistory(t *testing.T) {
 				m.Headers[MessageHistoryHeader] = tc.start
 			}
 			if tc.set != nil {
-				m.SetHistory(tc.set)
+				m.setHistory(tc.set)
 			}
 			for _, name := range tc.append {
 				m.AppendToHistory(name)


### PR DESCRIPTION
Fixes #638 

## Proposed Changes

- Added a Knative-Message-History header containing information about the channels traversed by the message

History is made of composite objects, so I've not found a way to serialize it into a header better than JSON (open for discussion). For possible future enhancements, I've used Kubernetes ObjectReference as base type for a history item.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Messages contain information about the history of traversed channels in a header
```
