### PR TITLE
Add a flag to the e2e tests to use a custom ClusterChannelProvisioner.

### DIFF
--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -124,6 +124,9 @@ func SingleEvent(t *testing.T, encoding string) {
 	// create channel
 
 	logger.Infof("Creating Channel and Subscription")
+	if test.EventingFlags.Provisioner == "" {
+		t.Fatal("ClusterChannelProvisioner must be set to a non-empty string. Either do not specify --clusterChannelProvisioner or set to something other than the empty string")
+	}
 	channel := test.Channel(channelName, ns, test.ClusterChannelProvisioner(test.EventingFlags.Provisioner))
 	logger.Infof("channel: %#v", channel)
 	sub := test.Subscription(subscriptionName, ns, test.ChannelRef(channelName), test.SubscriberSpecForService(routeName), nil)

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	channelName      = "e2e-singleevent"
-	provisionerName  = "in-memory-channel"
 	subscriberName   = "e2e-singleevent-subscriber"
 	senderName       = "e2e-singleevent-sender"
 	subscriptionName = "e2e-singleevent-subscription"
@@ -125,7 +124,7 @@ func SingleEvent(t *testing.T, encoding string) {
 	// create channel
 
 	logger.Infof("Creating Channel and Subscription")
-	channel := test.Channel(channelName, ns, test.ClusterChannelProvisioner(provisionerName))
+	channel := test.Channel(channelName, ns, test.ClusterChannelProvisioner(test.EventingFlags.Provisioner))
 	logger.Infof("channel: %#v", channel)
 	sub := test.Subscription(subscriptionName, ns, test.ChannelRef(channelName), test.SubscriberSpecForService(routeName), nil)
 	logger.Infof("sub: %#v", sub)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -33,8 +33,9 @@ var EventingFlags = initializeEventingFlags()
 
 // EventingEnvironmentFlags holds the e2e flags needed only by the eventing repo
 type EventingEnvironmentFlags struct {
-	DockerRepo string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
-	Tag        string // Tag for test images
+	DockerRepo  string // Docker repo (defaults to $DOCKER_REPO_OVERRIDE)
+	Tag         string // Tag for test images
+	Provisioner string // The name of the Channel's ClusterChannelProvisioner
 }
 
 func initializeEventingFlags() *EventingEnvironmentFlags {
@@ -51,6 +52,8 @@ func initializeEventingFlags() *EventingEnvironmentFlags {
 		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
 
 	flag.StringVar(&f.Tag, "tag", "e2e", "Provide the version tag for the test images.")
+
+	flag.StringVar(&f.Provisioner, "clusterChannelProvisioner", "in-memory-channel", "The name of the Channel's clusterChannelProvisioner. Only the in-memory-channel is installed by the tests, anything else must be installed before the tests are run.")
 
 	flag.Parse()
 


### PR DESCRIPTION
Fixes #769 

## Proposed Changes

- Add a flag to the e2e tests to use a custom ClusterChannelProvisioner.

Note: To use this locally I did the following:

```shell
export CLUSTER=<entry from ~/.kube/config file>
export NAMESPACE=<something random>

# This creates all the images. Without it, I was either seeing images that couldn't be pulled or stale images.
test/upload-test-images.sh e2e

# Actually running the tests.
go test -v -tags=e2e -count=1 ./test/e2e -dockerrepo=gcr.io/$PROJECT_ID -cluster=$CLUSTER -namespace=$NAMESPACE -clusterChannelProvisioner=kafka
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
