### PR TITLE
Emitting corev1 Events for debugging purposes

### DIFF
--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -92,6 +92,17 @@ rules:
       - watch
       - create
       - update
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
 
 ---
 

--- a/pkg/controller/eventing/inmemory/channel/reconcile.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile.go
@@ -91,6 +91,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.reconcile(ctx, c)
 	if err != nil {
 		logger.Info("Error reconciling Channel", zap.Error(err))
+		r.recorder.Eventf(c, corev1.EventTypeWarning, "ChannelReconcileFailed", "Failed to reconcile Channel: %v", err)
 		// Note that we do not return the error here, because we want to update the Status
 		// regardless of the error.
 	}
@@ -124,9 +125,11 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 
 	// We always need to sync the Channel config, so do it first.
 	if err := r.syncChannelConfig(ctx); err != nil {
-		logger.Info("Error updating syncing the Channel config", zap.Error(err))
+		logger.Info("Error syncing the Channel config", zap.Error(err))
+		r.recorder.Eventf(c, corev1.EventTypeWarning, "ChannelConfigSyncFailed", "Failed to sync Channel config: %v", err)
 		return err
 	}
+	r.recorder.Eventf(c, corev1.EventTypeNormal, "ChannelConfigSynced", "Channel config synced")
 
 	if c.DeletionTimestamp != nil {
 		// K8s garbage collection will delete the K8s service and VirtualService for this channel.
@@ -140,17 +143,22 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	svc, err := util.CreateK8sService(ctx, r.client, c)
 	if err != nil {
 		logger.Info("Error creating the Channel's K8s Service", zap.Error(err))
+		r.recorder.Eventf(c, corev1.EventTypeWarning, "K8sServiceCreateFailed", "Failed to create Channel's K8s Service: %v", err)
 		return err
 	}
 	c.Status.SetAddress(controller.ServiceHostName(svc.Name, svc.Namespace))
+	r.recorder.Eventf(c, corev1.EventTypeNormal, "K8sServiceCreated", "Channel's K8s Service created: %q", svc.Name)
 
-	_, err = util.CreateVirtualService(ctx, r.client, c, svc)
+	virtualService, err := util.CreateVirtualService(ctx, r.client, c, svc)
 	if err != nil {
 		logger.Info("Error creating the Virtual Service for the Channel", zap.Error(err))
+		r.recorder.Eventf(c, corev1.EventTypeWarning, "VirtualServiceCreateFailed", "Failed to create Virtual Service for the Channel: %v", err)
 		return err
 	}
+	r.recorder.Eventf(c, corev1.EventTypeNormal, "VirtualServiceCreated", "Virtual Service for the Channel created: %q", virtualService.Name)
 
 	c.Status.MarkProvisioned()
+	r.recorder.Eventf(c, corev1.EventTypeNormal, "ChannelProvisioned", "Channel Provisioned")
 	return nil
 }
 

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -466,13 +465,14 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}
-	recorder := record.NewBroadcaster().NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+
 	for _, tc := range testCases {
 		configMapKey := types.NamespacedName{
 			Namespace: cmNamespace,
 			Name:      cmName,
 		}
 		c := tc.GetClient()
+		recorder := tc.GetEventRecorder()
 		r := &reconciler{
 			client:       c,
 			recorder:     recorder,
@@ -483,7 +483,7 @@ func TestReconcile(t *testing.T) {
 			tc.ReconcileKey = fmt.Sprintf("/%s", cName)
 		}
 		tc.IgnoreTimes = true
-		t.Run(tc.Name, tc.Runner(t, r, c))
+		t.Run(tc.Name, tc.Runner(t, r, c, recorder))
 	}
 }
 

--- a/pkg/controller/eventing/inmemory/channel/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/channel/reconcile_test.go
@@ -177,6 +177,16 @@ var (
 			},
 		},
 	}
+
+	// map of events to set test cases' expectations easier
+	events = map[string]corev1.Event{
+		channelReconcileFailed:     {Reason: channelReconcileFailed, Type: corev1.EventTypeWarning},
+		channelReconciled:          {Reason: channelReconciled, Type: corev1.EventTypeNormal},
+		channelUpdateStatusFailed:  {Reason: channelUpdateStatusFailed, Type: corev1.EventTypeWarning},
+		channelConfigSyncFailed:    {Reason: channelConfigSyncFailed, Type: corev1.EventTypeWarning},
+		k8sServiceCreateFailed:     {Reason: k8sServiceCreateFailed, Type: corev1.EventTypeWarning},
+		virtualServiceCreateFailed: {Reason: virtualServiceCreateFailed, Type: corev1.EventTypeWarning},
+	}
 )
 
 func init() {
@@ -251,6 +261,9 @@ func TestReconcile(t *testing.T) {
 				makeDeletingChannel(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelConfigSyncFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel deleted - finalizer removed",
@@ -259,6 +272,9 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				makeDeletingChannelWithoutFinalizer(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
 			},
 		},
 		{
@@ -270,6 +286,9 @@ func TestReconcile(t *testing.T) {
 				MockLists: errorListingChannels(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelConfigSyncFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel config sync fails - can't get ConfigMap",
@@ -280,6 +299,9 @@ func TestReconcile(t *testing.T) {
 				MockGets: errorGettingConfigMap(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelConfigSyncFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel config sync fails - can't create ConfigMap",
@@ -290,6 +312,9 @@ func TestReconcile(t *testing.T) {
 				MockCreates: errorCreatingConfigMap(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelConfigSyncFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel config sync fails - can't update ConfigMap",
@@ -301,6 +326,9 @@ func TestReconcile(t *testing.T) {
 				MockUpdates: errorUpdatingConfigMap(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelConfigSyncFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "K8s service get fails",
@@ -315,6 +343,9 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithFinalizer(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[k8sServiceCreateFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "K8s service creation fails",
@@ -330,6 +361,9 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithFinalizer(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[k8sServiceCreateFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Virtual service get fails",
@@ -348,6 +382,9 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithFinalizerAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[virtualServiceCreateFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Virtual service creation fails",
@@ -365,6 +402,9 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithFinalizerAndAddress(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[virtualServiceCreateFailed], events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel get for update fails",
@@ -378,6 +418,9 @@ func TestReconcile(t *testing.T) {
 				MockGets: errorOnSecondChannelGet(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelReconciled], events[channelUpdateStatusFailed],
+			},
 		},
 		{
 			Name: "Channel update fails",
@@ -391,6 +434,9 @@ func TestReconcile(t *testing.T) {
 				MockUpdates: errorUpdatingChannel(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelReconciled], events[channelUpdateStatusFailed],
+			},
 		}, {
 			Name: "Channel status update fails",
 			InitialState: []runtime.Object{
@@ -403,6 +449,9 @@ func TestReconcile(t *testing.T) {
 				MockStatusUpdates: errorUpdatingChannelStatus(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelReconciled], events[channelUpdateStatusFailed],
+			},
 		}, {
 			Name: "Channel reconcile successful - Channel list follows pagination",
 			InitialState: []runtime.Object{
@@ -422,6 +471,9 @@ func TestReconcile(t *testing.T) {
 				makeK8sService(),
 				makeVirtualService(),
 				makeConfigMapWithVerifyConfigMapData(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
 			},
 		},
 		{
@@ -462,6 +514,9 @@ func TestReconcile(t *testing.T) {
 				makeK8sService(),
 				makeVirtualService(),
 				makeConfigMapWithVerifyConfigMapData(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
 			},
 		},
 	}

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile.go
@@ -40,6 +40,13 @@ const (
 
 	// Channel is the name of the Channel resource in eventing.knative.dev/v1alpha1.
 	Channel = "Channel"
+
+	// Name of the corev1.Events emitted from the reconciliation process
+	ccpReconciled          = "CcpReconciled"
+	ccpReconcileFailed     = "CcpReconcileFailed"
+	ccpUpdateStatusFailed  = "CcpUpdateStatusFailed"
+	k8sServiceCreateFailed = "K8sServiceCreateFailed"
+	k8sServiceDeleteFailed = "K8sServiceDeleteFailed"
 )
 
 type reconciler struct {
@@ -96,13 +103,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.reconcile(ctx, ccp)
 	if err != nil {
 		logger.Info("Error reconciling ClusterChannelProvisioner", zap.Error(err))
-		r.recorder.Eventf(ccp, corev1.EventTypeWarning, "ReconcileClusterChannelProvisionerFailed", "Failed to reconcile ClusterChannelProvisioner: %v", err)
+		r.recorder.Eventf(ccp, corev1.EventTypeWarning, ccpReconcileFailed, "Failed to reconcile ClusterChannelProvisioner: %v", err)
 		// Note that we do not return the error here, because we want to update the Status
 		// regardless of the error.
+	} else {
+		logger.Info("ClusterChannelProvisioner reconciled")
+		r.recorder.Eventf(ccp, corev1.EventTypeNormal, ccpReconciled, "ClusterChannelProvisioner reconciled: %q", ccp.Name)
 	}
 
 	if updateStatusErr := util.UpdateClusterChannelProvisionerStatus(ctx, r.client, ccp); updateStatusErr != nil {
 		logger.Info("Error updating ClusterChannelProvisioner Status", zap.Error(updateStatusErr))
+		r.recorder.Eventf(ccp, corev1.EventTypeWarning, ccpUpdateStatusFailed, "Failed to update ClusterChannelProvisioner's status: %v", err)
 		return reconcile.Result{}, updateStatusErr
 	}
 
@@ -141,10 +152,9 @@ func (r *reconciler) reconcile(ctx context.Context, ccp *eventingv1alpha1.Cluste
 
 	if err != nil {
 		logger.Info("Error creating the ClusterChannelProvisioner's K8s Service", zap.Error(err))
-		r.recorder.Eventf(ccp, corev1.EventTypeWarning, "CreateK8sServiceFailed", "Failed to create ClusterChannelProvisioner's K8s Service: %v", err)
+		r.recorder.Eventf(ccp, corev1.EventTypeWarning, k8sServiceCreateFailed, "Failed to create ClusterChannelProvisioner's K8s Service: %v", err)
 		return err
 	}
-	r.recorder.Eventf(ccp, corev1.EventTypeNormal, "K8sServiceCreated", "ClusterChannelProvisioner's K8s Service created: %q", svc.Name)
 
 	// Check if this ClusterChannelProvisioner is the owner of the K8s service.
 	if !metav1.IsControlledBy(svc, ccp) {
@@ -156,12 +166,11 @@ func (r *reconciler) reconcile(ctx context.Context, ccp *eventingv1alpha1.Cluste
 	err = r.deleteOldDispatcherService(ctx, ccp)
 	if err != nil {
 		logger.Info("Error deleting the old ClusterChannelProvisioner's K8s Service", zap.Error(err))
-		r.recorder.Eventf(ccp, corev1.EventTypeWarning, "DeleteOldK8sServiceFailed", "Failed to delete the old ClusterChannelProvisioner's K8s Service: %v", err)
+		r.recorder.Eventf(ccp, corev1.EventTypeWarning, k8sServiceDeleteFailed, "Failed to delete the old ClusterChannelProvisioner's K8s Service: %v", err)
 		return err
 	}
 
 	ccp.Status.MarkReady()
-	r.recorder.Eventf(ccp, corev1.EventTypeNormal, "ClusterChannelProvisionerReady", "ClusterChannelProvisioner ready: %q", ccp.Name)
 	return nil
 }
 

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -51,6 +50,15 @@ var (
 	deletionTime = metav1.Now().Rfc3339Copy()
 
 	truePointer = true
+
+	// map of events to set test cases' expectations easier
+	events = map[string]corev1.Event{
+		ccpReconciled:          {Reason: ccpReconciled, Type: corev1.EventTypeNormal},
+		ccpReconcileFailed:     {Reason: ccpReconcileFailed, Type: corev1.EventTypeWarning},
+		ccpUpdateStatusFailed:  {Reason: ccpUpdateStatusFailed, Type: corev1.EventTypeWarning},
+		k8sServiceCreateFailed: {Reason: k8sServiceCreateFailed, Type: corev1.EventTypeWarning},
+		k8sServiceDeleteFailed: {Reason: k8sServiceDeleteFailed, Type: corev1.EventTypeWarning},
+	}
 )
 
 func init() {
@@ -156,6 +164,9 @@ func TestReconcile(t *testing.T) {
 			InitialState: []runtime.Object{
 				makeDeletingClusterChannelProvisioner(),
 			},
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
+			},
 		},
 		{
 			Name: "Create dispatcher fails",
@@ -168,6 +179,9 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[k8sServiceCreateFailed], events[ccpReconcileFailed],
+			},
 		},
 		{
 			Name: "Create dispatcher - already exists",
@@ -177,6 +191,9 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				makeReadyClusterChannelProvisioner(),
+			},
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
 			},
 		},
 		{
@@ -192,6 +209,9 @@ func TestReconcile(t *testing.T) {
 			WantAbsent: []runtime.Object{
 				makeOldK8sService(),
 			},
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
+			},
 		},
 		{
 			Name: "Create dispatcher - not owned by CCP",
@@ -202,6 +222,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeReadyClusterChannelProvisioner(),
 			},
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
+			},
 		},
 		{
 			Name: "Create dispatcher succeeds",
@@ -211,6 +234,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeReadyClusterChannelProvisioner(),
 				makeK8sService(),
+			},
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
 			},
 		},
 		{
@@ -223,6 +249,9 @@ func TestReconcile(t *testing.T) {
 				makeK8sService(),
 			},
 			ReconcileKey: fmt.Sprintf("%s/%s", testNS, Name),
+			WantEvent: []corev1.Event{
+				events[ccpReconciled],
+			},
 		},
 		{
 			Name: "Error getting CCP for updating Status",
@@ -235,6 +264,9 @@ func TestReconcile(t *testing.T) {
 				MockGets: oneSuccessfulClusterChannelProvisionerGet(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[ccpReconciled], events[ccpUpdateStatusFailed],
+			},
 		},
 		{
 			Name: "Error updating Status",
@@ -249,11 +281,15 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[ccpReconciled], events[ccpUpdateStatusFailed],
+			},
 		},
 	}
-	recorder := record.NewBroadcaster().NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+
 	for _, tc := range testCases {
 		c := tc.GetClient()
+		recorder := tc.GetEventRecorder()
 		r := &reconciler{
 			client:   c,
 			recorder: recorder,
@@ -263,7 +299,7 @@ func TestReconcile(t *testing.T) {
 			tc.ReconcileKey = fmt.Sprintf("/%s", Name)
 		}
 		tc.IgnoreTimes = true
-		t.Run(tc.Name, tc.Runner(t, r, c))
+		t.Run(tc.Name, tc.Runner(t, r, c, recorder))
 	}
 }
 

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -67,6 +67,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	err = r.reconcile(subscription)
 	if _, updateStatusErr := r.updateStatus(subscription.DeepCopy()); updateStatusErr != nil {
 		glog.Warningf("Failed to update subscription status: %v", updateStatusErr)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "SubscriptionReconcileFailed", "Failed to reconcile Subscription: %v", err)
 		return reconcile.Result{}, updateStatusErr
 	}
 
@@ -93,8 +94,10 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 			err := r.syncPhysicalChannel(subscription, true)
 			if err != nil {
 				glog.Warningf("Failed to sync physical from Channel : %s", err)
+				r.recorder.Eventf(subscription, corev1.EventTypeWarning, "PhysicalChannelSyncFailed", "Failed to sync physical Channel: %v", err)
 				return err
 			}
+			r.recorder.Eventf(subscription, corev1.EventTypeNormal, "PhysicalChannelSynced", "Physical Channel synced")
 		}
 		removeFinalizer(subscription)
 		return nil
@@ -104,23 +107,29 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	_, err = r.fetchObjectReference(subscription.Namespace, &subscription.Spec.Channel)
 	if err != nil {
 		glog.Warningf("Failed to validate `channel` exists: %+v, %v", subscription.Spec.Channel, err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "ObjectReferenceFetchFailed", "Failed to validate Channel exists: %v", err)
 		return err
 	}
+	r.recorder.Eventf(subscription, corev1.EventTypeNormal, "ObjectReferenceFetched", "Validated Channel exists: %q", subscription.Spec.Channel.Name)
 
 	if subscriberURI, err := r.resolveSubscriberSpec(subscription.Namespace, subscription.Spec.Subscriber); err != nil {
 		glog.Warningf("Failed to resolve Subscriber %+v : %s", *subscription.Spec.Subscriber, err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "SubscriberResolveFailed", "Failed to resolve Subscriber: %v", err)
 		return err
 	} else {
 		subscription.Status.PhysicalSubscription.SubscriberURI = subscriberURI
 		glog.Infof("Resolved subscriber to: %q", subscriberURI)
+		r.recorder.Eventf(subscription, corev1.EventTypeNormal, "SubscriberResolved", "Subscriber resolved to: %q", subscriberURI)
 	}
 
 	if replyURI, err := r.resolveResult(subscription.Namespace, subscription.Spec.Reply); err != nil {
 		glog.Warningf("Failed to resolve Result %v : %v", subscription.Spec.Reply, err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "ResultResolveFailed", "Failed to resolve Result: %v", err)
 		return err
 	} else {
 		subscription.Status.PhysicalSubscription.ReplyURI = replyURI
 		glog.Infof("Resolved reply to: %q", replyURI)
+		r.recorder.Eventf(subscription, corev1.EventTypeNormal, "ResultResolved", "Resolved Response to: %q", replyURI)
 	}
 
 	// Everything that was supposed to be resolved was, so flip the status bit on that.
@@ -131,10 +140,12 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	err = r.syncPhysicalChannel(subscription, false)
 	if err != nil {
 		glog.Warningf("Failed to sync physical Channel : %s", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "PhysicalChannelSyncFailed", "Failed to sync physical Channel: %v", err)
 		return err
 	}
 	// Everything went well, set the fact that subscriptions have been modified
 	subscription.Status.MarkChannelReady()
+	r.recorder.Eventf(subscription, corev1.EventTypeNormal, "SubscriptionReady", "Subscription Ready")
 	addFinalizer(subscription)
 	return nil
 }

--- a/pkg/controller/eventing/subscription/reconcile.go
+++ b/pkg/controller/eventing/subscription/reconcile.go
@@ -42,6 +42,15 @@ import (
 
 const (
 	finalizerName = controllerAgentName
+
+	// Name of the corev1.Events emitted from the reconciliation process
+	subscriptionReconciled         = "SubscriptionReconciled"
+	subscriptionReconcileFailed    = "SubscriptionReconcileFailed"
+	subscriptionUpdateStatusFailed = "SubscriptionUpdateStatusFailed"
+	physicalChannelSyncFailed      = "PhysicalChannelSyncFailed"
+	objectReferenceFetchFailed     = "ObjectReferenceFetchFailed"
+	subscriberResolveFailed        = "SubscriberResolveFailed"
+	resultResolveFailed            = "ResultResolveFailed"
 )
 
 // Reconcile compares the actual state with the desired, and attempts to
@@ -65,9 +74,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Reconcile this copy of the Subscription and then write back any status
 	// updates regardless of whether the reconcile error out.
 	err = r.reconcile(subscription)
+	if err != nil {
+		glog.Warningf("Error reconciling Subscription: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, subscriptionReconcileFailed, "Failed to reconcile Subscription: %v", err)
+	} else {
+		glog.Info("Subscription reconciled")
+		r.recorder.Eventf(subscription, corev1.EventTypeNormal, subscriptionReconciled, "Subscription reconciled: %q", subscription.Name)
+	}
+
 	if _, updateStatusErr := r.updateStatus(subscription.DeepCopy()); updateStatusErr != nil {
 		glog.Warningf("Failed to update subscription status: %v", updateStatusErr)
-		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "SubscriptionReconcileFailed", "Failed to reconcile Subscription: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, subscriptionUpdateStatusFailed, "Failed to update Subscription's status: %v", err)
 		return reconcile.Result{}, updateStatusErr
 	}
 
@@ -94,10 +111,9 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 			err := r.syncPhysicalChannel(subscription, true)
 			if err != nil {
 				glog.Warningf("Failed to sync physical from Channel : %s", err)
-				r.recorder.Eventf(subscription, corev1.EventTypeWarning, "PhysicalChannelSyncFailed", "Failed to sync physical Channel: %v", err)
+				r.recorder.Eventf(subscription, corev1.EventTypeWarning, physicalChannelSyncFailed, "Failed to sync physical Channel: %v", err)
 				return err
 			}
-			r.recorder.Eventf(subscription, corev1.EventTypeNormal, "PhysicalChannelSynced", "Physical Channel synced")
 		}
 		removeFinalizer(subscription)
 		return nil
@@ -107,29 +123,26 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	_, err = r.fetchObjectReference(subscription.Namespace, &subscription.Spec.Channel)
 	if err != nil {
 		glog.Warningf("Failed to validate `channel` exists: %+v, %v", subscription.Spec.Channel, err)
-		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "ObjectReferenceFetchFailed", "Failed to validate Channel exists: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, objectReferenceFetchFailed, "Failed to validate Channel exists: %v", err)
 		return err
 	}
-	r.recorder.Eventf(subscription, corev1.EventTypeNormal, "ObjectReferenceFetched", "Validated Channel exists: %q", subscription.Spec.Channel.Name)
 
 	if subscriberURI, err := r.resolveSubscriberSpec(subscription.Namespace, subscription.Spec.Subscriber); err != nil {
 		glog.Warningf("Failed to resolve Subscriber %+v : %s", *subscription.Spec.Subscriber, err)
-		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "SubscriberResolveFailed", "Failed to resolve Subscriber: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, subscriberResolveFailed, "Failed to resolve Subscriber: %v", err)
 		return err
 	} else {
 		subscription.Status.PhysicalSubscription.SubscriberURI = subscriberURI
 		glog.Infof("Resolved subscriber to: %q", subscriberURI)
-		r.recorder.Eventf(subscription, corev1.EventTypeNormal, "SubscriberResolved", "Subscriber resolved to: %q", subscriberURI)
 	}
 
 	if replyURI, err := r.resolveResult(subscription.Namespace, subscription.Spec.Reply); err != nil {
 		glog.Warningf("Failed to resolve Result %v : %v", subscription.Spec.Reply, err)
-		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "ResultResolveFailed", "Failed to resolve Result: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, resultResolveFailed, "Failed to resolve Result: %v", err)
 		return err
 	} else {
 		subscription.Status.PhysicalSubscription.ReplyURI = replyURI
 		glog.Infof("Resolved reply to: %q", replyURI)
-		r.recorder.Eventf(subscription, corev1.EventTypeNormal, "ResultResolved", "Resolved Response to: %q", replyURI)
 	}
 
 	// Everything that was supposed to be resolved was, so flip the status bit on that.
@@ -140,12 +153,11 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	err = r.syncPhysicalChannel(subscription, false)
 	if err != nil {
 		glog.Warningf("Failed to sync physical Channel : %s", err)
-		r.recorder.Eventf(subscription, corev1.EventTypeWarning, "PhysicalChannelSyncFailed", "Failed to sync physical Channel: %v", err)
+		r.recorder.Eventf(subscription, corev1.EventTypeWarning, physicalChannelSyncFailed, "Failed to sync physical Channel: %v", err)
 		return err
 	}
 	// Everything went well, set the fact that subscriptions have been modified
 	subscription.Status.MarkChannelReady()
-	r.recorder.Eventf(subscription, corev1.EventTypeNormal, "SubscriptionReady", "Subscription Ready")
 	addFinalizer(subscription)
 	return nil
 }

--- a/pkg/controller/eventing/subscription/reconcile_test.go
+++ b/pkg/controller/eventing/subscription/reconcile_test.go
@@ -40,6 +40,17 @@ var (
 	// deletionTime is used when objects are marked as deleted. Rfc3339Copy()
 	// truncates to seconds to match the loss of precision during serialization.
 	deletionTime = metav1.Now().Rfc3339Copy()
+
+	// map of events to set test cases' expectations easier
+	events = map[string]corev1.Event{
+		subscriptionReconciled:         {Reason: subscriptionReconciled, Type: corev1.EventTypeNormal},
+		subscriptionReconcileFailed:    {Reason: subscriptionReconcileFailed, Type: corev1.EventTypeWarning},
+		subscriptionUpdateStatusFailed: {Reason: subscriptionUpdateStatusFailed, Type: corev1.EventTypeWarning},
+		physicalChannelSyncFailed:      {Reason: physicalChannelSyncFailed, Type: corev1.EventTypeWarning},
+		objectReferenceFetchFailed:     {Reason: objectReferenceFetchFailed, Type: corev1.EventTypeWarning},
+		subscriberResolveFailed:        {Reason: subscriberResolveFailed, Type: corev1.EventTypeWarning},
+		resultResolveFailed:            {Reason: resultResolveFailed, Type: corev1.EventTypeWarning},
+	}
 )
 
 const (
@@ -77,6 +88,9 @@ var testCases = []controllertesting.TestCase{
 			Subscription(),
 		},
 		WantErrMsg: `channels.eventing.knative.dev "fromchannel" not found`,
+		WantEvent: []corev1.Event{
+			events[objectReferenceFetchFailed], events[subscriptionReconcileFailed],
+		},
 	}, {
 		Name: "subscription, but From is not subscribable",
 		InitialState: []runtime.Object{
@@ -87,7 +101,10 @@ var testCases = []controllertesting.TestCase{
 		// failure for now, until upstream is fixed. It should actually fail saying that there is no
 		// Spec.Subscribers field.
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -146,6 +163,9 @@ var testCases = []controllertesting.TestCase{
 		WantPresent: []runtime.Object{
 			Subscription().UnknownConditions(),
 		},
+		WantEvent: []corev1.Event{
+			events[subscriberResolveFailed], events[subscriptionReconcileFailed],
+		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
@@ -172,7 +192,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().UnknownConditions(),
 		},
 		WantErrMsg: "status does not contain address",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[subscriberResolveFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -212,7 +235,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().UnknownConditions().PhysicalSubscriber(targetDNS),
 		},
 		WantErrMsg: `channels.eventing.knative.dev "resultchannel" not found`,
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[resultResolveFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -256,6 +282,9 @@ var testCases = []controllertesting.TestCase{
 			// something else up here. later...
 			// Subscription().ReferencesResolved(),
 			Subscription().UnknownConditions().PhysicalSubscriber(targetDNS),
+		},
+		WantEvent: []corev1.Event{
+			events[resultResolveFailed], events[subscriptionReconcileFailed],
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -317,7 +346,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -382,7 +414,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().NilReply().ReferencesResolved().PhysicalSubscriber(targetDNS),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -428,7 +463,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).EmptyNonNilReply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -474,7 +512,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).EmptyNonNilReply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -519,7 +560,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().NilSubscriber().ReferencesResolved().Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -569,7 +613,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().NilReply().ReferencesResolved().PhysicalSubscriber(targetDNS),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -613,7 +660,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().NilSubscriber().ReferencesResolved().Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -662,7 +712,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().EmptyNonNilSubscriber().ReferencesResolved().Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -708,7 +761,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().ToK8sService().UnknownConditions(),
 		},
 		WantErrMsg: "services \"testk8sservice\" not found",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[subscriberResolveFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -739,7 +795,10 @@ var testCases = []controllertesting.TestCase{
 			Subscription().ToK8sService().ReferencesResolved().PhysicalSubscriber(k8sServiceDNS).Reply(),
 		},
 		WantErrMsg: "invalid JSON document",
-		Scheme:     scheme.Scheme,
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
+		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source channel
 			&unstructured.Unstructured{
@@ -798,6 +857,9 @@ var testCases = []controllertesting.TestCase{
 		WantErrMsg: "invalid JSON document",
 		WantPresent: []runtime.Object{
 			Subscription().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
+		},
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
 		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
@@ -894,6 +956,9 @@ var testCases = []controllertesting.TestCase{
 			Subscription().Renamed().ReferencesResolved().PhysicalSubscriber(targetDNS).Reply(),
 			Subscription().DifferentChannel(),
 		},
+		WantEvent: []corev1.Event{
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
+		},
 		Scheme: scheme.Scheme,
 		Objects: []runtime.Object{
 			// Source with a reference to the From Channel
@@ -988,7 +1053,7 @@ var testCases = []controllertesting.TestCase{
 			//getChannelWithOtherSubscription(),
 		},
 		WantEvent: []corev1.Event{
-			{Reason: "PhysicalChannelSyncFailed", Type: corev1.EventTypeWarning,},
+			events[physicalChannelSyncFailed], events[subscriptionReconcileFailed],
 		},
 		Objects: []runtime.Object{
 			// Source channel

--- a/pkg/controller/testing/mock_event_recorder.go
+++ b/pkg/controller/testing/mock_event_recorder.go
@@ -20,10 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
 )
-
-var _ record.EventRecorder = (*MockEventRecorder)(nil)
 
 // mockEventRecorder is a recorder.EventRecorder that allows to save v1 Events emitted.
 type MockEventRecorder struct {
@@ -35,23 +32,28 @@ func NewEventRecorder() *MockEventRecorder {
 }
 
 func (m *MockEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
-	// Create an event with only the information that we need to verify in the test.
-	// Should include more information if we want to check other fields
+	appendEvent(eventtype, reason, m)
+}
+
+func (m *MockEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	appendEvent(eventtype, reason, m)
+}
+
+func (m *MockEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+	appendEvent(eventtype, reason, m)
+}
+
+func (m *MockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	appendEvent(eventtype, reason, m)
+}
+
+// Helper function to append an event type and reason to the MockEventRecorder
+// Only interested in type and reason of Events for now. If we are planning on verifying other fields in
+// the test cases, we need to include them here.
+func appendEvent(eventtype, reason string, m *MockEventRecorder) {
 	event := corev1.Event{
 		Reason: reason,
 		Type:   eventtype,
 	}
 	m.events = append(m.events, event)
-}
-
-func (m *MockEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
-	panic("not implemented")
-}
-
-func (m *MockEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
-	panic("not implemented")
-}
-
-func (m *MockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
-	panic("not implemented")
 }

--- a/pkg/controller/testing/mock_event_recorder.go
+++ b/pkg/controller/testing/mock_event_recorder.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+var _ record.EventRecorder = (*MockEventRecorder)(nil)
+
+// mockEventRecorder is a recorder.EventRecorder that allows to save v1 Events emitted.
+type MockEventRecorder struct {
+	events []corev1.Event
+}
+
+func NewEventRecorder() *MockEventRecorder {
+	return &MockEventRecorder{}
+}
+
+func (m *MockEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	// Create an event with only the information that we need to verify in the test.
+	// Should include more information if we want to check other fields
+	event := corev1.Event{
+		Reason: reason,
+		Type:   eventtype,
+	}
+	m.events = append(m.events, event)
+}
+
+func (m *MockEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	panic("not implemented")
+}
+
+func (m *MockEventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+	panic("not implemented")
+}
+
+func (m *MockEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	panic("not implemented")
+}

--- a/pkg/controller/testing/table.go
+++ b/pkg/controller/testing/table.go
@@ -19,6 +19,8 @@ package testing
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -70,6 +72,10 @@ type TestCase struct {
 	// after reconciliation completes.
 	WantAbsent []runtime.Object
 
+	// WantEvent holds the list of events expected to exist after
+	// reconciliation completes.
+	WantEvent []corev1.Event
+
 	// Mocks that tamper with the client's responses.
 	Mocks Mocks
 
@@ -93,7 +99,7 @@ type TestCase struct {
 }
 
 // Runner returns a testing func that can be passed to t.Run.
-func (tc *TestCase) Runner(t *testing.T, r reconcile.Reconciler, c *MockClient) func(t *testing.T) {
+func (tc *TestCase) Runner(t *testing.T, r reconcile.Reconciler, c *MockClient, recorder *MockEventRecorder) func(t *testing.T) {
 	return func(t *testing.T) {
 		result, recErr := tc.Reconcile(r)
 
@@ -116,6 +122,10 @@ func (tc *TestCase) Runner(t *testing.T, r reconcile.Reconciler, c *MockClient) 
 			t.Error(err)
 		}
 
+		if err := tc.VerifyWantEvent(recorder); err != nil {
+			t.Error(err)
+		}
+
 		for _, av := range tc.AdditionalVerification {
 			av(t, tc)
 		}
@@ -135,6 +145,11 @@ func (tc *TestCase) GetClient() *MockClient {
 	builtObjects := buildAllObjects(tc.InitialState)
 	innerClient := fake.NewFakeClient(builtObjects...)
 	return NewMockClient(innerClient, tc.Mocks)
+}
+
+// GetEventRecorder returns the mockEventRecorder to use for this test case.
+func (tc *TestCase) GetEventRecorder() *MockEventRecorder {
+	return NewEventRecorder()
 }
 
 // Reconcile calls the given reconciler's Reconcile() function with the test
@@ -263,6 +278,23 @@ func (tc *TestCase) VerifyWantAbsent(c client.Client) error {
 		return errs
 	}
 	return nil
+}
+
+// VerifyWantEvent verifies that the eventRecorder does contain the events
+// expected to be emitted after reconciliation.
+func (tc *TestCase) VerifyWantEvent(eventRecorder *MockEventRecorder) error {
+	if !reflect.DeepEqual(tc.WantEvent, eventRecorder.events) {
+		return fmt.Errorf("expected %s, got %s", getEventsAsString(tc.WantEvent), getEventsAsString(eventRecorder.events))
+	}
+	return nil
+}
+
+func getEventsAsString(events []corev1.Event) []string {
+	eventsAsString := make([]string, 0)
+	for _, event := range events {
+		eventsAsString = append(eventsAsString, fmt.Sprintf("(%s,%s)", event.Reason, event.Type))
+	}
+	return eventsAsString
 }
 
 func buildAllObjects(objs []runtime.Object) []runtime.Object {


### PR DESCRIPTION
Fixes #724 

## Proposed Changes

- Adding corev1.Events to InMemoryChannel, ClusterChannelProvisioner and Subscription objects in their respective reconcile processes, in order to make debugging easier.
- Adding a MockEventRecorder that contains a slice with the events emitted, and verifies their existence afterwards.
- Adding permissions to manipulate events to the in-memory-channel default configuration
- Here is the list of the events emitted:

### InMemoryChannel

Name | Type | Description
-- | -- | --
ChannelConfigSyncFailed | Warning | When the Channel's config couldn't be synced. Includes the go error string.
K8sServiceCreateFailed | Warning | When the K8s Service couldn't be created. Includes the go error string.
VirtualServiceCreateFailed | Warning | When the Virtual Service couldn't be created. Includes the go error string.
ChannelUpdateStatusFailed | Warning | When the Channel's status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
ChannelReconcileFailed | Warning | When there was some problem in the Channel's reconciliation process. Includes the go error string.
ChannelReconciled | Normal | When the Channel's reconciliation process succeeds. This is the "Success" event. Includes the channel name.

### ClusterChannelProvisioner

Name | Type | Description
-- | -- | --
K8sServiceCreateFailed | Warning | When the K8s Service couldn't be created. Includes the go error string.
K8sServiceDeleteFailed | Warning | When the old K8s Service couldn't be deleted. Includes the go error string.
CcpUpdateStatusFailed | Warning | When the Ccp's status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
CcpReconcileFailed | Warning | When there was some problem in the Ccp's reconciliation process. Includes the go error string.
CcpReconciled | Normal | When the Ccp's reconciliation process succeeds. This is the "Success" event. Includes the ccp name.

### Subscription

Name | Type | Description
-- | -- | --
PhysicalChannelSyncFailed | Warning | When the physical Channel couldn't not be synced. Includes the go error string.
ObjectReferenceFetchFailed | Warning | When we couldn't validate the existence of the Channel. Includes the go error string.
SubscriberResolveFailed | Warning | When we couldn't resolve the Subscriber's URI. Includes the go error string.
ResultResolveFailed| Warning | When we couldn't resolve the Subscription's reply. Includes the go error string.
SubscriptionUpdateStatusFailed | Warning | When the Subscription's status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
SubscriptionReconcileFailed | Warning | When there was some problem in the Subscription's reconciliation process. Includes the go error string.
SubscriptionReconciled | Normal | When the reconciliation process succeeds. This is the "Success" event. Includes the subscription name.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
InMemoryChannel, ClusterChannelProvisioner, and Subscription are now more detailed when errors occur.
```
