### PR TITLE
refactor in-memory channel to support sync and async handlers

### DIFF
--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -15,6 +15,14 @@
 apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
+  name: in-memory
+spec: {}
+
+---
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: ClusterChannelProvisioner
+metadata:
   name: in-memory-channel
 spec: {}
 
@@ -128,7 +136,7 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      clusterChannelProvisioner: in-memory-channel
+      clusterChannelProvisioner: in-memory
       role: controller
   template:
     metadata:
@@ -191,7 +199,7 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      clusterChannelProvisioner: in-memory-channel
+      clusterChannelProvisioner: in-memory
       role: dispatcher
   template:
     metadata:

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -136,7 +136,7 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      clusterChannelProvisioner: in-memory
+      clusterChannelProvisioner: in-memory-channel
       role: controller
   template:
     metadata:
@@ -199,7 +199,7 @@ spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      clusterChannelProvisioner: in-memory
+      clusterChannelProvisioner: in-memory-channel
       role: dispatcher
   template:
     metadata:

--- a/pkg/controller/eventing/inmemory/channel/reconcile.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile.go
@@ -39,13 +39,14 @@ import (
 
 const (
 	finalizerName = controllerAgentName
-
 	// Name of the corev1.Events emitted from the reconciliation process
 	channelReconciled          = "ChannelReconciled"
 	channelUpdateStatusFailed  = "ChannelUpdateStatusFailed"
 	channelConfigSyncFailed    = "ChannelConfigSyncFailed"
 	k8sServiceCreateFailed     = "K8sServiceCreateFailed"
 	virtualServiceCreateFailed = "VirtualServiceCreateFailed"
+	// TODO after in-memory-channel is retired, asyncProvisionerName should be removed
+	asyncProvisionerName = "in-memory"
 )
 
 type reconciler struct {
@@ -110,7 +111,6 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		r.recorder.Eventf(c, corev1.EventTypeWarning, channelUpdateStatusFailed, "Failed to update Channel's status: %v", err)
 		return reconcile.Result{}, updateStatusErr
 	}
-
 	return reconcile.Result{}, err
 }
 
@@ -157,11 +157,26 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	}
 	c.Status.SetAddress(controller.ServiceHostName(svc.Name, svc.Namespace))
 
-	_, err = util.CreateVirtualService(ctx, r.client, c, svc)
-	if err != nil {
-		logger.Info("Error creating the Virtual Service for the Channel", zap.Error(err))
-		r.recorder.Eventf(c, corev1.EventTypeWarning, virtualServiceCreateFailed, "Failed to reconcile Virtual Service for the Channel: %v", err)
-		return err
+	if c.Spec.Provisioner.Name == asyncProvisionerName {
+		_, err = util.CreateVirtualService(ctx, r.client, c, svc)
+		if err != nil {
+			logger.Info("Error creating the Virtual Service for the Channel", zap.Error(err))
+			r.recorder.Eventf(c, corev1.EventTypeWarning, virtualServiceCreateFailed, "Failed to reconcile Virtual Service for the Channel: %v", err)
+			return err
+		}
+	} else {
+		// We need to have a single dispatcher that is pointed at by _both_
+		// ClusterChannelProvisioners. So fake the channel, by saying that its provisioner is the
+		// one with the single dispatcher. The faked provisioner is used only to determine the
+		// dispatcher Service's name.
+		cCopy := c.DeepCopy()
+		cCopy.Spec.Provisioner.Name = asyncProvisionerName
+		_, err = util.CreateVirtualService(ctx, r.client, cCopy, svc)
+		if err != nil {
+			logger.Info("Error creating the Virtual Service for the Channel", zap.Error(err))
+			r.recorder.Eventf(c, corev1.EventTypeWarning, virtualServiceCreateFailed, "Failed to reconcile Virtual Service for the Channel: %v", err)
+			return err
+		}
 	}
 
 	c.Status.MarkProvisioned()
@@ -225,8 +240,14 @@ func multiChannelFanoutConfig(channels []eventingv1alpha1.Channel) *multichannel
 			Name:      c.Name,
 		}
 		if c.Spec.Subscribable != nil {
+			// TODO After in-memory-channel is retired, this logic must be refactored.
+			asyncHandler := false
+			if c.Spec.Provisioner.Name == asyncProvisionerName {
+				asyncHandler = true
+			}
 			channelConfig.FanoutConfig = fanout.Config{
 				Subscriptions: c.Spec.Subscribable.Subscribers,
+				AsyncHandler:  asyncHandler,
 			}
 		}
 		cc = append(cc, channelConfig)

--- a/pkg/controller/eventing/inmemory/channel/reconcile.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile.go
@@ -149,9 +149,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 
 	util.AddFinalizer(c, finalizerName)
 
-	cCopy := c.DeepCopy()
-	cCopy.Spec.Provisioner.Name = asyncProvisionerName
-	svc, err := util.CreateK8sService(ctx, r.client, cCopy)
+	svc, err := util.CreateK8sService(ctx, r.client, c)
 	if err != nil {
 		logger.Info("Error creating the Channel's K8s Service", zap.Error(err))
 		r.recorder.Eventf(c, corev1.EventTypeWarning, k8sServiceCreateFailed, "Failed to reconcile Channel's K8s Service: %v", err)
@@ -171,6 +169,8 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 		// ClusterChannelProvisioners. So fake the channel, by saying that its provisioner is the
 		// one with the single dispatcher. The faked provisioner is used only to determine the
 		// dispatcher Service's name.
+		cCopy := c.DeepCopy()
+		cCopy.Spec.Provisioner.Name = asyncProvisionerName
 		_, err = util.CreateVirtualService(ctx, r.client, cCopy, svc)
 		if err != nil {
 			logger.Info("Error creating the Virtual Service for the Channel", zap.Error(err))

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -527,7 +527,7 @@ func TestReconcile(t *testing.T) {
 			Mocks: controllertesting.Mocks{},
 			WantPresent: []runtime.Object{
 				makeVirtualService(),
-				makeK8sService(),
+				makeK8sService("in-memory"),
 			},
 			WantEvent: []corev1.Event{
 				events[channelReconciled],
@@ -543,7 +543,7 @@ func TestReconcile(t *testing.T) {
 			Mocks: controllertesting.Mocks{},
 			WantPresent: []runtime.Object{
 				makeVirtualService(),
-				makeK8sService(),
+				makeK8sService("in-memory-channel"),
 			},
 			WantEvent: []corev1.Event{
 				events[channelReconciled],
@@ -672,7 +672,7 @@ func makeConfigMapWithVerifyConfigMapData() *corev1.ConfigMap {
 	return cm
 }
 
-func makeK8sService() *corev1.Service {
+func makeK8sService(pn ...string) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -684,8 +684,8 @@ func makeK8sService() *corev1.Service {
 			Labels: map[string]string{
 				util.EventingChannelLabel:        cName,
 				util.OldEventingChannelLabel:     cName,
-				util.EventingProvisionerLabel:    asyncCCPName,
-				util.OldEventingProvisionerLabel: asyncCCPName,
+				util.EventingProvisionerLabel:    getProvisionerName(pn),
+				util.OldEventingProvisionerLabel: getProvisionerName(pn),
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -521,6 +521,8 @@ func TestReconcile(t *testing.T) {
 		},
 		{
 			Name: "Channel reconcile successful - Async channel",
+			// VirtualService should have channel provisioner name
+			// defaults to in-memory-channel but the service should match provisioner's service name
 			InitialState: []runtime.Object{
 				makeChannel("in-memory"),
 			},
@@ -536,14 +538,14 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "Channel reconcile successful - Non Async channel",
 			// VirtualService should have channel provisioner name
-			// overwritten to "in-memory"
+			// defaults to in-memory-channel
 			InitialState: []runtime.Object{
-				makeChannel("in-memory-channel"),
+				makeChannel(),
 			},
 			Mocks: controllertesting.Mocks{},
 			WantPresent: []runtime.Object{
 				makeVirtualService(),
-				makeK8sService("in-memory-channel"),
+				makeK8sService(),
 			},
 			WantEvent: []corev1.Event{
 				events[channelReconciled],
@@ -721,8 +723,8 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 			Labels: map[string]string{
 				util.EventingChannelLabel:        cName,
 				util.OldEventingChannelLabel:     cName,
-				util.EventingProvisionerLabel:    asyncCCPName,
-				util.OldEventingProvisionerLabel: asyncCCPName,
+				util.EventingProvisionerLabel:    ccpName,
+				util.OldEventingProvisionerLabel: ccpName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -746,7 +748,7 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "in-memory-dispatcher.knative-eventing.svc.cluster.local",
+						Host: "in-memory-channel-dispatcher.knative-eventing.svc.cluster.local",
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -519,6 +519,34 @@ func TestReconcile(t *testing.T) {
 				events[channelReconciled],
 			},
 		},
+		{
+			Name: "Channel reconcile successful - Async channel",
+			InitialState: []runtime.Object{
+				makeChannel("in-memory"),
+			},
+			Mocks: controllertesting.Mocks{},
+			WantPresent: []runtime.Object{
+				makeVirtualService(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
+		},
+		{
+			Name: "Channel reconcile successful - Non Async channel",
+			// VirtualService should have channel provisioner name
+			// overwritten to "in-memory"
+			InitialState: []runtime.Object{
+				makeChannel("in-memory-channel"),
+			},
+			Mocks: controllertesting.Mocks{},
+			WantPresent: []runtime.Object{
+				makeVirtualService(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -542,7 +570,11 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func makeChannel() *eventingv1alpha1.Channel {
+func makeChannel(pn ...string) *eventingv1alpha1.Channel {
+	provisionerName := ccpName
+	if len(pn) != 0 {
+		provisionerName = pn[0]
+	}
 	c := &eventingv1alpha1.Channel{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
@@ -555,7 +587,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		},
 		Spec: eventingv1alpha1.ChannelSpec{
 			Provisioner: &corev1.ObjectReference{
-				Name: ccpName,
+				Name: provisionerName,
 			},
 		},
 	}
@@ -632,7 +664,11 @@ func makeConfigMapWithVerifyConfigMapData() *corev1.ConfigMap {
 	return cm
 }
 
-func makeK8sService() *corev1.Service {
+func makeK8sService(pn ...string) *corev1.Service {
+	provisionerName := ccpName
+	if len(pn) != 0 {
+		provisionerName = pn[0]
+	}
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -644,8 +680,8 @@ func makeK8sService() *corev1.Service {
 			Labels: map[string]string{
 				util.EventingChannelLabel:        cName,
 				util.OldEventingChannelLabel:     cName,
-				util.EventingProvisionerLabel:    ccpName,
-				util.OldEventingProvisionerLabel: ccpName,
+				util.EventingProvisionerLabel:    provisionerName,
+				util.OldEventingProvisionerLabel: provisionerName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -43,7 +43,8 @@ import (
 )
 
 const (
-	ccpName = "in-memory-channel"
+	ccpName      = "in-memory-channel"
+	asyncCCPName = "in-memory"
 
 	cNamespace = "test-namespace"
 	cName      = "test-channel"
@@ -680,8 +681,8 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 			Labels: map[string]string{
 				util.EventingChannelLabel:        cName,
 				util.OldEventingChannelLabel:     cName,
-				util.EventingProvisionerLabel:    ccpName,
-				util.OldEventingProvisionerLabel: ccpName,
+				util.EventingProvisionerLabel:    asyncCCPName,
+				util.OldEventingProvisionerLabel: asyncCCPName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -705,7 +706,7 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "in-memory-channel-dispatcher.knative-eventing.svc.cluster.local",
+						Host: "in-memory-dispatcher.knative-eventing.svc.cluster.local",
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
@@ -35,9 +35,6 @@ import (
 )
 
 const (
-	// Name is the name of the in-memory channel ClusterChannelProvisioner.
-	Name = "in-memory-channel"
-
 	// Channel is the name of the Channel resource in eventing.knative.dev/v1alpha1.
 	Channel = "Channel"
 
@@ -46,6 +43,11 @@ const (
 	ccpUpdateStatusFailed  = "CcpUpdateStatusFailed"
 	k8sServiceCreateFailed = "K8sServiceCreateFailed"
 	k8sServiceDeleteFailed = "K8sServiceDeleteFailed"
+)
+
+var (
+	// provisionerNames contains the list of provisioners' names served by this controller
+	provisionerNames = []string{"in-memory-channel", "in-memory"}
 )
 
 type reconciler struct {
@@ -130,7 +132,12 @@ func IsControlled(ref *corev1.ObjectReference) bool {
 // shouldReconcile determines if this Controller should control (and therefore reconcile) a given
 // ClusterChannelProvisioner. This Controller only handles in-memory channels.
 func shouldReconcile(namespace, name string) bool {
-	return namespace == "" && name == Name
+	for _, p := range provisionerNames {
+		if namespace == "" && name == p {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *reconciler) reconcile(ctx context.Context, ccp *eventingv1alpha1.ClusterChannelProvisioner) error {

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
@@ -42,6 +42,7 @@ const (
 	ccpUid           = "test-uid"
 	testErrorMessage = "test-induced-error"
 	testNS           = "test-ns"
+	Name             = "in-memory-channel"
 )
 
 var (

--- a/pkg/controller/eventing/inmemory/controller/main.go
+++ b/pkg/controller/eventing/inmemory/controller/main.go
@@ -35,7 +35,7 @@ func main() {
 	logger := provisioners.NewProvisionerLoggerFromConfig(logConfig)
 	defer logger.Sync()
 	logger = logger.With(
-		zap.String("eventing.knative.dev/clusterChannelProvisioner", clusterchannelprovisioner.Name),
+		zap.String("eventing.knative.dev/clusterChannelProvisioner", "in-memory"),
 		zap.String("eventing.knative.dev/clusterChannelProvisionerComponent", "Controller"),
 	)
 	flag.Parse()

--- a/pkg/sidecar/fanout/fanout_handler.go
+++ b/pkg/sidecar/fanout/fanout_handler.go
@@ -40,6 +40,9 @@ const (
 // Configuration for a fanout.Handler.
 type Config struct {
 	Subscriptions []eventingduck.ChannelSubscriberSpec `json:"subscriptions"`
+	// AsyncHandler controls whether the Subscriptions are called synchronous or asynchronously.
+	// It is expected to be false when used as a sidecar.
+	AsyncHandler bool `json:"asyncHandler,omitempty"`
 }
 
 // http.Handler that takes a single request in and fans it out to N other servers.
@@ -83,6 +86,13 @@ func NewHandler(logger *zap.Logger, config Config) *Handler {
 
 func createReceiverFunction(f *Handler) func(provisioners.ChannelReference, *provisioners.Message) error {
 	return func(_ provisioners.ChannelReference, m *provisioners.Message) error {
+		if f.config.AsyncHandler {
+			go func() {
+				// Any returned error is already logged in f.dispatch().
+				_ = f.dispatch(m)
+			}()
+			return nil
+		}
 		return f.dispatch(m)
 	}
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -89,18 +89,17 @@ go_test_e2e ./test/e2e
 exit_result=$?
 if [ ${exit_result} -ne 0 ]; then
 # Collecting logs from all knative's eventing pods
+  echo "============================================================"
   for namespace in "knative-eventing" "e2etestfn3"; do
     for pod in $(kubectl get pod -n $namespace | grep Running | awk '{print $1}' ); do
-      echo "========== Collecting logs for pod: "${pod}" in $namespace ================="
       for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
-        echo "----------------------------------------------------------"
-        echo "Container: "${container}
+        echo "Namespace, Pod, Container: ${namespace}, ${pod}, ${container}"
         kubectl logs -n $namespace "${pod}" -c "${container}" || true
         echo "----------------------------------------------------------"
+        echo "Namespace, Pod, Container (Previous instance): ${namespace}, ${pod}, ${container}"
         kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
-        echo "----------------------------------------------------------"
+        echo "============================================================"
       done
-      echo "============================================================"
     done
   done
   fail_test

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -85,6 +85,25 @@ $(dirname $0)/upload-test-images.sh e2e || fail_test "Error uploading test image
 # Setup resources common to all eventing tests
 setup_events_test_resources|| fail_test "Error setting up test resources"
 
-go_test_e2e ./test/e2e || fail_test
+go_test_e2e ./test/e2e 
+exit_result=$?
+if [ ${exit_result} -ne 0 ]; then
+# Collecting logs from all knative's eventing pods
+  for namespace in "knative-eventing" "e2etestfn3"; do
+    for pod in $(kubectl get pod -n $namespace | grep Running | awk '{print $1}' ); do
+      echo "========== Collecting logs for pod: "${pod}" in $namespace ================="
+      for container in $(kubectl get pod "${pod}" -n $namespace -ojsonpath='{.spec.containers[*].name}'); do
+        echo "----------------------------------------------------------"
+        echo "Container: "${container}
+        kubectl logs -n $namespace "${pod}" -c "${container}" || true
+        echo "----------------------------------------------------------"
+        kubectl logs -p -n $namespace "${pod}" -c "${container}" || true
+        echo "----------------------------------------------------------"
+      done
+      echo "============================================================"
+    done
+  done
+  fail_test
+fi
 
 success


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

```release-note
This PR add support of async way of calling fanout handler and refactors in-memory-channel to support for both types, sync(old) and async(new)
```
