### PR TITLE
Inform controller's metrics port is 9090

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -34,6 +34,9 @@ spec:
           "-logtostderr",
           "-stderrthreshold", "INFO"
         ]
+        ports:
+          - containerPort: 9090
+            name: metrics
         volumeMounts:
           - name: config-logging
             mountPath: /etc/config-logging


### PR DESCRIPTION
### Proposed Changes

Although event controller opens 9090 port for metrics, there are
no information about the port except for start logs.

This patch clarify the port in Deployment to be easily noticed by
users.

**Release Note**

```release-note
NONE
```
