### PR TITLE
Mention Channel provisioners in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,7 +11,8 @@ This doc explains how to setup a development environment so you can get started
 1. [Create and checkout a repo fork](#checkout-your-fork)
 
 Once you meet these requirements, you can
-[start the eventing-controller](#starting-eventing-controller)!
+[start the eventing-controller](#starting-eventing-controller) and
+[install a channel provisioner](#installing-a-channel-provisioner)!
 
 Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -73,6 +74,21 @@ You can access the Eventing Controller's logs with:
 ```shell
 kubectl -n knative-eventing logs $(kubectl -n knative-eventing get pods -l app=eventing-controller -o name)
 ```
+
+## Installing a Channel Provisioner
+
+You'll need a `ClusterChannelProvisioner` installed before you can use
+any Channels. Eventing release artifacts include the
+[in-memory-channel](./config/provisioners/in-memory-channel/) out of
+the box. You can install it during development with:
+
+```shell
+ko apply -f config/provisioners/in-memory-channel/
+```
+
+There are other `ClusterChannelProvisioner` implementations available
+under the [contrib](./contrib/) subdirectory, but those likely aren't
+needed for development unless you're working on one of them directly.
 
 ## Iterating
 


### PR DESCRIPTION
Someone installing Eventing from source doesn't get a
`ClusterChannelProvisioner` out of the box. So, add a note about
installing one in DEVELOPMENT.md.
