### PR TITLE
updated the link to WORKING-GROUPS.md in the README.md of the Eventin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For complete Knative Eventing documentation, see
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
-[Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#events).
+[Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/contributing/WORKING-GROUPS.md#eventing).
 
 Please join
 [knative-users](https://groups.google.com/forum/#!forum/knative-users) to view


### PR DESCRIPTION
The link to WORKING-GROUPS.md in README.md is pointing to a location that no longer exists.

Fixes
Updated the link in README.md to reference the updated location for WORKING-GROUPS.md#eventing

https://github.com/knative/docs/blob/master/contributing/WORKING-GROUPS.md#eventing