### PR TITLE
Configure natss url and cluster id via the environment

### DIFF
--- a/contrib/natss/config/README.md
+++ b/contrib/natss/config/README.md
@@ -1,5 +1,24 @@
 # NATS Streaming Channels
 
+NATS Streaming channels are beta-quality Channels that are backed by
+[NATS Streaming](https://github.com/nats-io/nats-streaming-server).
+
+They offer:
+
+- Persistence
+  - If the Channel's Pod goes down, all events already ACKed by the Channel will
+    persist and be retransmitted when the Pod restarts.
+- Redelivery attempts
+  - If downstream rejects an event, that request is attempted again. NOTE: downstream must
+    successfully process the event within one minute or the delivery is assumed to have failed 
+    and will be reattempted.
+
+They do not offer:
+
+- Ordering guarantees
+  - Events seen downstream may not occur in the same order they were inserted
+    into the Channel.
+
 ## Deployment steps
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
@@ -46,3 +65,18 @@ Dispatcher for all natss Channels.
 ```shell
 kubectl get deployment -n knative-eventing natss-dispatcher
 ```
+
+By default the components are configured to connect to NATS at `nats://nats-streaming.natss.svc:4222` with NATS Streaming cluster ID `knative-nats-streaming`. This may be overridden by configuring both the `natss-channel-controller` and `natss-dispatcher` deployments with
+environment variables:
+
+  ```yaml
+          env:
+          - name: DEFAULT_NATSS_URL
+            value: nats://natss.custom-namespace.svc.cluster.local:4222
+          - name: DEFAULT_CLUSTER_ID
+            value: custom-cluster-id
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace  
+  ```

--- a/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
+++ b/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
@@ -35,10 +35,10 @@ const (
 )
 
 // ProvideController returns a flow controller.
-func ProvideController(mgr manager.Manager, defaultNatssURL, defaultClusterID string, logger *zap.Logger) (controller.Controller, error) {
+func ProvideController(mgr manager.Manager, natssURL, clusterID string, logger *zap.Logger) (controller.Controller, error) {
 	// check the connection to NATSS
 	var err error
-	if _, err := stanutil.Connect(defaultClusterID, clientID, defaultNatssURL, logger.Sugar()); err != nil {
+	if _, err := stanutil.Connect(clusterID, clientID, natssURL, logger.Sugar()); err != nil {
 		logger.Error("Connect() failed: ", zap.Error(err))
 		return nil, err
 	}

--- a/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
+++ b/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
@@ -17,8 +17,6 @@ limitations under the License.
 package clusterchannelprovisioner
 
 import (
-	"fmt"
-
 	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -27,25 +25,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"github.com/knative/eventing/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
-	// NATSS
-	ClusterId    = "knative-nats-streaming"
-	NatssUrlTmpl = "nats://nats-streaming.natss.svc.%s:4222"
-	clientId     = "knative-natss-controller"
+	clientID = "knative-natss-controller"
 	// controllerAgentName is the string used by this controller to identify itself when creating events.
 	controllerAgentName = "natss-provisioner-controller"
 )
 
 // ProvideController returns a flow controller.
-func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Controller, error) {
+func ProvideController(mgr manager.Manager, defaultNatssURL, defaultClusterID string, logger *zap.Logger) (controller.Controller, error) {
 	// check the connection to NATSS
 	var err error
-	natssUrl := fmt.Sprintf(NatssUrlTmpl, utils.GetClusterDomainName())
-	if _, err := stanutil.Connect(ClusterId, clientId, natssUrl, logger.Sugar()); err != nil {
+	if _, err := stanutil.Connect(defaultClusterID, clientID, defaultNatssURL, logger.Sugar()); err != nil {
 		logger.Error("Connect() failed: ", zap.Error(err))
 		return nil, err
 	}

--- a/contrib/natss/pkg/controller/main.go
+++ b/contrib/natss/pkg/controller/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/knative/eventing/contrib/natss/pkg/controller/channel"
 	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
+	"github.com/knative/eventing/contrib/natss/pkg/util"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
@@ -49,7 +50,7 @@ func main() {
 	eventingv1alpha1.AddToScheme(mgr.GetScheme())
 	istiov1alpha3.AddToScheme(mgr.GetScheme())
 
-	_, err = clusterchannelprovisioner.ProvideController(mgr, logger.Desugar())
+	_, err = clusterchannelprovisioner.ProvideController(mgr, util.GetDefaultNatssURL(), util.GetDefaultClusterID(), logger.Desugar())
 	if err != nil {
 		logger.Fatal("Unable to create Provisioner controller", zap.Error(err))
 	}

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
 	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"github.com/knative/eventing/pkg/provisioners"
 	stan "github.com/nats-io/go-nats-streaming"
@@ -52,8 +51,9 @@ type SubscriptionsSupervisor struct {
 	subscriptionsMux sync.Mutex
 	subscriptions    map[provisioners.ChannelReference]map[subscriptionReference]*stan.Subscription
 
-	connect  chan struct{}
-	natssURL string
+	connect   chan struct{}
+	natssURL  string
+	clusterID string
 	// natConnMux is used to protect natssConn and natssConnInProgress during
 	// the transition from not connected to connected states.
 	natssConnMux        sync.Mutex
@@ -62,12 +62,13 @@ type SubscriptionsSupervisor struct {
 }
 
 // NewDispatcher returns a new SubscriptionsSupervisor.
-func NewDispatcher(natssUrl string, logger *zap.Logger) (*SubscriptionsSupervisor, error) {
+func NewDispatcher(natssURL, clusterID string, logger *zap.Logger) (*SubscriptionsSupervisor, error) {
 	d := &SubscriptionsSupervisor{
 		logger:        logger,
 		dispatcher:    provisioners.NewMessageDispatcher(logger.Sugar()),
 		connect:       make(chan struct{}, maxElements),
-		natssURL:      natssUrl,
+		natssURL:      natssURL,
+		clusterID:     clusterID,
 		subscriptions: make(map[provisioners.ChannelReference]map[subscriptionReference]*stan.Subscription),
 	}
 	d.receiver = provisioners.NewMessageReceiver(createReceiverFunction(d, logger.Sugar()), logger.Sugar())
@@ -128,7 +129,7 @@ func (s *SubscriptionsSupervisor) connectWithRetry(stopCh <-chan struct{}) {
 	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 	for {
-		nConn, err := stanutil.Connect(clusterchannelprovisioner.ClusterId, clientID, s.natssURL, s.logger.Sugar())
+		nConn, err := stanutil.Connect(s.clusterID, clientID, s.natssURL, s.logger.Sugar())
 		if err == nil {
 			// Locking here in order to reduce time in locked state.
 			s.natssConnMux.Lock()

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
 	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
@@ -47,7 +46,7 @@ const (
 )
 
 var (
-	clusterID   = clusterchannelprovisioner.ClusterId
+	clusterID   = "knative-nats-streaming"
 	logger      *zap.SugaredLogger
 	core        zapcore.Core
 	observed    *observer.ObservedLogs
@@ -86,7 +85,7 @@ func TestMain(m *testing.M) {
 	}
 	defer stopNatss(stanServer)
 	// Create and start Dispatcher.
-	s, err = NewDispatcher(natssTestURL, testLogger)
+	s, err = NewDispatcher(natssTestURL, clusterID, testLogger)
 	if err != nil {
 		logger.Fatalf("Unable to create NATSS dispatcher: %v", err)
 	}

--- a/contrib/natss/pkg/dispatcher/main.go
+++ b/contrib/natss/pkg/dispatcher/main.go
@@ -17,19 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/knative/eventing/contrib/natss/pkg/dispatcher/channel"
 	"github.com/knative/eventing/contrib/natss/pkg/dispatcher/dispatcher"
+	"github.com/knative/eventing/contrib/natss/pkg/util"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/knative/eventing/contrib/natss/pkg/controller/clusterchannelprovisioner"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"github.com/knative/eventing/pkg/utils"
 )
 
 func main() {
@@ -50,8 +48,7 @@ func main() {
 	}
 
 	logger.Info("Dispatcher starting...")
-	natssUrl := fmt.Sprintf(clusterchannelprovisioner.NatssUrlTmpl, utils.GetClusterDomainName())
-	d, err := dispatcher.NewDispatcher(natssUrl, logger)
+	d, err := dispatcher.NewDispatcher(util.GetDefaultNatssURL(), util.GetDefaultClusterID(), logger)
 	if err != nil {
 		logger.Fatal("Unable to create NATSS dispatcher.", zap.Error(err))
 	}

--- a/contrib/natss/pkg/util/util.go
+++ b/contrib/natss/pkg/util/util.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"fmt"
+	"os"
+
+	eventingutils "github.com/knative/eventing/pkg/utils"
+)
+
+const (
+	// DefaultNatssURLKey is the environment variable that can be set to specify the natss url
+	defaultNatssURLVar  = "DEFAULT_NATSS_URL"
+	defaultClusterIDVar = "DEFAULT_CLUSTER_ID"
+
+	fallbackDefaultNatssURLTmpl = "nats://nats-streaming.natss.svc.%s:4222"
+	fallbackDefaultClusterID    = "knative-nats-streaming"
+)
+
+// GetDefaultNatssURL returns the default natss url to connect to
+func GetDefaultNatssURL() string {
+	return getEnv(defaultNatssURLVar, fmt.Sprintf(fallbackDefaultNatssURLTmpl, eventingutils.GetClusterDomainName()))
+}
+
+// GetDefaultClusterID returns the default cluster id to connect with
+func GetDefaultClusterID() string {
+	return getEnv(defaultClusterIDVar, fallbackDefaultClusterID)
+}
+
+func getEnv(envKey string, fallback string) string {
+	val, ok := os.LookupEnv(envKey)
+	if !ok {
+		return fallback
+	}
+	return val
+}


### PR DESCRIPTION
## Proposed Changes

- Optionally configure the natss url and cluster id using the environment variables `DEFAULT_NATSS_URL` and `DEFAULT_CLUSTER_ID`.
- Update README.md to include documentation on new options as well as properties of the channel.

Note that the environment variables are named similarly to the gcp provisioner. I assume they're named with the prefix `DEFAULT` in case channels can be optionally configured with arguments in the future.

Test Plan: `go test ./...`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add DEFAULT_NATSS_URL and DEFAULT_CLUSTER_ID configuration to NATS provisioner
```