### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/main.go
+++ b/contrib/kafka/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/contrib/kafka/pkg/controller/types.go
+++ b/contrib/kafka/pkg/controller/types.go
@@ -1,6 +1,6 @@
 package controller
 
-import "github.com/bsm/sarama-cluster"
+import cluster "github.com/bsm/sarama-cluster"
 
 type KafkaProvisionerConfig struct {
 	Brokers      []string

--- a/contrib/kafka/pkg/controller/util.go
+++ b/contrib/kafka/pkg/controller/util.go
@@ -2,8 +2,9 @@ package controller
 
 import (
 	"fmt"
-	"github.com/bsm/sarama-cluster"
 	"strings"
+
+	cluster "github.com/bsm/sarama-cluster"
 
 	"github.com/knative/pkg/configmap"
 )

--- a/contrib/kafka/pkg/controller/util_test.go
+++ b/contrib/kafka/pkg/controller/util_test.go
@@ -1,11 +1,12 @@
 package controller
 
 import (
-	"github.com/bsm/sarama-cluster"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	cluster "github.com/bsm/sarama-cluster"
 
 	"github.com/google/go-cmp/cmp"
 	_ "github.com/knative/pkg/system/testing"

--- a/contrib/kafka/pkg/dispatcher/dispatcher_test.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher_test.go
@@ -3,13 +3,14 @@ package dispatcher
 import (
 	"errors"
 	"fmt"
-	"github.com/bsm/sarama-cluster"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	cluster "github.com/bsm/sarama-cluster"
 
 	"github.com/Shopify/sarama"
 	"github.com/google/go-cmp/cmp"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
