### PR TITLE
Fix config map name for kafka channel dispatcher in README

### DIFF
--- a/contrib/kafka/config/README.md
+++ b/contrib/kafka/config/README.md
@@ -87,5 +87,5 @@ The Channel Dispatcher Config Map is used to send information about Channels and
 Subscriptions from the Channel Controller to the Channel Dispatcher:
 
 ```shell
-kubectl get configmap -n knative-eventing kafka-channel-dispatcher-config-map
+kubectl get configmap -n knative-eventing kafka-channel-dispatcher
 ```


### PR DESCRIPTION
## Proposed Changes
- Fix invalid configmap name in REAME.md for kafka.


**Release Note**

```release-note
NONE
```


