### PR TITLE
Switch the default channel provisioner from 'in-memory-channel' to 'in-memory'

### DIFF
--- a/config/400-default-channel-config.yaml
+++ b/config/400-default-channel-config.yaml
@@ -24,7 +24,7 @@ data:
     clusterdefault:
       apiversion: eventing.knative.dev/v1alpha1
       kind: ClusterChannelProvisioner
-      name: in-memory-channel
+      name: in-memory
     namespacedefaults:
       some-namespace:
         apiversion: eventing.knative.dev/v1alpha1


### PR DESCRIPTION
## Proposed Changes

- Switch the default channel provisioner from 'in-memory-channel' to 'in-memory'

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
