### PR TITLE
golang format tools

### DIFF
--- a/pkg/controller/names.go
+++ b/pkg/controller/names.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/knative/eventing/pkg/utils"
 )
 

--- a/pkg/provisioners/message_dispatcher.go
+++ b/pkg/provisioners/message_dispatcher.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"github.com/knative/eventing/pkg/utils"
 )

--- a/pkg/provisioners/natss/controller/clusterchannelprovisioner/controller.go
+++ b/pkg/provisioners/natss/controller/clusterchannelprovisioner/controller.go
@@ -18,6 +18,7 @@ package clusterchannelprovisioner
 
 import (
 	"fmt"
+
 	"github.com/knative/eventing/pkg/provisioners/natss/stanutil"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -19,6 +19,9 @@ package e2e
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/knative/eventing/test"
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
@@ -26,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"testing"
-	"time"
 )
 
 const (


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
