### PR TITLE
replacing references to cluster.local with actual cluster's domain name

### DIFF
--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -93,7 +93,7 @@ type ChannelStatus struct {
 	// fully-qualified DNS name which will distribute traffic over the
 	// provided targets from inside the cluster.
 	//
-	// It generally has the form {channel}.{namespace}.svc.cluster.local
+	// It generally has the form {channel}.{namespace}.svc.{cluster domain name}
 	Address duckv1alpha1.Addressable `json:"address,omitempty"`
 
 	// Represents the latest available observations of a channel's current state.

--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -16,8 +16,11 @@
 
 package controller
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/knative/eventing/pkg/utils"
+)
 
 func ServiceHostName(serviceName, namespace string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace)
+	return fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, utils.GetClusterDomainName())
 }

--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -18,6 +18,7 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/controller"
 	"github.com/knative/eventing/pkg/system"
+	"github.com/knative/eventing/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -230,7 +231,6 @@ func UpdateChannel(ctx context.Context, client runtimeClient.Client, u *eventing
 		if err := client.Update(ctx, channel); err != nil {
 			return err
 		}
-
 		channelChanged = true
 	}
 
@@ -360,5 +360,5 @@ func channelServiceName(channelName string) string {
 }
 
 func channelHostName(channelName, namespace string) string {
-	return fmt.Sprintf("%s.%s.channels.cluster.local", channelName, namespace)
+	return fmt.Sprintf("%s.%s.channels.%s", channelName, namespace, utils.GetClusterDomainName())
 }

--- a/pkg/provisioners/message_dispatcher.go
+++ b/pkg/provisioners/message_dispatcher.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"go.uber.org/zap"
+	"github.com/knative/eventing/pkg/utils"
 )
 
 const correlationIDHeaderName = "Knative-Correlation-Id"
@@ -201,7 +202,7 @@ func (d *MessageDispatcher) resolveURL(destination string, defaultNamespace stri
 		return url
 	}
 	if strings.Index(destination, ".") == -1 {
-		destination = fmt.Sprintf("%s.%s.svc.cluster.local", destination, defaultNamespace)
+		destination = fmt.Sprintf("%s.%s.svc.%s", destination, defaultNamespace, utils.GetClusterDomainName())
 	}
 	return &url.URL{
 		Scheme: "http",

--- a/pkg/provisioners/natss/controller/clusterchannelprovisioner/controller.go
+++ b/pkg/provisioners/natss/controller/clusterchannelprovisioner/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterchannelprovisioner
 
 import (
+	"fmt"
 	"github.com/knative/eventing/pkg/provisioners/natss/stanutil"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -25,14 +26,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"github.com/knative/eventing/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	// NATSS
-	ClusterId = "knative-nats-streaming"
-	NatssUrl  = "nats://nats-streaming.natss.svc.cluster.local:4222"
-	clientId  = "knative-natss-controller"
+	ClusterId    = "knative-nats-streaming"
+	NatssUrlTmpl = "nats://nats-streaming.natss.svc.%s:4222"
+	clientId     = "knative-natss-controller"
 	// controllerAgentName is the string used by this controller to identify itself when creating events.
 	controllerAgentName = "natss-provisioner-controller"
 )
@@ -41,7 +43,8 @@ const (
 func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Controller, error) {
 	// check the connection to NATSS
 	var err error
-	if _, err := stanutil.Connect(ClusterId, clientId, NatssUrl, logger.Sugar()); err != nil {
+	natssUrl := fmt.Sprintf(NatssUrlTmpl, utils.GetClusterDomainName())
+	if _, err := stanutil.Connect(ClusterId, clientId, natssUrl, logger.Sugar()); err != nil {
 		logger.Error("Connect() failed: ", zap.Error(err))
 		return nil, err
 	}

--- a/pkg/provisioners/natss/dispatcher/main.go
+++ b/pkg/provisioners/natss/dispatcher/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners/natss/controller/clusterchannelprovisioner"
+	"github.com/knative/eventing/pkg/utils"
 )
 
 var (
@@ -61,7 +63,8 @@ func main() {
 	var g errgroup.Group
 
 	logger.Info("Dispatcher starting...")
-	dispatcher, err := dispatcher.NewDispatcher(clusterchannelprovisioner.NatssUrl, logger)
+	natssUrl := fmt.Sprintf(clusterchannelprovisioner.NatssUrlTmpl, utils.GetClusterDomainName())
+	dispatcher, err := dispatcher.NewDispatcher(natssUrl, logger)
 	if err != nil {
 		logger.Fatal("Unable to create NATSS dispatcher.", zap.Error(err))
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+const (
+	resolverFileName  = "/etc/resolv.conf"
+	defaultDomainName = "cluster.local"
+)
+
+var (
+	domainName string
+	once       sync.Once
+)
+
+// GetClusterDomainName returns cluster's domain name or an error
+// Closes issue: https://github.com/knative/eventing/issues/714
+func GetClusterDomainName() string {
+	once.Do(func() {
+		f, err := os.Open(resolverFileName)
+		if err == nil {
+			defer f.Close()
+			domainName = getClusterDomainName(f)
+
+		} else {
+			domainName = defaultDomainName
+		}
+	})
+
+	return domainName
+}
+
+func getClusterDomainName(r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		elements := strings.Split(scanner.Text(), " ")
+		if elements[0] != "search" {
+			continue
+		}
+		for i := 1; i < len(elements)-1; i++ {
+			if strings.HasPrefix(elements[i], "svc.") {
+				return elements[i][4:]
+			}
+		}
+	}
+	// For all abnormal cases return default domain name
+	return defaultDomainName
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetDomainName(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolvConf string
+		want       string
+	}{
+		{
+			name: "all good",
+			resolvConf: `
+nameserver 1.1.1.1
+search default.svc.abc.com svc.abc.com abc.com
+options ndots:5
+`,
+			want: "abc.com",
+		},
+		{
+			name: "missing search line",
+			resolvConf: `
+nameserver 1.1.1.1
+options ndots:5
+`,
+			want: defaultDomainName,
+		},
+		{
+			name: "non k8s resolv.conf format",
+			resolvConf: `
+nameserver 1.1.1.1
+search  abc.com xyz.com
+options ndots:5
+`,
+			want: defaultDomainName,
+		},
+	}
+	for _, tt := range tests {
+		got := getClusterDomainName(strings.NewReader(tt.resolvConf))
+		if got != tt.want {
+			t.Errorf("Test %s failed expected: %s but got: %s", tt.name, tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Fixes #714

```release-note
removes hardcoded cluster.local, the search of dns resolver should be able to figure out actual dns name.
```
