### PR TITLE
Write CCP status via client.Status().Update

### DIFF
--- a/config/provisioners/gcppubsub/README.md
+++ b/config/provisioners/gcppubsub/README.md
@@ -38,7 +38,7 @@ They do not offer:
    1. Create a secret for the downloaded key:
 
       ```shell
-      kubectl -n knative-sources create secret generic gcppubsub-channel-key --from-file=key.json=PATH_TO_KEY_FILE.json
+      kubectl -n knative-eventing create secret generic gcppubsub-channel-key --from-file=key.json=PATH_TO_KEY_FILE.json
       ```
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).

--- a/config/provisioners/gcppubsub/gcppubsub.yaml
+++ b/config/provisioners/gcppubsub/gcppubsub.yaml
@@ -39,6 +39,7 @@ rules:
       - channels
       - channels/status
       - clusterchannelprovisioners
+      - clusterchannelprovisioners/status
     verbs:
       - get
       - list

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -39,6 +39,7 @@ rules:
       - channels
       - channels/status
       - clusterchannelprovisioners
+      - clusterchannelprovisioners/status
     verbs:
       - get
       - list

--- a/contrib/kafka/config/README.md
+++ b/contrib/kafka/config/README.md
@@ -13,7 +13,7 @@ Deployment steps:
 
 1. Now that Apache Kafka is installed, you need to configure the
    `bootstrap_servers` value in the `kafka-channel-controller-config` ConfigMap,
-   located inside the `config/provisioners/kafka/kafka-channel.yaml` file:
+   located inside the `contrib/kafka/config/kafka.yaml` file:
    `... apiVersion: v1 kind: ConfigMap metadata: name: kafka-channel-controller-config namespace: knative-eventing data: # Broker URL's for the provisioner bootstrap_servers: kafkabroker.kafka:9092 ...` >
    Note: The `bootstrap_servers` needs to contain the address of at least one
    broker of your Apache Kafka cluster. If you are using Strimzi, you need to

--- a/contrib/kafka/config/kafka.yaml
+++ b/contrib/kafka/config/kafka.yaml
@@ -37,6 +37,7 @@ rules:
       - channels
       - channels/status
       - clusterchannelprovisioners
+      - clusterchannelprovisioners/status
     verbs:
       - get
       - list

--- a/contrib/natss/config/provisioner.yaml
+++ b/contrib/natss/config/provisioner.yaml
@@ -39,6 +39,7 @@ rules:
       - channels
       - channels/status
       - clusterchannelprovisioners
+      - clusterchannelprovisioners/status
     verbs:
       - get
       - list

--- a/contrib/natss/config/provisioner.yaml
+++ b/contrib/natss/config/provisioner.yaml
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: natss-controller
       containers:
         - name: controller
-          image: github.com/knative/eventing/pkg/provisioners/natss/controller
+          image: github.com/knative/eventing/contrib/natss/pkg/controller
 
 ---
 
@@ -174,4 +174,4 @@ spec:
       serviceAccountName: natss-dispatcher
       containers:
         - name: dispatcher
-          image: github.com/knative/eventing/pkg/provisioners/natss/dispatcher
+          image: github.com/knative/eventing/contrib/natss/pkg/dispatcher

--- a/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/controller/eventing/inmemory/clusterchannelprovisioner/reconcile_test.go
@@ -275,8 +275,8 @@ func TestReconcile(t *testing.T) {
 				makeK8sService(),
 			},
 			Mocks: controllertesting.Mocks{
-				MockUpdates: []controllertesting.MockUpdate{
-					errorUpdating(),
+				MockStatusUpdates: []controllertesting.MockStatusUpdate{
+					errorUpdatingStatus(),
 				},
 			},
 			WantErrMsg: testErrorMessage,
@@ -410,7 +410,7 @@ func oneSuccessfulClusterChannelProvisionerGet() []controllertesting.MockGet {
 	}
 }
 
-func errorUpdating() controllertesting.MockUpdate {
+func errorUpdatingStatus() controllertesting.MockStatusUpdate {
 	return func(client.Client, context.Context, runtime.Object) (controllertesting.MockHandled, error) {
 		return controllertesting.Handled, errors.New(testErrorMessage)
 	}

--- a/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/provisioners/gcppubsub/controller/clusterchannelprovisioner/reconcile_test.go
@@ -176,8 +176,8 @@ func TestReconcile(t *testing.T) {
 				makeClusterChannelProvisioner(),
 			},
 			Mocks: controllertesting.Mocks{
-				MockUpdates: []controllertesting.MockUpdate{
-					errorUpdating(),
+				MockStatusUpdates: []controllertesting.MockStatusUpdate{
+					errorUpdatingStatus(),
 				},
 			},
 			WantErrMsg: testErrorMessage,
@@ -253,7 +253,7 @@ func oneSuccessfulClusterChannelProvisionerGet() []controllertesting.MockGet {
 	}
 }
 
-func errorUpdating() controllertesting.MockUpdate {
+func errorUpdatingStatus() controllertesting.MockStatusUpdate {
 	return func(client.Client, context.Context, runtime.Object) (controllertesting.MockHandled, error) {
 		return controllertesting.Handled, errors.New(testErrorMessage)
 	}

--- a/pkg/provisioners/provisioner_util.go
+++ b/pkg/provisioners/provisioner_util.go
@@ -42,7 +42,7 @@ func UpdateClusterChannelProvisionerStatus(ctx context.Context, client runtimeCl
 
 	if !equality.Semantic.DeepEqual(o.Status, u.Status) {
 		o.Status = u.Status
-		return client.Update(ctx, o)
+		return client.Status().Update(ctx, o)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #760 

## Proposed Changes

- As of #699 ClusterChannelProvisioner's status is a subresource. This commit updates the system to write the status via client.Status().Update(...).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The RBAC for ClusterChannelProvisioner Controllers will need to be updated.
```
