### PR TITLE
test/e2e-tests.sh runs on the newly created cluster

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -87,6 +87,8 @@ function dump_extra_cluster_state() {
 
 initialize $@
 
-go_test_e2e ./test/e2e || fail_test
+k8s_cluster=$(kubectl config current-context)
+
+go_test_e2e ./test/e2e -cluster "$k8s_cluster" || fail_test
 
 success


### PR DESCRIPTION
## Proposed Changes

- `test/e2e-tests.sh` runs on the newly created cluster
    - Previously, it would run on whatever `$K8S_CLUSTER_OVERRIDE` happened to be.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
