### PR TITLE
Distinguish config-logging

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
-	configMapWatcher.Watch(logconfig.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Controller, logconfig.Controller))
+	configMapWatcher.Watch(logconfig.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Controller, logconfig.Controller))
 	if err = configMapWatcher.Start(stopCh); err != nil {
 		logger.Fatalf("Failed to start controller config map watcher: %v", err)
 	}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -71,7 +71,7 @@ func main() {
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
 
-	configMapWatcher.Watch(logconfig.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Webhook, logconfig.Webhook))
+	configMapWatcher.Watch(logconfig.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Webhook, logconfig.Webhook))
 
 	// Watch the default-channel-webhook ConfigMap and dynamically update the default
 	// ClusterChannelProvisioner.

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -42,7 +42,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
       volumes:
         - name: config-logging
           configMap:
-            name: eventing-config-logging
+            name: config-logging

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: config-logging
+            name: eventing-config-logging

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -44,7 +44,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
       volumes:
         - name: config-logging
           configMap:
-            name: eventing-config-logging
+            name: config-logging

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -47,4 +47,4 @@ spec:
       volumes:
         - name: config-logging
           configMap:
-            name: config-logging
+            name: eventing-config-logging

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: eventing-config-logging
+  name: config-logging
   namespace: knative-eventing
 data:
   # Common configuration for all Knative codebase

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: eventing-config-logging
   namespace: knative-eventing
 data:
   # Common configuration for all Knative codebase

--- a/pkg/logconfig/config.go
+++ b/pkg/logconfig/config.go
@@ -18,7 +18,7 @@ package logconfig
 
 const (
 	// ConfigName is the name of the config map used for knative-eventing logging config.
-	ConfigName = "config-logging"
+	ConfigName = "eventing-config-logging"
 
 	// Named Loggers are used to override the default log level. config-logging.yaml will use the follow:
 	//

--- a/pkg/logconfig/config.go
+++ b/pkg/logconfig/config.go
@@ -16,9 +16,14 @@ limitations under the License.
 
 package logconfig
 
+import (
+	"fmt"
+	"os"
+)
+
 const (
-	// ConfigName is the name of the config map used for knative-eventing logging config.
-	ConfigName = "eventing-config-logging"
+	// ConfigMapNameEnv is the environment value to get the name of the config map used for knative-eventing logging config.
+	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
 
 	// Named Loggers are used to override the default log level. config-logging.yaml will use the follow:
 	//
@@ -31,3 +36,19 @@ const (
 	// Webhook is the name of the override key used inside of the logging config for Webhook Controller.
 	Webhook = "webhook"
 )
+
+func ConfigMapName() string {
+	if cm := os.Getenv(ConfigMapNameEnv); cm != "" {
+		return cm
+	}
+
+	panic(fmt.Sprintf(`The environment variable %q is not set
+
+If this is a process running on Kubernetes, then it should be using the downward
+API to initialize this variable via:
+
+  env:
+  - name: CONFIG_LOGGING_NAME
+    value: config-logging
+`, ConfigMapNameEnv))
+}


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/3321

## Proposed Changes

Just want use the unique `config-logging` name. So change the configmap `config-logging` to `eventing-config-logging`.
