### PR TITLE
update deps:test-infra for fixing release.yaml not found error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -399,14 +399,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a8e2ce2f9c6b771c66a527bdd26ade610ab07310519236426e319ec8a647f143"
+  digest = "1:ccd1d4f72ea906f07c82a7cbba2a312505929469d261ff4c4b3de26ea9f3091b"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "31319e986ac00fd10c15ad0608131b35dafb62bb"
+  revision = "9c32cdca8409302f34530da1e3fee02e4bac912d"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/vendor/github.com/knative/test-infra/scripts/library.sh
+++ b/vendor/github.com/knative/test-infra/scripts/library.sh
@@ -27,7 +27,7 @@ readonly KNATIVE_BASE_YAML_SOURCE=https://storage.googleapis.com/knative-nightly
 readonly KNATIVE_ISTIO_CRD_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml
 readonly KNATIVE_ISTIO_YAML=${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml
 readonly KNATIVE_SERVING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/serving}/serving.yaml
-readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/release.yaml
+readonly KNATIVE_BUILD_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/build}/build.yaml
 readonly KNATIVE_EVENTING_RELEASE=${KNATIVE_BASE_YAML_SOURCE/@/eventing}/release.yaml
 
 # Conveniently set GOPATH if unset


### PR DESCRIPTION
continous and presubmit tests are failing due to release/yaml not found error, this is fixed in test-infra repo, update it here

Fixes #804 