### PR TITLE
User can specify webhook deployment name

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -45,13 +45,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading logging configuration: %v", err)
 	}
-	config, err := logging.NewConfigFromMap(cm, logconfig.Webhook)
+	config, err := logging.NewConfigFromMap(cm, logconfig.WebhookName())
 	if err != nil {
 		log.Fatalf("Error parsing logging configuration: %v", err)
 	}
-	logger, atomicLevel := logging.NewLoggerFromConfig(config, logconfig.Webhook)
+	logger, atomicLevel := logging.NewLoggerFromConfig(config, logconfig.WebhookName())
 	defer logger.Sync()
-	logger = logger.With(zap.String(logkey.ControllerType, logconfig.Webhook))
+	logger = logger.With(zap.String(logkey.ControllerType, logconfig.WebhookName()))
 
 	logger.Infow("Starting the Eventing Webhook")
 
@@ -71,7 +71,7 @@ func main() {
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
 
-	configMapWatcher.Watch(logconfig.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Webhook, logconfig.Webhook))
+	configMapWatcher.Watch(logconfig.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.WebhookName(), logconfig.WebhookName()))
 
 	// Watch the default-channel-webhook ConfigMap and dynamically update the default
 	// ClusterChannelProvisioner.
@@ -84,8 +84,8 @@ func main() {
 	}
 
 	options := webhook.ControllerOptions{
-		ServiceName:    "webhook",
-		DeploymentName: "webhook",
+		ServiceName:    logconfig.WebhookName(),
+		DeploymentName: logconfig.WebhookName(),
 		Namespace:      system.Namespace(),
 		Port:           443,
 		SecretName:     "webhook-certs",

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -46,6 +46,8 @@ spec:
               fieldPath: metadata.namespace
         - name: CONFIG_LOGGING_NAME
           value: config-logging
+        - name: WEBHOOK_NAME
+          value: webhook
         resources:
           limits:
             memory: 1000Mi   # An initial guess, but consistent with serving

--- a/pkg/logconfig/config.go
+++ b/pkg/logconfig/config.go
@@ -34,7 +34,7 @@ const (
 	Controller = "controller"
 
 	// Webhook is the name of the override key used inside of the logging config for Webhook Controller.
-	Webhook = "webhook"
+	WebhookNameEnv = "WEBHOOK_NAME"
 )
 
 func ConfigMapName() string {
@@ -51,4 +51,20 @@ API to initialize this variable via:
   - name: CONFIG_LOGGING_NAME
     value: config-logging
 `, ConfigMapNameEnv))
+}
+
+func WebhookName() string {
+	if webhook := os.Getenv(WebhookNameEnv); webhook != "" {
+		return webhook
+	}
+
+	panic(fmt.Sprintf(`The environment variable %q is not set
+
+If this is a process running on Kubernetes, then it should be using the downward
+API to initialize this variable via:
+
+  env:
+  - name: WEBHOOK_NAME
+    value: webhook
+`, WebhookNameEnv))
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

User can specify webhook deployment name




