### PR TITLE
Set memory limits

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -52,6 +52,9 @@ spec:
         ports:
           - containerPort: 9090
             name: metrics
+        resources:
+          limits:
+            memory: 1000Mi  # An initial guess, but consistent with serving
         volumeMounts:
           - name: config-logging
             mountPath: /etc/config-logging

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -46,6 +46,9 @@ spec:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        resources:
+          limits:
+            memory: 1000Mi   # An initial guess, but consistent with serving
       volumes:
         - name: config-logging
           configMap:


### PR DESCRIPTION
We're seeing OOM issues at the Node level when we don't set the limit on some pods. This will allow the pod to restart gracefully w/o taking down the entire node.

I'm not stuck on the specific value so we can pick a different one.

See https://github.com/knative/serving/pull/3332 for the serving equivalent.

Signed-off-by: Doug Davis <dug@us.ibm.com>

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
