### PR TITLE
Enable status subresource eventing CRDs

### DIFF
--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -29,3 +29,5 @@ spec:
     shortNames:
     - chan
   scope: Namespaced
+  subresources:
+    status: {}

--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -30,3 +30,7 @@ spec:
     shortNames:
     - ccp
   scope: Cluster
+  # This is done so that metadata.generation will start incrementing
+  # in Kubernetes v1.11+
+  subresources:
+    status: {}

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -29,3 +29,5 @@ spec:
     shortNames:
     - sub
   scope: Namespaced
+  subresources:
+    status: {}

--- a/config/provisioners/gcppubsub/gcppubsub.yaml
+++ b/config/provisioners/gcppubsub/gcppubsub.yaml
@@ -37,6 +37,7 @@ rules:
       - eventing.knative.dev
     resources:
       - channels
+      - channels/status
       - clusterchannelprovisioners
     verbs:
       - get
@@ -137,6 +138,7 @@ rules:
       - eventing.knative.dev
     resources:
       - channels
+      - channels/status
     verbs:
       - get
       - list

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -37,6 +37,7 @@ rules:
       - eventing.knative.dev
     resources:
       - channels
+      - channels/status
       - clusterchannelprovisioners
     verbs:
       - get

--- a/config/provisioners/kafka/kafka.yaml
+++ b/config/provisioners/kafka/kafka.yaml
@@ -35,6 +35,7 @@ rules:
       - eventing.knative.dev
     resources:
       - channels
+      - channels/status
       - clusterchannelprovisioners
     verbs:
       - get

--- a/config/provisioners/natss/provisioner.yaml
+++ b/config/provisioners/natss/provisioner.yaml
@@ -37,6 +37,7 @@ rules:
       - eventing.knative.dev
     resources:
       - channels
+      - channels/status
       - clusterchannelprovisioners
     verbs:
       - get

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -27,7 +27,6 @@ import (
 )
 
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Channel is an abstract resource that implements the Addressable contract.
@@ -57,12 +56,14 @@ var _ webhook.GenericCRD = (*Channel)(nil)
 // ChannelSpec specifies the Provisioner backing a channel and the configuration
 // arguments for a Channel.
 type ChannelSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// TODO By enabling the status subresource metadata.generation should increment
+	// thus making this property obsolete.
+	//
+	// We should be able to drop this property with a CRD conversion webhook
+	// in the future
+	//
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// Provisioner defines the name of the Provisioner backing this channel.
 	Provisioner *corev1.ObjectReference `json:"provisioner,omitempty"`

--- a/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
@@ -53,12 +53,14 @@ var _ webhook.GenericCRD = (*ClusterChannelProvisioner)(nil)
 
 // ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.
 type ClusterChannelProvisionerSpec struct {
-	// TODO: Generation does not work correctly with CRD. They are scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once that gets fixed, remove this and use
-	// ObjectMeta.Generation instead.
+	// TODO By enabling the status subresource metadata.generation should increment
+	// thus making this property obsolete.
+	//
+	// We should be able to drop this property with a CRD conversion webhook
+	// in the future
+	//
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 }
 
 var ccProvCondSet = duckv1alpha1.NewLivingConditionSet()

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -60,12 +60,14 @@ var _ webhook.GenericCRD = (*Subscription)(nil)
 // no-op function (identity transformation):
 // channel --> reply
 type SubscriptionSpec struct {
-	// TODO: Generation used to not work correctly with CRD. They were scrubbed
-	// by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
-	// So, we add Generation here. Once the above bug gets rolled out to production
-	// clusters, remove this and use ObjectMeta.Generation instead.
+	// TODO By enabling the status subresource metadata.generation should increment
+	// thus making this property obsolete.
+	//
+	// We should be able to drop this property with a CRD conversion webhook
+	// in the future
+	//
 	// +optional
-	Generation int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64 `json:"generation,omitempty"`
 
 	// Reference to a channel that will be used to create the subscription
 	// for receiving events. The channel must have spec.subscriptions

--- a/pkg/client/clientset/versioned/typed/eventing/v1alpha1/channel.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1alpha1/channel.go
@@ -37,6 +37,7 @@ type ChannelsGetter interface {
 type ChannelInterface interface {
 	Create(*v1alpha1.Channel) (*v1alpha1.Channel, error)
 	Update(*v1alpha1.Channel) (*v1alpha1.Channel, error)
+	UpdateStatus(*v1alpha1.Channel) (*v1alpha1.Channel, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.Channel, error)
@@ -114,6 +115,22 @@ func (c *channels) Update(channel *v1alpha1.Channel) (result *v1alpha1.Channel, 
 		Namespace(c.ns).
 		Resource("channels").
 		Name(channel.Name).
+		Body(channel).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *channels) UpdateStatus(channel *v1alpha1.Channel) (result *v1alpha1.Channel, err error) {
+	result = &v1alpha1.Channel{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("channels").
+		Name(channel.Name).
+		SubResource("status").
 		Body(channel).
 		Do().
 		Into(result)

--- a/pkg/client/clientset/versioned/typed/eventing/v1alpha1/fake/fake_channel.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1alpha1/fake/fake_channel.go
@@ -100,6 +100,18 @@ func (c *FakeChannels) Update(channel *v1alpha1.Channel) (result *v1alpha1.Chann
 	return obj.(*v1alpha1.Channel), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeChannels) UpdateStatus(channel *v1alpha1.Channel) (*v1alpha1.Channel, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(channelsResource, "status", c.ns, channel), &v1alpha1.Channel{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Channel), err
+}
+
 // Delete takes name of the channel and deletes it. Returns an error if one occurs.
 func (c *FakeChannels) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -392,8 +392,19 @@ func TestReconcile(t *testing.T) {
 				MockUpdates: errorUpdatingChannel(),
 			},
 			WantErrMsg: testErrorMessage,
-		},
-		{
+		}, {
+			Name: "Channel status update fails",
+			InitialState: []runtime.Object{
+				makeChannel(),
+				makeConfigMap(),
+				makeK8sService(),
+				makeVirtualService(),
+			},
+			Mocks: controllertesting.Mocks{
+				MockStatusUpdates: errorUpdatingChannelStatus(),
+			},
+			WantErrMsg: testErrorMessage,
+		}, {
 			Name: "Channel reconcile successful - Channel list follows pagination",
 			InitialState: []runtime.Object{
 				makeChannel(),
@@ -743,6 +754,17 @@ func errorCreatingVirtualService() []controllertesting.MockCreate {
 
 func errorUpdatingChannel() []controllertesting.MockUpdate {
 	return []controllertesting.MockUpdate{
+		func(_ client.Client, _ context.Context, obj runtime.Object) (controllertesting.MockHandled, error) {
+			if _, ok := obj.(*eventingv1alpha1.Channel); ok {
+				return controllertesting.Handled, errors.New(testErrorMessage)
+			}
+			return controllertesting.Unhandled, nil
+		},
+	}
+}
+
+func errorUpdatingChannelStatus() []controllertesting.MockStatusUpdate {
+	return []controllertesting.MockStatusUpdate{
 		func(_ client.Client, _ context.Context, obj runtime.Object) (controllertesting.MockHandled, error) {
 			if _, ok := obj.(*eventingv1alpha1.Channel); ok {
 				return controllertesting.Handled, errors.New(testErrorMessage)

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -160,6 +160,7 @@ func isNilOrEmptyReply(reply *v1alpha1.ReplyStrategy) bool {
 	return reply == nil || equality.Semantic.DeepEqual(reply, &v1alpha1.ReplyStrategy{})
 }
 
+// updateStatus may in fact update the subscription's finalizers in addition to the status
 func (r *reconciler) updateStatus(subscription *v1alpha1.Subscription) (*v1alpha1.Subscription, error) {
 	objectKey := client.ObjectKey{Namespace: subscription.Namespace, Name: subscription.Name}
 	newSubscription := &v1alpha1.Subscription{}

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -163,40 +163,40 @@ func isNilOrEmptyReply(reply *v1alpha1.ReplyStrategy) bool {
 // updateStatus may in fact update the subscription's finalizers in addition to the status
 func (r *reconciler) updateStatus(subscription *v1alpha1.Subscription) (*v1alpha1.Subscription, error) {
 	objectKey := client.ObjectKey{Namespace: subscription.Namespace, Name: subscription.Name}
-	newSubscription := &v1alpha1.Subscription{}
+	latestSubscription := &v1alpha1.Subscription{}
 
-	if err := r.client.Get(context.TODO(), objectKey, newSubscription); err != nil {
+	if err := r.client.Get(context.TODO(), objectKey, latestSubscription); err != nil {
 		return nil, err
 	}
 
 	subscriptionChanged := false
 
-	if !equality.Semantic.DeepEqual(newSubscription.Finalizers, subscription.Finalizers) {
-		newSubscription.SetFinalizers(subscription.ObjectMeta.Finalizers)
-		if err := r.client.Update(context.TODO(), newSubscription); err != nil {
+	if !equality.Semantic.DeepEqual(latestSubscription.Finalizers, subscription.Finalizers) {
+		latestSubscription.SetFinalizers(subscription.ObjectMeta.Finalizers)
+		if err := r.client.Update(context.TODO(), latestSubscription); err != nil {
 			return nil, err
 		}
 		subscriptionChanged = true
 	}
 
-	if equality.Semantic.DeepEqual(newSubscription.Status, subscription.Status) {
-		return newSubscription, nil
+	if equality.Semantic.DeepEqual(latestSubscription.Status, subscription.Status) {
+		return latestSubscription, nil
 	}
 
 	if subscriptionChanged {
 		// Refetch
-		newSubscription := &v1alpha1.Subscription{}
-		if err := r.client.Get(context.TODO(), objectKey, newSubscription); err != nil {
+		latestSubscription = &v1alpha1.Subscription{}
+		if err := r.client.Get(context.TODO(), objectKey, latestSubscription); err != nil {
 			return nil, err
 		}
 	}
 
-	newSubscription.Status = subscription.Status
-	if err := r.client.Status().Update(context.TODO(), newSubscription); err != nil {
+	latestSubscription.Status = subscription.Status
+	if err := r.client.Status().Update(context.TODO(), latestSubscription); err != nil {
 		return nil, err
 	}
 
-	return newSubscription, nil
+	return latestSubscription, nil
 }
 
 // resolveSubscriberSpec resolves the Spec.Call object. If it's an

--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -170,26 +170,42 @@ func CreateVirtualService(ctx context.Context, client runtimeClient.Client, chan
 }
 
 func UpdateChannel(ctx context.Context, client runtimeClient.Client, u *eventingv1alpha1.Channel) error {
+	objectKey := runtimeClient.ObjectKey{Namespace: u.Namespace, Name: u.Name}
 	channel := &eventingv1alpha1.Channel{}
-	err := client.Get(ctx, runtimeClient.ObjectKey{Namespace: u.Namespace, Name: u.Name}, channel)
-	if err != nil {
+
+	if err := client.Get(ctx, objectKey, channel); err != nil {
 		return err
 	}
 
-	updated := false
+	channelChanged := false
+
 	if !equality.Semantic.DeepEqual(channel.Finalizers, u.Finalizers) {
 		channel.SetFinalizers(u.ObjectMeta.Finalizers)
-		updated = true
+		if err := client.Update(ctx, channel); err != nil {
+			return err
+		}
+
+		channelChanged = true
 	}
 
-	if !equality.Semantic.DeepEqual(channel.Status, u.Status) {
-		channel.Status = u.Status
-		updated = true
+	if equality.Semantic.DeepEqual(channel.Status, u.Status) {
+		return nil
 	}
 
-	if updated {
-		return client.Update(ctx, channel)
+	if channelChanged {
+		// Refetch
+		channel = &eventingv1alpha1.Channel{}
+		if err := client.Get(ctx, objectKey, channel); err != nil {
+			return err
+		}
 	}
+
+	channel.Status = u.Status
+
+	if err := client.Status().Update(ctx, channel); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -297,6 +297,8 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 		},
+		// Note - we do not test update status since this dispatcher only adds
+		// finalizers to the channel
 	}
 	recorder := record.NewBroadcaster().NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 	for _, tc := range testCases {


### PR DESCRIPTION
I've enabled it on all CRDs so that the metadata.generation will start to be
incremented by the Kubernetes API server

Fixes #697 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Status Subresource has been enabled on the eventing CRDs. Thus if you're a contributor creating custom channels you'll need to use the appropriate /status endpoint when updating a channel's status
```
