### PR TITLE
Remove markdown lint presubmit check in favor of the sockpuppet.

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,6 +21,11 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
+# Markdown linting failures don't show up properly in Gubernator resulting
+# in a net-negative contributor experience. Also, sockpuppet will correct
+# markdown issues with less human involvement.
+export DISABLE_MD_LINTING=1
+
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
## Proposed Changes

- Removes markdown linting in favor of the sockpuppet. #862 has hard tabs in the go code (as is appropriate for go code) referenced in the markdown file. prettier.io is fine with this and formats correctly. The linter does not. I see three ways forward:
  - Replace tabs with spaces in the go code, requiring reformatting it when copy-pasting.
  - Add MD10 to the set of exceptions, allowing a mix of tabs and spaces *everywhere* in markdown.
  - Remove the linter that randomly breaks submits, where the error reporting is not clear about the problem, and adds extra human toil to comply (vs sockpuppet, which just adds toil to approve the fixups, which are very easy to review).