### PR TITLE
Fix `env` var indentation and grouping in contrib yamls

### DIFF
--- a/contrib/gcppubsub/config/gcppubsub.yaml
+++ b/contrib/gcppubsub/config/gcppubsub.yaml
@@ -126,11 +126,10 @@ spec:
             value: gcppubsub-channel-key
           - name: DEFAULT_SECRET_KEY
             value: key.json
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
 
 ---
 
@@ -215,19 +214,18 @@ spec:
         - name: dispatcher
           image: github.com/knative/eventing/contrib/gcppubsub/pkg/dispatcher/cmd
           env:
-            - name: DEFAULT_GCP_PROJECT
-              value: REPLACE_WITH_GCP_PROJECT
-            - name: DEFAULT_SECRET_NAMESPACE
-              value: knative-eventing
-            - name: DEFAULT_SECRET_NAME
-              value: gcppubsub-channel-key
-            - name: DEFAULT_SECRET_KEY
-              value: key.json
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          - name: DEFAULT_GCP_PROJECT
+            value: REPLACE_WITH_GCP_PROJECT
+          - name: DEFAULT_SECRET_NAMESPACE
+            value: knative-eventing
+          - name: DEFAULT_SECRET_NAME
+            value: gcppubsub-channel-key
+          - name: DEFAULT_SECRET_KEY
+            value: key.json
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
 
 ---
 

--- a/contrib/natss/config/provisioner.yaml
+++ b/contrib/natss/config/provisioner.yaml
@@ -103,11 +103,11 @@ spec:
       containers:
         - name: controller
           image: github.com/knative/eventing/contrib/natss/pkg/controller
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          env:
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
 
 ---
 
@@ -180,8 +180,8 @@ spec:
       containers:
         - name: dispatcher
           image: github.com/knative/eventing/contrib/natss/pkg/dispatcher
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          env:
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace


### PR DESCRIPTION
Fixes #711 

## Proposed Changes

- Fix `env` indentation for `gcppubsub` and `natss` ClusterChannelProvisioners.

**Release Note**

```release-note
* Allow `gcp-pubsub.yaml` and `natss.yaml` to be built and released. 
```

<!--
/assign @n3wscott 
-->