### PR TITLE
Fix invalid log message format

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -137,7 +137,7 @@ func main() {
 	srv := &http.Server{Addr: metricsScrapeAddr}
 	http.Handle(metricsScrapePath, promhttp.Handler())
 	go func() {
-		logger.Info("Starting metrics listener at %s", metricsScrapeAddr)
+		logger.Infof("Starting metrics listener at %s", metricsScrapeAddr)
 		if err := srv.ListenAndServe(); err != nil {
 			logger.Infof("Httpserver: ListenAndServe() finished with error: %s", err)
 		}


### PR DESCRIPTION
### Proposed Changes

Currently metrics starting log is not correctly formatted as:

```
$ kubectl  -n knative-eventing logs eventing-controller-756d56fc7-g64cd
  ...
{..snip.. msg":"Starting metrics listener at %s:9090","knative.dev/controller":"controller"}
```
(Please find `%s` in the message.)

This patch makes a tiny change to fix it by replacing `logger.Info`
with `logger.Infof`.

**Release Note**

```release-note
NONE
```
