### PR TITLE
ConfigMapWatcher.Start() blocks, rather than eagerly returning nil

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1254,7 +1254,6 @@
     "go.uber.org/zap/zapcore",
     "go.uber.org/zap/zaptest/observer",
     "golang.org/x/oauth2/google",
-    "golang.org/x/sync/errgroup",
     "google.golang.org/api/option",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",

--- a/cmd/fanoutsidecar/main.go
+++ b/cmd/fanoutsidecar/main.go
@@ -100,8 +100,10 @@ func main() {
 		WriteTimeout: writeTimeout,
 	}
 
-	logger.Info("Fanout sidecar listening", zap.String("address", s.Addr))
-	err = mgr.Add(&runnableServer{s: s})
+	err = mgr.Add(&runnableServer{
+		logger: logger,
+		s: s,
+	})
 	if err != nil {
 		logger.Fatal("Unable to add ListenAndServe", zap.Error(err))
 	}
@@ -181,9 +183,11 @@ func setupConfigMapWatcher(logger *zap.Logger, mgr manager.Manager, configUpdate
 // runnableServer is a small wrapper around http.Server so that it matches the manager.Runnable
 // interface.
 type runnableServer struct {
+	logger *zap.Logger
 	s *http.Server
 }
 
 func (r *runnableServer) Start(<-chan struct{}) error {
+	r.logger.Info("Fanout sidecar listening", zap.String("address", r.s.Addr))
 	return r.s.ListenAndServe()
 }

--- a/cmd/fanoutsidecar/main.go
+++ b/cmd/fanoutsidecar/main.go
@@ -113,16 +113,14 @@ func main() {
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 	// Start blocks forever.
-	err = mgr.Start(stopCh)
-	if err != nil {
+	if err = mgr.Start(stopCh); err != nil {
 		logger.Error("manager.Start() returned an error", zap.Error(err))
 	}
 	logger.Info("Exiting...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 	defer cancel()
-	err = s.Shutdown(ctx)
-	if err != nil {
+	if err = s.Shutdown(ctx); err != nil {
 		logger.Error("Shutdown returned an error", zap.Error(err))
 	}
 }
@@ -155,8 +153,7 @@ func setupConfigMapVolume(logger *zap.Logger, mgr manager.Manager, configUpdated
 		logger.Error("Unable to create filesystem.ConifgMapWatcher", zap.Error(err))
 		return err
 	}
-	err = mgr.Add(cmn)
-	if err != nil {
+	if err = mgr.Add(cmn); err != nil {
 		logger.Error("Unable to add the config map watcher", zap.Error(err))
 		return err
 	}
@@ -174,8 +171,7 @@ func setupConfigMapWatcher(logger *zap.Logger, mgr manager.Manager, configUpdate
 		return err
 	}
 
-	err = mgr.Add(utils.NewBlockingStart(logger, cmw))
-	if err != nil {
+	if err = mgr.Add(utils.NewBlockingStart(logger, cmw)); err != nil {
 		logger.Error("Unable to add the config map watcher", zap.Error(err))
 		return err
 	}

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -227,3 +227,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+
+---
+
+# Create the ConfigMap, because if we don't the dispatcher will flap when it first comes online and
+# this can cause the integration tests to fail.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: in-memory-channel-dispatcher-config-map
+  namespace: knative-eventing
+data:
+  multiChannelFanoutConfig: '{}'

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
@@ -120,8 +120,7 @@ func (s *SubscriptionsSupervisor) Start(stopCh <-chan struct{}) error {
 	go s.Connect(stopCh)
 	// Trigger Connect to establish connection with NATS
 	s.signalReconnect()
-	s.receiver.Start(stopCh)
-	return nil
+	return s.receiver.Start(stopCh)
 }
 
 func (s *SubscriptionsSupervisor) connectWithRetry(stopCh <-chan struct{}) {

--- a/pkg/utils/blocking_start.go
+++ b/pkg/utils/blocking_start.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// blockingStart wraps a manager.Runnable that eagerly returns and makes it return only if either a
+// non-nil error is returned or the stop channel is closed.
+type blockingStart struct {
+	logger *zap.Logger
+	r      manager.Runnable
+}
+
+// NewBlockingStart creates a wrapper around the provided runnable that will block until either the
+// runnable returns a non-nil error or the stop channel is closed.
+func NewBlockingStart(logger *zap.Logger, runnable manager.Runnable) manager.Runnable {
+	return &blockingStart{
+		logger: logger,
+		r:      runnable,
+	}
+}
+
+func (b *blockingStart) Start(stopCh <-chan struct{}) error {
+	err := b.r.Start(stopCh)
+	b.logger.Debug("blockingStart finished", zap.Error(err))
+	if err != nil {
+		return err
+	}
+	<-stopCh
+	b.logger.Debug("blockingStart exiting")
+	return nil
+}

--- a/pkg/utils/blocking_start_test.go
+++ b/pkg/utils/blocking_start_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"testing"
+	"time"
+)
+
+var (
+	errorFromImmediateError = errors.New("error from immediate error")
+)
+
+func TestBlockingStart(t *testing.T) {
+	testCases := map[string]struct {
+		f        manager.RunnableFunc
+		expected error
+	}{
+		"error exits immediately": {
+			f:        immediateError,
+			expected: errorFromImmediateError,
+		},
+		"nil blocks until stopCh closes": {
+			f:        blockUntilStopChCloses,
+			expected: nil,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			runnable := &runnableWrapper{f: tc.f}
+			sb := NewBlockingStart(zap.NewNop(), runnable)
+
+			stopCh := make(chan struct{})
+			stopChClosed := false
+			defer func() {
+				if !stopChClosed {
+					close(stopCh)
+				}
+			}()
+
+			returned := make(chan error)
+
+			go func() {
+				returned <- sb.Start(stopCh)
+			}()
+
+			for i := 0; i < 2; i++ {
+				timer := time.NewTimer(50 * time.Millisecond)
+				select {
+				case <-timer.C:
+					if tc.expected != nil {
+						t.Fatalf("Start() should have returned an error before the time ran out")
+					}
+					if stopChClosed {
+						t.Fatalf("The stop channel has already been closed, we should not have reached a timeout again")
+					}
+					// Close the stop channel then let the loop run again. While waiting for the next timer,
+					// blockingStart should finish.
+					stopChClosed = true
+					close(stopCh)
+				case actual := <-returned:
+					if tc.expected != actual {
+						t.Errorf("Unexpected response. Expected %v. Actual %v.", tc.expected, actual)
+					}
+					return
+				}
+			}
+			t.Fatalf("Exited the for loop without returning.")
+		})
+	}
+}
+
+type runnableWrapper struct {
+	f func(<-chan struct{}) error
+}
+
+func (r *runnableWrapper) Start(stopCh <-chan struct{}) error {
+	return r.f(stopCh)
+}
+
+func immediateError(_ <-chan struct{}) error {
+	return errorFromImmediateError
+}
+
+func blockUntilStopChCloses(stopCh <-chan struct{}) error {
+	<-stopCh
+	return nil
+}

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"encoding/json"
 	"os"
 	"os/signal"
 
@@ -89,7 +90,8 @@ func (c *Cleaner) Clean(awaitDeletion bool) error {
 		if err != nil {
 			c.logger.Errorf("Failed to get to-be cleaned resource %q : %s", deleter.Name, err)
 		} else {
-			c.logger.Infof("Cleaning resource: %q\n%+v", deleter.Name, r)
+			bytes, _ := json.MarshalIndent(r, "", "  ")
+			c.logger.Infof("Cleaning resource: %q\n%+v", deleter.Name, string(bytes))
 		}
 		if err := deleter.Resource.Delete(deleter.Name, nil); err != nil {
 			c.logger.Errorf("Error: %v", err)

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -154,6 +154,8 @@ func SingleEvent(t *testing.T, encoding string) {
 	}
 
 	if err := WaitForLogContent(clients, logger, routeName, subscriberPod.Spec.Containers[0].Name, ns, body); err != nil {
+		PodLogs(clients, senderName, "sendevent", ns, logger)
+		PodLogs(clients, senderName, "istio-proxy", ns, logger)
 		t.Fatalf("String %q not found in logs of subscriber pod %q: %v", body, routeName, err)
 	}
 }

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -90,15 +90,16 @@ func SingleEvent(t *testing.T, encoding string) {
 	logger := logging.GetContextLogger("TestSingleEvent")
 
 	clients, cleaner := Setup(t, logger)
-	defer TearDown(clients, cleaner, logger)
 
 	// verify namespace
-
 	ns, cleanupNS := namespaceExists(t, clients)
 	defer cleanupNS()
 
-	// create logger pod
+	// TearDown() needs to be deferred after cleanupNS(). Otherwise the namespace is deleted and all
+	// resources in it. So when TearDown() runs, it spews a lot of not found errors.
+	defer TearDown(clients, cleaner, logger)
 
+	// create logger pod
 	logger.Infof("creating subscriber pod")
 	selector := map[string]string{"e2etest": string(uuid.NewUUID())}
 	subscriberPod := test.EventLoggerPod(routeName, ns, selector)


### PR DESCRIPTION
## Proposed Changes

- `ConfigMapWatcher.Start()` blocks, rather than eagerly returning `nil`.
    - This is needed before we can upgrade our version of Controller Runtime, because in the newer version any returns from `Start()`, including `nil`, will stop all the controllers added to that manager.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
