### PR TITLE
Do not call Fatal log during reconciling of kafka channel controller

### DIFF
--- a/contrib/kafka/config/kafka.yaml
+++ b/contrib/kafka/config/kafka.yaml
@@ -77,6 +77,14 @@ rules:
       - watch
       - create
       - update
+  - apiGroups:
+      - "" # Core API Group.
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,11 @@ const (
 
 	// DefaultReplicationFactor defines the default number of replications
 	DefaultReplicationFactor = 1
+
+	// Name of the corev1.Events emitted from the reconciliation process
+	dispatcherReconciled         = "DispatcherReconciled"
+	dispatcherReconcileFailed    = "DispatcherReconcileFailed"
+	dispatcherUpdateStatusFailed = "DispatcherUpdateStatusFailed"
 )
 
 type channelArgs struct {
@@ -106,8 +112,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		err = fmt.Errorf("ClusterChannelProvisioner %s is not ready", clusterChannelProvisioner.Name)
 	}
 
+	if err != nil {
+		r.logger.Error("Dispatcher reconciliation failed", zap.Error(err))
+		r.recorder.Eventf(newChannel, v1.EventTypeWarning, dispatcherReconcileFailed, "Dispatcher reconciliation failed: %v", err)
+	} else {
+		r.logger.Info("Channel reconciled")
+		r.recorder.Eventf(newChannel, v1.EventTypeNormal, dispatcherReconciled, "Dispatcher reconciled: %q", newChannel.Name)
+	}
+
 	if updateChannelErr := util.UpdateChannel(ctx, r.client, newChannel); updateChannelErr != nil {
 		r.logger.Info("failed to update channel status", zap.Error(updateChannelErr))
+		r.recorder.Eventf(newChannel, v1.EventTypeWarning, dispatcherUpdateStatusFailed, "Failed to update Channel's dispatcher status: %v", err)
 		return reconcile.Result{}, updateChannelErr
 	}
 
@@ -137,7 +152,7 @@ func (r *reconciler) reconcile(ctx context.Context, channel *eventingv1alpha1.Ch
 		var err error
 		kafkaClusterAdmin, err = createKafkaAdminClient(r.config)
 		if err != nil {
-			r.logger.Fatal("unable to build kafka admin client", zap.Error(err))
+			r.logger.Error(fmt.Sprintf("unable to build kafka admin client for %v", r.config), zap.Error(err))
 			return false, err
 		}
 	}

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -51,7 +51,6 @@ const (
 	DefaultReplicationFactor = 1
 
 	// Name of the corev1.Events emitted from the reconciliation process
-	dispatcherReconciled         = "DispatcherReconciled"
 	dispatcherReconcileFailed    = "DispatcherReconcileFailed"
 	dispatcherUpdateStatusFailed = "DispatcherUpdateStatusFailed"
 )
@@ -116,8 +115,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		r.logger.Error("Dispatcher reconciliation failed", zap.Error(err))
 		r.recorder.Eventf(newChannel, v1.EventTypeWarning, dispatcherReconcileFailed, "Dispatcher reconciliation failed: %v", err)
 	} else {
-		r.logger.Info("Channel reconciled")
-		r.recorder.Eventf(newChannel, v1.EventTypeNormal, dispatcherReconciled, "Dispatcher reconciled: %q", newChannel.Name)
+		r.logger.Debug("Channel reconciled")
 	}
 
 	if updateChannelErr := util.UpdateChannel(ctx, r.client, newChannel); updateChannelErr != nil {

--- a/contrib/kafka/pkg/controller/channel/reconcile_test.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile_test.go
@@ -60,6 +60,11 @@ var (
 	// serviceAddress is the address of the K8s Service. It uses a GeneratedName and the fake client
 	// does not fill in Name, so the name is the empty string.
 	serviceAddress = fmt.Sprintf("%s.%s.svc.%s", "", testNS, utils.GetClusterDomainName())
+
+	// map of events to set test cases' expectations easier
+	events = map[string]corev1.Event{
+		dispatcherReconcileFailed: {Reason: dispatcherReconcileFailed, Type: corev1.EventTypeWarning},
+	}
 )
 
 func init() {
@@ -167,6 +172,9 @@ var testCases = []controllertesting.TestCase{
 		WantPresent: []runtime.Object{
 			getNewChannelNotProvisionedStatus(channelName, clusterChannelProvisionerName,
 				"ClusterChannelProvisioner "+clusterChannelProvisionerName+" is not ready"),
+		},
+		WantEvent: []corev1.Event{
+			events[dispatcherReconcileFailed],
 		},
 	},
 	{


### PR DESCRIPTION
Currently kafka channel controller keeps restarting if fails to build
admin client. Controller should try to reconcile without restart.

Having said that, users would like to notice the error easily. Hence
this patch introduces event logs for reconciler failures as well.

Fixes https://github.com/knative/eventing/issues/870

## Proposed Changes
- Replace Fatal log inside reconcile with Error log.
- Produce event message from kafka channel controller

**Release Note**

```release-note
NONE
```
