### PR TITLE
do not unsubscribe for existing consumers upon config map update

### DIFF
--- a/contrib/kafka/pkg/dispatcher/dispatcher.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher.go
@@ -102,18 +102,12 @@ func (d *KafkaDispatcher) UpdateConfig(config *multichannelfanout.Config) error 
 			}
 			for _, subSpec := range cc.FanoutConfig.Subscriptions {
 				sub := newSubscription(subSpec)
-				if _, ok := d.kafkaConsumers[channelRef][sub]; ok {
-					// subscribe can be called multiple times for the same subscription,
-					// unsubscribe before we resubscribe.
-					// TODO The behavior to unsubscribe and re-subscribe is retained from the older kafka bus
-					// implementation. It is not clear as to why this is needed instead of just re-using the same
-					// consumer.
-					err := d.unsubscribe(channelRef, sub)
-					if err != nil {
-						return err
-					}
+				if _, ok := d.kafkaConsumers[channelRef][sub]; !ok {
+					// only subscribe when not exists in channel-subscriptions map
+					// do not need to resubscribe every time channel fanout config is updated
+					d.subscribe(channelRef, sub)
 				}
-				d.subscribe(channelRef, sub)
+
 				newSubs[sub] = true
 			}
 		}


### PR DESCRIPTION
Fixes #620 

## Proposed Changes

- unsubscribe/resubscribe for existing consumers upon fanout config update is quite discruptive for real time event processing and do not see a reason why this is needed
- propose to reuse the consumer and only subscribe when subscriber is not in the channel-subscriptions map  


**Release Note**



```release-note
Changed old behavior for kafka channel that existing kafka consumers are stopped and resubscribed when fanout configs are updated, now kafka consumers are reused until corresponding subscription gets deleted.
```