### PR TITLE
golang format tools

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,13 +19,14 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/knative/eventing/pkg/controller/eventing/subscription"
-	"k8s.io/apimachinery/pkg/runtime"
 	"log"
 	"net/http"
+	"time"
+
+	"github.com/knative/eventing/pkg/controller/eventing/subscription"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"time"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/contrib/natss/pkg/controller/channel/reconcile.go
+++ b/contrib/natss/pkg/controller/channel/reconcile.go
@@ -28,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	ccpcontroller "github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 )
 
 type reconciler struct {

--- a/contrib/natss/pkg/controller/main.go
+++ b/contrib/natss/pkg/controller/main.go
@@ -19,10 +19,10 @@ package main
 import (
 	"flag"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/channel"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"github.com/knative/eventing/pkg/provisioners"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"

--- a/contrib/natss/pkg/dispatcher/channel/controller.go
+++ b/contrib/natss/pkg/dispatcher/channel/controller.go
@@ -23,8 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/contrib/natss/pkg/dispatcher/dispatcher"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 )
 
 const (

--- a/contrib/natss/pkg/dispatcher/channel/reconcile.go
+++ b/contrib/natss/pkg/dispatcher/channel/reconcile.go
@@ -19,16 +19,16 @@ package channel
 import (
 	"context"
 
-	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/contrib/natss/pkg/dispatcher/dispatcher"
+	"github.com/knative/eventing/pkg/provisioners"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	ccpcontroller "github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 )
 
 type reconciler struct {

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
 	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
+	"github.com/knative/eventing/pkg/provisioners"
 	stan "github.com/nats-io/go-nats-streaming"
 	"go.uber.org/zap"
 

--- a/contrib/natss/pkg/dispatcher/main.go
+++ b/contrib/natss/pkg/dispatcher/main.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/utils"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
