### PR TITLE
Fix broken links to docs repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Contributor Covenant Code of Conduct
 
 Please see the Knative Community
-[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/community/CODE-OF-CONDUCT.md).
+[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/contributing/CODE-OF-CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution guidelines
 
 So you want to hack on Knative Eventing? Yay! Please refer to Knative's overall
-[contribution guidelines](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
+[contribution guidelines](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
 to find out how you can help.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -129,6 +129,6 @@ ko delete -f config/
 
 To access Telemetry see:
 
-- [Accessing Metrics](https://github.com/knative/docs/blob/master/serving/accessing-metrics.md)
-- [Accessing Logs](https://github.com/knative/docs/blob/master/serving/accessing-logs.md)
-- [Accessing Traces](https://github.com/knative/docs/blob/master/serving/accessing-traces.md)
+- [Accessing Metrics](https://github.com/knative/docs/blob/master/docs/serving/accessing-metrics.md)
+- [Accessing Logs](https://github.com/knative/docs/blob/master/docs/serving/accessing-logs.md)
+- [Accessing Traces](https://github.com/knative/docs/blob/master/docs/serving/accessing-traces.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For complete Knative Eventing documentation, see
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
-[Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#events).
+[Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/contributing/WORKING-GROUPS.md#events).
 
 Please join
 [knative-users](https://groups.google.com/forum/#!forum/knative-users) to view

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -19,7 +19,7 @@ Docs in this directory:
 <!-- TODO(n3wscott): * [Sample API usage](normative_examples.md) -->
 
 See the
-[Knative Eventing Docs Architecture](https://github.com/knative/docs/blob/master/eventing/README.md#architecture)
+[Knative Eventing Docs Architecture](https://github.com/knative/docs/blob/master/docs/eventing/README.md#architecture)
 for more high level details.
 
 <!-- TODO(#498): Update the docs/Architecture page. -->


### PR DESCRIPTION
Recent commits in the docs repo, https://github.com/knative/docs/commit/2205ab84e67955391f8ff7728ae97210240a9289 and https://github.com/knative/docs/commit/3c04f86ad7b7f937ae552a1b93eca97a5d312449, have resulted in broken links.

