### PR TITLE
adding link to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ For complete Knative Eventing documentation, see
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
 [Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#events).
+
+The planned project releases are covered in this
+[roadmap](https://docs.google.com/document/d/1z0z412rL9FsBsF8kwKxG6w7sflJLKe9hIECkc7jWfOY/edit#).


### PR DESCRIPTION
I feel that the roadmap document is a bit hidden.  Therefore adding a more present link to the landing page of this repo

cc @evankanderson 