### PR TITLE
Fix some broker vet and lint issues

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -163,6 +163,6 @@ func (h *handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *
 
 func (h *handler) sendEvent(ctx context.Context, tctx cehttp.TransportContext, event cloudevents.Event) error {
 	sendingCTX := broker.SendingContext(ctx, tctx, h.channelURI)
-	_, err := h.ceHttp.Send(sendingCTX, event)
+	_, err := h.ceHTTP.Send(sendingCTX, event)
 	return err
 }

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -122,7 +122,7 @@ type handler struct {
 
 func (h *handler) Start(stopCh <-chan struct{}) error {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer ctx.Done()
+	defer cancel()
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -67,11 +67,23 @@ func main() {
 		Path:   "/",
 	}
 
-	h, err := New(logger, channelURI)
+	// Create an event handler.
+	ceHTTP, err := cehttp.New(cehttp.WithBinaryEncoding(), cehttp.WithPort(defaultPort))
 	if err != nil {
-		logger.Fatal("Unable to create handler", zap.Error(err))
+		logger.Fatal("Unable to create CE transport", zap.Error(err))
+	}
+	ceClient, err := ceclient.New(ceHTTP)
+	if err != nil {
+		logger.Fatal("Unable to create CE client", zap.Error(err))
+	}
+	h := &handler{
+		logger:     logger,
+		ceClient:   ceClient,
+		ceHTTP:     ceHTTP,
+		channelURI: channelURI,
 	}
 
+	// Run the event handler with the manager.
 	err = mgr.Add(h)
 	if err != nil {
 		logger.Fatal("Unable to add handler", zap.Error(err))
@@ -96,27 +108,10 @@ func getRequiredEnv(envKey string) string {
 	return val
 }
 
-func New(logger *zap.Logger, channelURI *url.URL) (*handler, error) {
-	ceHttp, err := cehttp.New(cehttp.WithBinaryEncoding(), cehttp.WithPort(defaultPort))
-	if err != nil {
-		return nil, err
-	}
-	ceClient, err := ceclient.New(ceHttp)
-	if err != nil {
-		return nil, err
-	}
-	return &handler{
-		logger:     logger,
-		ceClient:   ceClient,
-		ceHttp:     ceHttp,
-		channelURI: channelURI,
-	}, nil
-}
-
 type handler struct {
 	logger     *zap.Logger
 	ceClient   ceclient.Client
-	ceHttp     *cehttp.Transport
+	ceHTTP     *cehttp.Transport
 	channelURI *url.URL
 }
 

--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -44,17 +44,17 @@ type Receiver struct {
 	logger   *zap.Logger
 	client   client.Client
 	ceClient ceclient.Client
-	ceHttp   *cehttp.Transport
+	ceHTTP   *cehttp.Transport
 }
 
 // New creates a new Receiver and its associated MessageReceiver. The caller is responsible for
 // Start()ing the returned MessageReceiver.
 func New(logger *zap.Logger, client client.Client) (*Receiver, error) {
-	ceHttp, err := cehttp.New(cehttp.WithBinaryEncoding(), cehttp.WithPort(defaultPort))
+	ceHTTP, err := cehttp.New(cehttp.WithBinaryEncoding(), cehttp.WithPort(defaultPort))
 	if err != nil {
 		return nil, err
 	}
-	ceClient, err := ceclient.New(ceHttp)
+	ceClient, err := ceclient.New(ceHTTP)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func New(logger *zap.Logger, client client.Client) (*Receiver, error) {
 		logger:   logger,
 		client:   client,
 		ceClient: ceClient,
-		ceHttp:   ceHttp,
+		ceHTTP:   ceHTTP,
 	}
 	err = r.initClient()
 	if err != nil {
@@ -182,7 +182,7 @@ func (r *Receiver) sendEvent(ctx context.Context, tctx cehttp.TransportContext, 
 	}
 
 	sendingCTX := SendingContext(ctx, tctx, subscriberURI)
-	return r.ceHttp.Send(sendingCTX, *event)
+	return r.ceHTTP.Send(sendingCTX, *event)
 }
 
 func (r *Receiver) getTrigger(ctx context.Context, ref provisioners.ChannelReference) (*eventingv1alpha1.Trigger, error) {

--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -94,7 +94,7 @@ func (r *Receiver) initClient() error {
 // This method will block until a message is received on the stop channel.
 func (r *Receiver) Start(stopCh <-chan struct{}) error {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer ctx.Done()
+	defer cancel()
 
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Some things that golint and govet caught in the new broker code:

- vet complained that `cancel()` wasn't being called properly for all return paths. I fixed the defer that was calling `ctx.Done()` instead of `cancel()`.
- lint complained about returning an unexported type from an exported function. I removed the function.
- link complained about `ceHttp` instead of `ceHTTP`. I renamed those fields.

/cc @Harwayne 
