### PR TITLE
Upgrade `knative/pkg` to latest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -351,7 +351,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:9e87cc32eebacc20127e352edabb39625a3f82473b6b1b1b3333627f3cf37f97"
+  digest = "1:0b42caffe8c483db591a13446081a03025ff391c7895c50955125844c0574ea7"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -375,7 +375,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "d3a9e54be7d4213b4018135d82b586de45f6a694"
+  revision = "1982208dd91a4cc4fea9612e4e72fb109c77ab22"
 
 [[projects]]
   digest = "1:9a3d5c1186e9299dc3c3b9f28c3521abdf6abf0834f8ddd169ab005762097378"
@@ -541,6 +541,14 @@
   pruneopts = "NUT"
   revision = "635575b42742856941dbc767b44905bb9ba083f6"
   version = "v2.0.7"
+
+[[projects]]
+  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:7c7cfeecd2b7147bcfec48a4bf622b4879e26aec145a9e373ce51d0c23b16f6b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,12 @@ required = [
   name = "golang.org/x/oauth2"
   revision = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
 
-# TODO why is this overridden?
+# Deliberately upgrade knative/pkg -- this is not versioned per se, and
+# we don't want to constantly fetch the latest during other changes.
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-01-16
-  revision = "d3a9e54be7d4213b4018135d82b586de45f6a694"
+  # HEAD as of 2019-02-12
+  revision = "1982208dd91a4cc4fea9612e4e72fb109c77ab22"
 
 [[constraint]]
   name = "github.com/knative/serving"

--- a/test/test_images/logevents/main.go
+++ b/test/test_images/logevents/main.go
@@ -28,7 +28,7 @@ type Heartbeat struct {
 }
 
 func handler(ctx context.Context, data map[string]interface{}) {
-	metadata := cloudevents.FromContext(ctx)
+	metadata := cloudevents.FromContext(ctx).AsV01()
 	log.Printf("[%s] %s %s: %+v", metadata.EventTime.Format(time.RFC3339), metadata.ContentType, metadata.Source, data)
 }
 

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -4220,6 +4220,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
+Import: github.com/knative/eventing/vendor/github.com/pkg/errors
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+===========================================================
 Import: github.com/knative/eventing/vendor/github.com/prometheus/client_golang
 
                                  Apache License

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/condition_set.go
@@ -280,7 +280,7 @@ func (r conditionsImpl) MarkUnknown(t ConditionType, reason, messageFormat strin
 			// Double check that the happy condition is also false.
 			happy := r.GetCondition(r.happy)
 			if !happy.IsFalse() {
-				r.MarkFalse(r.happy, reason, messageFormat, messageA)
+				r.MarkFalse(r.happy, reason, messageFormat, messageA...)
 			}
 			return
 		}
@@ -324,9 +324,10 @@ func (r conditionsImpl) MarkFalse(t ConditionType, reason, messageFormat string,
 // InitializeConditions updates all Conditions in the ConditionSet to Unknown
 // if not set.
 func (r conditionsImpl) InitializeConditions() {
-	for _, t := range append(r.dependents, r.happy) {
+	for _, t := range r.dependents {
 		r.InitializeCondition(t)
 	}
+	r.InitializeCondition(r.happy)
 }
 
 // InitializeCondition updates a Condition to Unknown if not set.

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -47,8 +47,10 @@ type ConditionSeverity string
 
 const (
 	// ConditionSeverityError specifies that a failure of a condition type
-	// should be viewed as an error.
-	ConditionSeverityError ConditionSeverity = "Error"
+	// should be viewed as an error.  As "Error" is the default for conditions
+	// we use the empty string (coupled with omitempty) to avoid confusion in
+	// the case where the condition is in state "True" (aka nothing is wrong).
+	ConditionSeverityError ConditionSeverity = ""
 	// ConditionSeverityWarning specifies that a failure of a condition type
 	// should be viewed as a warning, but that things could still work.
 	ConditionSeverityWarning ConditionSeverity = "Warning"

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -192,7 +192,7 @@ func asKey(key string) string {
 //   err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
 //   err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
 //   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
-//   err(bar).ViaIndex(0).ViaIndex[1].ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
+//   err(bar).ViaIndex(0).ViaIndex(1).ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
 func flatten(path []string) string {
 	var newPath []string
 	for _, part := range path {
@@ -298,6 +298,12 @@ func ErrDisallowedFields(fieldPaths ...string) *FieldError {
 		Message: "must not set the field(s)",
 		Paths:   fieldPaths,
 	}
+}
+
+// ErrInvalidArrayValue consturcts a FieldError for a repetetive `field`
+// at `index` that has received an invalid string value.
+func ErrInvalidArrayValue(value, field string, index int) *FieldError {
+	return ErrInvalidValue(value, CurrentField).ViaFieldIndex(field, index)
 }
 
 // ErrInvalidValue constructs a FieldError for a field that has received an

--- a/vendor/github.com/knative/pkg/apis/interfaces.go
+++ b/vendor/github.com/knative/pkg/apis/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apis
 
 import (
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,4 +47,9 @@ type Listable interface {
 	runtime.Object
 
 	GetListType() runtime.Object
+}
+
+// Annotatable indicates that a particular type applies various annotations.
+type Annotatable interface {
+	AnnotateUserInfo(previous Annotatable, ui *authenticationv1.UserInfo)
 }

--- a/vendor/github.com/knative/pkg/apis/istio/common/v1alpha1/string.go
+++ b/vendor/github.com/knative/pkg/apis/istio/common/v1alpha1/string.go
@@ -28,7 +28,7 @@ type StringMatch struct {
 	Prefix string `json:"prefix,omitempty"`
 
 	// suffix-based match.
-	Suffix string `json:"prefix,omitempty"`
+	Suffix string `json:"suffix,omitempty"`
 
 	// ECMAscript style regex-based match
 	Regex string `json:"regex,omitempty"`

--- a/vendor/github.com/knative/pkg/apis/istio/v1alpha3/destinationrule_types.go
+++ b/vendor/github.com/knative/pkg/apis/istio/v1alpha3/destinationrule_types.go
@@ -206,7 +206,7 @@ type PortTrafficPolicy struct {
 type Subset struct {
 	// REQUIRED. Name of the subset. The service name and the subset name can
 	// be used for traffic splitting in a route rule.
-	Name string `json:"port"`
+	Name string `json:"name"`
 
 	// REQUIRED. Labels apply a filter over the endpoints of a service in the
 	// service registry. See route rules for examples of usage.

--- a/vendor/github.com/knative/pkg/cloudevents/builder.go
+++ b/vendor/github.com/knative/pkg/cloudevents/builder.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CloudEventEncoding is used to tell the builder which encoding to select.
+// the default is Binary.
+type CloudEventEncoding int
+
+const (
+	// Binary v0.1
+	BinaryV01 CloudEventEncoding = iota
+	// Structured v0.1
+	StructuredV01
+)
+
+// Builder holds settings that do not change over CloudEvents. It is intended
+// to represent a builder of only a single CloudEvent type.
+type Builder struct {
+	// A URI describing the event producer.
+	Source string
+	// Type of occurrence which has happened.
+	EventType string
+	// The version of the `eventType`; this is producer-specific.
+	EventTypeVersion string
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string
+	// Additional metadata without a well-defined structure.
+	Extensions map[string]interface{}
+
+	// Encoding specifies the requested output encoding of the CloudEvent.
+	Encoding CloudEventEncoding
+}
+
+// Build produces a http request with the constant data embedded in the builder
+// merged with the new data provided in the build function. The request will
+// send a pre-assembled cloud event to the given target. The target is assumed
+// to be a URL with a scheme, ie: "http://localhost:8080"
+func (b *Builder) Build(target string, data interface{}, overrides ...SendContext) (*http.Request, error) {
+	if len(overrides) > 1 {
+		return nil, fmt.Errorf("Build was called with more than one override")
+	}
+
+	var overridesV01 *V01EventContext
+	if len(overrides) == 1 {
+		switch t := overrides[0].(type) {
+		case V01EventContext:
+			o := overrides[0].(V01EventContext)
+			overridesV01 = &o
+		default:
+			return nil, fmt.Errorf("Build was called with unknown override type %v", t)
+		}
+	}
+	// TODO: when V02 is supported this will have to shuffle a little.
+	ctx := b.cloudEventsContextV01(overridesV01)
+
+	if ctx.Source == "" {
+		return nil, fmt.Errorf("ctx.Source resolved empty")
+	}
+	if ctx.EventType == "" {
+		return nil, fmt.Errorf("ctx.EventType resolved empty")
+	}
+
+	switch b.Encoding {
+	case BinaryV01:
+		return Binary.NewRequest(target, data, ctx)
+	case StructuredV01:
+		return Structured.NewRequest(target, data, ctx)
+	default:
+		return nil, fmt.Errorf("unsupported encoding: %v", b.Encoding)
+	}
+}
+
+// cloudEventsContext creates a CloudEvent context object, assumes
+// application/json as the content type.
+func (b *Builder) cloudEventsContextV01(overrides *V01EventContext) V01EventContext {
+	ctx := V01EventContext{
+		CloudEventsVersion: CloudEventsVersion,
+		EventType:          b.EventType,
+		EventID:            uuid.New().String(),
+		EventTypeVersion:   b.EventTypeVersion,
+		SchemaURL:          b.SchemaURL,
+		Source:             b.Source,
+		ContentType:        "application/json",
+		EventTime:          time.Now(),
+		Extensions:         b.Extensions,
+	}
+	if overrides != nil {
+		if overrides.Source != "" {
+			ctx.Source = overrides.Source
+		}
+		if overrides.EventID != "" {
+			ctx.EventID = overrides.EventID
+		}
+		if overrides.EventType != "" {
+			ctx.EventType = overrides.EventType
+		}
+		if !overrides.EventTime.IsZero() {
+			ctx.EventTime = overrides.EventTime
+		}
+		if overrides.ContentType != "" {
+			ctx.ContentType = overrides.ContentType
+		}
+		if len(overrides.Extensions) > 0 {
+			if ctx.Extensions == nil {
+				ctx.Extensions = make(map[string]interface{})
+			}
+			for k, v := range overrides.Extensions {
+				ctx.Extensions[k] = v
+			}
+		}
+	}
+	return ctx
+}

--- a/vendor/github.com/knative/pkg/cloudevents/client.go
+++ b/vendor/github.com/knative/pkg/cloudevents/client.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// Client wraps Builder, and is intended to be configured for a single event
+// type and target
+type Client struct {
+	builder Builder
+	Target  string
+}
+
+// NewClient returns a CloudEvent Client used to send CloudEvents. It is
+// intended that a user would create a new client for each tuple of eventType
+// and target. This is an optional helper method to avoid the tricky creation
+// of the embedded Builder struct.
+func NewClient(target string, builder Builder) *Client {
+	c := &Client{
+		builder: builder,
+		Target:  target,
+	}
+	return c
+}
+
+// Send creates a request based on the client's settings and sends the data
+// struct to the target set for this client. It returns error if there was an
+// issue sending the event, otherwise nil means the event was accepted.
+func (c *Client) Send(data interface{}, overrides ...SendContext) error {
+	req, err := c.builder.Build(c.Target, data, overrides...)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if accepted(resp) {
+		return nil
+	}
+	return fmt.Errorf("error sending cloudevent: %s", status(resp))
+}
+
+// accepted is a helper method to understand if the response from the target
+// accepted the CloudEvent.
+func accepted(resp *http.Response) bool {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true
+	}
+	return false
+}
+
+// status is a helper method to read the response of the target.
+func status(resp *http.Response) string {
+	status := resp.Status
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Sprintf("Status[%s] error reading response body: %v", status, err)
+	}
+	return fmt.Sprintf("Status[%s] %s", status, body)
+}

--- a/vendor/github.com/knative/pkg/cloudevents/doc.go
+++ b/vendor/github.com/knative/pkg/cloudevents/doc.go
@@ -19,5 +19,4 @@ limitations under the License.
 // https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md
 // and
 // https://github.com/cloudevents/spec/blob/v0.1/spec.md
-
 package cloudevents

--- a/vendor/github.com/knative/pkg/cloudevents/encoding_structured.go
+++ b/vendor/github.com/knative/pkg/cloudevents/encoding_structured.go
@@ -34,73 +34,100 @@ const (
 
 type structured int
 
-type structuredEnvelope struct {
-	EventContext
-	RawData json.RawMessage `json:"data"`
+// StructuredSender implements an interface for translating an EventContext
+// (possibly one of severals versions) to a structured encoding HTTP request.
+type StructuredSender interface {
+	// AsJSON encodes the object into a map from string to JSON data, which
+	// allows additional keys to be encoded later.
+	AsJSON() (map[string]json.RawMessage, error)
+}
+
+// StructuredLoader implements an interface for translating a structured
+// encoding HTTP request or response to a an EventContext (possibly one of
+// several versions).
+type StructuredLoader interface {
+	// FromJSON assumes that the object has already been decoded into a raw map
+	// from string to json.RawMessage, because this is needed to extract the
+	// CloudEvents version.
+	FromJSON(map[string]json.RawMessage) error
 }
 
 // FromRequest parses a CloudEvent from structured content encoding.
-func (structured) FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
-	var e structuredEnvelope
-	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
+func (structured) FromRequest(data interface{}, r *http.Request) (LoadContext, error) {
+	raw := make(map[string]json.RawMessage)
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 		return nil, err
 	}
 
-	contentType := e.EventContext.ContentType
+	rawData := raw["data"]
+	delete(raw, "data")
+
+	var ec LoadContext
+	v := ""
+	if err := json.Unmarshal(raw["specversion"], &v); err == nil && v == V02CloudEventsVersion {
+		ec = &V02EventContext{}
+	} else if err := json.Unmarshal(raw["cloudEventsVersion"], &v); err == nil && v == V01CloudEventsVersion {
+		ec = &V01EventContext{}
+	} else {
+		return nil, fmt.Errorf("Could not determine Cloud Events version from payload: %q", data)
+	}
+
+	if err := ec.FromJSON(raw); err != nil {
+		return nil, err
+	}
+
+	contentType := ec.DataContentType()
 	if contentType == "" {
 		contentType = contentTypeJSON
 	}
 	var reader io.Reader
 	if !isJSONEncoding(contentType) {
 		var jsonDecoded string
-		if err := json.Unmarshal(e.RawData, &jsonDecoded); err != nil {
-			return nil, fmt.Errorf("Could not JSON decode %q value %q", contentType, string(e.RawData))
+		if err := json.Unmarshal(rawData, &jsonDecoded); err != nil {
+			return nil, fmt.Errorf("Could not JSON decode %q value %q", contentType, rawData)
 		}
 		reader = strings.NewReader(jsonDecoded)
 	} else {
-		reader = bytes.NewReader(e.RawData)
-	}
-	if e.EventContext.Extensions == nil {
-		e.EventContext.Extensions = make(map[string]interface{}, 0)
+		reader = bytes.NewReader(rawData)
 	}
 	if err := unmarshalEventData(contentType, reader, data); err != nil {
 		return nil, err
 	}
-	return &e.EventContext, nil
+	return ec, nil
 }
 
 // NewRequest creates an HTTP request for Structured content encoding.
-func (structured) NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+func (structured) NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := ensureRequiredFields(context); err != nil {
+	fields, err := context.AsJSON()
+	if err != nil {
 		return nil, err
 	}
 
-	contentType := context.ContentType
+	// TODO: remove this defaulting?
+	contentType := context.DataContentType()
 	if contentType == "" {
 		contentType = contentTypeJSON
 	}
-	e := structuredEnvelope{
-		EventContext: context,
-	}
+
 	dataBytes, err := marshalEventData(contentType, data)
 	if err != nil {
 		return nil, err
 	}
 	if isJSONEncoding(contentType) {
-		e.RawData = json.RawMessage(dataBytes)
+		fields["data"] = json.RawMessage(dataBytes)
 	} else {
-		e.RawData, err = json.Marshal(string(dataBytes))
+		fields["data"], err = json.Marshal(string(dataBytes))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	b, err := json.Marshal(e)
+	b, err := json.Marshal(fields)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/knative/pkg/cloudevents/event.go
+++ b/vendor/github.com/knative/pkg/cloudevents/event.go
@@ -24,14 +24,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"time"
 )
 
 const (
-	// CloudEventsVersion is the version of the CloudEvents spec targeted
-	// by this library.
-	CloudEventsVersion = "0.1"
-
 	// ContentTypeStructuredJSON is the content-type for "Structured" encoding
 	// where an event envelope is written in JSON and the body is arbitrary
 	// data which might be an alternate encoding.
@@ -48,43 +43,68 @@ const (
 	// HeaderContentType is the standard HTTP header "Content-Type"
 	HeaderContentType = "Content-Type"
 
-	// required attributes
-	fieldCloudEventsVersion = "CloudEventsVersion"
-	fieldEventID            = "EventID"
-	fieldEventType          = "EventType"
-	fieldSource             = "Source"
+	// CloudEventsVersion is a legacy alias of V01CloudEventsVersion, for compatibility.
+	CloudEventsVersion = V01CloudEventsVersion
 )
 
-// EventContext holds standard metadata about an event. See
-// https://github.com/cloudevents/spec/blob/v0.1/spec.md#context-attributes for
-// details on these fields.
-type EventContext struct {
-	// The version of the CloudEvents specification used by the event.
-	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
-	// ID of the event; must be non-empty and unique within the scope of the producer.
-	EventID string `json:"eventID"`
-	// Timestamp when the event happened.
-	EventTime time.Time `json:"eventTime,omitempty"`
-	// Type of occurrence which has happened.
-	EventType string `json:"eventType"`
-	// The version of the `eventType`; this is producer-specific.
-	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
-	// A link to the schema that the `data` attribute adheres to.
-	SchemaURL string `json:"schemaURL,omitempty"`
-	// A MIME (RFC 2046) string describing the media type of `data`.
-	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
-	ContentType string `json:"contentType,omitempty"`
-	// A URI describing the event producer.
-	Source string `json:"source"`
-	// Additional metadata without a well-defined structure.
-	Extensions map[string]interface{} `json:"extensions,omitempty"`
-}
+// EventContext is a legacy un-versioned alias, from when we thought that field names would stay the same.
+type EventContext = V01EventContext
 
 // HTTPMarshaller implements a scheme for decoding CloudEvents over HTTP.
 // Implementations are Binary, Structured, and Any
 type HTTPMarshaller interface {
-	FromRequest(data interface{}, r *http.Request) (*EventContext, error)
-	NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error)
+	FromRequest(data interface{}, r *http.Request) (LoadContext, error)
+	NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error)
+}
+
+// ContextTranslator provides a set of translation methods between the
+// different versions of the CloudEvents spec, which allows programs to
+// interoperate with different versions of the CloudEvents spec by
+// converting EventContexts to their preferred version.
+type ContextTranslator interface {
+	// AsV01 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
+	// from extensions as necessary.
+	AsV01() V01EventContext
+
+	// AsV02 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.2 field names, moving fields to or
+	// from extensions as necessary.
+	AsV02() V02EventContext
+
+	// DataContentType returns the MIME content type for encoding data, which is
+	// needed by both encoding and decoding.
+	DataContentType() string
+}
+
+// SendContext provides an interface for extracting information from an
+// EventContext (the set of non-data event attributes of a CloudEvent).
+type SendContext interface {
+	ContextTranslator
+
+	StructuredSender
+	BinarySender
+}
+
+// LoadContext provides an interface for extracting information from an
+// EventContext (the set of non-data event attributes of a CloudEvent).
+type LoadContext interface {
+	ContextTranslator
+
+	StructuredLoader
+	BinaryLoader
+}
+
+// ContextType is a unified interface for both sending and loading the
+// CloudEvent data across versions.
+type ContextType interface {
+	ContextTranslator
+
+	StructuredSender
+	BinarySender
+
+	StructuredLoader
+	BinaryLoader
 }
 
 func anyError(errs ...error) error {
@@ -94,13 +114,6 @@ func anyError(errs ...error) error {
 		}
 	}
 	return nil
-}
-
-func ensureRequiredFields(context EventContext) error {
-	return anyError(
-		require(fieldEventID, context.EventID),
-		require(fieldEventType, context.EventType),
-		require(fieldSource, context.Source))
 }
 
 func require(name string, value string) error {
@@ -169,7 +182,7 @@ func marshalEventData(encoding string, data interface{}) ([]byte, error) {
 }
 
 // FromRequest parses a CloudEvent from any known encoding.
-func FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
+func FromRequest(data interface{}, r *http.Request) (LoadContext, error) {
 	switch r.Header.Get(HeaderContentType) {
 	case ContentTypeStructuredJSON:
 		return Structured.FromRequest(data, r)
@@ -184,16 +197,16 @@ func FromRequest(data interface{}, r *http.Request) (*EventContext, error) {
 }
 
 // NewRequest craetes an HTTP request for Structured content encoding.
-func NewRequest(urlString string, data interface{}, context EventContext) (*http.Request, error) {
+func NewRequest(urlString string, data interface{}, context SendContext) (*http.Request, error) {
 	return Structured.NewRequest(urlString, data, context)
 }
 
-// Opaque key type used to store EventContexts in a context.Context
+// Opaque key type used to store V01EventContexts in a context.Context
 type contextKeyType struct{}
 
 var contextKey = contextKeyType{}
 
-// FromContext loads an EventContext from a normal context.Context
-func FromContext(ctx context.Context) *EventContext {
-	return ctx.Value(contextKey).(*EventContext)
+// FromContext loads an V01EventContext from a normal context.Context
+func FromContext(ctx context.Context) LoadContext {
+	return ctx.Value(contextKey).(LoadContext)
 }

--- a/vendor/github.com/knative/pkg/cloudevents/event_v01.go
+++ b/vendor/github.com/knative/pkg/cloudevents/event_v01.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// V01CloudEventsVersion is the version of the CloudEvents spec targeted
+	// by this library.
+	V01CloudEventsVersion = "0.1"
+
+	// v0.1 field names
+	fieldCloudEventsVersion = "CloudEventsVersion"
+	fieldEventID            = "EventID"
+	fieldEventType          = "EventType"
+)
+
+// V01EventContext holds standard metadata about an event. See
+// https://github.com/cloudevents/spec/blob/v0.1/spec.md#context-attributes for
+// details on these fields.
+type V01EventContext struct {
+	// The version of the CloudEvents specification used by the event.
+	CloudEventsVersion string `json:"cloudEventsVersion,omitempty"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	EventID string `json:"eventID"`
+	// Timestamp when the event happened.
+	EventTime time.Time `json:"eventTime,omitempty"`
+	// Type of occurrence which has happened.
+	EventType string `json:"eventType"`
+	// The version of the `eventType`; this is producer-specific.
+	EventTypeVersion string `json:"eventTypeVersion,omitempty"`
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string `json:"schemaURL,omitempty"`
+	// A MIME (RFC 2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, or auto-detect the content?
+	ContentType string `json:"contentType,omitempty"`
+	// A URI describing the event producer.
+	Source string `json:"source"`
+	// Additional metadata without a well-defined structure.
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+// AsV01 implements the ContextTranslator interface.
+func (ec V01EventContext) AsV01() V01EventContext {
+	return ec
+}
+
+// AsV02 implements the ContextTranslator interface.
+func (ec V01EventContext) AsV02() V02EventContext {
+	ret := V02EventContext{
+		SpecVersion: V02CloudEventsVersion,
+		Type:        ec.EventType,
+		Source:      ec.Source,
+		ID:          ec.EventID,
+		Time:        ec.EventTime,
+		SchemaURL:   ec.SchemaURL,
+		ContentType: ec.ContentType,
+		Extensions:  make(map[string]interface{}),
+	}
+	// eventTypeVersion was retired in v0.2, so put it in an extension.
+	if ec.EventTypeVersion != "" {
+		ret.Extensions["eventtypeversion"] = ec.EventTypeVersion
+	}
+	for k, v := range ec.Extensions {
+		ret.Extensions[k] = v
+	}
+	return ret
+}
+
+// AsHeaders implements the BinarySender interface.
+func (ec V01EventContext) AsHeaders() (http.Header, error) {
+	h := http.Header{}
+	h.Set("CE-CloudEventsVersion", ec.CloudEventsVersion)
+	h.Set("CE-EventID", ec.EventID)
+	h.Set("CE-EventType", ec.EventType)
+	h.Set("CE-Source", ec.Source)
+	if ec.CloudEventsVersion == "" {
+		h.Set("CE-CloudEventsVersion", V01CloudEventsVersion)
+	}
+	if !ec.EventTime.IsZero() {
+		h.Set("CE-EventTime", ec.EventTime.Format(time.RFC3339Nano))
+	}
+	if ec.EventTypeVersion != "" {
+		h.Set("CE-EventTypeVersion", ec.EventTypeVersion)
+	}
+	if ec.SchemaURL != "" {
+		h.Set("CE-SchemaUrl", ec.SchemaURL)
+	}
+	if ec.ContentType != "" {
+		h.Set("Content-Type", ec.ContentType)
+	}
+	for k, v := range ec.Extensions {
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		// Preserve case in v0.1, even though HTTP headers are case-insensitive.
+		h["CE-X-"+k] = []string{string(encoded)}
+	}
+	return h, nil
+}
+
+// FromHeaders implements the BinaryLoader interface.
+func (ec *V01EventContext) FromHeaders(in http.Header) error {
+	missingField := func(name string) error {
+		if in.Get("CE-"+name) == "" {
+			return fmt.Errorf("Missing field %q in %v: %q", "CE-"+name, in, in.Get("CE-"+name))
+		}
+		return nil
+	}
+	if err := anyError(
+		missingField("CloudEventsVersion"),
+		missingField("EventID"),
+		missingField("EventType"),
+		missingField("Source")); err != nil {
+		return err
+	}
+	data := V01EventContext{
+		CloudEventsVersion: in.Get("CE-CloudEventsVersion"),
+		EventID:            in.Get("CE-EventID"),
+		EventType:          in.Get("CE-EventType"),
+		EventTypeVersion:   in.Get("CE-EventTypeVersion"),
+		SchemaURL:          in.Get("CE-SchemaURL"),
+		ContentType:        in.Get("Content-Type"),
+		Source:             in.Get("CE-Source"),
+		Extensions:         make(map[string]interface{}),
+	}
+	if timeStr := in.Get("CE-EventTime"); timeStr != "" {
+		var err error
+		if data.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	for k, v := range in {
+		if strings.EqualFold(k[:len("CE-X-")], "CE-X-") {
+			key := k[len("CE-X-"):]
+			var tmp interface{}
+			if err := json.Unmarshal([]byte(v[0]), &tmp); err == nil {
+				data.Extensions[key] = tmp
+			} else {
+				// If we can't unmarshal the data, treat it as a string.
+				data.Extensions[key] = v[0]
+			}
+		}
+	}
+	*ec = data
+	return nil
+}
+
+// AsJSON implements the StructuredSender interface.
+func (ec V01EventContext) AsJSON() (map[string]json.RawMessage, error) {
+	ret := make(map[string]json.RawMessage)
+	err := anyError(
+		encodeKey(ret, "cloudEventsVersion", ec.CloudEventsVersion),
+		encodeKey(ret, "eventID", ec.EventID),
+		encodeKey(ret, "eventTime", ec.EventTime),
+		encodeKey(ret, "eventType", ec.EventType),
+		encodeKey(ret, "eventTypeVersion", ec.EventTypeVersion),
+		encodeKey(ret, "schemaURL", ec.SchemaURL),
+		encodeKey(ret, "contentType", ec.ContentType),
+		encodeKey(ret, "source", ec.Source),
+		encodeKey(ret, "extensions", ec.Extensions))
+	return ret, err
+}
+
+// DataContentType implements the StructuredSender interface.
+func (ec V01EventContext) DataContentType() string {
+	return ec.ContentType
+}
+
+// FromJSON implements the StructuredLoader interface.
+func (ec *V01EventContext) FromJSON(in map[string]json.RawMessage) error {
+	data := V01EventContext{
+		CloudEventsVersion: extractKey(in, "cloudEventsVersion"),
+		EventID:            extractKey(in, "eventID"),
+		EventType:          extractKey(in, "eventType"),
+		Source:             extractKey(in, "source"),
+	}
+	var err error
+	if timeStr := extractKey(in, "eventTime"); timeStr != "" {
+		if data.EventTime, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	extractKeyTo(in, "eventTypeVersion", &data.EventTypeVersion)
+	extractKeyTo(in, "schemaURL", &data.SchemaURL)
+	extractKeyTo(in, "contentType", &data.ContentType)
+	if len(in["extensions"]) == 0 {
+		in["extensions"] = []byte("{}")
+	}
+	if err = json.Unmarshal(in["extensions"], &data.Extensions); err != nil {
+		return err
+	}
+	*ec = data
+	return nil
+}
+
+func encodeKey(out map[string]json.RawMessage, key string, value interface{}) (err error) {
+	if s, ok := value.(string); ok && s == "" {
+		// Skip empty strings.
+		return nil
+	}
+	out[key], err = json.Marshal(value)
+	return
+}
+
+func extractKey(in map[string]json.RawMessage, key string) (s string) {
+	extractKeyTo(in, key, &s)
+	return
+}
+
+func extractKeyTo(in map[string]json.RawMessage, key string, out *string) error {
+	tmp := in[key]
+	delete(in, key)
+	return json.Unmarshal(tmp, out)
+}

--- a/vendor/github.com/knative/pkg/cloudevents/event_v02.go
+++ b/vendor/github.com/knative/pkg/cloudevents/event_v02.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// V02CloudEventsVersion is the version of the CloudEvents spec targeted
+	// by this library.
+	V02CloudEventsVersion = "0.2"
+
+	// required attributes
+	fieldSpecVersion  = "specversion"
+	fieldID           = "id"
+	fieldType         = "type"
+	fieldSource       = "source"
+	fieldTime         = "time"
+	fieldSchemaURL    = "schemaurl"
+	fieldContentType  = "contenttype"
+	headerContentType = "Content-Type"
+)
+
+// V02EventContext represents the non-data attributes of a CloudEvents v0.2
+// event.
+type V02EventContext struct {
+	// The version of the CloudEvents specification used by the event.
+	SpecVersion string `json:"specversion"`
+	// The type of the occurrence which has happened.
+	Type string `json:"type"`
+	// A URI describing the event producer.
+	Source string `json:"source"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	ID string `json:"id"`
+	// Timestamp when the event happened.
+	Time time.Time `json:"time,omitempty"`
+	// A link to the schema that the `data` attribute adheres to.
+	SchemaURL string `json:"schemaurl,omitempty"`
+	// A MIME (RFC2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, `application/octet-stream`, or auto-detect the content?
+	ContentType string `json:"contenttype,omitempty"`
+	// Additional extension metadata beyond the base spec.
+	Extensions map[string]interface{} `json:"-,omitempty"`
+}
+
+// AsV01 implements the ContextTranslator interface.
+func (ec V02EventContext) AsV01() V01EventContext {
+	ret := V01EventContext{
+		CloudEventsVersion: V01CloudEventsVersion,
+		EventID:            ec.ID,
+		EventTime:          ec.Time,
+		EventType:          ec.Type,
+		SchemaURL:          ec.SchemaURL,
+		ContentType:        ec.ContentType,
+		Source:             ec.Source,
+		Extensions:         make(map[string]interface{}),
+	}
+	for k, v := range ec.Extensions {
+		// eventTypeVersion was retired in v0.2
+		if strings.EqualFold(k, "eventTypeVersion") {
+			etv, ok := v.(string)
+			if ok {
+				ret.EventTypeVersion = etv
+			}
+			continue
+		}
+		ret.Extensions[k] = v
+	}
+	return ret
+}
+
+// AsV02 implements the ContextTranslator interface.
+func (ec V02EventContext) AsV02() V02EventContext {
+	return ec
+}
+
+// AsHeaders implements the BinarySender interface.
+func (ec V02EventContext) AsHeaders() (http.Header, error) {
+	h := http.Header{}
+	h.Set("CE-"+fieldSpecVersion, ec.SpecVersion)
+	h.Set("CE-"+fieldType, ec.Type)
+	h.Set("CE-"+fieldSource, ec.Source)
+	h.Set("CE-"+fieldID, ec.ID)
+	if ec.SpecVersion == "" {
+		h.Set("CE-"+fieldSpecVersion, V02CloudEventsVersion)
+	}
+	if !ec.Time.IsZero() {
+		h.Set("CE-"+fieldTime, ec.Time.Format(time.RFC3339Nano))
+	}
+	if ec.SchemaURL != "" {
+		h.Set("CE-"+fieldSchemaURL, ec.SchemaURL)
+	}
+	if ec.ContentType != "" {
+		h.Set(headerContentType, ec.ContentType)
+	}
+	for k, v := range ec.Extensions {
+		// Per spec, map-valued extensions are converted to a list of headers as:
+		// CE-attrib-key
+		if mapVal, ok := v.(map[string]interface{}); ok {
+			for subkey, subval := range mapVal {
+				encoded, err := json.Marshal(subval)
+				if err != nil {
+					return nil, err
+				}
+				h.Set("CE-"+k+"-"+subkey, string(encoded))
+			}
+			continue
+		}
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		h.Set("CE-"+k, string(encoded))
+	}
+
+	return h, nil
+}
+
+// FromHeaders implements the BinaryLoader interface.
+func (ec *V02EventContext) FromHeaders(in http.Header) error {
+	missingField := func(name string) error {
+		if in.Get("CE-"+name) == "" {
+			return fmt.Errorf("Missing field %q in %v: %q", "CE-"+name, in, in.Get("CE-"+name))
+		}
+		return nil
+	}
+	err := anyError(
+		missingField(fieldSpecVersion),
+		missingField(fieldID),
+		missingField(fieldType),
+		missingField(fieldSource),
+	)
+	if err != nil {
+		return err
+	}
+	data := V02EventContext{
+		ContentType: in.Get(headerContentType),
+		Extensions:  make(map[string]interface{}),
+	}
+	// Extensions and top-level fields are mixed under "CE-" headers.
+	// Extract them all here rather than trying to clear fields in headers.
+	for k, v := range in {
+		if strings.EqualFold(k[:len("CE-")], "CE-") {
+			key, value := strings.ToLower(string(k[len("CE-"):])), v[0]
+			switch key {
+			case fieldSpecVersion:
+				data.SpecVersion = value
+			case fieldType:
+				data.Type = value
+			case fieldSource:
+				data.Source = value
+			case fieldID:
+				data.ID = value
+			case fieldSchemaURL:
+				data.SchemaURL = value
+			case fieldTime:
+				if data.Time, err = time.Parse(time.RFC3339Nano, value); err != nil {
+					return err
+				}
+			default:
+				var tmp interface{}
+				if err = json.Unmarshal([]byte(value), &tmp); err != nil {
+					tmp = value
+				}
+				// Per spec, map-valued extensions are converted to a list of headers as:
+				// CE-attrib-key. This is where things get a bit crazy... see
+				// https://github.com/cloudevents/spec/issues/367 for additional notes.
+				if strings.Contains(key, "-") {
+					items := strings.SplitN(key, "-", 2)
+					key, subkey := items[0], items[1]
+					if _, ok := data.Extensions[key]; !ok {
+						data.Extensions[key] = make(map[string]interface{})
+					}
+					if submap, ok := data.Extensions[key].(map[string]interface{}); ok {
+						submap[subkey] = tmp
+					}
+				} else {
+					data.Extensions[key] = tmp
+				}
+			}
+		}
+	}
+	*ec = data
+	return nil
+}
+
+// AsJSON implementsn the StructuredSender interface.
+func (ec V02EventContext) AsJSON() (map[string]json.RawMessage, error) {
+	ret := make(map[string]json.RawMessage)
+	err := anyError(
+		encodeKey(ret, fieldSpecVersion, ec.SpecVersion),
+		encodeKey(ret, fieldType, ec.Type),
+		encodeKey(ret, fieldSource, ec.Source),
+		encodeKey(ret, fieldID, ec.ID),
+		encodeKey(ret, fieldTime, ec.Time),
+		encodeKey(ret, fieldSchemaURL, ec.SchemaURL),
+		encodeKey(ret, fieldContentType, ec.ContentType),
+	)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range ec.Extensions {
+		if err = encodeKey(ret, k, v); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+// DataContentType implements the StructuredSender interface.
+func (ec V02EventContext) DataContentType() string {
+	return ec.ContentType
+}
+
+// FromJSON implements the StructuredLoader interface.
+func (ec *V02EventContext) FromJSON(in map[string]json.RawMessage) error {
+	data := V02EventContext{
+		SpecVersion: extractKey(in, fieldSpecVersion),
+		Type:        extractKey(in, fieldType),
+		Source:      extractKey(in, fieldSource),
+		ID:          extractKey(in, fieldID),
+		Extensions:  make(map[string]interface{}),
+	}
+	var err error
+	if timeStr := extractKey(in, fieldTime); timeStr != "" {
+		if data.Time, err = time.Parse(time.RFC3339Nano, timeStr); err != nil {
+			return err
+		}
+	}
+	extractKeyTo(in, fieldSchemaURL, &data.SchemaURL)
+	extractKeyTo(in, fieldContentType, &data.ContentType)
+	// Extract the remaining items from in by converting to JSON and then
+	// unpacking into Extensions. This avoids having to do funny type
+	// checking/testing in the loop over values.
+	extensionsJSON, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(extensionsJSON, &data.Extensions)
+	*ec = data
+	return err
+}

--- a/vendor/github.com/knative/pkg/test/clients.go
+++ b/vendor/github.com/knative/pkg/test/clients.go
@@ -35,7 +35,7 @@ type KubeClient struct {
 
 // NewSpoofingClient returns a spoofing client to make requests
 func NewSpoofingClient(client *KubeClient, logger *logging.BaseLogger, domain string, resolvable bool) (*spoof.SpoofingClient, error) {
-	return spoof.New(client.Kube, logger, domain, resolvable)
+	return spoof.New(client.Kube, logger, domain, resolvable, Flags.IngressEndpoint)
 }
 
 // NewKubeClient instantiates and returns several clientsets required for making request to the

--- a/vendor/github.com/knative/pkg/test/e2e_flags.go
+++ b/vendor/github.com/knative/pkg/test/e2e_flags.go
@@ -32,11 +32,12 @@ var Flags = initializeFlags()
 
 // EnvironmentFlags define the flags that are needed to run the e2e tests.
 type EnvironmentFlags struct {
-	Cluster     string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
-	Kubeconfig  string // Path to kubeconfig (defaults to ./kube/config)
-	Namespace   string // K8s namespace (blank by default, to be overwritten by test suite)
-	LogVerbose  bool   // Enable verbose logging
-	EmitMetrics bool   // Emit metrics
+	Cluster         string // K8s cluster (defaults to $K8S_CLUSTER_OVERRIDE)
+	Kubeconfig      string // Path to kubeconfig (defaults to ./kube/config)
+	Namespace       string // K8s namespace (blank by default, to be overwritten by test suite)
+	IngressEndpoint string // Host to use for ingress endpoint
+	LogVerbose      bool   // Enable verbose logging
+	EmitMetrics     bool   // Emit metrics
 }
 
 func initializeFlags() *EnvironmentFlags {
@@ -55,6 +56,8 @@ func initializeFlags() *EnvironmentFlags {
 
 	flag.StringVar(&f.Namespace, "namespace", "",
 		"Provide the namespace you would like to use for these tests.")
+
+	flag.StringVar(&f.IngressEndpoint, "ingressendpoint", "", "Provide a static endpoint url to the ingress server used during tests.")
 
 	flag.BoolVar(&f.LogVerbose, "logverbose", false,
 		"Set this flag to true if you would like to see verbose logging.")

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -29,6 +29,7 @@ import (
 	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 const (
@@ -72,4 +73,16 @@ func WaitForPodListState(client *KubeClient, inState func(p *corev1.PodList) (bo
 		}
 		return inState(p)
 	})
+}
+
+// GetConfigMap gets the configmaps for a given namespace
+func GetConfigMap(client *KubeClient, namespace string) k8styped.ConfigMapInterface {
+	return client.Kube.CoreV1().ConfigMaps(namespace)
+}
+
+// Returns a func that evaluates if a deployment has scaled to 0 pods
+func DeploymentScaledToZeroFunc() func(d *apiv1beta1.Deployment) (bool, error) {
+	return func(d *apiv1beta1.Deployment) (bool, error) {
+		return d.Status.ReadyReplicas == 0, nil
+	}
 }

--- a/vendor/github.com/knative/pkg/test/logging/logging.go
+++ b/vendor/github.com/knative/pkg/test/logging/logging.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
 	"github.com/knative/pkg/logging"
 	"go.opencensus.io/stats/view"
@@ -58,9 +59,9 @@ type BaseLogger struct {
 // ExportView will emit the view data vd (i.e. the stats that have been
 // recorded) to the zap logger.
 func (e *zapMetricExporter) ExportView(vd *view.Data) {
-	// We are not curretnly consuming these metrics, so for now we'll juse
+	// We are not currently consuming these metrics, so for now we'll juse
 	// dump the view.Data object as is.
-	e.logger.Info(vd)
+	e.logger.Debug(spew.Sprint(vd))
 }
 
 // ExportSpan will emit the trace data to the zap logger.

--- a/vendor/github.com/knative/pkg/test/spoof/spoof.go
+++ b/vendor/github.com/knative/pkg/test/spoof/spoof.go
@@ -26,10 +26,11 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/knative/pkg/test/logging"
-	zipkin "github.com/knative/pkg/test/zipkin"
+	"github.com/knative/pkg/test/zipkin"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -44,13 +45,9 @@ const (
 	requestInterval = 1 * time.Second
 	requestTimeout  = 5 * time.Minute
 	// TODO(tcnghia): These probably shouldn't be hard-coded here?
-	ingressNamespace = "istio-system"
+	istioIngressNamespace = "istio-system"
+	istioIngressName      = "istio-ingressgateway"
 )
-
-// Temporary work around the upgrade test issue for knative/serving#2434.
-// TODO(lichuqiang): remove the backward compatibility for knative-ingressgateway
-// once knative/serving#2434 is merged
-var ingressNames = []string{"knative-ingressgateway", "istio-ingressgateway"}
 
 // Response is a stripped down subset of http.Response. The is primarily useful
 // for ResponseCheckers to inspect the response body without consuming it.
@@ -96,7 +93,7 @@ type SpoofingClient struct {
 // follow the ingress if it moves (or if there are multiple ingresses).
 //
 // If that's a problem, see test/request.go#WaitForEndpointState for oneshot spoofing.
-func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain string, resolvable bool) (*SpoofingClient, error) {
+func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain string, resolvable bool, endpointOverride string) (*SpoofingClient, error) {
 	sc := SpoofingClient{
 		Client:          &http.Client{Transport: &ochttp.Transport{Propagation: &b3.HTTPFormat{}}}, // Using ochttp Transport required for zipkin-tracing
 		RequestInterval: requestInterval,
@@ -105,12 +102,16 @@ func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain
 	}
 
 	if !resolvable {
-		// If the domain that the Route controller is configured to assign to Route.Status.Domain
-		// (the domainSuffix) is not resolvable, we need to retrieve the IP of the endpoint and
-		// spoof the Host in our requests.
-		e, err := GetServiceEndpoint(kubeClientset)
-		if err != nil {
-			return nil, err
+		e := &endpointOverride
+		if endpointOverride == "" {
+			var err error
+			// If the domain that the Route controller is configured to assign to Route.Status.Domain
+			// (the domainSuffix) is not resolvable, we need to retrieve the IP of the endpoint and
+			// spoof the Host in our requests.
+			e, err = GetServiceEndpoint(kubeClientset)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		sc.endpoint = *e
@@ -125,24 +126,24 @@ func New(kubeClientset *kubernetes.Clientset, logger *logging.BaseLogger, domain
 
 // GetServiceEndpoint gets the endpoint IP or hostname to use for the service.
 func GetServiceEndpoint(kubeClientset *kubernetes.Clientset) (*string, error) {
-	var err error
-
-	for _, ingressName := range ingressNames {
-		var ingress *v1.Service
-		ingress, err = kubeClientset.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
-		if err != nil {
-			continue
-		}
-
-		var endpoint string
-		endpoint, err = endpointFromService(ingress)
-		if err != nil {
-			continue
-		}
-
-		return &endpoint, nil
+	ingressName := istioIngressName
+	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
+		ingressName = gatewayOverride
 	}
-	return nil, err
+	ingressNamespace := istioIngressNamespace
+	if gatewayNsOverride := os.Getenv("GATEWAY_NAMESPACE_OVERRIDE"); gatewayNsOverride != "" {
+		ingressNamespace = gatewayNsOverride
+	}
+
+	ingress, err := kubeClientset.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := endpointFromService(ingress)
+	if err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
 }
 
 // endpointFromService extracts the endpoint from the service's ingress.
@@ -240,6 +241,7 @@ func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
 	if err != nil {
 		return fmt.Errorf("Error retrieving Zipkin trace: %v", err)
 	}
+	defer resp.Body.Close()
 
 	trace, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -247,11 +249,10 @@ func (sc *SpoofingClient) LogZipkinTrace(traceID string) error {
 	}
 
 	var prettyJSON bytes.Buffer
-	error := json.Indent(&prettyJSON, trace, "", "\t")
-	if error != nil {
+	if error := json.Indent(&prettyJSON, trace, "", "\t"); error != nil {
 		return fmt.Errorf("JSON Parser Error while trying for Pretty-Format: %v, Original Response: %s", error, string(trace))
 	}
-	sc.logger.Infof(prettyJSON.String())
+	sc.logger.Info(prettyJSON.String())
 
 	return nil
 }

--- a/vendor/github.com/knative/pkg/test/zipkin/util.go
+++ b/vendor/github.com/knative/pkg/test/zipkin/util.go
@@ -50,8 +50,10 @@ const (
 
 var zipkinPortForwardPID int
 
-// SetupZipkinTracing sets up zipkin tracing which involves a) Setting up port-forwarding from localhost to zipkin pod on the cluster (pid of the process doing Port-Forward is stored in a global variable).
-// b) enable AlwaysSample config for tracing.
+// SetupZipkinTracing sets up zipkin tracing which involves:
+// 1. Setting up port-forwarding from localhost to zipkin pod on the cluster
+//    (pid of the process doing Port-Forward is stored in a global variable).
+// 2. Enable AlwaysSample config for tracing.
 func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 	logger := logging.GetContextLogger("SpoofUtil")
 
@@ -61,7 +63,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 
 	zipkinPods, err := kubeClientset.CoreV1().Pods(ZipkinNamespace).List(metav1.ListOptions{LabelSelector: "app=zipkin"})
 	if err != nil {
-		return fmt.Errorf("Error retrieving Zipkin pod details : %v", err)
+		return fmt.Errorf("Error retrieving Zipkin pod details: %v", err)
 	}
 
 	if len(zipkinPods.Items) == 0 {
@@ -70,8 +72,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 
 	portForwardCmd := exec.Command("kubectl", "port-forward", "--namespace="+ZipkinNamespace, zipkinPods.Items[0].Name, fmt.Sprintf("%d:%d", ZipkinPort, ZipkinPort))
 	if err = portForwardCmd.Start(); err != nil {
-		return fmt.Errorf("Error starting kubectl port-forward command : %v", err)
-
+		return fmt.Errorf("Error starting kubectl port-forward command: %v", err)
 	}
 	zipkinPortForwardPID = portForwardCmd.Process.Pid
 	logger.Infof("Zipkin port-forward process started with PID: %d", zipkinPortForwardPID)
@@ -79,7 +80,7 @@ func SetupZipkinTracing(kubeClientset *kubernetes.Clientset) error {
 	// Applying AlwaysSample config to ensure we propagate zipkin header for every request made by this client.
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
-	logger.Infof("Successfully setup SpoofingClient for Zipkin Tracing")
+	logger.Info("Successfully setup SpoofingClient for Zipkin Tracing")
 
 	return nil
 }
@@ -93,7 +94,7 @@ func CleanupZipkinTracingSetup() error {
 		return fmt.Errorf("Encoutered error killing port-forward process in CleanupZipkingTracingSetup() : %v", err)
 	}
 
-	logger.Infof("Successfully killed Zipkin port-forward process")
+	logger.Info("Successfully killed Zipkin port-forward process")
 	return nil
 }
 

--- a/vendor/github.com/knative/pkg/webhook/webhook.go
+++ b/vendor/github.com/knative/pkg/webhook/webhook.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -35,13 +34,16 @@ import (
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/kmp"
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/logging/logkey"
+	perrors "github.com/pkg/errors"
 
 	"github.com/markbates/inflect"
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,7 +84,7 @@ type ControllerOptions struct {
 	// registration.
 	SecretName string
 
-	// Namespace is the namespace in which everything above lives
+	// Namespace is the namespace in which everything above lives.
 	Namespace string
 
 	// Port where the webhook is served. Per k8s admission
@@ -200,46 +202,64 @@ func getOrGenerateKeyCertsFromSecret(ctx context.Context, client kubernetes.Inte
 	return serverKey, serverCert, caCert, nil
 }
 
-// Validate checks whether "new" and "old" implement HasImmutableFields and checks them,
+// validate checks whether "new" and "old" implement HasImmutableFields and checks them,
 // it then delegates validation to apis.Validatable on "new".
-func Validate(ctx context.Context) ResourceCallback {
-	return func(patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
-		if immutableNew, ok := new.(apis.Immutable); ok && old != nil {
-			// Copy the old object and set defaults so that we don't reject our own
-			// defaulting done earlier in the webhook.
-			old = old.DeepCopyObject().(GenericCRD)
-			old.SetDefaults()
+func validate(old GenericCRD, new GenericCRD) error {
+	if immutableNew, ok := new.(apis.Immutable); ok && old != nil {
+		// Copy the old object and set defaults so that we don't reject our own
+		// defaulting done earlier in the webhook.
+		old = old.DeepCopyObject().(GenericCRD)
+		old.SetDefaults()
 
-			immutableOld, ok := old.(apis.Immutable)
-			if !ok {
-				return fmt.Errorf("unexpected type mismatch %T vs. %T", old, new)
-			}
-			if err := immutableNew.CheckImmutableFields(immutableOld); err != nil {
-				return err
-			}
+		immutableOld, ok := old.(apis.Immutable)
+		if !ok {
+			return fmt.Errorf("unexpected type mismatch %T vs. %T", old, new)
 		}
-		// Can't just `return new.Validate()` because it doesn't properly nil-check.
-		if err := new.Validate(); err != nil {
+		if err := immutableNew.CheckImmutableFields(immutableOld); err != nil {
 			return err
 		}
-		return nil
 	}
+	// Can't just `return new.Validate()` because it doesn't properly nil-check.
+	if err := new.Validate(); err != nil {
+		return err
+	}
+	return nil
 }
 
-// SetDefaults simply leverages apis.Defaultable to set defaults.
-func SetDefaults(ctx context.Context) ResourceDefaulter {
-	return func(patches *[]jsonpatch.JsonPatchOperation, crd GenericCRD) error {
-		before, after := crd.DeepCopyObject(), crd
-		after.SetDefaults()
-
-		patch, err := duck.CreatePatch(before, after)
-		if err != nil {
-			return err
-		}
-
-		*patches = append(*patches, patch...)
-		return nil
+func setAnnotations(patches duck.JSONPatch, new, old GenericCRD, ui *authenticationv1.UserInfo) (duck.JSONPatch, error) {
+	// Nowhere to set the annotations.
+	if new == nil {
+		return patches, nil
 	}
+	na, ok := new.(apis.Annotatable)
+	if !ok {
+		return patches, nil
+	}
+	var oa apis.Annotatable
+	if old != nil {
+		oa = old.(apis.Annotatable)
+	}
+	b, a := new.DeepCopyObject().(apis.Annotatable), na
+
+	a.AnnotateUserInfo(oa, ui)
+	patch, err := duck.CreatePatch(b, a)
+	if err != nil {
+		return nil, err
+	}
+	return append(patches, patch...), nil
+}
+
+// setDefaults simply leverages apis.Defaultable to set defaults.
+func setDefaults(patches duck.JSONPatch, crd GenericCRD) (duck.JSONPatch, error) {
+	before, after := crd.DeepCopyObject(), crd
+	after.SetDefaults()
+
+	patch, err := duck.CreatePatch(before, after)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(patches, patch...), nil
 }
 
 func configureCerts(ctx context.Context, client kubernetes.Interface, options *ControllerOptions) (*tls.Config, []byte, error) {
@@ -269,7 +289,7 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) error {
 	ctx := logging.WithLogger(context.TODO(), logger)
 	tlsConfig, caCert, err := configureCerts(ctx, ac.Client, &ac.Options)
 	if err != nil {
-		logger.Error("Could not configure admission webhook certs", zap.Error(err))
+		logger.Errorw("could not configure admission webhook certs", zap.Error(err))
 		return err
 	}
 
@@ -297,7 +317,7 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) error {
 	case <-time.After(ac.Options.RegistrationDelay):
 		cl := ac.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 		if err := ac.register(ctx, cl, caCert); err != nil {
-			logger.Error("Failed to register webhook", zap.Error(err))
+			logger.Errorw("failed to register webhook", zap.Error(err))
 			return err
 		}
 		logger.Info("Successfully registered webhook")
@@ -308,7 +328,7 @@ func (ac *AdmissionController) Run(stop <-chan struct{}) error {
 	serverBootstrapErrCh := make(chan struct{})
 	go func() {
 		if err := server.ListenAndServeTLS("", ""); err != nil {
-			logger.Error("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
+			logger.Errorw("ListenAndServeTLS for admission webhook returned error", zap.Error(err))
 			close(serverBootstrapErrCh)
 		}
 	}()
@@ -375,31 +395,33 @@ func (ac *AdmissionController) register(
 		}},
 	}
 
-	// Set the owner to our deployment
+	// Set the owner to our deployment.
 	deployment, err := ac.Client.ExtensionsV1beta1().Deployments(ac.Options.Namespace).Get(ac.Options.DeploymentName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to fetch our deployment: %s", err)
+		return fmt.Errorf("failed to fetch our deployment: %v", err)
 	}
 	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
 	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
 
-	// Try to create the webhook and if it already exists validate webhook rules
+	// Try to create the webhook and if it already exists validate webhook rules.
 	_, err = client.Create(webhook)
 	if err != nil {
 		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("Failed to create a webhook: %s", err)
+			return fmt.Errorf("failed to create a webhook: %v", err)
 		}
 		logger.Info("Webhook already exists")
 		configuredWebhook, err := client.Get(ac.Options.WebhookName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("Error retrieving webhook: %s", err)
+			return fmt.Errorf("error retrieving webhook: %v", err)
 		}
-		if !reflect.DeepEqual(configuredWebhook.Webhooks, webhook.Webhooks) {
+		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
+			return fmt.Errorf("error diffing webhooks: %v", err)
+		} else if !ok {
 			logger.Info("Updating webhook")
 			// Set the ResourceVersion as required by update.
 			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
 			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("Failed to update webhook: %s", err)
+				return fmt.Errorf("failed to update webhook: %s", err)
 			}
 		} else {
 			logger.Info("Webhook is already valid")
@@ -413,10 +435,12 @@ func (ac *AdmissionController) register(
 // ServeHTTP implements the external admission webhook for mutating
 // serving resources.
 func (ac *AdmissionController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
 	logger := ac.Logger
 	logger.Infof("Webhook ServeHTTP request=%#v", r)
 
-	// verify the content type is accurate
+	// Verify the content type is accurate.
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
 		http.Error(w, "invalid Content-Type, want `application/json`", http.StatusUnsupportedMediaType)
@@ -424,7 +448,6 @@ func (ac *AdmissionController) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	var review admissionv1beta1.AdmissionReview
-	defer r.Body.Close()
 	if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
 		http.Error(w, fmt.Sprintf("could not decode body: %v", err), http.StatusBadRequest)
 		return
@@ -445,7 +468,7 @@ func (ac *AdmissionController) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		response.Response.UID = review.Request.UID
 	}
 
-	logger.Infof("AdmissionReview for %s: %v/%v response=%v",
+	logger.Infof("AdmissionReview for %#v: %s/%s response=%#v",
 		review.Request.Kind, review.Request.Namespace, review.Request.Name, reviewResponse)
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -471,7 +494,7 @@ func (ac *AdmissionController) admit(ctx context.Context, request *admissionv1be
 		return &admissionv1beta1.AdmissionResponse{Allowed: true}
 	}
 
-	patchBytes, err := ac.mutate(ctx, request.Kind, request.OldObject.Raw, request.Object.Raw)
+	patchBytes, err := ac.mutate(ctx, request)
 	if err != nil {
 		return makeErrorStatus("mutation failed: %v", err)
 	}
@@ -487,7 +510,10 @@ func (ac *AdmissionController) admit(ctx context.Context, request *admissionv1be
 	}
 }
 
-func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVersionKind, oldBytes []byte, newBytes []byte) ([]byte, error) {
+func (ac *AdmissionController) mutate(ctx context.Context, req *admissionv1beta1.AdmissionRequest) ([]byte, error) {
+	kind := req.Kind
+	newBytes := req.Object.Raw
+	oldBytes := req.OldObject.Raw
 	// Why, oh why are these different types...
 	gvk := schema.GroupVersionKind{
 		Group:   kind.Group,
@@ -498,63 +524,64 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 	logger := logging.FromContext(ctx)
 	handler, ok := ac.Handlers[gvk]
 	if !ok {
-		logger.Errorf("Unhandled kind %v", gvk)
+		logger.Errorf("Unhandled kind: %v", gvk)
 		return nil, fmt.Errorf("unhandled kind: %v", gvk)
 	}
 
-	oldObj := handler.DeepCopyObject().(GenericCRD)
-	newObj := handler.DeepCopyObject().(GenericCRD)
+	// nil values denote absence of `old` (create) or `new` (delete) objects.
+	var oldObj, newObj GenericCRD
 
 	if len(newBytes) != 0 {
+		newObj = handler.DeepCopyObject().(GenericCRD)
 		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
 		if err := newDecoder.Decode(&newObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming new object: %v", err)
 		}
-	} else {
-		// Use nil to denote the absence of a new object (delete)
-		newObj = nil
 	}
-
 	if len(oldBytes) != 0 {
+		oldObj = handler.DeepCopyObject().(GenericCRD)
 		oldDecoder := json.NewDecoder(bytes.NewBuffer(oldBytes))
 		if err := oldDecoder.Decode(&oldObj); err != nil {
 			return nil, fmt.Errorf("cannot decode incoming old object: %v", err)
 		}
-	} else {
-		// Use nil to denote the absence of an old object (create)
-		oldObj = nil
 	}
+	var patches duck.JSONPatch
 
-	var patches []jsonpatch.JsonPatchOperation
-
-	err := updateGeneration(ctx, &patches, oldObj, newObj)
+	// Add these before defaulting fields, otherwise defaulting may cause an illegal patch because
+	// it expects the round tripped through Golang fields to be present already.
+	rtp, err := roundTripPatch(newBytes, newObj)
 	if err != nil {
-		logger.Error("Failed to update generation", zap.Error(err))
-		return nil, fmt.Errorf("Failed to update generation: %s", err)
+		return nil, fmt.Errorf("cannot create patch for round tripped newBytes: %v", err)
+	}
+	patches = append(patches, rtp...)
+
+	if patches, err = updateGeneration(ctx, patches, oldObj, newObj); err != nil {
+		logger.Errorw("Failed to update generation", zap.Error(err))
+		return nil, perrors.Wrap(err, "failed to update generation")
 	}
 
-	if defaulter := SetDefaults(ctx); defaulter != nil {
-		if err := defaulter(&patches, newObj); err != nil {
-			logger.Error("Failed the resource specific defaulter", zap.Error(err))
-			// Return the error message as-is to give the defaulter callback
-			// discretion over (our portion of) the message that the user sees.
-			return nil, err
-		}
+	if patches, err = setDefaults(patches, newObj); err != nil {
+		logger.Errorw("Failed the resource specific defaulter", zap.Error(err))
+		// Return the error message as-is to give the defaulter callback
+		// discretion over (our portion of) the message that the user sees.
+		return nil, err
+	}
+
+	if patches, err = setAnnotations(patches, newObj, oldObj, &req.UserInfo); err != nil {
+		logger.Errorw("Failed the resource annotator", zap.Error(err))
+		return nil, perrors.Wrap(err, "error setting annotations")
 	}
 
 	// None of the validators will accept a nil value for newObj.
 	if newObj == nil {
 		return nil, errMissingNewObject
 	}
-	if validator := Validate(ctx); validator != nil {
-		if err := validator(&patches, oldObj, newObj); err != nil {
-			logger.Error("Failed the resource specific validation", zap.Error(err))
-			// Return the error message as-is to give the validation callback
-			// discretion over (our portion of) the message that the user sees.
-			return nil, err
-		}
+	if err := validate(oldObj, newObj); err != nil {
+		logger.Errorw("Failed the resource specific validation", zap.Error(err))
+		// Return the error message as-is to give the validation callback
+		// discretion over (our portion of) the message that the user sees.
+		return nil, err
 	}
-
 	return json.Marshal(patches)
 }
 
@@ -566,30 +593,47 @@ func (ac *AdmissionController) mutate(ctx context.Context, kind metav1.GroupVers
 // by the APIserver (https://github.com/kubernetes/kubernetes/issues/58778)
 // So, we add Generation here. Once that gets fixed, remove this and use
 // ObjectMeta.Generation instead.
-func updateGeneration(ctx context.Context, patches *[]jsonpatch.JsonPatchOperation, old GenericCRD, new GenericCRD) error {
+func updateGeneration(ctx context.Context, patches duck.JSONPatch, old GenericCRD, new GenericCRD) (duck.JSONPatch, error) {
 	logger := logging.FromContext(ctx)
 
 	if chg, err := hasChanged(ctx, old, new); err != nil {
-		return err
+		return nil, err
 	} else if !chg {
 		logger.Info("No changes in the spec, not bumping generation")
-		return nil
+		return patches, nil
 	}
 
 	// Leverage Spec duck typing to bump the Generation of the resource.
-	before, err := asGenerational(ctx, new)
+	before, err := asGenerational(new)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	after := before.DeepCopyObject().(*duckv1alpha1.Generational)
 	after.Spec.Generation = after.Spec.Generation + 1
 
 	genBump, err := duck.CreatePatch(before, after)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	*patches = append(*patches, genBump...)
-	return nil
+	return append(patches, genBump...), nil
+}
+
+// roundTripPatch generates the JSONPatch that corresponds to round tripping the given bytes through
+// the Golang type (JSON -> Golang type -> JSON). Because it is not always true that
+// bytes == json.Marshal(json.Unmarshal(bytes)).
+//
+// For example, if bytes did not contain a 'spec' field and the Golang type specifies its 'spec'
+// field without omitempty, then by round tripping through the Golang type, we would have added
+// `'spec': {}`.
+func roundTripPatch(bytes []byte, unmarshalled interface{}) (duck.JSONPatch, error) {
+	if unmarshalled == nil {
+		return duck.JSONPatch{}, nil
+	}
+	marshaledBytes, err := json.Marshal(unmarshalled)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal interface: %v", err)
+	}
+	return jsonpatch.CreatePatch(bytes, marshaledBytes)
 }
 
 // Not worth fully duck typing since there's no shared schema.
@@ -617,18 +661,17 @@ func hasChanged(ctx context.Context, old, new GenericCRD) (bool, error) {
 
 	oldSpecJSON, err := getSpecJSON(old)
 	if err != nil {
-		logger.Error("Failed to get Spec JSON for old", zap.Error(err))
+		logger.Errorw("Failed to get Spec JSON for old", zap.Error(err))
 		return false, err
 	}
 	newSpecJSON, err := getSpecJSON(new)
 	if err != nil {
-		logger.Error("Failed to get Spec JSON for new", zap.Error(err))
+		logger.Errorw("Failed to get Spec JSON for new", zap.Error(err))
 		return false, err
 	}
 
 	specPatches, err := jsonpatch.CreatePatch(oldSpecJSON, newSpecJSON)
 	if err != nil {
-		fmt.Printf("Error creating JSON patch:%v", err)
 		return false, err
 	}
 	if len(specPatches) == 0 {
@@ -636,14 +679,14 @@ func hasChanged(ctx context.Context, old, new GenericCRD) (bool, error) {
 	}
 	specPatchesJSON, err := json.Marshal(specPatches)
 	if err != nil {
-		logger.Error("Failed to marshal spec patches", zap.Error(err))
+		logger.Errorw("Failed to marshal spec patches", zap.Error(err))
 		return false, err
 	}
-	logger.Infof("Specs differ:\n%+v\n", string(specPatchesJSON))
+	logger.Infof("Specs differ:\n%s\n", string(specPatchesJSON))
 	return true, nil
 }
 
-func asGenerational(ctx context.Context, crd GenericCRD) (*duckv1alpha1.Generational, error) {
+func asGenerational(crd GenericCRD) (*duckv1alpha1.Generational, error) {
 	raw, err := json.Marshal(crd)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}


### PR DESCRIPTION
Fixes https://github.com/knative/eventing-sources/issues/190
Related https://github.com/knative/pkg/issues/193

## Proposed Changes

  * Upgrades `knative/pkg`. I had to update a few files to match the pkg/cloudevents package upgrade, but this does not move event handling to v0.2 CloudEvents. (Most of eventing does not use the cloudevents library right now anyway.)

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Removed the `Severity: Error` field from Conditions which was needlessly alarming human readers for conditions with Status=True.
```