### PR TITLE
golang format tools

### DIFF
--- a/pkg/utils/blocking_start_test.go
+++ b/pkg/utils/blocking_start_test.go
@@ -18,10 +18,11 @@ package utils
 
 import (
 	"errors"
-	"go.uber.org/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
