### PR TITLE
Adding verbs to emit corev1.Events to gcp-pubsub dispatcher.

### DIFF
--- a/contrib/gcppubsub/config/gcppubsub.yaml
+++ b/contrib/gcppubsub/config/gcppubsub.yaml
@@ -161,6 +161,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 
 ---
 


### PR DESCRIPTION
## Proposed Changes

- Adding create/update/patch verbs to emit v1 events.
- This was a bug introduced with a previous [PR](https://github.com/knative/eventing/pull/795)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
