### PR TITLE
add instructions on how to view roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
 [Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#events).
 
-The planned project releases are covered in this
+Please join [knative-users](https://groups.google.com/forum/#!forum/knative-users) to view planned project releases in
 [roadmap](https://docs.google.com/document/d/1z0z412rL9FsBsF8kwKxG6w7sflJLKe9hIECkc7jWfOY/edit#).


### PR DESCRIPTION
People need to join knative-users to view the roadmap doc
Added note in README to make that clear