### PR TITLE
Precreate the Kafka ConfigMap, because the dispatcher will flap until it exists

### DIFF
--- a/contrib/kafka/config/kafka.yaml
+++ b/contrib/kafka/config/kafka.yaml
@@ -212,3 +212,16 @@ spec:
         - name: kafka-channel-controller-config
           configMap:
             name: kafka-channel-controller-config
+
+---
+
+# Create the ConfigMap, because the dispatcher will flap until this ConfigMap exists. And the
+# controller doesn't create the ConfigMap until the first kafka Channel is reconciled.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+data:
+  multiChannelFanoutConfig: '{}'


### PR DESCRIPTION
## Proposed Changes

- Precreate the Kafka ConfigMap, because the dispatcher will flap until it exists. And the controller doesn't create the ConfigMap until the first kafka Channel is reconciled. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Applying the full YAML will cause the existing ConfigMap's data to be removed. It will be recreated the next time the Channel controller reconciles a Kafka Channel.
```
