### PR TITLE
Remove unnecessary printing format

### DIFF
--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -239,7 +239,7 @@ func (r *reconciler) deprovisionChannel(channel *eventingv1alpha1.Channel, kafka
 	} else if err != nil {
 		r.logger.Error("error deleting topic", zap.String("topic", topicName), zap.Error(err))
 	} else {
-		r.logger.Info("successfully deleted topic %s", zap.String("topic", topicName))
+		r.logger.Info("successfully deleted topic", zap.String("topic", topicName))
 	}
 	return err
 }


### PR DESCRIPTION
## Proposed Changes

This patch makes a tiny change by removing unnecessary printing
format `%s`.

- BFORE:
```
... msg":"successfully deleted topic %s","topic":"knative-eventing-channel.test-namespace.test-channel"}
```

- AFTER:
```
... "msg":"successfully deleted topic","topic":"knative-eventing-channel.test-namespace.test-channel"}
```

**Release Note**

```release-note
NONE
```
