### PR TITLE
Fix flag parse error by calling flag.Parse from kafka channel dispatcher

### DIFF
--- a/contrib/kafka/cmd/dispatcher/main.go
+++ b/contrib/kafka/cmd/dispatcher/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -43,6 +44,7 @@ func main() {
 		configMapNamespace = system.Namespace()
 	}
 
+	flag.Parse()
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("unable to create logger: %v", err)


### PR DESCRIPTION
### Proposed Changes

Currently kafka-channel-dispatcher outputs `ERROR: logging before
flag.Parse` messages.

This patch changes to calls flag.Parse() when program started to fix
the issue.

- c.f.  currently channel dispatcher keeps producing following log messages.
```
$ kubectl  -n knative-eventing logs kafka-channel-dispatcher-0  -c dispatcher  -f
{"level":"info","ts":1551770419.020345,"caller":"provisioners/message_receiver.go:73","msg":"Starting web server"}
{"level":"info","ts":1551770578.578232,"caller":"dispatcher/dispatcher.go:93","msg":"Updating config (-old +new)","diff":"{*multichannelfanout.Config}.ChannelConfigs:\n\t-: []multichannelfanout.ChannelConfig(nil)\n\t+: []multichannelfanout.ChannelConfig{{Namespace: \"default\", Name: \"my-kafka-channel\"}}\n"}
ERROR: logging before flag.Parse: W0305 07:26:05.129295       1 reflector.go:341] github.com/knative/eventing/vendor/k8s.io/client-go/informers/factory.go:130: watch of *v1.ConfigMap ended with: too old resource version: 16754 (16803)
ERROR: logging before flag.Parse: W0305 07:32:36.142470       1 reflector.go:341] github.com/knative/eventing/vendor/k8s.io/client-go/informers/factory.go:130: watch of *v1.ConfigMap ended with: too old resource version: 17201 (17772)
ERROR: logging before flag.Parse: W0305 07:39:12.156224       1 reflector.go:341] github.com/knative/eventing/vendor/k8s.io/client-go/informers/factory.go:130: watch of *v1.ConfigMap ended with: too old resource version: 18173 (18739)
.. continue ..
```

**Release Note**

```release-note
NONE
```
