### PR TITLE
Use DeletionTimestamp field in subscription struct

### DIFF
--- a/pkg/reconciler/v1alpha1/subscription/subscription.go
+++ b/pkg/reconciler/v1alpha1/subscription/subscription.go
@@ -150,10 +150,8 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		return nil
 	}
 
-	var err error
-
 	// Verify that `channel` exists.
-	_, err = r.fetchObjectReference(subscription.Namespace, &subscription.Spec.Channel)
+	_, err := r.fetchObjectReference(subscription.Namespace, &subscription.Spec.Channel)
 	if err != nil {
 		glog.Warningf("Failed to validate `channel` exists: %+v, %v", subscription.Spec.Channel, err)
 		r.recorder.Eventf(subscription, corev1.EventTypeWarning, channelReferenceFetchFailed, "Failed to validate spec.channel exists: %v", err)

--- a/pkg/reconciler/v1alpha1/subscription/subscription.go
+++ b/pkg/reconciler/v1alpha1/subscription/subscription.go
@@ -38,7 +38,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -135,14 +134,7 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 	subscription.Status.InitializeConditions()
 
 	// See if the subscription has been deleted
-	accessor, err := meta.Accessor(subscription)
-	if err != nil {
-		glog.Warningf("Failed to get metadata accessor: %s", err)
-		return err
-	}
-	deletionTimestamp := accessor.GetDeletionTimestamp()
-	glog.Infof("DeletionTimestamp: %v", deletionTimestamp)
-
+	glog.Infof("DeletionTimestamp: %v", subscription.DeletionTimestamp)
 	if subscription.DeletionTimestamp != nil {
 		// If the subscription is Ready, then we have to remove it
 		// from the channel's subscriber list.
@@ -157,6 +149,8 @@ func (r *reconciler) reconcile(subscription *v1alpha1.Subscription) error {
 		removeFinalizer(subscription)
 		return nil
 	}
+
+	var err error
 
 	// Verify that `channel` exists.
 	_, err = r.fetchObjectReference(subscription.Namespace, &subscription.Spec.Channel)


### PR DESCRIPTION
## Proposed Changes

This patch refactors by stop using `meta.Accessor()` as subscription has
`DeletionTimestamp` field.

Current code gets `deletionTimeStamp` via
`accessor.GetDeletionTimestamp()`, but the result is used just for log
outputs.

This patch refactors it.

**Release Note**

```release-note
NONE
```
