### PR TITLE
Clean up unit tests to use actual domain name

### DIFF
--- a/contrib/gcppubsub/pkg/controller/channel/reconcile_test.go
+++ b/contrib/gcppubsub/pkg/controller/channel/reconcile_test.go
@@ -35,8 +35,9 @@ import (
 	"github.com/knative/eventing/contrib/gcppubsub/pkg/util/fakepubsub"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	util "github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
+	"github.com/knative/eventing/pkg/utils"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -737,7 +738,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 
 func makeChannelWithFinalizerAndPCSAndAddress() *eventingv1alpha1.Channel {
 	c := makeChannelWithFinalizerAndPCS()
-	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.cluster.local", c.Name, c.Namespace))
+	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.%s", c.Name, c.Namespace, utils.GetClusterDomainName()))
 	return c
 }
 
@@ -1004,16 +1005,16 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 		},
 		Spec: istiov1alpha3.VirtualServiceSpec{
 			Hosts: []string{
-				fmt.Sprintf("%s-channel.%s.svc.cluster.local", cName, cNamespace),
-				fmt.Sprintf("%s.%s.channels.cluster.local", cName, cNamespace),
+				fmt.Sprintf("%s-channel.%s.svc.%s", cName, cNamespace, utils.GetClusterDomainName()),
+				fmt.Sprintf("%s.%s.channels.%s", cName, cNamespace, utils.GetClusterDomainName()),
 			},
 			Http: []istiov1alpha3.HTTPRoute{{
 				Rewrite: &istiov1alpha3.HTTPRewrite{
-					Authority: fmt.Sprintf("%s.%s.channels.cluster.local", cName, cNamespace),
+					Authority: fmt.Sprintf("%s.%s.channels.%s", cName, cNamespace, utils.GetClusterDomainName()),
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "in-memory-channel-clusterbus.knative-eventing.svc.cluster.local",
+						Host: "in-memory-channel-clusterbus.knative-eventing.svc." + utils.GetClusterDomainName(),
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
+++ b/contrib/gcppubsub/pkg/dispatcher/dispatcher/reconcile_test.go
@@ -36,9 +36,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
-
 	"github.com/knative/eventing/contrib/gcppubsub/pkg/util/testcreds"
+	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
+	"github.com/knative/eventing/pkg/utils"
 
 	"github.com/knative/eventing/contrib/gcppubsub/pkg/util/fakepubsub"
 
@@ -486,7 +486,7 @@ func makeChannel() *eventingv1alpha1.Channel {
 		},
 	}
 	c.Status.InitializeConditions()
-	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.cluster.local", c.Name, c.Namespace))
+	c.Status.SetAddress(fmt.Sprintf("%s-channel.%s.svc.%s", c.Name, c.Namespace, utils.GetClusterDomainName()))
 	c.Status.MarkProvisioned()
 	pcs := &util.GcpPubSubChannelStatus{
 		GCPProject: gcpProject,

--- a/contrib/gcppubsub/pkg/dispatcher/receiver/receiver_test.go
+++ b/contrib/gcppubsub/pkg/dispatcher/receiver/receiver_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/knative/eventing/contrib/gcppubsub/pkg/util/fakepubsub"
+	"github.com/knative/eventing/pkg/utils"
 	"go.uber.org/zap"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +135,7 @@ func TestReceiver(t *testing.T) {
 				fakepubsub.Creator(tc.pubSubData))
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest("POST", "/", strings.NewReader(validMessage))
-			req.Host = "test-channel.test-namespace.channels.cluster.local"
+			req.Host = "test-channel.test-namespace.channels." + utils.GetClusterDomainName()
 			mr.newMessageReceiver().HandleRequest(resp, req)
 			if tc.expectedErr {
 				if resp.Result().StatusCode >= 200 && resp.Result().StatusCode < 300 {

--- a/contrib/kafka/pkg/controller/channel/reconcile_test.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile_test.go
@@ -28,9 +28,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/eventing/contrib/kafka/pkg/controller"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/provisioners"
 	util "github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
+	"github.com/knative/eventing/pkg/utils"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +57,7 @@ var (
 
 	// serviceAddress is the address of the K8s Service. It uses a GeneratedName and the fake client
 	// does not fill in Name, so the name is the empty string.
-	serviceAddress = fmt.Sprintf("%s.%s.svc.cluster.local", "", testNS)
+	serviceAddress = fmt.Sprintf("%s.%s.svc.%s", "", testNS, utils.GetClusterDomainName())
 )
 
 func init() {
@@ -529,15 +530,15 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 		Spec: istiov1alpha3.VirtualServiceSpec{
 			Hosts: []string{
 				serviceAddress,
-				fmt.Sprintf("%s.%s.channels.cluster.local", channelName, testNS),
+				fmt.Sprintf("%s.%s.channels.%s", channelName, testNS, utils.GetClusterDomainName()),
 			},
 			Http: []istiov1alpha3.HTTPRoute{{
 				Rewrite: &istiov1alpha3.HTTPRewrite{
-					Authority: fmt.Sprintf("%s.%s.channels.cluster.local", channelName, testNS),
+					Authority: fmt.Sprintf("%s.%s.channels.%s", channelName, testNS, utils.GetClusterDomainName()),
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "kafka-provisioner.knative-eventing.svc.cluster.local",
+						Host: "kafka-provisioner.knative-eventing.svc." + utils.GetClusterDomainName(),
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/contrib/natss/pkg/controller/channel/reconcile_test.go
+++ b/contrib/natss/pkg/controller/channel/reconcile_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/provisioners"
 	util "github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
+	"github.com/knative/eventing/pkg/utils"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ var (
 
 	// serviceAddress is the address of the K8s Service. It uses a GeneratedName and the fake client
 	// does not fill in Name, so the name is the empty string.
-	serviceAddress = fmt.Sprintf("%s.%s.svc.cluster.local", "", testNS)
+	serviceAddress = fmt.Sprintf("%s.%s.svc.%s", "", testNS, utils.GetClusterDomainName())
 )
 
 func init() {
@@ -239,15 +240,15 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 		Spec: istiov1alpha3.VirtualServiceSpec{
 			Hosts: []string{
 				serviceAddress,
-				fmt.Sprintf("%s.%s.channels.cluster.local", channelName, testNS),
+				fmt.Sprintf("%s.%s.channels.%s", channelName, testNS, utils.GetClusterDomainName()),
 			},
 			Http: []istiov1alpha3.HTTPRoute{{
 				Rewrite: &istiov1alpha3.HTTPRewrite{
-					Authority: fmt.Sprintf("%s.%s.channels.cluster.local", channelName, testNS),
+					Authority: fmt.Sprintf("%s.%s.channels.%s", channelName, testNS, utils.GetClusterDomainName()),
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "kafka-provisioner.knative-eventing.svc.cluster.local",
+						Host: "kafka-provisioner.knative-eventing.svc." + utils.GetClusterDomainName(),
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/pkg/provisioners/inmemory/channel/reconcile_test.go
+++ b/pkg/provisioners/inmemory/channel/reconcile_test.go
@@ -26,11 +26,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	util "github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/sidecar/configmap"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
+	"github.com/knative/eventing/pkg/utils"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ var (
 
 	// serviceAddress is the address of the K8s Service. It uses a GeneratedName and the fake client
 	// does not fill in Name, so the name is the empty string.
-	serviceAddress = fmt.Sprintf("%s.%s.svc.cluster.local", "", cNamespace)
+	serviceAddress = fmt.Sprintf("%s.%s.svc.%s", "", cNamespace, utils.GetClusterDomainName())
 
 	// channelsConfig and channels are linked together. A change to one, will likely require a
 	// change to the other. channelsConfig is the serialized config of channels for everything
@@ -740,15 +741,15 @@ func makeVirtualService() *istiov1alpha3.VirtualService {
 		Spec: istiov1alpha3.VirtualServiceSpec{
 			Hosts: []string{
 				serviceAddress,
-				fmt.Sprintf("%s.%s.channels.cluster.local", cName, cNamespace),
+				fmt.Sprintf("%s.%s.channels.%s", cName, cNamespace, utils.GetClusterDomainName()),
 			},
 			Http: []istiov1alpha3.HTTPRoute{{
 				Rewrite: &istiov1alpha3.HTTPRewrite{
-					Authority: fmt.Sprintf("%s.%s.channels.cluster.local", cName, cNamespace),
+					Authority: fmt.Sprintf("%s.%s.channels.%s", cName, cNamespace, utils.GetClusterDomainName()),
 				},
 				Route: []istiov1alpha3.DestinationWeight{{
 					Destination: istiov1alpha3.Destination{
-						Host: "in-memory-channel-dispatcher.knative-eventing.svc.cluster.local",
+						Host: "in-memory-channel-dispatcher.knative-eventing.svc." + utils.GetClusterDomainName(),
 						Port: istiov1alpha3.PortSelector{
 							Number: util.PortNumber,
 						},

--- a/pkg/provisioners/message_receiver_test.go
+++ b/pkg/provisioners/message_receiver_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/knative/eventing/pkg/utils"
 
 	"go.uber.org/zap"
 )
@@ -83,7 +84,7 @@ func TestMessageReceiver_HandleRequest(t *testing.T) {
 				"x-ot-pass":                 {"true"},
 			},
 			body: "message-body",
-			host: "test-name.test-namespace.svc.cluster.local",
+			host: "test-name.test-namespace.svc." + utils.GetClusterDomainName(),
 			receiverFunc: func(r ChannelReference, m *Message) error {
 				if r.Namespace != "test-namespace" || r.Name != "test-name" {
 					return fmt.Errorf("test receiver func -- bad reference: %v", r)
@@ -100,7 +101,7 @@ func TestMessageReceiver_HandleRequest(t *testing.T) {
 					"cE-pass-through":           "true",
 					"x-B3-pass":                 "true",
 					"x-ot-pass":                 "true",
-					"ce-knativehistory":         "test-name.test-namespace.svc.cluster.local",
+					"ce-knativehistory":         "test-name.test-namespace.svc." + utils.GetClusterDomainName(),
 				}
 				if diff := cmp.Diff(expectedHeaders, m.Headers); diff != "" {
 					return fmt.Errorf("test receiver func -- bad headers (-want, +got): %s", diff)
@@ -120,7 +121,7 @@ func TestMessageReceiver_HandleRequest(t *testing.T) {
 				tc.path = "/"
 			}
 			if tc.host == "" {
-				tc.host = "test-channel.test-namespace.svc.cluster.local"
+				tc.host = "test-channel.test-namespace.svc." + utils.GetClusterDomainName()
 			}
 
 			f := tc.receiverFunc

--- a/pkg/reconciler/names/names_test.go
+++ b/pkg/reconciler/names/names_test.go
@@ -17,6 +17,7 @@
 package names
 
 import (
+	"github.com/knative/eventing/pkg/utils"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestNames(t *testing.T) {
 		F: func() string {
 			return ServiceHostName("foo", "namespace")
 		},
-		Want: "foo.namespace.svc.cluster.local",
+		Want: "foo.namespace.svc." + utils.GetClusterDomainName(),
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/reconciler/v1alpha1/subscription/subscription_test.go
+++ b/pkg/reconciler/v1alpha1/subscription/subscription_test.go
@@ -23,6 +23,7 @@ import (
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
+	"github.com/knative/eventing/pkg/utils"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,22 +54,25 @@ var (
 )
 
 const (
-	fromChannelName     = "fromchannel"
-	resultChannelName   = "resultchannel"
-	sourceName          = "source"
-	routeName           = "subscriberroute"
-	channelKind         = "Channel"
-	routeKind           = "Route"
-	sourceKind          = "Source"
-	subscriptionKind    = "Subscription"
-	targetDNS           = "myfunction.mynamespace.svc.cluster.local"
-	sinkableDNS         = "myresultchannel.mynamespace.svc.cluster.local"
-	eventType           = "myeventtype"
-	subscriptionName    = "testsubscription"
-	testNS              = "testnamespace"
-	k8sServiceName      = "testk8sservice"
-	k8sServiceDNS       = "testk8sservice.testnamespace.svc.cluster.local"
-	otherAddressableDNS = "other-sinkable-channel.mynamespace.svc.cluster.local"
+	fromChannelName   = "fromchannel"
+	resultChannelName = "resultchannel"
+	sourceName        = "source"
+	routeName         = "subscriberroute"
+	channelKind       = "Channel"
+	routeKind         = "Route"
+	sourceKind        = "Source"
+	subscriptionKind  = "Subscription"
+	eventType         = "myeventtype"
+	subscriptionName  = "testsubscription"
+	testNS            = "testnamespace"
+	k8sServiceName    = "testk8sservice"
+)
+
+var (
+	targetDNS           = "myfunction.mynamespace.svc." + utils.GetClusterDomainName()
+	sinkableDNS         = "myresultchannel.mynamespace.svc." + utils.GetClusterDomainName()
+	k8sServiceDNS       = "testk8sservice.testnamespace.svc." + utils.GetClusterDomainName()
+	otherAddressableDNS = "other-sinkable-channel.mynamespace.svc." + utils.GetClusterDomainName()
 )
 
 func init() {

--- a/pkg/sidecar/configmap/filesystem/filesystem_watcher_test.go
+++ b/pkg/sidecar/configmap/filesystem/filesystem_watcher_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/knative/eventing/pkg/sidecar/configmap"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
+	"github.com/knative/eventing/pkg/utils"
 	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -83,21 +84,20 @@ func TestReadConfigMap(t *testing.T) {
 					name: c1
 					fanoutConfig:
 					  subscriptions:
-						- subscriberURI: event-changer.default.svc.cluster.local
-						  replyURI: message-dumper-bar.default.svc.cluster.local
-						- subscriberURI: message-dumper-foo.default.svc.cluster.local
-						- replyURI: message-dumper-bar.default.svc.cluster.local
+						- subscriberURI: event-changer.default.svc.` + utils.GetClusterDomainName() + `
+						  replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
+						- subscriberURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
+						- replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: default
 					name: c2
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: other
 					name: c3
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
-				`,
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName(),
 			expected: &multichannelfanout.Config{
 				ChannelConfigs: []multichannelfanout.ChannelConfig{
 					{
@@ -106,14 +106,14 @@ func TestReadConfigMap(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									SubscriberURI: "event-changer.default.svc.cluster.local",
-									ReplyURI:      "message-dumper-bar.default.svc.cluster.local",
+									SubscriberURI: "event-changer.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI:      "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									SubscriberURI: "message-dumper-foo.default.svc.cluster.local",
+									SubscriberURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									ReplyURI: "message-dumper-bar.default.svc.cluster.local",
+									ReplyURI: "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -124,7 +124,7 @@ func TestReadConfigMap(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -135,7 +135,7 @@ func TestReadConfigMap(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},

--- a/pkg/sidecar/configmap/parse_test.go
+++ b/pkg/sidecar/configmap/parse_test.go
@@ -24,6 +24,7 @@ import (
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"
+	"github.com/knative/eventing/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -65,21 +66,20 @@ func TestNewFanoutConfig(t *testing.T) {
 					name: c1
 					fanoutConfig:
 					  subscriptions:
-						- subscriberURI: event-changer.default.svc.cluster.local
-						  replyURI: message-dumper-bar.default.svc.cluster.local
-						- subscriberURI: message-dumper-foo.default.svc.cluster.local
-						- replyURI: message-dumper-bar.default.svc.cluster.local
+						- subscriberURI: event-changer.default.svc.` + utils.GetClusterDomainName() + `
+						  replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
+						- subscriberURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
+						- replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: default
 					name: c2
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: other
 					name: c3
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
-				`,
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName(),
 			expected: &multichannelfanout.Config{
 				ChannelConfigs: []multichannelfanout.ChannelConfig{
 					{
@@ -88,14 +88,14 @@ func TestNewFanoutConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									SubscriberURI: "event-changer.default.svc.cluster.local",
-									ReplyURI:      "message-dumper-bar.default.svc.cluster.local",
+									SubscriberURI: "event-changer.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI:      "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									SubscriberURI: "message-dumper-foo.default.svc.cluster.local",
+									SubscriberURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									ReplyURI: "message-dumper-bar.default.svc.cluster.local",
+									ReplyURI: "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -106,7 +106,7 @@ func TestNewFanoutConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -117,7 +117,7 @@ func TestNewFanoutConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},

--- a/pkg/sidecar/multichannelfanout/parse_test.go
+++ b/pkg/sidecar/multichannelfanout/parse_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
+	"github.com/knative/eventing/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -64,21 +65,21 @@ func TestConfigMapData(t *testing.T) {
 					name: c1
 					fanoutConfig:
 					  subscriptions:
-						- subscriberURI: event-changer.default.svc.cluster.local
-						  replyURI: message-dumper-bar.default.svc.cluster.local
-						- subscriberURI: message-dumper-foo.default.svc.cluster.local
-						- replyURI: message-dumper-bar.default.svc.cluster.local
+						- subscriberURI: event-changer.default.svc.` + utils.GetClusterDomainName() + `
+						  replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
+						- subscriberURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
+						- replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: default
 					name: c2
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: other
 					name: c3
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.cluster.local
-				`,
+						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName(),
+
 			expected: &Config{
 				ChannelConfigs: []ChannelConfig{
 					{
@@ -87,14 +88,14 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									SubscriberURI: "event-changer.default.svc.cluster.local",
-									ReplyURI:      "message-dumper-bar.default.svc.cluster.local",
+									SubscriberURI: "event-changer.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI:      "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									SubscriberURI: "message-dumper-foo.default.svc.cluster.local",
+									SubscriberURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 								{
-									ReplyURI: "message-dumper-bar.default.svc.cluster.local",
+									ReplyURI: "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -105,7 +106,7 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},
@@ -116,7 +117,7 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc.cluster.local",
+									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
 								},
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Some unit tests were using hard coded `cluster.local` domain name, this PR switches them to use `utils.GetClusterDomainName() instead`

```release-note
None
```
