### PR TITLE
Adding corev1.Events to GCP PubSub channel for easier debugging

### DIFF
--- a/contrib/gcppubsub/config/gcppubsub.yaml
+++ b/contrib/gcppubsub/config/gcppubsub.yaml
@@ -71,6 +71,14 @@ rules:
       - watch
       - create
       - update
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 
 ---
 

--- a/contrib/gcppubsub/pkg/controller/channel/reconcile.go
+++ b/contrib/gcppubsub/pkg/controller/channel/reconcile.go
@@ -24,8 +24,8 @@ import (
 	pubsubutil "github.com/knative/eventing/contrib/gcppubsub/pkg/util"
 	"github.com/knative/eventing/contrib/gcppubsub/pkg/util/logging"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"github.com/knative/eventing/pkg/reconciler/names"
 	util "github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/reconciler/names"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
 	v1 "k8s.io/api/core/v1"
@@ -46,6 +46,20 @@ type persistence int
 const (
 	persistStatus persistence = iota
 	noNeedToPersist
+
+	// Name of the corev1.Events emitted from the reconciliation process
+	channelReconciled          = "ChannelReconciled"
+	channelUpdateStatusFailed  = "ChannelUpdateStatusFailed"
+	channelReadStatusFailed    = "ChannelReadStatusFailed"
+	gcpCredentialsReadFailed   = "GcpCredentialsReadFailed"
+	gcpResourcesPlanFailed     = "GcpResourcesPlanFailed"
+	gcpResourcesPersistFailed  = "GcpResourcesPersistFailed"
+	virtualServiceCreateFailed = "VirtualServiceCreateFailed"
+	k8sServiceCreateFailed     = "K8sServiceCreateFailed"
+	topicCreateFailed          = "TopicCreateFailed"
+	topicDeleteFailed          = "TopicDeleteFailed"
+	subscriptionSyncFailed     = "SubscriptionSyncFailed"
+	subscriptionDeleteFailed   = "SubscriptionDeleteFailed"
 )
 
 // reconciler reconciles GCP-PubSub Channels by creating the K8s Service and Istio VirtualService
@@ -116,10 +130,14 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		logging.FromContext(ctx).Info("Error reconciling Channel", zap.Error(reconcileErr))
 		// Note that we do not return the error here, because we want to update the Status
 		// regardless of the error.
+	} else {
+		logging.FromContext(ctx).Info("Channel reconciled")
+		r.recorder.Eventf(c, v1.EventTypeNormal, channelReconciled, "Channel reconciled: %q", c.Name)
 	}
 
 	if err = util.UpdateChannel(ctx, r.client, c); err != nil {
 		logging.FromContext(ctx).Info("Error updating Channel Status", zap.Error(err))
+		r.recorder.Eventf(c, v1.EventTypeWarning, channelUpdateStatusFailed, "Failed to update Channel's status: %v", err)
 		return reconcile.Result{}, err
 	}
 
@@ -155,6 +173,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	originalPCS, err := pubsubutil.GetInternalStatus(c)
 	if err != nil {
 		logging.FromContext(ctx).Error("Unable to read the status.internal", zap.Error(err))
+		r.recorder.Eventf(c, v1.EventTypeWarning, channelReadStatusFailed, "Failed to read Channel's status.internal: %v", err)
 		return false, err
 	}
 
@@ -162,6 +181,7 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	gcpCreds, err := pubsubutil.GetCredentials(ctx, r.client, r.defaultSecret, r.defaultSecretKey)
 	if err != nil {
 		logging.FromContext(ctx).Info("Unable to generate GCP creds", zap.Error(err))
+		r.recorder.Eventf(c, v1.EventTypeWarning, gcpCredentialsReadFailed, "Failed to generate GCP credentials: %v", err)
 		return false, err
 	}
 
@@ -174,10 +194,12 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 		// Topic is nil because it is only used for sub creation, not deletion.
 		err = r.syncSubscriptions(ctx, originalPCS, gcpCreds, nil, subsToSync)
 		if err != nil {
+			r.recorder.Eventf(c, v1.EventTypeWarning, subscriptionSyncFailed, "Failed to sync Subscription for the Channel: %v", err)
 			return false, err
 		}
 		err = r.deleteTopic(ctx, originalPCS, gcpCreds)
 		if err != nil {
+			r.recorder.Eventf(c, v1.EventTypeWarning, topicDeleteFailed, "Failed to delete Topic for the Channel: %v", err)
 			return false, err
 		}
 		util.RemoveFinalizer(c, finalizerName)
@@ -197,10 +219,12 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	// only at the status, not the spec.
 	persist, plannedPCS, subsToSync, err := r.planGcpResources(ctx, c, originalPCS)
 	if err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, gcpResourcesPlanFailed, "Failed to plan Channel's resources: %v", err)
 		return false, err
 	}
 	if persist == persistStatus {
 		if err = pubsubutil.SetInternalStatus(ctx, c, plannedPCS); err != nil {
+			r.recorder.Eventf(c, v1.EventTypeWarning, gcpResourcesPersistFailed, "Failed to persist Channel's resources: %v", err)
 			return false, err
 		}
 		// Persist this and run another reconcile loop to enact it.
@@ -209,26 +233,31 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 
 	svc, err := r.createK8sService(ctx, c)
 	if err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, k8sServiceCreateFailed, "Failed to reconcile Channel's K8s Service: %v", err)
 		return false, err
 	}
 
 	err = r.createVirtualService(ctx, c, svc)
 	if err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, virtualServiceCreateFailed, "Failed to reconcile Virtual Service for the Channel: %v", err)
 		return false, err
 	}
 
 	topic, err := r.createTopic(ctx, plannedPCS, gcpCreds)
 	if err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, topicCreateFailed, "Failed to reconcile Topic for the Channel: %v", err)
 		return false, err
 	}
 
 	err = r.syncSubscriptions(ctx, plannedPCS, gcpCreds, topic, subsToSync)
 	if err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, subscriptionSyncFailed, "Failed to reconcile Subscription for the Channel: %v", err)
 		return false, err
 	}
 	// Now that the subs have synced successfully, remove the old ones from the status.
 	plannedPCS.Subscriptions = subsToSync.subsToCreate
 	if err = pubsubutil.SetInternalStatus(ctx, c, plannedPCS); err != nil {
+		r.recorder.Eventf(c, v1.EventTypeWarning, subscriptionDeleteFailed, "Failed to delete old Subscriptions from the Channel's status: %v", err)
 		return false, err
 	}
 

--- a/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile.go
+++ b/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile.go
@@ -45,9 +45,9 @@ const (
 	finalizerName = controllerAgentName
 
 	// Name of the corev1.Events emitted from the reconciliation process
-	channelReconciled         = "ChannelReconciled"
-	channelReconcileFailed    = "ChannelReconcileFailed"
-	channelUpdateStatusFailed = "ChannelUpdateStatusFailed"
+	dispatcherReconciled         = "DispatcherReconciled"
+	dispatcherReconcileFailed    = "DispatcherReconcileFailed"
+	dispatcherUpdateStatusFailed = "DispatcherUpdateStatusFailed"
 )
 
 type channelName = types.NamespacedName
@@ -126,17 +126,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	requeue, reconcileErr := r.reconcile(logging.With(ctx, zap.Any("channel", c)), c, pcs)
 	if reconcileErr != nil {
 		logging.FromContext(ctx).Info("Error reconciling Channel", zap.Error(reconcileErr))
-		r.recorder.Eventf(c, v1.EventTypeWarning, channelReconcileFailed, "Channel reconciliation failed: %v", err)
+		r.recorder.Eventf(c, v1.EventTypeWarning, dispatcherReconcileFailed, "Dispatcher reconciliation failed: %v", err)
 		// Note that we do not return the error here, because we want to update the finalizers
 		// regardless of the error.
 	} else {
 		logging.FromContext(ctx).Info("Channel reconciled")
-		r.recorder.Eventf(c, v1.EventTypeNormal, channelReconciled, "Channel reconciled: %q", c.Name)
+		r.recorder.Eventf(c, v1.EventTypeNormal, dispatcherReconciled, "Dispatcher reconciled: %q", c.Name)
 	}
 
 	if err = util.UpdateChannel(ctx, r.client, c); err != nil {
 		logging.FromContext(ctx).Info("Error updating Channel Status", zap.Error(err))
-		r.recorder.Eventf(c, v1.EventTypeWarning, channelUpdateStatusFailed, "Failed to update Channel's status: %v", err)
+		r.recorder.Eventf(c, v1.EventTypeWarning, dispatcherUpdateStatusFailed, "Failed to update Channel's dispatcher status: %v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile.go
+++ b/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"k8s.io/client-go/util/workqueue"
 
 	ccpcontroller "github.com/knative/eventing/contrib/gcppubsub/pkg/controller/clusterchannelprovisioner"
@@ -41,6 +43,11 @@ import (
 
 const (
 	finalizerName = controllerAgentName
+
+	// Name of the corev1.Events emitted from the reconciliation process
+	channelReconciled         = "ChannelReconciled"
+	channelReconcileFailed    = "ChannelReconcileFailed"
+	channelUpdateStatusFailed = "ChannelUpdateStatusFailed"
 )
 
 type channelName = types.NamespacedName
@@ -119,12 +126,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	requeue, reconcileErr := r.reconcile(logging.With(ctx, zap.Any("channel", c)), c, pcs)
 	if reconcileErr != nil {
 		logging.FromContext(ctx).Info("Error reconciling Channel", zap.Error(reconcileErr))
+		r.recorder.Eventf(c, v1.EventTypeWarning, channelReconcileFailed, "Channel reconciliation failed: %v", err)
 		// Note that we do not return the error here, because we want to update the finalizers
 		// regardless of the error.
+	} else {
+		logging.FromContext(ctx).Info("Channel reconciled")
+		r.recorder.Eventf(c, v1.EventTypeNormal, channelReconciled, "Channel reconciled: %q", c.Name)
 	}
 
 	if err = util.UpdateChannel(ctx, r.client, c); err != nil {
 		logging.FromContext(ctx).Info("Error updating Channel Status", zap.Error(err))
+		r.recorder.Eventf(c, v1.EventTypeWarning, channelUpdateStatusFailed, "Failed to update Channel's status: %v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
+++ b/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
@@ -94,9 +94,9 @@ var (
 
 	// map of events to set test cases' expectations easier
 	events = map[string]corev1.Event{
-		channelReconciled:         {Reason: channelReconciled, Type: corev1.EventTypeNormal},
-		channelReconcileFailed:    {Reason: channelReconcileFailed, Type: corev1.EventTypeWarning},
-		channelUpdateStatusFailed: {Reason: channelUpdateStatusFailed, Type: corev1.EventTypeWarning},
+		dispatcherReconciled:         {Reason: dispatcherReconciled, Type: corev1.EventTypeNormal},
+		dispatcherReconcileFailed:    {Reason: dispatcherReconcileFailed, Type: corev1.EventTypeWarning},
+		dispatcherUpdateStatusFailed: {Reason: dispatcherUpdateStatusFailed, Type: corev1.EventTypeWarning},
 	}
 )
 
@@ -190,7 +190,7 @@ func TestReconcile(t *testing.T) {
 				makeDeletingChannelWithSubscribersWithoutFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -203,7 +203,7 @@ func TestReconcile(t *testing.T) {
 				makeDeletingChannelWithoutFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -218,7 +218,7 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithSubscribersAndFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testcreds.InvalidCredsError,
 			WantEvent: []corev1.Event{
-				events[channelReconcileFailed],
+				events[dispatcherReconcileFailed],
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantEvent: []corev1.Event{
-				events[channelReconcileFailed],
+				events[dispatcherReconcileFailed],
 			},
 		},
 		{
@@ -283,7 +283,7 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithSubscribersAndFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -308,7 +308,7 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithSubscribersAndFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -333,7 +333,7 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithSubscribersAndFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -358,7 +358,7 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithFinalizer(),
 			},
 			WantEvent: []corev1.Event{
-				events[channelReconciled],
+				events[dispatcherReconciled],
 			},
 		},
 		{
@@ -372,7 +372,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantErrMsg: testErrorMessage,
 			WantEvent: []corev1.Event{
-				events[channelReconciled], events[channelUpdateStatusFailed],
+				events[dispatcherReconciled], events[dispatcherUpdateStatusFailed],
 			},
 		},
 		// Note - we do not test update status since this dispatcher only adds

--- a/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
+++ b/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
@@ -91,6 +91,13 @@ var (
 			},
 		},
 	}
+
+	// map of events to set test cases' expectations easier
+	events = map[string]corev1.Event{
+		channelReconciled:         {Reason: channelReconciled, Type: corev1.EventTypeNormal},
+		channelReconcileFailed:    {Reason: channelReconcileFailed, Type: corev1.EventTypeWarning},
+		channelUpdateStatusFailed: {Reason: channelUpdateStatusFailed, Type: corev1.EventTypeWarning},
+	}
 )
 
 func init() {
@@ -182,6 +189,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeDeletingChannelWithSubscribersWithoutFinalizer(),
 			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
 		},
 		{
 			Name: "Channel deleted - finalizer removed",
@@ -191,6 +201,9 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				makeDeletingChannelWithoutFinalizer(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
 			},
 		},
 		{
@@ -204,6 +217,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeChannelWithSubscribersAndFinalizer(),
 			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
 		},
 		{
 			Name: "GetCredential fails",
@@ -215,6 +231,9 @@ func TestReconcile(t *testing.T) {
 				makeChannelWithSubscribersAndFinalizer(),
 			},
 			WantErrMsg: testcreds.InvalidCredsError,
+			WantEvent: []corev1.Event{
+				events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Channel update fails - cannot create PubSub client",
@@ -228,6 +247,9 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelReconcileFailed],
+			},
 		},
 		{
 			Name: "Receive errors",
@@ -260,6 +282,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeChannelWithSubscribersAndFinalizer(),
 			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
 		},
 		{
 			Name: "PubSub Subscription.Receive already running",
@@ -281,6 +306,9 @@ func TestReconcile(t *testing.T) {
 			},
 			WantPresent: []runtime.Object{
 				makeChannelWithSubscribersAndFinalizer(),
+			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
 			},
 		},
 		{
@@ -304,6 +332,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeChannelWithSubscribersAndFinalizer(),
 			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
 		},
 		{
 			Name: "Delete all old Subscriptions",
@@ -326,6 +357,9 @@ func TestReconcile(t *testing.T) {
 			WantPresent: []runtime.Object{
 				makeChannelWithFinalizer(),
 			},
+			WantEvent: []corev1.Event{
+				events[channelReconciled],
+			},
 		},
 		{
 			Name: "Channel update fails",
@@ -337,6 +371,9 @@ func TestReconcile(t *testing.T) {
 				MockUpdates: errorUpdatingChannel(),
 			},
 			WantErrMsg: testErrorMessage,
+			WantEvent: []corev1.Event{
+				events[channelReconciled], events[channelUpdateStatusFailed],
+			},
 		},
 		// Note - we do not test update status since this dispatcher only adds
 		// finalizers to the channel


### PR DESCRIPTION
Contributes to fix #724 

## Proposed Changes

- Adding corev1.Events to GCP PubSub channel in order to make debugging easier.
- Adding verbs to create/update/patch events to the gcppubsub default configuration
- Here is the list of the events emitted:

### Channel Controller

Name | Type | Description
-- | -- | --
ChannelReadStatusFailed | Warning | When there was an error trying to get the internal status of the channel. Includes the go error string.
SubscriptionSyncFailed | Warning | When the Channel's subscription couldn't be synced. Includes the go error string.
SubscriptionDeleteFailed | Warning | When the old Channel's subscriptions couldn't be deleted. Includes the go error string.
GcpCredentialsReadFailed | Warning | When the GCP credentials couldn't be generated. Includes the go error string.
GcpResourcesPlanFailed | Warning | When there was an error creating a plan of reconciliation for the GCP resources. Includes the go error string.
GcpResourcesPersistFailed | Warning | When there was an error trying to persist the planned resources. Includes the go error string.
TopicCreateFailed | Warning | When there was an error reconciling the topic for the channel. Includes the go error string.
TopicDeleteFailed | Warning | When there was an error deleting the old topic for the channel. Includes the go error string.
K8sServiceCreateFailed | Warning | When the K8s Service couldn't be created. Includes the go error string.
VirtualServiceCreateFailed | Warning | When the Virtual Service couldn't be created. Includes the go error string.
ChannelUpdateStatusFailed | Warning | When the Channel's status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
ChannelReconciled | Normal | When the Channel's reconciliation process succeeds. This is the "Success" event. Includes the channel name.

### ClusterChannelProvisioner Controller

Name | Type | Description
-- | -- | --
CcpReconcileFailed | Warning | When there was a problem reconciling the CCP. Includes the go error string.
CcpUpdateStatusFailed | Warning | When the CCP's status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
CcpReconciled | Normal | When the CCP's reconciliation process succeeds. This is the "Success" event. Includes the CCP name.

### Dispatcher Controller

Name | Type | Description
-- | -- | --
DispatcherReconcileFailed | Warning | When there was a problem reconciling the dispatcher. Includes the go error string.
DispatcherUpdateStatusFailed | Warning | When the channel's dispatcher status couldn't be updated. It can happen even if the reconciliation process was successful. Includes the go error string.
DispatcherReconciled | Normal | When the dispatcher reconciliation process succeeds. This is the "Success" event. Includes the channel name.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
GCP PubSub channel has detailed information when errors occur.

```
