### PR TITLE
Remove fake ListOptions

### DIFF
--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -334,14 +334,9 @@ func (r *reconciler) listAllChannels(ctx context.Context) ([]eventingv1alpha1.Ch
 	channels := make([]eventingv1alpha1.Channel, 0)
 
 	opts := &client.ListOptions{
-		// TODO this is here because the fake client needs it. Remove this when it's no longer
-		// needed.
-		Raw: &metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-				Kind:       "Channel",
-			},
-		},
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
 	for {
 		cl := &eventingv1alpha1.ChannelList{}

--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -76,14 +76,9 @@ func getK8sService(ctx context.Context, client runtimeClient.Client, c *eventing
 		Namespace: c.Namespace,
 		// TODO After the full release start selecting on new set of labels by using k8sServiceLabels(c)
 		LabelSelector: labels.SelectorFromSet(k8sOldServiceLabels(c)),
-		// TODO this is here because the fake client needs it. Remove this when it's no longer
-		// needed.
-		Raw: &metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: corev1.SchemeGroupVersion.String(),
-				Kind:       "Service",
-			},
-		},
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
 
 	err := client.List(ctx, opts, list)
@@ -134,14 +129,9 @@ func getVirtualService(ctx context.Context, client runtimeClient.Client, c *even
 		Namespace: c.Namespace,
 		// TODO After the full release start selecting on new set of labels by using virtualServiceLabels(c)
 		LabelSelector: labels.SelectorFromSet(virtualOldServiceLabels(c)),
-		// TODO this is here because the fake client needs it. Remove this when it's no longer
-		// needed.
-		Raw: &metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: istiov1alpha3.SchemeGroupVersion.String(),
-				Kind:       "VirtualService",
-			},
-		},
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
 
 	err := client.List(ctx, opts, list)

--- a/pkg/provisioners/inmemory/channel/reconcile.go
+++ b/pkg/provisioners/inmemory/channel/reconcile.go
@@ -261,14 +261,9 @@ func (r *reconciler) listAllChannels(ctx context.Context) ([]eventingv1alpha1.Ch
 	channels := make([]eventingv1alpha1.Channel, 0)
 
 	opts := &client.ListOptions{
-		// TODO this is here because the fake client needs it. Remove this when it's no longer
-		// needed.
-		Raw: &metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-				Kind:       "Channel",
-			},
-		},
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
 	for {
 		cl := &eventingv1alpha1.ChannelList{}

--- a/pkg/reconciler/v1alpha1/subscription/subscription.go
+++ b/pkg/reconciler/v1alpha1/subscription/subscription.go
@@ -372,15 +372,10 @@ func (r *reconciler) listAllSubscriptionsWithPhysicalChannel(sub *v1alpha1.Subsc
 	subs := make([]v1alpha1.Subscription, 0)
 
 	opts := &client.ListOptions{
-		// TODO this is here because the fake client needs it. Remove this when it's no longer
-		// needed.
-		Raw: &metav1.ListOptions{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: v1alpha1.SchemeGroupVersion.String(),
-				Kind:       "Subscription",
-			},
-		},
 		Namespace: sub.Namespace,
+		// Set Raw because if we need to get more than one page, then we will put the continue token
+		// into opts.Raw.Continue.
+		Raw: &metav1.ListOptions{},
 	}
 	ctx := context.TODO()
 	for {


### PR DESCRIPTION
## Proposed Changes

- Remove the fake ListOptions that were used exclusively for limitations in the fake client. #833 updated the fake client to remove the need for these options.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
