### PR TITLE
Make in-memory-channel dispatcher non-blocking

### DIFF
--- a/cmd/fanoutsidecar/main.go
+++ b/cmd/fanoutsidecar/main.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/knative/eventing/pkg/sidecar/configmap/filesystem"
 	"github.com/knative/eventing/pkg/sidecar/configmap/watcher"
+	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
 	"github.com/knative/eventing/pkg/sidecar/swappable"
 	"github.com/knative/eventing/pkg/system"
 	"go.uber.org/zap"
@@ -53,6 +54,7 @@ var (
 	writeTimeout = 1 * time.Minute
 
 	port               int
+	blocking           bool
 	configMapNoticer   string
 	configMapNamespace string
 	configMapName      string
@@ -60,6 +62,7 @@ var (
 
 func init() {
 	flag.IntVar(&port, "sidecar_port", -1, "The port to run the sidecar on.")
+	flag.BoolVar(&blocking, "blocking", true, "Block on receive while dispatching.")
 	flag.StringVar(&configMapNoticer, "config_map_noticer", "", fmt.Sprintf("The system to notice changes to the ConfigMap. Valid values are: %s", configMapNoticerValues()))
 	flag.StringVar(&configMapNamespace, "config_map_namespace", system.Namespace, "The namespace of the ConfigMap that is watched for configuration.")
 	flag.StringVar(&configMapName, "config_map_name", defaultConfigMapName, "The name of the ConfigMap that is watched for configuration.")
@@ -86,7 +89,7 @@ func main() {
 		logger.Fatal("Unable to create swappable.Handler", zap.Error(err))
 	}
 
-	mgr, err := setupConfigMapNoticer(logger, sh.UpdateConfig)
+	mgr, err := setupConfigMapNoticer(logger, sh.UpdateConfig, blocking)
 	if err != nil {
 		logger.Fatal("Unable to create configMap noticer.", zap.Error(err))
 	}
@@ -119,18 +122,26 @@ func main() {
 	s.Shutdown(ctx)
 }
 
-func setupConfigMapNoticer(logger *zap.Logger, configUpdated swappable.UpdateConfig) (manager.Manager, error) {
+func setupConfigMapNoticer(logger *zap.Logger, configUpdated swappable.UpdateConfig, blocking bool) (manager.Manager, error) {
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
 		return nil, err
 		logger.Error("Error starting manager.", zap.Error(err))
 	}
 
+	wrappedConfigUpdated := func(config *multichannelfanout.Config) error {
+		// update fanout config for blocking
+		for _, c := range config.ChannelConfigs {
+			c.FanoutConfig.Blocking = blocking
+		}
+		return configUpdated(config)
+	}
+
 	switch configMapNoticer {
 	case cmnfVolume:
-		err = setupConfigMapVolume(logger, mgr, configUpdated)
+		err = setupConfigMapVolume(logger, mgr, wrappedConfigUpdated)
 	case cmnfWatcher:
-		err = setupConfigMapWatcher(logger, mgr, configUpdated)
+		err = setupConfigMapWatcher(logger, mgr, wrappedConfigUpdated)
 	default:
 		err = fmt.Errorf("need to provide the --config_map_noticer flag (valid values are %s)", configMapNoticerValues())
 	}

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -197,6 +197,7 @@ spec:
           image: github.com/knative/eventing/cmd/fanoutsidecar
           args:
             - --sidecar_port=8080
+            - --blocking=false
             - --config_map_noticer=watcher
             - --config_map_namespace=knative-eventing
             - --config_map_name=in-memory-channel-dispatcher-config-map

--- a/pkg/sidecar/swappable/swappable.go
+++ b/pkg/sidecar/swappable/swappable.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
 	"go.uber.org/zap"
 )
@@ -54,8 +55,8 @@ func NewHandler(handler *multichannelfanout.Handler, logger *zap.Logger) *Handle
 	return h
 }
 
-func NewEmptyHandler(logger *zap.Logger) (*Handler, error) {
-	h, err := multichannelfanout.NewHandler(logger, multichannelfanout.Config{})
+func NewEmptyHandler(logger *zap.Logger, staticConfig fanout.StaticConfig) (*Handler, error) {
+	h, err := multichannelfanout.NewHandler(logger, multichannelfanout.Config{}, staticConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sidecar/swappable/swappable_test.go
+++ b/pkg/sidecar/swappable/swappable_test.go
@@ -76,7 +76,7 @@ func TestHandler(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyHandler(zap.NewNop())
+			h, err := NewEmptyHandler(zap.NewNop(), fanout.StaticConfig{})
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -125,7 +125,7 @@ func TestHandler_InvalidConfigChange(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyHandler(zap.NewNop())
+			h, err := NewEmptyHandler(zap.NewNop(), fanout.StaticConfig{})
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -153,7 +153,7 @@ func TestHandler_InvalidConfigChange(t *testing.T) {
 }
 
 func TestHandler_NilConfigChange(t *testing.T) {
-	h, err := NewEmptyHandler(zap.NewNop())
+	h, err := NewEmptyHandler(zap.NewNop(), fanout.StaticConfig{})
 	if err != nil {
 		t.Errorf("Unexpected error creating handler: %v", err)
 	}


### PR DESCRIPTION
Refs #535 

The in-memory-channel currently holds the request open when receiving a new event until the event has been dispatched. If an error is encountered while dispatching, that error is reported back to the caller. This is in contrast to other channels which acknowledge receiving an event to the caller independent of dispatching the event to subscribers.

This behavior is leaking out of the fanout sidecar which when operating as a dispatching sidecar should be blocking. However, the in-memory-channel dispatcher is only the fanout sidecar. To my knowledge, the fanout sidecar is unused other than the in-memory-channel. Rather than scrap the sidecar, I made it optionally non-blocking.

## Proposed Changes

- allow the fanout sidecar to optionally be non-blocking, by default it is still blocking
- configure the fanout sidecar in the in-memory-channel dispatcher to be non-blocking

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The in-memory-channel no longer blocks requests while the event is dispatched. New events will be immediately acked with a 202 Accepted when received. Dispatch errors will not be reported to the caller.
```

/assign @adamharwayne 