### PR TITLE
Format markdown

### DIFF
--- a/contrib/natss/config/broker/README.md
+++ b/contrib/natss/config/broker/README.md
@@ -11,4 +11,5 @@
    NATS Streaming is deployed as a StatefulSet, using "nats-streaming" ConfigMap
    in the namespace "natss".
 
-For tuning NATS Streaming, see [here](https://github.com/nats-io/nats-streaming-server#configuring)
+For tuning NATS Streaming, see
+[here](https://github.com/nats-io/nats-streaming-server#configuring)


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`