### PR TITLE
Basic CI setup release-0.3 branch on OpenShift 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,8 @@ generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images in-memory-channel-controller
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
 .PHONY: generate-dockerfiles
+
+# Generates a release.yaml for a specific branch.
+generate-release:
+	./openshift/ci-operator/generate-release.sh $(BRANCH) > release.yaml
+.PHONY: generate-release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+#This makefile is used by ci-operator
+
+CGO_ENABLED=0
+GOOS=linux
+CORE_IMAGES=./cmd/controller/ ./cmd/webhook/ ./pkg/provisioners/kafka ./cmd/fanoutsidecar
+TEST_IMAGES=./test/test_images/k8sevents
+
+install:
+	go install $(CORE_IMAGES)
+	go build -o $(GOPATH)/bin/in-memory-channel-controller ./pkg/controller/eventing/inmemory/controller
+.PHONY: install
+
+test-install:
+	go install $(TEST_IMAGES)
+.PHONY: test-install
+
+test-e2e:
+	sh openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generate Dockerfiles used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images in-memory-channel-controller
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles

--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,8 @@
-approvers:
-- evankanderson
-- grantr
-- inlined
-- scothis
-- vaikas-google
+# The OWNERS file is used by prow to automatically merge approved PRs.
 
-# Reviewers are suggested from the reviewers list first, then the approvers
-# list. To add reviewers while spreading the load among existing approvers,
-# copy the approvers to the reviewers list too.
+approvers:
+- eventing-approvers
+
 reviewers:
-- evankanderson
-- grantr
-- inlined
-- scothis
-- vaikas-google
-# Add reviewers below
-- Harwayne
+- eventing-reviewers
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,23 @@
+aliases:
+  eventing-approvers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni
+  eventing-reviewers:
+  - alanfx
+  - mgencur
+  - mvinkler
+  - bbrowning
+  - jcrossley3
+  - bobmcwhirter
+  - markusthoemmes
+  - vdemeester
+  - evanchooly
+  - arilivigni

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,11 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM openshift/origin-release:golang-1.10
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/generate-release.sh
+++ b/openshift/ci-operator/generate-release.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+branch=${1-'knative-v0.3'}
+
+cat <<EOF
+tag_specification:
+  name: '4.0'
+  namespace: ocp
+promotion:
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch
+base_images:
+  base:
+    name: '4.0'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: github.com/knative/eventing
+binary_build_commands: make install
+test_binary_build_commands: make test-install
+tests:
+- as: e2e
+  commands: "INTERNAL_REGISTRY=image-registry.openshift-image-registry.svc:5000 ENABLE_ADMISSION_WEBHOOKS=false make test-e2e"
+  openshift_installer_src:
+    cluster_profile: aws
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+images:
+EOF
+
+core_images=$(find ./openshift/ci-operator/knative-images -mindepth 1 -maxdepth 1 -type d)
+for img in $core_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-eventing-$image_base
+EOF
+done
+
+test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d)
+for img in $test_images; do
+  image_base=$(basename $img)
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-test-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    test-bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-eventing-test-$image_base
+EOF
+done

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD controller /usr/bin/controller
+ENTRYPOINT ["/usr/bin/controller"]

--- a/openshift/ci-operator/knative-images/fanoutsidecar/Dockerfile
+++ b/openshift/ci-operator/knative-images/fanoutsidecar/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD fanoutsidecar /usr/bin/fanoutsidecar
+ENTRYPOINT ["/usr/bin/fanoutsidecar"]

--- a/openshift/ci-operator/knative-images/in-memory-channel-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/in-memory-channel-controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD in-memory-channel-controller /usr/bin/in-memory-channel-controller
+ENTRYPOINT ["/usr/bin/in-memory-channel-controller"]

--- a/openshift/ci-operator/knative-images/kafka/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD kafka /usr/bin/kafka
+ENTRYPOINT ["/usr/bin/kafka"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD webhook /usr/bin/webhook
+ENTRYPOINT ["/usr/bin/webhook"]

--- a/openshift/ci-operator/knative-test-images/k8sevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/k8sevents/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM ocp/4.0
+
+ADD k8sevents /usr/bin/k8sevents
+ENTRYPOINT ["/usr/bin/k8sevents"]


### PR DESCRIPTION
All of this is required for the PR in ci-operator repo to pass checks: https://github.com/openshift/release/pull/2918
When the current PR and pull/2918 are integrated I'll issue a new PR with the script that executes tests.
