### PR TITLE
Add status.internal to Channels

### DIFF
--- a/config/provisioners/gcppubsub/gcppubsub.yaml
+++ b/config/provisioners/gcppubsub/gcppubsub.yaml
@@ -190,15 +190,6 @@ spec:
       containers:
         - name: dispatcher
           image: github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/cmd
-          env:
-            - name: DEFAULT_GCP_PROJECT
-              value: REPLACE_WITH_GCP_PROJECT
-            - name: DEFAULT_SECRET_NAMESPACE
-              value: knative-eventing
-            - name: DEFAULT_SECRET_NAME
-              value: gcppubsub-channel-key
-            - name: DEFAULT_SECRET_KEY
-              value: key.json
 
 ---
 

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -104,7 +104,7 @@ type ChannelStatus struct {
 
 	// Internal is status unique to each ClusterChannelProvisioner.
 	// +optional
-	Internal *runtime.RawExtension `json:"raw,omitempty"`
+	Internal *runtime.RawExtension `json:"internal,omitempty"`
 }
 
 const (

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -102,9 +102,9 @@ type ChannelStatus struct {
 	// +patchStrategy=merge
 	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
-	// Raw is status unique to each ClusterChannelProvisioner.
+	// Internal is status unique to each ClusterChannelProvisioner.
 	// +optional
-	Raw *runtime.RawExtension `json:"raw,omitempty"`
+	Internal *runtime.RawExtension `json:"raw,omitempty"`
 }
 
 const (

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -100,6 +100,10 @@ type ChannelStatus struct {
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	Conditions duckv1alpha1.Conditions `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// Raw is status unique to each ClusterChannelProvisioner.
+	// +optional
+	Raw *runtime.RawExtension `json:"raw,omitempty"`
 }
 
 const (

--- a/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -142,6 +142,15 @@ func (in *ChannelStatus) DeepCopyInto(out *ChannelStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Raw != nil {
+		in, out := &in.Raw, &out.Raw
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(runtime.RawExtension)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -142,8 +142,8 @@ func (in *ChannelStatus) DeepCopyInto(out *ChannelStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Raw != nil {
-		in, out := &in.Raw, &out.Raw
+	if in.Internal != nil {
+		in, out := &in.Internal, &out.Internal
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/provisioners/gcppubsub/controller/channel/names.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/names.go
@@ -27,12 +27,12 @@ import (
 
 // generateTopicName generates the GCP PubSub Topic name given the Knative Channel.
 func generateTopicName(c *v1alpha1.Channel) string {
-	return utils.TopicName("_", c.Name, string(c.UID))
+	return utils.TopicNameWithUID("_", c.Name, c.UID)
 }
 
 // generateSubName Generates the GCP PubSub Subscription name given the Knative Channel's
 // subscriber.
 // Note that this requires the subscriber's ref to be set correctly.
 func generateSubName(cs *eventduck.ChannelSubscriberSpec) string {
-	return utils.TopicName("_", cs.Ref.Name, string(cs.Ref.UID))
+	return utils.TopicNameWithUID("_", cs.Ref.Name, cs.Ref.UID)
 }

--- a/pkg/provisioners/gcppubsub/controller/channel/names.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/names.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package channel
 
 import (
 	"github.com/knative/eventing/pkg/provisioners/utils"
@@ -25,19 +25,15 @@ import (
 // Underscore is used as a separator between the namespace and name so the concatenated version
 // can't accidentally overlap.
 
-// GenerateTopicName generates the GCP PubSub Topic name given the Knative Channel's namespace and
+// generateTopicName generates the GCP PubSub Topic name given the Knative Channel's namespace and
 // name.
-// Note that it must be stable. The controller and dispatcher rely on this being generated
-// identically.
-func GenerateTopicName(channelNamespace, channelName string) string {
+func generateTopicName(channelNamespace, channelName string) string {
 	return utils.TopicName("_", channelNamespace, channelName)
 }
 
-// GenerateSubname Generates the GCP PubSub Subscription name given the Knative Channel's
+// generateSubName Generates the GCP PubSub Subscription name given the Knative Channel's
 // subscriber's namespace and name.
 // Note that this requires the subscriber's ref to be set correctly.
-// Note that it must be stable. The controller and dispatcher rely on this being generated
-// identically.
-func GenerateSubName(cs *eventduck.ChannelSubscriberSpec) string {
+func generateSubName(cs *eventduck.ChannelSubscriberSpec) string {
 	return utils.TopicName("_", cs.Ref.Name, string(cs.Ref.UID))
 }

--- a/pkg/provisioners/gcppubsub/controller/channel/names.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/names.go
@@ -17,22 +17,21 @@ limitations under the License.
 package channel
 
 import (
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners/utils"
 
 	eventduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 )
 
-// Underscore is used as a separator between the namespace and name so the concatenated version
-// can't accidentally overlap.
+// Underscore is used as a separator so the concatenated version can't accidentally overlap.
 
-// generateTopicName generates the GCP PubSub Topic name given the Knative Channel's namespace and
-// name.
-func generateTopicName(channelNamespace, channelName string) string {
-	return utils.TopicName("_", channelNamespace, channelName)
+// generateTopicName generates the GCP PubSub Topic name given the Knative Channel.
+func generateTopicName(c *v1alpha1.Channel) string {
+	return utils.TopicName("_", c.Name, string(c.UID))
 }
 
 // generateSubName Generates the GCP PubSub Subscription name given the Knative Channel's
-// subscriber's namespace and name.
+// subscriber.
 // Note that this requires the subscriber's ref to be set correctly.
 func generateSubName(cs *eventduck.ChannelSubscriberSpec) string {
 	return utils.TopicName("_", cs.Ref.Name, string(cs.Ref.UID))

--- a/pkg/provisioners/gcppubsub/controller/channel/names_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/names_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package channel
 
 import (
 	"testing"
@@ -24,13 +24,11 @@ import (
 )
 
 // These tests are here so that any changes made to the generation algorithm are noticed. Because
-// the name is assumed to be stable and is calculated in both the controller and the dispatcher.
-// TODO Generate the names in the controller and pass them through the Channel's status to the
-// dispatcher.
+// the name is assumed to be stable across controller runs.
 
 func TestGenerateTopicName(t *testing.T) {
 	expected := "knative-eventing-channel_channel-namespace_channel-name"
-	actual := GenerateTopicName("channel-namespace", "channel-name")
+	actual := generateTopicName("channel-namespace", "channel-name")
 	if expected != actual {
 		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
 	}
@@ -38,7 +36,7 @@ func TestGenerateTopicName(t *testing.T) {
 
 func TestGenerateSubName(t *testing.T) {
 	expected := "knative-eventing-channel_sub-name_sub-uid"
-	actual := GenerateSubName(&v1alpha1.ChannelSubscriberSpec{
+	actual := generateSubName(&v1alpha1.ChannelSubscriberSpec{
 		Ref: &v1.ObjectReference{
 			Name: "sub-name",
 			UID:  "sub-uid",

--- a/pkg/provisioners/gcppubsub/controller/channel/names_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/names_test.go
@@ -20,15 +20,22 @@ import (
 	"testing"
 
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // These tests are here so that any changes made to the generation algorithm are noticed. Because
 // the name is assumed to be stable across controller runs.
 
 func TestGenerateTopicName(t *testing.T) {
-	expected := "knative-eventing-channel_channel-namespace_channel-name"
-	actual := generateTopicName("channel-namespace", "channel-name")
+	expected := "knative-eventing-channel_channel-name_channel-uid"
+	actual := generateTopicName(&eventingv1alpha1.Channel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "channel-name",
+			UID:  "channel-uid",
+		},
+	})
 	if expected != actual {
 		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
 	}

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
@@ -152,7 +152,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	// First we will plan all the names out for steps 3 and 4 persist them to status.internal. Then, on a
 	// subsequent reconcile, we manipulate all the GCP resources in steps 3 and 4.
 
-	originalPCS, err := pubsubutil.GetInternalStatus(ctx, c)
+	originalPCS, err := pubsubutil.GetInternalStatus(c)
 	if err != nil {
 		logging.FromContext(ctx).Error("Unable to read the status.internal", zap.Error(err))
 		return false, err

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
@@ -29,7 +29,7 @@ import (
 	util "github.com/knative/eventing/pkg/provisioners"
 	ccpcontroller "github.com/knative/eventing/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner"
 	pubsubutil "github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/logging"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
 	v1 "k8s.io/api/core/v1"
@@ -84,7 +84,7 @@ func (r *reconciler) InjectClient(c client.Client) error {
 
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.TODO()
-	ctx = logging.WithLogger(ctx, r.logger.With(zap.Any("request", request)).Sugar())
+	ctx = logging.WithLogger(ctx, r.logger.With(zap.Any("request", request)))
 
 	c := &eventingv1alpha1.Channel{}
 	err := r.client.Get(ctx, request.NamespacedName, c)

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile.go
@@ -151,12 +151,12 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	// 3. The GCP PubSub Topic (one for the Channel).
 	// 4. The GCP PubSub Subscriptions (one for each Subscriber of the Channel).
 
-	// First we will plan all the names out for steps 3 and 4 persist them to status.raw. Then, on a
+	// First we will plan all the names out for steps 3 and 4 persist them to status.internal. Then, on a
 	// subsequent reconcile, we manipulate all the GCP resources in steps 3 and 4.
 
-	originalPCS, err := pubsubutil.GetRawStatus(ctx, c)
+	originalPCS, err := pubsubutil.GetInternalStatus(ctx, c)
 	if err != nil {
-		logging.FromContext(ctx).Error("Unable to read the raw status", zap.Error(err))
+		logging.FromContext(ctx).Error("Unable to read the status.internal", zap.Error(err))
 		return false, err
 	}
 
@@ -202,7 +202,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 		return false, err
 	}
 	if persist == persistStatus {
-		if err = pubsubutil.SetRawStatus(ctx, c, plannedPCS); err != nil {
+		if err = pubsubutil.SetInternalStatus(ctx, c, plannedPCS); err != nil {
 			return false, err
 		}
 		// Persist this and run another reconcile loop to enact it.
@@ -230,7 +230,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	}
 	// Now that the subs have synced successfully, remove the old ones from the status.
 	plannedPCS.Subscriptions = subsToSync.subsToCreate
-	if err = pubsubutil.SetRawStatus(ctx, c, plannedPCS); err != nil {
+	if err = pubsubutil.SetInternalStatus(ctx, c, plannedPCS); err != nil {
 		return false, err
 	}
 

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
@@ -786,7 +786,7 @@ func makeChannelWithFinalizer() *eventingv1alpha1.Channel {
 
 func makeChannelWithFinalizerAndPCS() *eventingv1alpha1.Channel {
 	c := makeChannelWithFinalizer()
-	err := pubsubutil.SaveRawStatus(context.Background(), c, &pubsubutil.GcpPubSubChannelStatus{
+	err := pubsubutil.SetRawStatus(context.Background(), c, &pubsubutil.GcpPubSubChannelStatus{
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 		GCPProject: gcpProject,
@@ -866,7 +866,7 @@ func makeChannelWithFinalizerAndSubscriberWithoutUID() *eventingv1alpha1.Channel
 
 func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1alpha1.Channel {
 	c := makeChannelWithFinalizerAndPCS()
-	pcs, err := pubsubutil.ReadRawStatus(context.Background(), c)
+	pcs, err := pubsubutil.GetRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
@@ -897,7 +897,7 @@ func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1a
 		pcs.Subscriptions = append(pcs.Subscriptions, sub)
 	}
 
-	err = pubsubutil.SaveRawStatus(context.Background(), c, pcs)
+	err = pubsubutil.SetRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}
@@ -925,7 +925,7 @@ func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1a
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pcs, err := pubsubutil.ReadRawStatus(context.Background(), c)
+	pcs, err := pubsubutil.GetRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
@@ -937,7 +937,7 @@ func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscrib
 			Subscription:  "test-subscription-id",
 		})
 	}
-	err = pubsubutil.SaveRawStatus(context.Background(), c, pcs)
+	err = pubsubutil.SetRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
@@ -265,7 +265,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel deleted - No raw status",
 			InitialState: []runtime.Object{
-				makeDeletingChannelWithoutPBS(),
+				makeDeletingChannelWithoutPCS(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			OtherTestData: map[string]interface{}{
@@ -283,7 +283,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			WantPresent: []runtime.Object{
-				makeDeletingChannelWithoutFinalizerOrPBS(),
+				makeDeletingChannelWithoutFinalizerOrPCS(),
 			},
 		},
 		{
@@ -389,21 +389,21 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "K8s service get fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			Mocks: controllertesting.Mocks{
 				MockLists: errorListingK8sService(),
 			},
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "K8s service creation fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			Mocks: controllertesting.Mocks{
@@ -411,14 +411,14 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the K8s Service failed.
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "Virtual service get fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -429,14 +429,14 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the VirtualService
 				// failed.
-				makeChannelWithFinalizerAndPBSAndAddress(),
+				makeChannelWithFinalizerAndPCSAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "Virtual service creation fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				testcreds.MakeSecretWithCreds(),
 			},
@@ -446,14 +446,14 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the VirtualService
 				// failed.
-				makeChannelWithFinalizerAndPBSAndAddress(),
+				makeChannelWithFinalizerAndPCSAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "VirtualService already exists - not owned by Channel",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualServiceNotOwnedByChannel(),
 				testcreds.MakeSecretWithCreds(),
@@ -489,7 +489,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Topic - problem creating client",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -501,13 +501,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndPBSAndAddress(),
+				makeChannelWithFinalizerAndPCSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - problem checking existence",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -523,13 +523,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndPBSAndAddress(),
+				makeChannelWithFinalizerAndPCSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - topic already exists",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -550,7 +550,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Topic - error creating topic",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -564,13 +564,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndPBSAndAddress(),
+				makeChannelWithFinalizerAndPCSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - topic create succeeds",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -582,7 +582,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Subscriptions - problem checking exists",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBS(),
+				makeChannelWithSubscribersAndFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -598,13 +598,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBSAndAddress(),
+				makeChannelWithSubscribersAndFinalizerAndPCSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Subscriptions - already exists",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBS(),
+				makeChannelWithSubscribersAndFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -625,7 +625,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Subscriptions - create fails",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBS(),
+				makeChannelWithSubscribersAndFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -639,13 +639,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBSAndAddress(),
+				makeChannelWithSubscribersAndFinalizerAndPCSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Subscriptions - create succeeds",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndPBS(),
+				makeChannelWithSubscribersAndFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -657,7 +657,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel get for update fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -682,7 +682,7 @@ func TestReconcile(t *testing.T) {
 		}, {
 			Name: "Channel status update fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizerAndPBS(),
+				makeChannelWithFinalizerAndPCS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -735,15 +735,15 @@ func makeChannel() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeChannelWithFinalizerAndPBSAndAddress() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndPBS()
+func makeChannelWithFinalizerAndPCSAndAddress() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPCS()
 	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.cluster.local", c.Name, c.Namespace))
 	return c
 }
 
 func makeReadyChannel() *eventingv1alpha1.Channel {
 	// Ready channels have the finalizer and are Addressable.
-	c := makeChannelWithFinalizerAndPBSAndAddress()
+	c := makeChannelWithFinalizerAndPCSAndAddress()
 	c.Status.MarkProvisioned()
 	return c
 }
@@ -766,14 +766,14 @@ func makeChannelWithWrongProvisionerName() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeChannelWithSubscribersAndFinalizerAndPBS() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndPBS()
+func makeChannelWithSubscribersAndFinalizerAndPCS() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPCS()
 	addSubscribers(c, subscribers)
 	return c
 }
 
-func makeChannelWithSubscribersAndFinalizerAndPBSAndAddress() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndPBSAndAddress()
+func makeChannelWithSubscribersAndFinalizerAndPCSAndAddress() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPCSAndAddress()
 	addSubscribers(c, subscribers)
 	return c
 }
@@ -784,7 +784,7 @@ func makeChannelWithFinalizer() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeChannelWithFinalizerAndPBS() *eventingv1alpha1.Channel {
+func makeChannelWithFinalizerAndPCS() *eventingv1alpha1.Channel {
 	c := makeChannelWithFinalizer()
 	err := pubsubutil.SaveRawStatus(context.Background(), c, &pubsubutil.GcpPubSubChannelStatus{
 		Secret:     testcreds.Secret,
@@ -805,12 +805,12 @@ func makeReadyChannelWithSubscribers() *eventingv1alpha1.Channel {
 }
 
 func makeDeletingChannel() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndPBS()
+	c := makeChannelWithFinalizerAndPCS()
 	c.DeletionTimestamp = &deletionTime
 	return c
 }
 
-func makeDeletingChannelWithoutPBS() *eventingv1alpha1.Channel {
+func makeDeletingChannelWithoutPCS() *eventingv1alpha1.Channel {
 	c := makeDeletingChannel()
 	c.Status.Raw = nil
 	return c
@@ -822,7 +822,7 @@ func makeDeletingChannelWithoutFinalizer() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeDeletingChannelWithoutFinalizerOrPBS() *eventingv1alpha1.Channel {
+func makeDeletingChannelWithoutFinalizerOrPCS() *eventingv1alpha1.Channel {
 	c := makeDeletingChannelWithoutFinalizer()
 	c.Status.Raw = nil
 	return c
@@ -865,8 +865,8 @@ func makeChannelWithFinalizerAndSubscriberWithoutUID() *eventingv1alpha1.Channel
 }
 
 func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndPBS()
-	pbs, err := pubsubutil.ReadRawStatus(context.Background(), c)
+	c := makeChannelWithFinalizerAndPCS()
+	pcs, err := pubsubutil.ReadRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
@@ -894,10 +894,10 @@ func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1a
 		if plannedSubUID == "add-sub" {
 			sub.Subscription = "knative-eventing-channel_add-sub_add-sub"
 		}
-		pbs.Subscriptions = append(pbs.Subscriptions, sub)
+		pcs.Subscriptions = append(pcs.Subscriptions, sub)
 	}
 
-	err = pubsubutil.SaveRawStatus(context.Background(), c, pbs)
+	err = pubsubutil.SaveRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}
@@ -925,19 +925,19 @@ func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1a
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pbs, err := pubsubutil.ReadRawStatus(context.Background(), c)
+	pcs, err := pubsubutil.ReadRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
 	for _, sub := range subscribable.Subscribers {
-		pbs.Subscriptions = append(pbs.Subscriptions, pubsubutil.GcpPubSubSubscriptionStatus{
+		pcs.Subscriptions = append(pcs.Subscriptions, pubsubutil.GcpPubSubSubscriptionStatus{
 			Ref:           sub.Ref,
 			ReplyURI:      sub.ReplyURI,
 			SubscriberURI: sub.SubscriberURI,
 			Subscription:  "test-subscription-id",
 		})
 	}
-	err = pubsubutil.SaveRawStatus(context.Background(), c, pbs)
+	err = pubsubutil.SaveRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
@@ -866,7 +866,7 @@ func makeChannelWithFinalizerAndSubscriberWithoutUID() *eventingv1alpha1.Channel
 
 func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1alpha1.Channel {
 	c := makeChannelWithFinalizerAndPCS()
-	pcs, err := pubsubutil.GetInternalStatus(context.Background(), c)
+	pcs, err := pubsubutil.GetInternalStatus(c)
 	if err != nil {
 		panic(err)
 	}
@@ -925,7 +925,7 @@ func makeChannelWithFinalizerAndPossiblyOutdatedPlan(outdated bool) *eventingv1a
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pcs, err := pubsubutil.GetInternalStatus(context.Background(), c)
+	pcs, err := pubsubutil.GetInternalStatus(c)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/controller/channel/reconcile_test.go
@@ -52,6 +52,7 @@ const (
 	cNamespace = "test-namespace"
 	cName      = "test-channel"
 	cUID       = "test-uid"
+	topicName  = "knative-eventing-channel_test-channel_test-uid"
 
 	testErrorMessage = "test induced error"
 
@@ -355,21 +356,21 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "K8s service get fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			Mocks: controllertesting.Mocks{
 				MockLists: errorListingK8sService(),
 			},
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "K8s service creation fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				testcreds.MakeSecretWithCreds(),
 			},
 			Mocks: controllertesting.Mocks{
@@ -377,14 +378,14 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the K8s Service failed.
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "Virtual service get fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -395,14 +396,14 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the VirtualService
 				// failed.
-				makeChannelWithFinalizerAndAddress(),
+				makeChannelWithFinalizerAndPBSAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "Virtual service creation fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				testcreds.MakeSecretWithCreds(),
 			},
@@ -412,14 +413,14 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				// TODO: This should have a useful error message saying that the VirtualService
 				// failed.
-				makeChannelWithFinalizerAndAddress(),
+				makeChannelWithFinalizerAndPBSAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
 		},
 		{
 			Name: "VirtualService already exists - not owned by Channel",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualServiceNotOwnedByChannel(),
 				testcreds.MakeSecretWithCreds(),
@@ -431,7 +432,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Topic - problem creating client",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -443,13 +444,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndAddress(),
+				makeChannelWithFinalizerAndPBSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - problem checking existence",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -465,13 +466,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndAddress(),
+				makeChannelWithFinalizerAndPBSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - topic already exists",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -492,7 +493,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Topic - error creating topic",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -506,13 +507,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithFinalizerAndAddress(),
+				makeChannelWithFinalizerAndPBSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Topic - topic create succeeds",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -524,7 +525,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Subscriptions - problem checking exists",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizer(),
+				makeChannelWithSubscribersAndFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -540,13 +541,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndAddress(),
+				makeChannelWithSubscribersAndFinalizerAndPBSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Subscriptions - already exists",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizer(),
+				makeChannelWithSubscribersAndFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -567,7 +568,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Create Subscriptions - create fails",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizer(),
+				makeChannelWithSubscribersAndFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -581,13 +582,13 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantPresent: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizerAndAddress(),
+				makeChannelWithSubscribersAndFinalizerAndPBSAndAddress(),
 			},
 		},
 		{
 			Name: "Create Subscriptions - create succeeds",
 			InitialState: []runtime.Object{
-				makeChannelWithSubscribersAndFinalizer(),
+				makeChannelWithSubscribersAndFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -599,7 +600,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel get for update fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -612,7 +613,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel update fails",
 			InitialState: []runtime.Object{
-				makeChannelWithFinalizer(),
+				makeChannelWithFinalizerAndPBS(),
 				makeK8sService(),
 				makeVirtualService(),
 				testcreds.MakeSecretWithCreds(),
@@ -665,25 +666,16 @@ func makeChannel() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeChannelWithFinalizerAndAddress() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizer()
+func makeChannelWithFinalizerAndPBSAndAddress() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPBS()
 	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.cluster.local", c.Name, c.Namespace))
 	return c
 }
 
 func makeReadyChannel() *eventingv1alpha1.Channel {
 	// Ready channels have the finalizer and are Addressable.
-	c := makeChannelWithFinalizerAndAddress()
+	c := makeChannelWithFinalizerAndPBSAndAddress()
 	c.Status.MarkProvisioned()
-	pbs := &pubsubutil.GcpPubSubChannelStatus{
-		Secret:     testcreds.Secret,
-		SecretKey:  testcreds.SecretKey,
-		GCPProject: gcpProject,
-		Topic:      "test-topic-ID",
-	}
-	if err := pubsubutil.SaveRawStatus(context.Background(), c, pbs); err != nil {
-		panic(err)
-	}
 	return c
 }
 
@@ -705,27 +697,35 @@ func makeChannelWithWrongProvisionerName() *eventingv1alpha1.Channel {
 	return c
 }
 
-func makeChannelWithSubscribers() *eventingv1alpha1.Channel {
-	c := makeChannel()
-	c.Spec.Subscribable = subscribers
+func makeChannelWithSubscribersAndFinalizerAndPBS() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPBS()
+	addSubscribers(c, subscribers)
 	return c
 }
 
-func makeChannelWithSubscribersAndFinalizer() *eventingv1alpha1.Channel {
-	c := makeChannelWithSubscribers()
-	c.Finalizers = []string{finalizerName}
-	return c
-}
-
-func makeChannelWithSubscribersAndFinalizerAndAddress() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizerAndAddress()
-	c.Spec.Subscribable = subscribers
+func makeChannelWithSubscribersAndFinalizerAndPBSAndAddress() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizerAndPBSAndAddress()
+	addSubscribers(c, subscribers)
 	return c
 }
 
 func makeChannelWithFinalizer() *eventingv1alpha1.Channel {
 	c := makeChannel()
 	c.Finalizers = []string{finalizerName}
+	return c
+}
+
+func makeChannelWithFinalizerAndPBS() *eventingv1alpha1.Channel {
+	c := makeChannelWithFinalizer()
+	err := pubsubutil.SaveRawStatus(context.Background(), c, &pubsubutil.GcpPubSubChannelStatus{
+		Secret:     testcreds.Secret,
+		SecretKey:  testcreds.SecretKey,
+		GCPProject: gcpProject,
+		Topic:      topicName,
+	})
+	if err != nil {
+		panic(err)
+	}
 	return c
 }
 
@@ -736,7 +736,7 @@ func makeReadyChannelWithSubscribers() *eventingv1alpha1.Channel {
 }
 
 func makeDeletingChannel() *eventingv1alpha1.Channel {
-	c := makeChannelWithFinalizer()
+	c := makeChannelWithFinalizerAndPBS()
 	c.DeletionTimestamp = &deletionTime
 	return c
 }
@@ -749,7 +749,7 @@ func makeDeletingChannelWithoutFinalizer() *eventingv1alpha1.Channel {
 
 func makeDeletingChannelWithSubscribers() *eventingv1alpha1.Channel {
 	c := makeDeletingChannel()
-	c.Spec.Subscribable = subscribers
+	addSubscribers(c, subscribers)
 	return c
 }
 

--- a/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner/reconcile.go
+++ b/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner/reconcile.go
@@ -19,17 +19,15 @@ package clusterchannelprovisioner
 import (
 	"context"
 
-	"github.com/knative/pkg/logging"
-
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	util "github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/logging"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	util "github.com/knative/eventing/pkg/provisioners"
 )
 
 const (
@@ -53,7 +51,7 @@ func (r *reconciler) InjectClient(c client.Client) error {
 
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.TODO()
-	ctx = logging.WithLogger(ctx, r.logger.With(zap.Any("request", request)).Sugar())
+	ctx = logging.WithLogger(ctx, r.logger.With(zap.Any("request", request)))
 
 	ccp := &eventingv1alpha1.ClusterChannelProvisioner{}
 	err := r.client.Get(ctx, request.NamespacedName, ccp)

--- a/pkg/provisioners/gcppubsub/dispatcher/cmd/main.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/cmd/main.go
@@ -18,30 +18,17 @@ package main
 
 import (
 	"flag"
-	"log"
-	"os"
-
-	"github.com/knative/eventing/pkg/provisioners"
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/dispatcher"
-
-	"github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/receiver"
-	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/dispatcher"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/dispatcher/receiver"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-)
-
-const (
-	defaultGcpProjectEnv      = "DEFAULT_GCP_PROJECT"
-	defaultSecretNamespaceEnv = "DEFAULT_SECRET_NAMESPACE"
-	defaultSecretNameEnv      = "DEFAULT_SECRET_NAME"
-	defaultSecretKeyEnv       = "DEFAULT_SECRET_KEY"
 )
 
 // This is the main method for the GCP PubSub Channel dispatcher. It handles all the data-plane
@@ -68,23 +55,16 @@ func main() {
 	// Add custom types to this array to get them into the manager's scheme.
 	eventingv1alpha1.AddToScheme(mgr.GetScheme())
 
-	defaultGcpProject := getRequiredEnv(defaultGcpProjectEnv)
-	defaultSecret := v1.ObjectReference{
-		APIVersion: v1.SchemeGroupVersion.String(),
-		Kind:       "Secret",
-		Namespace:  getRequiredEnv(defaultSecretNamespaceEnv),
-		Name:       getRequiredEnv(defaultSecretNameEnv),
-	}
-	defaultSecretKey := getRequiredEnv(defaultSecretKeyEnv)
-
 	// We are running both the receiver (takes messages in from the cluster and writes them to
 	// PubSub) and the dispatcher (takes messages in PubSub and sends them in cluster) in this
 	// binary.
 
-	_, mr := receiver.New(logger.Desugar(), mgr.GetClient(), util.GcpPubSubClientCreator, defaultGcpProject, &defaultSecret, defaultSecretKey)
-	err = mgr.Add(mr)
-	if err != nil {
-		logger.Fatal("Unable to add the MessageReceiver to the manager", zap.Error(err))
+	_, runnables := receiver.New(logger.Desugar(), mgr.GetClient(), util.GcpPubSubClientCreator)
+	for _, runnable := range runnables {
+		err = mgr.Add(runnable)
+		if err != nil {
+			logger.Fatal("Unable to start the receivers runnables", zap.Error(err), zap.Any("runnable", runnable))
+		}
 	}
 
 	// TODO Move this to just before mgr.Start(). We need to pass the stopCh to dispatcher.New
@@ -93,7 +73,7 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	_, err = dispatcher.New(mgr, logger.Desugar(), defaultGcpProject, &defaultSecret, defaultSecretKey, stopCh)
+	_, err = dispatcher.New(mgr, logger.Desugar(), stopCh)
 	if err != nil {
 		logger.Fatal("Unable to create the dispatcher", zap.Error(err))
 	}
@@ -104,12 +84,4 @@ func main() {
 	if err != nil {
 		logger.Fatal("Manager.Start() returned an error", zap.Error(err))
 	}
-}
-
-func getRequiredEnv(envKey string) string {
-	val, defined := os.LookupEnv(envKey)
-	if !defined {
-		log.Fatalf("required environment variable not defined '%s'", envKey)
-	}
-	return val
 }

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
@@ -97,12 +97,12 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logging.FromContext(ctx).Info("Not reconciling Channel, it is not controlled by this Controller", zap.Any("ref", c.Spec))
 		return reconcile.Result{}, nil
 	}
-	pcs, err := pubsubutil.GetRawStatus(ctx, c)
+	pcs, err := pubsubutil.GetInternalStatus(ctx, c)
 	if err != nil {
-		logging.FromContext(ctx).Info("Unable to read the raw status", zap.Error(err))
+		logging.FromContext(ctx).Info("Unable to read the status.internal", zap.Error(err))
 		return reconcile.Result{}, err
 	} else if pcs.IsEmpty() {
-		return reconcile.Result{}, errors.New("raw status is blank")
+		return reconcile.Result{}, errors.New("status.internal is blank")
 	}
 
 	logging.FromContext(ctx).Info("Reconciling Channel")

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
@@ -97,7 +97,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logging.FromContext(ctx).Info("Not reconciling Channel, it is not controlled by this Controller", zap.Any("ref", c.Spec))
 		return reconcile.Result{}, nil
 	}
-	pcs, err := pubsubutil.ReadRawStatus(ctx, c)
+	pcs, err := pubsubutil.GetRawStatus(ctx, c)
 	if err != nil {
 		logging.FromContext(ctx).Info("Unable to read the raw status", zap.Error(err))
 		return reconcile.Result{}, err

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile.go
@@ -97,7 +97,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logging.FromContext(ctx).Info("Not reconciling Channel, it is not controlled by this Controller", zap.Any("ref", c.Spec))
 		return reconcile.Result{}, nil
 	}
-	pcs, err := pubsubutil.GetInternalStatus(ctx, c)
+	pcs, err := pubsubutil.GetInternalStatus(c)
 	if err != nil {
 		logging.FromContext(ctx).Info("Unable to read the status.internal", zap.Error(err))
 		return reconcile.Result{}, err

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -538,7 +538,7 @@ func makeChannelWithBlankInternalStatus() *eventingv1alpha1.Channel {
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pcs, err := util.GetInternalStatus(context.Background(), c)
+	pcs, err := util.GetInternalStatus(c)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -455,7 +455,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SaveRawStatus(context.Background(), c, pcs); err != nil {
+	if err := util.SetRawStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c
@@ -538,7 +538,7 @@ func makeChannelWithBlankRawStatus() *eventingv1alpha1.Channel {
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pcs, err := util.ReadRawStatus(context.Background(), c)
+	pcs, err := util.GetRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
@@ -549,7 +549,7 @@ func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscrib
 			SubscriberURI: sub.SubscriberURI,
 		})
 	}
-	err = util.SaveRawStatus(context.Background(), c, pcs)
+	err = util.SetRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -450,12 +450,12 @@ func makeChannel() *eventingv1alpha1.Channel {
 	c.Status.InitializeConditions()
 	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.cluster.local", c.Name, c.Namespace))
 	c.Status.MarkProvisioned()
-	pbs := &util.GcpPubSubChannelStatus{
+	pcs := &util.GcpPubSubChannelStatus{
 		GCPProject: gcpProject,
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SaveRawStatus(context.Background(), c, pbs); err != nil {
+	if err := util.SaveRawStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c
@@ -538,18 +538,18 @@ func makeChannelWithBlankRawStatus() *eventingv1alpha1.Channel {
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pbs, err := util.ReadRawStatus(context.Background(), c)
+	pcs, err := util.ReadRawStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
 	for _, sub := range subscribable.Subscribers {
-		pbs.Subscriptions = append(pbs.Subscriptions, util.GcpPubSubSubscriptionStatus{
+		pcs.Subscriptions = append(pcs.Subscriptions, util.GcpPubSubSubscriptionStatus{
 			Ref:           sub.Ref,
 			ReplyURI:      sub.ReplyURI,
 			SubscriberURI: sub.SubscriberURI,
 		})
 	}
-	err = util.SaveRawStatus(context.Background(), c, pbs)
+	err = util.SaveRawStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/dispatcher/reconcile_test.go
@@ -149,18 +149,18 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			Name: "Unable to read Raw Status",
+			Name: "Unable to read Internal Status",
 			InitialState: []runtime.Object{
-				makeChannelWithBadRawStatus(),
+				makeChannelWithBadInternalStatus(),
 			},
 			WantErrMsg: "json: cannot unmarshal number into Go struct field GcpPubSubChannelStatus.secretKey of type string",
 		},
 		{
-			Name: "Empty raw status",
+			Name: "Empty status.internal",
 			InitialState: []runtime.Object{
-				makeChannelWithBlankRawStatus(),
+				makeChannelWithBlankInternalStatus(),
 			},
-			WantErrMsg: "raw status is blank",
+			WantErrMsg: "status.internal is blank",
 		},
 		{
 			Name: "Channel deleted - subscribers",
@@ -455,7 +455,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SetRawStatus(context.Background(), c, pcs); err != nil {
+	if err := util.SetInternalStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c
@@ -521,24 +521,24 @@ func makeDeletingChannelWithSubscribersWithoutFinalizer() *eventingv1alpha1.Chan
 	return c
 }
 
-func makeChannelWithBadRawStatus() *eventingv1alpha1.Channel {
+func makeChannelWithBadInternalStatus() *eventingv1alpha1.Channel {
 	c := makeChannel()
-	c.Status.Raw = &runtime.RawExtension{
+	c.Status.Internal = &runtime.RawExtension{
 		// SecretKey must be a string, not an integer, so this will fail during json.Unmarshal.
 		Raw: []byte(`{"secretKey": 123}`),
 	}
 	return c
 }
 
-func makeChannelWithBlankRawStatus() *eventingv1alpha1.Channel {
+func makeChannelWithBlankInternalStatus() *eventingv1alpha1.Channel {
 	c := makeChannel()
-	c.Status.Raw = nil
+	c.Status.Internal = nil
 	return c
 }
 
 func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscribable) {
 	c.Spec.Subscribable = subscribable
-	pcs, err := util.GetRawStatus(context.Background(), c)
+	pcs, err := util.GetInternalStatus(context.Background(), c)
 	if err != nil {
 		panic(err)
 	}
@@ -549,7 +549,7 @@ func addSubscribers(c *eventingv1alpha1.Channel, subscribable *v1alpha1.Subscrib
 			SubscriberURI: sub.SubscriberURI,
 		})
 	}
-	err = util.SetRawStatus(context.Background(), c, pcs)
+	err = util.SetInternalStatus(context.Background(), c, pcs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -67,8 +67,9 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 		logging.FromContext(ctx).Info("Unable to get the Channel", zap.Error(err), zap.Any("channelRef", channel))
 		return err
 	}
-	pcs, err := util.GetInternalStatus(ctx, c)
+	pcs, err := util.GetInternalStatus(c)
 	if err != nil {
+		logging.FromContext(ctx).Error("Unable to read status.internal", zap.Error(err), zap.Any("channel", c))
 		return err
 	} else if pcs.IsEmpty() {
 		logging.FromContext(ctx).Info("status.internal is blank")

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -18,14 +18,18 @@ package receiver
 
 import (
 	"context"
+	"errors"
 
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
-	v1 "k8s.io/api/core/v1"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
+	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // Receiver parses Cloud Events and sends them to GCP PubSub.
@@ -34,35 +38,18 @@ type Receiver struct {
 	client client.Client
 
 	pubSubClientCreator util.PubSubClientCreator
-
-	// Note that for all the default* parameters below, these must be kept in lock-step with the
-	// GCP PubSub Dispatcher's reconciler.
-	// Eventually, individual Channels should be allowed to specify different projects and secrets,
-	// but for now all Channels use the same project and secret.
-
-	// defaultGcpProject is the GCP project ID where PubSub Topics and Subscriptions are created.
-	defaultGcpProject string
-	// defaultSecret and defaultSecretKey are the K8s Secret and key in that secret that contain a
-	// JSON format GCP service account token, see
-	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-gcloud
-	defaultSecret    *v1.ObjectReference
-	defaultSecretKey string
 }
 
 // New creates a new Receiver and its associated MessageReceiver. The caller is responsible for
 // Start()ing the returned MessageReceiver.
-func New(logger *zap.Logger, client client.Client, pubSubClientCreator util.PubSubClientCreator, defaultGcpProject string, defaultSecret *v1.ObjectReference, defaultSecretKey string) (*Receiver, *provisioners.MessageReceiver) {
+func New(logger *zap.Logger, client client.Client, pubSubClientCreator util.PubSubClientCreator) (*Receiver, []manager.Runnable) {
 	r := &Receiver{
 		logger: logger,
 		client: client,
 
 		pubSubClientCreator: pubSubClientCreator,
-
-		defaultGcpProject: defaultGcpProject,
-		defaultSecret:     defaultSecret,
-		defaultSecretKey:  defaultSecretKey,
 	}
-	return r, r.newMessageReceiver()
+	return r, []manager.Runnable{r.newMessageReceiver()}
 }
 
 func (r *Receiver) newMessageReceiver() *provisioners.MessageReceiver {
@@ -74,20 +61,26 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 	r.logger.Debug("received message")
 	ctx := context.Background()
 
-	creds, err := util.GetCredentials(ctx, r.client, r.defaultSecret, r.defaultSecretKey)
+	c, err := r.getChannel(ctx, channel)
 	if err != nil {
-		r.logger.Error("Failed to extract creds", zap.Error(err))
+		logging.FromContext(ctx).Info("Unable to get the Channel", zap.Error(err), zap.Any("channelRef", channel))
+		return err
+	}
+	pbs, err := util.ReadRawStatus(ctx, c)
+	if err != nil {
+		return err
+	} else if pbs.IsEmpty() {
+		logging.FromContext(ctx).Info("Raw status is blank")
+		return errors.New("raw status is blank")
+	}
+
+	psr, err := r.createPubSubReceiver(ctx, pbs)
+	if err != nil {
+		logging.FromContext(ctx).Info("Unable to create pubSubReceiver", zap.Error(err))
 		return err
 	}
 
-	psc, err := r.pubSubClientCreator(ctx, creds, r.defaultGcpProject)
-	if err != nil {
-		r.logger.Error("Failed to create PubSub client", zap.Error(err))
-		return err
-	}
-	topicName := util.GenerateTopicName(channel.Namespace, channel.Name)
-	topic := psc.Topic(topicName)
-	result := topic.Publish(ctx, &pubsub.Message{
+	result := psr.Publish(ctx, &pubsub.Message{
 		Data:       message.Payload,
 		Attributes: message.Headers,
 	})
@@ -96,10 +89,36 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 	if err != nil {
 		return err
 	}
+	// TODO allow topics to be reused between publish events, call .Stop after an idle period.
+	psr.Stop()
 
-	// TODO allow topics to be reused between publish events, call .Stop after an idle period
-	topic.Stop()
-
-	r.logger.Debug("Published a message", zap.String("topicName", topicName), zap.String("pubSubMessageId", id))
+	r.logger.Debug("Published a message", zap.String("topicName", pbs.Topic), zap.String("pubSubMessageId", id))
 	return nil
+}
+
+func (r *Receiver) createPubSubReceiver(ctx context.Context, pbs *util.GcpPubSubChannelStatus) (util.PubSubTopic, error) {
+	creds, err := util.GetCredentials(ctx, r.client, pbs.Secret, pbs.SecretKey)
+	if err != nil {
+		r.logger.Info("Failed to extract creds", zap.Error(err))
+		return nil, err
+	}
+
+	psc, err := r.pubSubClientCreator(ctx, creds, pbs.GCPProject)
+	if err != nil {
+		r.logger.Info("Failed to create PubSub client", zap.Error(err))
+		return nil, err
+	}
+	return psc.Topic(pbs.Topic), nil
+}
+
+func (r *Receiver) getChannel(ctx context.Context, ref provisioners.ChannelReference) (*eventingv1alpha1.Channel, error) {
+	c := &eventingv1alpha1.Channel{}
+	err := r.client.Get(ctx,
+		types.NamespacedName{
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+		},
+		c)
+
+	return c, err
 }

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -20,12 +20,11 @@ import (
 	"context"
 	"errors"
 
+	"cloud.google.com/go/pubsub"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
-
-	"cloud.google.com/go/pubsub"
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
-	"github.com/knative/pkg/logging"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/logging"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -67,7 +67,7 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 		logging.FromContext(ctx).Info("Unable to get the Channel", zap.Error(err), zap.Any("channelRef", channel))
 		return err
 	}
-	pcs, err := util.ReadRawStatus(ctx, c)
+	pcs, err := util.GetRawStatus(ctx, c)
 	if err != nil {
 		return err
 	} else if pcs.IsEmpty() {

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -65,15 +65,15 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 		logging.FromContext(ctx).Info("Unable to get the Channel", zap.Error(err), zap.Any("channelRef", channel))
 		return err
 	}
-	pbs, err := util.ReadRawStatus(ctx, c)
+	pcs, err := util.ReadRawStatus(ctx, c)
 	if err != nil {
 		return err
-	} else if pbs.IsEmpty() {
+	} else if pcs.IsEmpty() {
 		logging.FromContext(ctx).Info("Raw status is blank")
 		return errors.New("raw status is blank")
 	}
 
-	psr, err := r.createPubSubReceiver(ctx, pbs)
+	psr, err := r.createPubSubReceiver(ctx, pcs)
 	if err != nil {
 		logging.FromContext(ctx).Info("Unable to create pubSubReceiver", zap.Error(err))
 		return err
@@ -91,23 +91,23 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 	// TODO allow topics to be reused between publish events, call .Stop after an idle period.
 	psr.Stop()
 
-	r.logger.Debug("Published a message", zap.String("topicName", pbs.Topic), zap.String("pubSubMessageId", id))
+	r.logger.Debug("Published a message", zap.String("topicName", pcs.Topic), zap.String("pubSubMessageId", id))
 	return nil
 }
 
-func (r *Receiver) createPubSubReceiver(ctx context.Context, pbs *util.GcpPubSubChannelStatus) (util.PubSubTopic, error) {
-	creds, err := util.GetCredentials(ctx, r.client, pbs.Secret, pbs.SecretKey)
+func (r *Receiver) createPubSubReceiver(ctx context.Context, pcs *util.GcpPubSubChannelStatus) (util.PubSubTopic, error) {
+	creds, err := util.GetCredentials(ctx, r.client, pcs.Secret, pcs.SecretKey)
 	if err != nil {
 		r.logger.Info("Failed to extract creds", zap.Error(err))
 		return nil, err
 	}
 
-	psc, err := r.pubSubClientCreator(ctx, creds, pbs.GCPProject)
+	psc, err := r.pubSubClientCreator(ctx, creds, pcs.GCPProject)
 	if err != nil {
 		r.logger.Info("Failed to create PubSub client", zap.Error(err))
 		return nil, err
 	}
-	return psc.Topic(pbs.Topic), nil
+	return psc.Topic(pcs.Topic), nil
 }
 
 func (r *Receiver) getChannel(ctx context.Context, ref provisioners.ChannelReference) (*eventingv1alpha1.Channel, error) {

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -67,12 +67,12 @@ func (r *Receiver) sendEventToTopic(channel provisioners.ChannelReference, messa
 		logging.FromContext(ctx).Info("Unable to get the Channel", zap.Error(err), zap.Any("channelRef", channel))
 		return err
 	}
-	pcs, err := util.GetRawStatus(ctx, c)
+	pcs, err := util.GetInternalStatus(ctx, c)
 	if err != nil {
 		return err
 	} else if pcs.IsEmpty() {
-		logging.FromContext(ctx).Info("Raw status is blank")
-		return errors.New("raw status is blank")
+		logging.FromContext(ctx).Info("status.internal is blank")
+		return errors.New("status.internal is blank")
 	}
 
 	psr, err := r.createPubSubReceiver(ctx, pcs)

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver.go
@@ -48,6 +48,8 @@ func New(logger *zap.Logger, client client.Client, pubSubClientCreator util.PubS
 
 		pubSubClientCreator: pubSubClientCreator,
 	}
+	// This currently only returns a single Runnable, but is expected to return multiple soon (i.e.
+	// for a TTL cache).
 	return r, []manager.Runnable{r.newMessageReceiver()}
 }
 

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
@@ -160,12 +160,12 @@ func makeChannel() *eventingv1alpha1.Channel {
 			Name:      "test-channel",
 		},
 	}
-	pbs := &util.GcpPubSubChannelStatus{
+	pcs := &util.GcpPubSubChannelStatus{
 		GCPProject: "project",
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SaveRawStatus(context.Background(), c, pbs); err != nil {
+	if err := util.SaveRawStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
@@ -165,7 +165,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SaveRawStatus(context.Background(), c, pcs); err != nil {
+	if err := util.SetRawStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
@@ -17,14 +17,21 @@
 package receiver
 
 import (
+	"context"
 	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util"
+
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"k8s.io/client-go/kubernetes/scheme"
+
 	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/fakepubsub"
 	"go.uber.org/zap"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -33,8 +40,6 @@ import (
 )
 
 const (
-	gcpProject = "my-gcp-project"
-
 	validMessage = `{
     "cloudEventsVersion" : "0.1",
     "eventType" : "com.example.someevent",
@@ -50,21 +55,48 @@ const (
 }`
 )
 
+func init() {
+	// Add types to scheme.
+	eventingv1alpha1.AddToScheme(scheme.Scheme)
+}
+
 func TestReceiver(t *testing.T) {
 	testCases := map[string]struct {
 		initialState []runtime.Object
 		pubSubData   fakepubsub.CreatorData
 		expectedErr  bool
 	}{
+		"can't get channel": {
+			initialState: []runtime.Object{
+				testcreds.MakeSecretWithInvalidCreds(),
+			},
+			expectedErr: true,
+		},
+		"can't read status": {
+			initialState: []runtime.Object{
+				testcreds.MakeSecretWithInvalidCreds(),
+				makeChannelWithBadStatus(),
+			},
+			expectedErr: true,
+		},
+		"blank status": {
+			initialState: []runtime.Object{
+				testcreds.MakeSecretWithInvalidCreds(),
+				makeChannelWithBlankStatus(),
+			},
+			expectedErr: true,
+		},
 		"credential fails": {
 			initialState: []runtime.Object{
 				testcreds.MakeSecretWithInvalidCreds(),
+				makeChannel(),
 			},
 			expectedErr: true,
 		},
 		"PubSub client fails": {
 			initialState: []runtime.Object{
 				testcreds.MakeSecretWithCreds(),
+				makeChannel(),
 			},
 			pubSubData: fakepubsub.CreatorData{
 				ClientCreateErr: errors.New("testInducedError"),
@@ -74,6 +106,7 @@ func TestReceiver(t *testing.T) {
 		"Publish fails": {
 			initialState: []runtime.Object{
 				testcreds.MakeSecretWithCreds(),
+				makeChannel(),
 			},
 			pubSubData: fakepubsub.CreatorData{
 				ClientData: fakepubsub.ClientData{
@@ -89,21 +122,20 @@ func TestReceiver(t *testing.T) {
 		"Publish succeeds": {
 			initialState: []runtime.Object{
 				testcreds.MakeSecretWithCreds(),
+				makeChannel(),
 			},
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, mr := New(
+			mr, _ := New(
 				zap.NewNop(),
 				fake.NewFakeClient(tc.initialState...),
-				fakepubsub.Creator(tc.pubSubData),
-				gcpProject,
-				testcreds.Secret,
-				testcreds.SecretKey)
+				fakepubsub.Creator(tc.pubSubData))
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest("POST", "/", strings.NewReader(validMessage))
-			mr.HandleRequest(resp, req)
+			req.Host = "test-channel.test-namespace.channels.cluster.local"
+			mr.newMessageReceiver().HandleRequest(resp, req)
 			if tc.expectedErr {
 				if resp.Result().StatusCode >= 200 && resp.Result().StatusCode < 300 {
 					t.Errorf("Expected an error. Actual: %v", resp.Result())
@@ -115,4 +147,41 @@ func TestReceiver(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeChannel() *eventingv1alpha1.Channel {
+	c := &eventingv1alpha1.Channel{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "eventing.knative.dev/v1alpha1",
+			Kind:       "Channel",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-channel",
+		},
+	}
+	pbs := &util.GcpPubSubChannelStatus{
+		GCPProject: "project",
+		Secret:     testcreds.Secret,
+		SecretKey:  testcreds.SecretKey,
+	}
+	if err := util.SaveRawStatus(context.Background(), c, pbs); err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func makeChannelWithBlankStatus() *eventingv1alpha1.Channel {
+	c := makeChannel()
+	c.Status = eventingv1alpha1.ChannelStatus{}
+	return c
+}
+
+func makeChannelWithBadStatus() *eventingv1alpha1.Channel {
+	c := makeChannel()
+	c.Status.Raw = &runtime.RawExtension{
+		// SecretKey must be a string, not an integer, so this will fail during json.Unmarshal.
+		Raw: []byte(`{"secretKey": 123}`),
+	}
+	return c
 }

--- a/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
+++ b/pkg/provisioners/gcppubsub/dispatcher/receiver/receiver_test.go
@@ -165,7 +165,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		Secret:     testcreds.Secret,
 		SecretKey:  testcreds.SecretKey,
 	}
-	if err := util.SetRawStatus(context.Background(), c, pcs); err != nil {
+	if err := util.SetInternalStatus(context.Background(), c, pcs); err != nil {
 		panic(err)
 	}
 	return c
@@ -179,7 +179,7 @@ func makeChannelWithBlankStatus() *eventingv1alpha1.Channel {
 
 func makeChannelWithBadStatus() *eventingv1alpha1.Channel {
 	c := makeChannel()
-	c.Status.Raw = &runtime.RawExtension{
+	c.Status.Internal = &runtime.RawExtension{
 		// SecretKey must be a string, not an integer, so this will fail during json.Unmarshal.
 		Raw: []byte(`{"secretKey": 123}`),
 	}

--- a/pkg/provisioners/gcppubsub/util/creds.go
+++ b/pkg/provisioners/gcppubsub/util/creds.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/logging"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/provisioners/gcppubsub/util/creds.go
+++ b/pkg/provisioners/gcppubsub/util/creds.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +34,9 @@ import (
 // GetCredentials gets GCP credentials from a secretRef. The credentials must be stored in JSON format
 // in the secretRef.
 func GetCredentials(ctx context.Context, client client.Client, secretRef *v1.ObjectReference, key string) (*google.Credentials, error) {
+	if secretRef == nil {
+		return nil, errors.New("nil secretRef")
+	}
 	secret := &v1.Secret{}
 	err := client.Get(ctx, types.NamespacedName{Namespace: secretRef.Namespace, Name: secretRef.Name}, secret)
 	if err != nil {

--- a/pkg/provisioners/gcppubsub/util/creds_test.go
+++ b/pkg/provisioners/gcppubsub/util/creds_test.go
@@ -32,6 +32,12 @@ func TestGetCredentials(t *testing.T) {
 		secret    *v1.Secret
 		err       bool
 	}{
+		"nil secretRef": {
+			secretRef: nil,
+			secret:    testcreds.MakeSecretWithCreds(),
+			key:       testcreds.SecretKey,
+			err:       true,
+		},
 		"secretRef not found": {
 			secretRef: &v1.ObjectReference{
 				APIVersion: "v1",

--- a/pkg/provisioners/gcppubsub/util/logging/logging.go
+++ b/pkg/provisioners/gcppubsub/util/logging/logging.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// logging is a copy of knative/pkg's logging package, except it uses desugared loggers.
+package logging
+
+import (
+	"context"
+
+	"github.com/knative/pkg/logging"
+	"go.uber.org/zap"
+)
+
+func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return logging.WithLogger(ctx, logger.Sugar())
+}
+
+func FromContext(ctx context.Context) *zap.Logger {
+	return logging.FromContext(ctx).Desugar()
+}
+
+func With(ctx context.Context, fields ...zap.Field) context.Context {
+	logger := FromContext(ctx)
+	return WithLogger(ctx, logger.With(fields...))
+}

--- a/pkg/provisioners/gcppubsub/util/pubsub_wrapper.go
+++ b/pkg/provisioners/gcppubsub/util/pubsub_wrapper.go
@@ -20,11 +20,9 @@ import (
 	"context"
 	"errors"
 
-	"google.golang.org/api/option"
-
-	"golang.org/x/oauth2/google"
-
 	"cloud.google.com/go/pubsub"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 )
 
 // This file exists so that we can unit test failures with the PubSub client.

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+
+	"github.com/knative/pkg/logging"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type GcpPubSubChannelStatus struct {
+	Secret    *corev1.ObjectReference `json:"secret"`
+	SecretKey string                  `json:"secretKey"`
+
+	GCPProject    string                        `json:"gcpProject"`
+	Topic         string                        `json:"topic,omitempty"`
+	Subscriptions []GcpPubSubSubscriptionStatus `json:"subscriptions,omitempty"`
+}
+
+type GcpPubSubSubscriptionStatus struct {
+	// +optional
+	Ref *corev1.ObjectReference `json:"ref,omitempty"`
+	// +optional
+	SubscriberURI string `json:"subscriberURI,omitempty"`
+	// +optional
+	ReplyURI string `json:"replyURI,omitempty"`
+
+	// Subscription is the name of the PubSub Subscription resource in GCP that represents this
+	// Knative eventing Subscription.
+	Subscription string `json:"subscription,omitempty"`
+}
+
+// IsEmpty determines if this GcpPubSubChannelStatus is equivalent to &GcpPubSubChannelStatus{}. It
+// exists because slices are not compared by golang's ==.
+func (pbs *GcpPubSubChannelStatus) IsEmpty() bool {
+	if pbs.Secret != nil {
+		return false
+	}
+	if pbs.SecretKey != "" {
+		return false
+	}
+	if pbs.GCPProject != "" {
+		return false
+	}
+	if pbs.Topic != "" {
+		return false
+	}
+	if len(pbs.Subscriptions) > 0 {
+		return false
+	}
+	return true
+}
+
+// SaveRawStatus saves GcpPubSubChannelStatus to the given Channel, which should only be one whose
+// provisioner is gcp-pubsub.
+func SaveRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pbs *GcpPubSubChannelStatus) error {
+	jb, err := json.Marshal(pbs)
+	if err != nil {
+		logging.FromContext(ctx).Error("Error saving the raw status", zap.Error(err), zap.Any("pbs", pbs))
+		return err
+	}
+	c.Status.Raw = &runtime.RawExtension{
+		Raw: jb,
+	}
+	return nil
+}
+
+// ReadRawStatus reads GcpPubSubChannelStatus from the given Channel, which should only be one whose
+// provisioner is gcp-pubsub. If the raw status is not set, then the empty GcpPubSubChannelStatus is
+// returned.
+func ReadRawStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPubSubChannelStatus, error) {
+	if c.Status.Raw == nil {
+		return &GcpPubSubChannelStatus{}, nil
+	}
+	bytes := c.Status.Raw.Raw
+	if len(bytes) == 0 {
+		return &GcpPubSubChannelStatus{}, nil
+	}
+	var pbs GcpPubSubChannelStatus
+	if err := json.Unmarshal(bytes, &pbs); err != nil {
+		logging.FromContext(ctx).Error("Unable to parse the raw status", zap.Error(err))
+		return nil, err
+	}
+	return &pbs, nil
+
+}

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -102,7 +102,7 @@ func SetInternalStatus(ctx context.Context, c *eventingv1alpha1.Channel, pcs *Gc
 // GetInternalStatus reads GcpPubSubChannelStatus from the given Channel, which should only be one whose
 // provisioner is gcp-pubsub. If the internal status is not set, then the empty GcpPubSubChannelStatus is
 // returned.
-func GetInternalStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPubSubChannelStatus, error) {
+func GetInternalStatus(c *eventingv1alpha1.Channel) (*GcpPubSubChannelStatus, error) {
 	if c.Status.Internal == nil {
 		return &GcpPubSubChannelStatus{}, nil
 	}
@@ -112,7 +112,6 @@ func GetInternalStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPu
 	}
 	var pcs GcpPubSubChannelStatus
 	if err := json.Unmarshal(bytes, &pcs); err != nil {
-		logging.FromContext(ctx).Error("Unable to parse status.internal", zap.Error(err))
 		return nil, err
 	}
 	return &pcs, nil

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -39,8 +39,8 @@ type GcpPubSubChannelStatus struct {
 	GCPProject string `json:"gcpProject"`
 	// Topic is the name of the PubSub Topic created in GCP to represent this Channel.
 	Topic string `json:"topic,omitempty"`
-	// Subscriptions is the list of Subscriptions to this Channel and the PubSub Subscription in GCP
-	// that represents the Knative Eventing Subscription.
+	// Subscriptions is the list of Knative Eventing Subscriptions to this Channel, each paired with
+	// the PubSub Subscription in GCP that represents it.
 	Subscriptions []GcpPubSubSubscriptionStatus `json:"subscriptions,omitempty"`
 }
 

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -61,12 +61,6 @@ type GcpPubSubSubscriptionStatus struct {
 	// Subscription is the name of the PubSub Subscription resource in GCP that represents this
 	// Knative Eventing Subscription.
 	Subscription string `json:"subscription,omitempty"`
-
-	// ShouldDispatch is used by the dispatcher to determine if it should dispatch this
-	// Subscription. It is expected to be false when the controller first saves the Subscription
-	// status, before actually creating the resource. This being false does not mean that it has not
-	// been created (e.g. the controller created it and crashed before writing to the API server).
-	ShouldDispatch bool `json:"shouldDispatch,omitempty"`
 }
 
 // IsEmpty determines if this GcpPubSubChannelStatus is equivalent to &GcpPubSubChannelStatus{}. It

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -63,20 +63,20 @@ type GcpPubSubSubscriptionStatus struct {
 
 // IsEmpty determines if this GcpPubSubChannelStatus is equivalent to &GcpPubSubChannelStatus{}. It
 // exists because slices are not compared by golang's ==.
-func (pbs *GcpPubSubChannelStatus) IsEmpty() bool {
-	if pbs.Secret != nil {
+func (pcs *GcpPubSubChannelStatus) IsEmpty() bool {
+	if pcs.Secret != nil {
 		return false
 	}
-	if pbs.SecretKey != "" {
+	if pcs.SecretKey != "" {
 		return false
 	}
-	if pbs.GCPProject != "" {
+	if pcs.GCPProject != "" {
 		return false
 	}
-	if pbs.Topic != "" {
+	if pcs.Topic != "" {
 		return false
 	}
-	if len(pbs.Subscriptions) > 0 {
+	if len(pcs.Subscriptions) > 0 {
 		return false
 	}
 	return true
@@ -84,10 +84,10 @@ func (pbs *GcpPubSubChannelStatus) IsEmpty() bool {
 
 // SaveRawStatus saves GcpPubSubChannelStatus to the given Channel, which should only be one whose
 // provisioner is gcp-pubsub.
-func SaveRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pbs *GcpPubSubChannelStatus) error {
-	jb, err := json.Marshal(pbs)
+func SaveRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pcs *GcpPubSubChannelStatus) error {
+	jb, err := json.Marshal(pcs)
 	if err != nil {
-		logging.FromContext(ctx).Error("Error saving the raw status", zap.Error(err), zap.Any("pbs", pbs))
+		logging.FromContext(ctx).Error("Error saving the raw status", zap.Error(err), zap.Any("pcs", pcs))
 		return err
 	}
 	c.Status.Raw = &runtime.RawExtension{
@@ -107,11 +107,11 @@ func ReadRawStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPubSub
 	if len(bytes) == 0 {
 		return &GcpPubSubChannelStatus{}, nil
 	}
-	var pbs GcpPubSubChannelStatus
-	if err := json.Unmarshal(bytes, &pbs); err != nil {
+	var pcs GcpPubSubChannelStatus
+	if err := json.Unmarshal(bytes, &pcs); err != nil {
 		logging.FromContext(ctx).Error("Unable to parse the raw status", zap.Error(err))
 		return nil, err
 	}
-	return &pbs, nil
+	return &pcs, nil
 
 }

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -82,12 +82,15 @@ func (pcs *GcpPubSubChannelStatus) IsEmpty() bool {
 	return true
 }
 
-// SaveRawStatus saves GcpPubSubChannelStatus to the given Channel, which should only be one whose
+// SetRawStatus saves GcpPubSubChannelStatus to the given Channel, which should only be one whose
 // provisioner is gcp-pubsub.
-func SaveRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pcs *GcpPubSubChannelStatus) error {
+func SetRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pcs *GcpPubSubChannelStatus) error {
 	jb, err := json.Marshal(pcs)
 	if err != nil {
-		logging.FromContext(ctx).Error("Error saving the raw status", zap.Error(err), zap.Any("pcs", pcs))
+		// I don't think this is reachable, because the GcpPubSubChannelStatus struct is designed to
+		// marshal to JSON and therefore doesn't have any incompatible fields. Nevertheless, this is
+		// here just in case.
+		logging.FromContext(ctx).Error("Error setting the raw status", zap.Error(err), zap.Any("pcs", pcs))
 		return err
 	}
 	c.Status.Raw = &runtime.RawExtension{
@@ -96,10 +99,10 @@ func SaveRawStatus(ctx context.Context, c *eventingv1alpha1.Channel, pcs *GcpPub
 	return nil
 }
 
-// ReadRawStatus reads GcpPubSubChannelStatus from the given Channel, which should only be one whose
+// GetRawStatus reads GcpPubSubChannelStatus from the given Channel, which should only be one whose
 // provisioner is gcp-pubsub. If the raw status is not set, then the empty GcpPubSubChannelStatus is
 // returned.
-func ReadRawStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPubSubChannelStatus, error) {
+func GetRawStatus(ctx context.Context, c *eventingv1alpha1.Channel) (*GcpPubSubChannelStatus, error) {
 	if c.Status.Raw == nil {
 		return &GcpPubSubChannelStatus{}, nil
 	}

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -29,25 +29,37 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// GcpPubSubChannelStatus is the struct saved to Channel's status.raw if the Channel's provisioner
+// is gcp-pubsub. It is used to send data to the dispatcher from the controller.
 type GcpPubSubChannelStatus struct {
-	Secret    *corev1.ObjectReference `json:"secret"`
-	SecretKey string                  `json:"secretKey"`
+	// Secret is the Secret that contains the credential to use.
+	Secret *corev1.ObjectReference `json:"secret"`
+	// SecretKey is the key in Secret that contains the credential to use.
+	SecretKey string `json:"secretKey"`
 
-	GCPProject    string                        `json:"gcpProject"`
-	Topic         string                        `json:"topic,omitempty"`
+	// GCPProject is the GCP project where the Topic and Subscription exist.
+	GCPProject string `json:"gcpProject"`
+	// Topic is the name of the PubSub Topic created in GCP to represent this Channel.
+	Topic string `json:"topic,omitempty"`
+	// Subscriptions is the list of Subscriptions to this Channel and the PubSub Subscription in GCP
+	// that represents the Knative Eventing Subscription.
 	Subscriptions []GcpPubSubSubscriptionStatus `json:"subscriptions,omitempty"`
 }
 
+// GcpPubSubSubscriptionStatus represents the saved status of a gcp-pubsub Channel.
 type GcpPubSubSubscriptionStatus struct {
+	// Ref is a reference to the Knative Eventing Subscription that this status represents.
 	// +optional
 	Ref *corev1.ObjectReference `json:"ref,omitempty"`
+	// SubscriberURI is a copy of the SubscriberURI of this Subscription.
 	// +optional
 	SubscriberURI string `json:"subscriberURI,omitempty"`
+	// ReplyURI is a copy of the ReplyURI of this Subscription.
 	// +optional
 	ReplyURI string `json:"replyURI,omitempty"`
 
 	// Subscription is the name of the PubSub Subscription resource in GCP that represents this
-	// Knative eventing Subscription.
+	// Knative Eventing Subscription.
 	Subscription string `json:"subscription,omitempty"`
 }
 

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -20,13 +20,11 @@ import (
 	"context"
 	"encoding/json"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-
-	"github.com/knative/pkg/logging"
+	"github.com/knative/eventing/pkg/provisioners/gcppubsub/util/logging"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // GcpPubSubChannelStatus is the struct saved to Channel's status.raw if the Channel's provisioner

--- a/pkg/provisioners/gcppubsub/util/status.go
+++ b/pkg/provisioners/gcppubsub/util/status.go
@@ -61,6 +61,12 @@ type GcpPubSubSubscriptionStatus struct {
 	// Subscription is the name of the PubSub Subscription resource in GCP that represents this
 	// Knative Eventing Subscription.
 	Subscription string `json:"subscription,omitempty"`
+
+	// ShouldDispatch is used by the dispatcher to determine if it should dispatch this
+	// Subscription. It is expected to be false when the controller first saves the Subscription
+	// status, before actually creating the resource. This being false does not mean that it has not
+	// been created (e.g. the controller created it and crashed before writing to the API server).
+	ShouldDispatch bool `json:"shouldDispatch,omitempty"`
 }
 
 // IsEmpty determines if this GcpPubSubChannelStatus is equivalent to &GcpPubSubChannelStatus{}. It

--- a/pkg/provisioners/gcppubsub/util/status_test.go
+++ b/pkg/provisioners/gcppubsub/util/status_test.go
@@ -84,33 +84,33 @@ func TestIsEmpty(t *testing.T) {
 	}
 }
 
-func TestReadRawStatus(t *testing.T) {
+func TestReadInternalStatus(t *testing.T) {
 	testCases := map[string]struct {
-		raw      *runtime.RawExtension
+		internal *runtime.RawExtension
 		expected *GcpPubSubChannelStatus
 		err      bool
 	}{
 		"nil": {
-			raw:      nil,
+			internal: nil,
 			expected: &GcpPubSubChannelStatus{},
 			err:      false,
 		},
 		"empty": {
-			raw: &runtime.RawExtension{
+			internal: &runtime.RawExtension{
 				Raw: []byte{},
 			},
 			expected: &GcpPubSubChannelStatus{},
 			err:      false,
 		},
 		"can't unmarshal": {
-			raw: &runtime.RawExtension{
+			internal: &runtime.RawExtension{
 				// The topic field is a string, so this will have an error during unmarshal.
 				Raw: []byte(`{"topic": 123}`),
 			},
 			err: true,
 		},
 		"success": {
-			raw: &runtime.RawExtension{
+			internal: &runtime.RawExtension{
 				Raw: []byte(`{"topic":"gcp-topic"}`),
 			},
 			expected: &GcpPubSubChannelStatus{
@@ -122,8 +122,8 @@ func TestReadRawStatus(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
-			c.Status.Raw = tc.raw
-			pcs, err := GetRawStatus(context.Background(), c)
+			c.Status.Internal = tc.internal
+			pcs, err := GetInternalStatus(context.Background(), c)
 			if tc.err != (err != nil) {
 				t.Fatalf("Unexpected error. Expected %v. Actual %v", tc.err, err)
 			}
@@ -134,7 +134,7 @@ func TestReadRawStatus(t *testing.T) {
 	}
 }
 
-func TestRawStatusRoundTrip(t *testing.T) {
+func TestInternalStatusRoundTrip(t *testing.T) {
 	testCases := map[string]struct {
 		pcs *GcpPubSubChannelStatus
 	}{
@@ -157,16 +157,16 @@ func TestRawStatusRoundTrip(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
-			err := SetRawStatus(context.Background(), c, tc.pcs)
+			err := SetInternalStatus(context.Background(), c, tc.pcs)
 			if err != nil {
-				t.Errorf("Unexpected error saving raw status. %v", err)
+				t.Errorf("Unexpected error saving internal status. %v", err)
 			}
-			pcs, err := GetRawStatus(context.Background(), c)
+			pcs, err := GetInternalStatus(context.Background(), c)
 			if err != nil {
-				t.Errorf("Unexpected error reading raw status. %v", err)
+				t.Errorf("Unexpected error reading internal status. %v", err)
 			}
 			if diff := cmp.Diff(tc.pcs, pcs); diff != "" {
-				t.Errorf("Unexpected parsed raw status (-want +got): %v", diff)
+				t.Errorf("Unexpected parsed internal status (-want +got): %v", diff)
 			}
 		})
 	}

--- a/pkg/provisioners/gcppubsub/util/status_test.go
+++ b/pkg/provisioners/gcppubsub/util/status_test.go
@@ -123,7 +123,7 @@ func TestReadRawStatus(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
 			c.Status.Raw = tc.raw
-			pcs, err := ReadRawStatus(context.Background(), c)
+			pcs, err := GetRawStatus(context.Background(), c)
 			if tc.err != (err != nil) {
 				t.Fatalf("Unexpected error. Expected %v. Actual %v", tc.err, err)
 			}
@@ -157,11 +157,11 @@ func TestRawStatusRoundTrip(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
-			err := SaveRawStatus(context.Background(), c, tc.pcs)
+			err := SetRawStatus(context.Background(), c, tc.pcs)
 			if err != nil {
 				t.Errorf("Unexpected error saving raw status. %v", err)
 			}
-			pcs, err := ReadRawStatus(context.Background(), c)
+			pcs, err := GetRawStatus(context.Background(), c)
 			if err != nil {
 				t.Errorf("Unexpected error reading raw status. %v", err)
 			}

--- a/pkg/provisioners/gcppubsub/util/status_test.go
+++ b/pkg/provisioners/gcppubsub/util/status_test.go
@@ -123,7 +123,7 @@ func TestReadInternalStatus(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
 			c.Status.Internal = tc.internal
-			pcs, err := GetInternalStatus(context.Background(), c)
+			pcs, err := GetInternalStatus(c)
 			if tc.err != (err != nil) {
 				t.Fatalf("Unexpected error. Expected %v. Actual %v", tc.err, err)
 			}
@@ -161,7 +161,7 @@ func TestInternalStatusRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error saving internal status. %v", err)
 			}
-			pcs, err := GetInternalStatus(context.Background(), c)
+			pcs, err := GetInternalStatus(c)
 			if err != nil {
 				t.Errorf("Unexpected error reading internal status. %v", err)
 			}

--- a/pkg/provisioners/gcppubsub/util/status_test.go
+++ b/pkg/provisioners/gcppubsub/util/status_test.go
@@ -30,11 +30,11 @@ import (
 
 func TestIsEmpty(t *testing.T) {
 	testCases := map[string]struct {
-		pbs      *GcpPubSubChannelStatus
+		pcs      *GcpPubSubChannelStatus
 		expected bool
 	}{
 		"secret": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				Secret: &v1.ObjectReference{
 					Name: "some-name",
 				},
@@ -42,25 +42,25 @@ func TestIsEmpty(t *testing.T) {
 			expected: false,
 		},
 		"secretKey": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				SecretKey: "some-key",
 			},
 			expected: false,
 		},
 		"gcpProject": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				GCPProject: "some-project",
 			},
 			expected: false,
 		},
 		"topic": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				Topic: "some-topic",
 			},
 			expected: false,
 		},
 		"subscriptions": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				Subscriptions: []GcpPubSubSubscriptionStatus{
 					{
 						Subscription: "some-subscription",
@@ -70,13 +70,13 @@ func TestIsEmpty(t *testing.T) {
 			expected: false,
 		},
 		"empty": {
-			pbs:      &GcpPubSubChannelStatus{},
+			pcs:      &GcpPubSubChannelStatus{},
 			expected: true,
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			actual := tc.pbs.IsEmpty()
+			actual := tc.pcs.IsEmpty()
 			if actual != tc.expected {
 				t.Errorf("Expected %v. Actual %v", tc.expected, actual)
 			}
@@ -123,11 +123,11 @@ func TestReadRawStatus(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
 			c.Status.Raw = tc.raw
-			pbs, err := ReadRawStatus(context.Background(), c)
+			pcs, err := ReadRawStatus(context.Background(), c)
 			if tc.err != (err != nil) {
 				t.Fatalf("Unexpected error. Expected %v. Actual %v", tc.err, err)
 			}
-			if diff := cmp.Diff(tc.expected, pbs); diff != "" {
+			if diff := cmp.Diff(tc.expected, pcs); diff != "" {
 				t.Fatalf("Unexpected difference (-want +got): %v", diff)
 			}
 		})
@@ -136,10 +136,10 @@ func TestReadRawStatus(t *testing.T) {
 
 func TestRawStatusRoundTrip(t *testing.T) {
 	testCases := map[string]struct {
-		pbs *GcpPubSubChannelStatus
+		pcs *GcpPubSubChannelStatus
 	}{
 		"all fields set": {
-			pbs: &GcpPubSubChannelStatus{
+			pcs: &GcpPubSubChannelStatus{
 				Secret: &v1.ObjectReference{
 					Name: "some-name",
 				},
@@ -157,15 +157,15 @@ func TestRawStatusRoundTrip(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			c := &v1alpha1.Channel{}
-			err := SaveRawStatus(context.Background(), c, tc.pbs)
+			err := SaveRawStatus(context.Background(), c, tc.pcs)
 			if err != nil {
 				t.Errorf("Unexpected error saving raw status. %v", err)
 			}
-			pbs, err := ReadRawStatus(context.Background(), c)
+			pcs, err := ReadRawStatus(context.Background(), c)
 			if err != nil {
 				t.Errorf("Unexpected error reading raw status. %v", err)
 			}
-			if diff := cmp.Diff(tc.pbs, pbs); diff != "" {
+			if diff := cmp.Diff(tc.pcs, pcs); diff != "" {
 				t.Errorf("Unexpected parsed raw status (-want +got): %v", diff)
 			}
 		})

--- a/pkg/provisioners/gcppubsub/util/status_test.go
+++ b/pkg/provisioners/gcppubsub/util/status_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+)
+
+func TestIsEmpty(t *testing.T) {
+	testCases := map[string]struct {
+		pbs      *GcpPubSubChannelStatus
+		expected bool
+	}{
+		"secret": {
+			pbs: &GcpPubSubChannelStatus{
+				Secret: &v1.ObjectReference{
+					Name: "some-name",
+				},
+			},
+			expected: false,
+		},
+		"secretKey": {
+			pbs: &GcpPubSubChannelStatus{
+				SecretKey: "some-key",
+			},
+			expected: false,
+		},
+		"gcpProject": {
+			pbs: &GcpPubSubChannelStatus{
+				GCPProject: "some-project",
+			},
+			expected: false,
+		},
+		"topic": {
+			pbs: &GcpPubSubChannelStatus{
+				Topic: "some-topic",
+			},
+			expected: false,
+		},
+		"subscriptions": {
+			pbs: &GcpPubSubChannelStatus{
+				Subscriptions: []GcpPubSubSubscriptionStatus{
+					{
+						Subscription: "some-subscription",
+					},
+				},
+			},
+			expected: false,
+		},
+		"empty": {
+			pbs:      &GcpPubSubChannelStatus{},
+			expected: true,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			actual := tc.pbs.IsEmpty()
+			if actual != tc.expected {
+				t.Errorf("Expected %v. Actual %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestReadRawStatus(t *testing.T) {
+	testCases := map[string]struct {
+		raw      *runtime.RawExtension
+		expected *GcpPubSubChannelStatus
+		err      bool
+	}{
+		"nil": {
+			raw:      nil,
+			expected: &GcpPubSubChannelStatus{},
+			err:      false,
+		},
+		"empty": {
+			raw: &runtime.RawExtension{
+				Raw: []byte{},
+			},
+			expected: &GcpPubSubChannelStatus{},
+			err:      false,
+		},
+		"can't unmarshal": {
+			raw: &runtime.RawExtension{
+				// The topic field is a string, so this will have an error during unmarshal.
+				Raw: []byte(`{"topic": 123}`),
+			},
+			err: true,
+		},
+		"success": {
+			raw: &runtime.RawExtension{
+				Raw: []byte(`{"topic":"gcp-topic"}`),
+			},
+			expected: &GcpPubSubChannelStatus{
+				Topic: "gcp-topic",
+			},
+			err: false,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			c := &v1alpha1.Channel{}
+			c.Status.Raw = tc.raw
+			pbs, err := ReadRawStatus(context.Background(), c)
+			if tc.err != (err != nil) {
+				t.Fatalf("Unexpected error. Expected %v. Actual %v", tc.err, err)
+			}
+			if diff := cmp.Diff(tc.expected, pbs); diff != "" {
+				t.Fatalf("Unexpected difference (-want +got): %v", diff)
+			}
+		})
+	}
+}
+
+func TestRawStatusRoundTrip(t *testing.T) {
+	testCases := map[string]struct {
+		pbs *GcpPubSubChannelStatus
+	}{
+		"all fields set": {
+			pbs: &GcpPubSubChannelStatus{
+				Secret: &v1.ObjectReference{
+					Name: "some-name",
+				},
+				SecretKey:  "some-key",
+				GCPProject: "some-project",
+				Topic:      "some-topic",
+				Subscriptions: []GcpPubSubSubscriptionStatus{
+					{
+						Subscription: "some-subscription",
+					},
+				},
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			c := &v1alpha1.Channel{}
+			err := SaveRawStatus(context.Background(), c, tc.pbs)
+			if err != nil {
+				t.Errorf("Unexpected error saving raw status. %v", err)
+			}
+			pbs, err := ReadRawStatus(context.Background(), c)
+			if err != nil {
+				t.Errorf("Unexpected error reading raw status. %v", err)
+			}
+			if diff := cmp.Diff(tc.pbs, pbs); diff != "" {
+				t.Errorf("Unexpected parsed raw status (-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/provisioners/provisioner_util_test.go
+++ b/pkg/provisioners/provisioner_util_test.go
@@ -54,7 +54,7 @@ func TestProvisionerUtils(t *testing.T) {
 			existing := makeDispatcherService()
 			existing.Spec.Selector = map[string]string{
 				"clusterChannelProvisioner": otherClusterChannelProvisionerName,
-				"role":                      "dispatcher",
+				"role": "dispatcher",
 			}
 			client := fake.NewFakeClient(existing)
 			CreateDispatcherService(context.TODO(), client, getNewClusterChannelProvisioner())

--- a/pkg/provisioners/utils/topic_names.go
+++ b/pkg/provisioners/utils/topic_names.go
@@ -1,9 +1,22 @@
 package utils
 
 import (
-	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TopicName(channelSeparator, channelNamespace, channelName string) string {
-	return fmt.Sprintf("knative-eventing-channel%s%s%s%s", channelSeparator, channelNamespace, channelSeparator, channelName)
+	return topicName(channelSeparator, channelNamespace, channelName)
+}
+
+func TopicNameWithUID(channelSeparator, channelName string, channelUID types.UID) string {
+	return topicName(channelSeparator, channelName, string(channelUID))
+}
+
+func topicName(channelSeparator string, pieces ...string) string {
+	parts := make([]string, 0, 1+len(pieces))
+	parts = append(parts, "knative-eventing-channel")
+	parts = append(parts, pieces...)
+	return strings.Join(parts, channelSeparator)
 }

--- a/pkg/provisioners/utils/topic_names.go
+++ b/pkg/provisioners/utils/topic_names.go
@@ -6,6 +6,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	knativeChannelPrefix = "knative-eventing-channel"
+)
+
 func TopicName(channelSeparator, channelNamespace, channelName string) string {
 	return topicName(channelSeparator, channelNamespace, channelName)
 }
@@ -16,7 +20,7 @@ func TopicNameWithUID(channelSeparator, channelName string, channelUID types.UID
 
 func topicName(channelSeparator string, pieces ...string) string {
 	parts := make([]string, 0, 1+len(pieces))
-	parts = append(parts, "knative-eventing-channel")
+	parts = append(parts, knativeChannelPrefix)
 	parts = append(parts, pieces...)
 	return strings.Join(parts, channelSeparator)
 }

--- a/pkg/provisioners/utils/topic_names_test.go
+++ b/pkg/provisioners/utils/topic_names_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGenerateTopicNameWithDot(t *testing.T) {
@@ -15,6 +17,14 @@ func TestGenerateTopicNameWithDot(t *testing.T) {
 func TestGenerateTopicNameWithHyphen(t *testing.T) {
 	expected := "knative-eventing-channel-channel-namespace-channel-name"
 	actual := TopicName("-", "channel-namespace", "channel-name")
+	if expected != actual {
+		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
+	}
+}
+
+func TestTopicNameWithUID(t *testing.T) {
+	expected := "knative-eventing-channel_gcp_78f8428c-15c3-11e9-9905-42010a80018a"
+	actual := TopicNameWithUID("_", "gcp", types.UID("78f8428c-15c3-11e9-9905-42010a80018a"))
 	if expected != actual {
 		t.Errorf("Expected '%s'. Actual '%s'", expected, actual)
 	}


### PR DESCRIPTION
Fixes #253 

## Proposed Changes

- Add `status.internal` to Channels that allows each `ClusterChannelProvisioner` to store unique information. This is analogous to Channel's `spec.arguments`.
- GCP PubSub channel uses this raw status to save the Subscription and Topic names. The controller generates the names, creates the GCP resources, and saves the names to `status.internal`. Then the dispatcher uses the names from the status.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Redeploy the Channel CRD to add the new field.
```
