### PR TITLE
Use new test image names in E2E tests

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path"
 
 	pkgTest "github.com/knative/pkg/test"
 	"github.com/knative/pkg/test/logging"
@@ -41,13 +40,12 @@ type EventingEnvironmentFlags struct {
 func initializeEventingFlags() *EventingEnvironmentFlags {
 	var f EventingEnvironmentFlags
 
-	repo := os.Getenv("DOCKER_REPO_OVERRIDE")
+	defaultRepo := os.Getenv("DOCKER_REPO_OVERRIDE")
 
-	if repo == "" {
-		repo = os.Getenv("KO_DOCKER_REPO")
+	if defaultRepo == "" {
+		defaultRepo = os.Getenv("KO_DOCKER_REPO")
 	}
 
-	defaultRepo := path.Join(repo, "github.com/knative/eventing/test/test_images")
 	flag.StringVar(&f.DockerRepo, "dockerrepo", defaultRepo,
 		"Provide the uri of the docker repo you have uploaded the test image to using `uploadtestimage.sh`. Defaults to $DOCKER_REPO_OVERRIDE")
 


### PR DESCRIPTION
PR #725 removed paths from test image names, but the e2e tests were still generating image URLs using the previous longer paths. This updates them to be consistent.

Tests might still have passed if the older images were still compatible, but I doubt they got the most recent builds.

## Proposed Changes

- Update test image URLs used in E2E tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @zxDiscovery 
