### PR TITLE
golang format tools

### DIFF
--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
