### PR TITLE
golang format tools

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	metricsScrapeAddr    = ":9090"
-	metricsScrapePath    = "/metrics"
+	metricsScrapeAddr = ":9090"
+	metricsScrapePath = "/metrics"
 )
 
 var (


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
