### PR TITLE
Opt knative-eventing into Istio injection 

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -15,3 +15,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-eventing
+  labels:
+    istio-injection: enabled


### PR DESCRIPTION
## Proposed Changes

- Opt `knative-eventing` into Istio injection (for those whose Istio is defaulted to opt-out).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
