### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -32,9 +32,9 @@ import (
 
 	"github.com/knative/eventing/contrib/kafka/pkg/controller"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	eventingNames "github.com/knative/eventing/pkg/reconciler/names"
 	util "github.com/knative/eventing/pkg/provisioners"
 	topicUtils "github.com/knative/eventing/pkg/provisioners/utils"
+	eventingNames "github.com/knative/eventing/pkg/reconciler/names"
 	"github.com/knative/eventing/pkg/sidecar/configmap"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
 	"github.com/knative/eventing/pkg/sidecar/multichannelfanout"

--- a/contrib/kafka/pkg/controller/reconcile_test.go
+++ b/contrib/kafka/pkg/controller/reconcile_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/contrib/natss/pkg/controller/channel/reconcile.go
+++ b/contrib/natss/pkg/controller/channel/reconcile.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/knative/eventing/pkg/reconciler/names"
 	"github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/reconciler/names"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"

--- a/contrib/natss/pkg/controller/clusterchannelprovisioner/reconcile_test.go
+++ b/contrib/natss/pkg/controller/clusterchannelprovisioner/reconcile_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/system"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/provisioners/inmemory/channel/controller_test.go
+++ b/pkg/provisioners/inmemory/channel/controller_test.go
@@ -18,6 +18,9 @@ package channel
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,8 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
-	"strings"
-	"testing"
 )
 
 type FakeManager struct {

--- a/pkg/provisioners/inmemory/clusterchannelprovisioner/controller_test.go
+++ b/pkg/provisioners/inmemory/clusterchannelprovisioner/controller_test.go
@@ -18,6 +18,9 @@ package clusterchannelprovisioner
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,8 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
-	"strings"
-	"testing"
 )
 
 type FakeManager struct {

--- a/pkg/provisioners/inmemory/clusterchannelprovisioner/reconcile_test.go
+++ b/pkg/provisioners/inmemory/clusterchannelprovisioner/reconcile_test.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	util "github.com/knative/eventing/pkg/provisioners"
+	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/system"
 )
 

--- a/pkg/provisioners/inmemory/controller/main.go
+++ b/pkg/provisioners/inmemory/controller/main.go
@@ -18,11 +18,12 @@ package main
 
 import (
 	"flag"
+
 	"github.com/knative/eventing/pkg/provisioners/inmemory/channel"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"github.com/knative/eventing/pkg/provisioners/inmemory/clusterchannelprovisioner"
 	"github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/provisioners/inmemory/clusterchannelprovisioner"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"

--- a/pkg/reconciler/names/names_test.go
+++ b/pkg/reconciler/names/names_test.go
@@ -17,8 +17,9 @@
 package names
 
 import (
-	"github.com/knative/eventing/pkg/utils"
 	"testing"
+
+	"github.com/knative/eventing/pkg/utils"
 )
 
 func TestNames(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/subscription/provider_test.go
+++ b/pkg/reconciler/v1alpha1/subscription/provider_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package subscription
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestProvideController(t *testing.T) {

--- a/pkg/reconciler/v1alpha1/subscription/subscription.go
+++ b/pkg/reconciler/v1alpha1/subscription/subscription.go
@@ -19,9 +19,10 @@ package subscription
 import (
 	"context"
 	"fmt"
+	"net/url"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -91,7 +92,6 @@ func ProvideController(mgr manager.Manager) (controller.Controller, error) {
 
 	return c, nil
 }
-
 
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Subscription resource
@@ -488,7 +488,6 @@ func removeFinalizer(sub *v1alpha1.Subscription) {
 	finalizers.Delete(finalizerName)
 	sub.Finalizers = finalizers.List()
 }
-
 
 func (r *reconciler) InjectClient(c client.Client) error {
 	r.client = c


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
