### PR TITLE
Publish components for channel provisioners

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,6 +22,9 @@ COMPONENTS=(
   ["eventing.yaml"]="config"
   ["in-memory-channel.yaml"]="config/provisioners/in-memory-channel"
   ["kafka.yaml"]="config/provisioners/kafka"
+# uncomment when gcp-pubsub is ready to be published
+#  ["gcp-pubsub.yaml"]="config/provisioners/gcppubsub"
+  ["natss.yaml"]="config/provisioners/natss"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
Adding the natss cluster channel provisioners (and staging gcp-pubsub)
to the release script as components. This will publish images and yaml
for the CCP with each nightly and tagged release.

This will not include the provisioners in the release.yaml, which only
includes the in-memory-channel CCP.

## Proposed Changes

- publish natss CCP as a component, but leave out of release.yaml
- stage publishing of gap-pubsub CPP as a component

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
The NATSS ClusterChannelProvisioner is available in the natss.yaml file, it is not included in the release.yaml and must be applied independently.
```

<!--
/assign @grantr
/cc @radufa 
-->