### PR TITLE
golang format tools

### DIFF
--- a/pkg/provisioners/provisioner_util_test.go
+++ b/pkg/provisioners/provisioner_util_test.go
@@ -54,7 +54,7 @@ func TestProvisionerUtils(t *testing.T) {
 			existing := makeDispatcherService()
 			existing.Spec.Selector = map[string]string{
 				"clusterChannelProvisioner": otherClusterChannelProvisionerName,
-				"role": "dispatcher",
+				"role":                      "dispatcher",
 			}
 			client := fake.NewFakeClient(existing)
 			CreateDispatcherService(context.TODO(), client, getNewClusterChannelProvisioner())


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
