### PR TITLE
Fix e2e tests on Minishift

### DIFF
--- a/test/crd.go
+++ b/test/crd.go
@@ -136,7 +136,7 @@ func EventSenderPod(name string, namespace string, sink string, event *CloudEven
 			Containers: []corev1.Container{{
 				Name:            "sendevent",
 				Image:           pkgTest.ImagePath("sendevent"),
-				ImagePullPolicy: corev1.PullAlways, // TODO: this might not be wanted for local.
+				ImagePullPolicy: corev1.PullPolicy(EventingFlags.ImagePullPolicy),
 				Args: []string{
 					"-event-id",
 					event.ID,
@@ -171,7 +171,7 @@ func EventLoggerPod(name string, namespace string, selector map[string]string) *
 			Containers: []corev1.Container{{
 				Name:            "logevents",
 				Image:           pkgTest.ImagePath("logevents"),
-				ImagePullPolicy: corev1.PullAlways, // TODO: this might not be wanted for local.
+				ImagePullPolicy: corev1.PullPolicy(EventingFlags.ImagePullPolicy),
 			}},
 			RestartPolicy: corev1.RestartPolicyAlways,
 		},
@@ -191,7 +191,7 @@ func EventTransformationPod(name string, namespace string, selector map[string]s
 			Containers: []corev1.Container{{
 				Name:            "transformevents",
 				Image:           pkgTest.ImagePath("transformevents"),
-				ImagePullPolicy: corev1.PullAlways, // TODO: this might not be wanted for local.
+				ImagePullPolicy: corev1.PullPolicy(EventingFlags.ImagePullPolicy),
 				Args: []string{
 					"-msg-postfix",
 					msgPostfix,

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/api/core/v1"
+	"os"
 	"strings"
 
 	"github.com/knative/pkg/logging"
@@ -70,6 +72,7 @@ func isValid(provisioner string) bool {
 type EventingEnvironmentFlags struct {
 	Provisioners
 	RunFromMain bool
+	ImagePullPolicy string // Image Pull Policy for the test images
 }
 
 func initializeEventingFlags() *EventingEnvironmentFlags {
@@ -77,6 +80,14 @@ func initializeEventingFlags() *EventingEnvironmentFlags {
 
 	flag.Var(&f.Provisioners, "clusterChannelProvisioners", "The names of the Channel's clusterChannelProvisioners, which are separated by comma.")
 	flag.BoolVar(&f.RunFromMain, "runFromMain", false, "If runFromMain is set to false, the TestMain will be skipped when we run tests.")
+
+	imagePullPolicy := string(v1.PullIfNotPresent)
+
+	if os.Getenv("IMAGE_PULL_POLICY") != imagePullPolicy {
+		imagePullPolicy = string(v1.PullAlways)
+	}
+
+	flag.StringVar(&f.ImagePullPolicy, "imagePullPolicy", imagePullPolicy, "Provide the image pull policy for the test images. Valid value is " + string(v1.PullIfNotPresent) + ", any other value will default to " + string(v1.PullAlways) + ".")
 
 	flag.Parse()
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -27,9 +27,16 @@ function upload_test_images() {
       ko publish -B ${image}
       if [ -n "$docker_tag" ]; then
           image=$KO_DOCKER_REPO/${image_name}
-          local digest=$(gcloud container images list-tags --filter="tags:latest" --format='get(digest)' ${image})
-          echo "Tagging ${image}@${digest} with $docker_tag"
-          gcloud -q container images add-tag ${image}@${digest} ${image}:$docker_tag
+          if [[ $KO_DOCKER_REPO = "ko.local" ]]
+          then
+              local digest=$(docker images | grep $image | head -1 | awk '{print $2}')
+              echo "Tagging ${image}@${digest} with $docker_tag"
+              docker tag $image:$digest $image:$docker_tag
+          else
+              local digest=$(gcloud container images list-tags --filter="tags:latest" --format='get(digest)' ${image})
+              echo "Tagging ${image}@${digest} with $docker_tag"
+              gcloud -q container images add-tag ${image}@${digest} ${image}:$docker_tag
+          fi
       fi
   done
 }


### PR DESCRIPTION
## Proposed Changes

- Provide the ability to tag docker images when using `ko.local` docker repository
- Change `ImagePullPolicy` to `PullIfNotPresent` for test images

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
This enables the tests to run on Minishift without its internal docker daemon to be configured with an upstream registry.
```
