### PR TITLE
Use DeletionTimestamp field in channel struct

### DIFF
--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -116,10 +116,9 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 // boolean indicates if this Channel should be immediately requeued for another reconcile loop. The
 // returned error indicates an error during reconciliation.
 func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Channel) (bool, error) {
-	var err error
 
 	// We always need to sync the Channel config, so do it first.
-	if err = r.syncChannelConfig(ctx); err != nil {
+	if err := r.syncChannelConfig(ctx); err != nil {
 		r.logger.Info("error updating syncing the Channel config", zap.Error(err))
 		return false, err
 	}
@@ -130,6 +129,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	// used to pass a fake admin client in the tests.
 	kafkaClusterAdmin := r.kafkaClusterAdmin
 	if kafkaClusterAdmin == nil {
+		var err error
 		kafkaClusterAdmin, err = createKafkaAdminClient(r.config)
 		if err != nil {
 			r.logger.Fatal("unable to build kafka admin client", zap.Error(err))
@@ -140,7 +140,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	// See if the channel has been deleted
 	if channel.DeletionTimestamp != nil {
 		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", channel.DeletionTimestamp))
-		if err = r.deprovisionChannel(channel, kafkaClusterAdmin); err != nil {
+		if err := r.deprovisionChannel(channel, kafkaClusterAdmin); err != nil {
 			return false, err
 		}
 		util.RemoveFinalizer(channel, finalizerName)
@@ -154,7 +154,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 		return true, nil
 	}
 
-	if err = r.provisionChannel(channel, kafkaClusterAdmin); err != nil {
+	if err := r.provisionChannel(channel, kafkaClusterAdmin); err != nil {
 		channel.Status.MarkNotProvisioned("NotProvisioned", "error while provisioning: %s", err)
 		return false, err
 	}

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -117,9 +116,10 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 // boolean indicates if this Channel should be immediately requeued for another reconcile loop. The
 // returned error indicates an error during reconciliation.
 func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Channel) (bool, error) {
+	var err error
 
 	// We always need to sync the Channel config, so do it first.
-	if err := r.syncChannelConfig(ctx); err != nil {
+	if err = r.syncChannelConfig(ctx); err != nil {
 		r.logger.Info("error updating syncing the Channel config", zap.Error(err))
 		return false, err
 	}
@@ -130,7 +130,6 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	// used to pass a fake admin client in the tests.
 	kafkaClusterAdmin := r.kafkaClusterAdmin
 	if kafkaClusterAdmin == nil {
-		var err error
 		kafkaClusterAdmin, err = createKafkaAdminClient(r.config)
 		if err != nil {
 			r.logger.Fatal("unable to build kafka admin client", zap.Error(err))
@@ -139,14 +138,8 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 	}
 
 	// See if the channel has been deleted
-	accessor, err := meta.Accessor(channel)
-	if err != nil {
-		r.logger.Info("failed to get metadata", zap.Error(err))
-		return false, err
-	}
-	deletionTimestamp := accessor.GetDeletionTimestamp()
-	if deletionTimestamp != nil {
-		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", deletionTimestamp))
+	if channel.DeletionTimestamp != nil {
+		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", channel.DeletionTimestamp))
 		if err = r.deprovisionChannel(channel, kafkaClusterAdmin); err != nil {
 			return false, err
 		}

--- a/contrib/kafka/pkg/controller/reconcile.go
+++ b/contrib/kafka/pkg/controller/reconcile.go
@@ -22,7 +22,6 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -89,14 +88,8 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 func (r *reconciler) reconcile(ctx context.Context, provisioner *v1alpha1.ClusterChannelProvisioner) error {
 	// See if the provisioner has been deleted
-	accessor, err := meta.Accessor(provisioner)
-	if err != nil {
-		r.logger.Info("failed to get metadata", zap.Error(err))
-		return err
-	}
-	deletionTimestamp := accessor.GetDeletionTimestamp()
-	if deletionTimestamp != nil {
-		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", deletionTimestamp))
+	if provisioner.DeletionTimestamp != nil {
+		r.logger.Info(fmt.Sprintf("DeletionTimestamp: %v", provisioner.DeletionTimestamp))
 		return nil
 	}
 


### PR DESCRIPTION
## Proposed Changes

This patch refactors by stop using meta.Accessor as channel struct has
DeletionTimestamp field.

This PR is same refactoring with https://github.com/knative/eventing/pull/855, but for Kafka.

**Release Note**

```release-note
NONE
```
