### PR TITLE
Resubscribe on nats client disconnect

### DIFF
--- a/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
+++ b/contrib/natss/pkg/controller/clusterchannelprovisioner/controller.go
@@ -38,7 +38,7 @@ const (
 func ProvideController(mgr manager.Manager, natssURL, clusterID string, logger *zap.Logger) (controller.Controller, error) {
 	// check the connection to NATSS
 	var err error
-	if _, err := stanutil.Connect(clusterID, clientID, natssURL, logger.Sugar()); err != nil {
+	if _, err := stanutil.Connect(clusterID, clientID, natssURL, logger.Sugar(), func(_ error) {}); err != nil {
 		logger.Error("Connect() failed: ", zap.Error(err))
 		return nil, err
 	}

--- a/contrib/natss/pkg/dispatcher/channel/controller.go
+++ b/contrib/natss/pkg/dispatcher/channel/controller.go
@@ -56,5 +56,16 @@ func ProvideController(ss *dispatcher.SubscriptionsSupervisor, mgr manager.Manag
 		return nil, err
 	}
 
+	// When the NATS client disconnects and we successfully reconnect we need to resubscribe to all
+	// channels. We use this watch on the ReconcileChan to trigger the reconciliation loop for all
+	// active channels on NATS client reconnect.
+	err = c.Watch(&source.Channel{
+		Source: ss.ReconcileChan(),
+	}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		logger.Error("Unable to watch the reconcile Channel", zap.Error(err))
+		return nil, err
+	}
+
 	return c, nil
 }

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
@@ -116,6 +116,8 @@ func TestMain(m *testing.M) {
 
 func TestSubscribeUnsubscribe(t *testing.T) {
 	logger.Info("TestSubscribeUnsubscribe()")
+	s.subscriptionsMux.Lock()
+	defer s.subscriptionsMux.Unlock()
 
 	cRef := provisioners.ChannelReference{Namespace: "test_namespace", Name: "test_channel"}
 	sRef := subscriptionReference{Name: "sub_name_2", Namespace: "sub_namespace_2", SubscriberURI: "", ReplyURI: ""}

--- a/contrib/natss/pkg/stanutil/stanutil.go
+++ b/contrib/natss/pkg/stanutil/stanutil.go
@@ -25,9 +25,11 @@ import (
 )
 
 // Connect creates a new NATS-Streaming connection
-func Connect(clusterId string, clientId string, natsUrl string, logger *zap.SugaredLogger) (*stan.Conn, error) {
+func Connect(clusterId string, clientId string, natsUrl string, logger *zap.SugaredLogger, connectionLostHandler func(reason error)) (*stan.Conn, error) {
 	logger.Infof("Connect(): clusterId: %v; clientId: %v; natssUrl: %v", clusterId, clientId, natsUrl)
-	sc, err := stan.Connect(clusterId, clientId, stan.NatsURL(natsUrl))
+	sc, err := stan.Connect(clusterId, clientId, stan.NatsURL(natsUrl), stan.SetConnectionLostHandler(func(_ stan.Conn, reason error) {
+		connectionLostHandler(reason)
+	}))
 	if err != nil {
 		logger.Errorf("Connect(): create new connection failed: %v", err)
 		return nil, err

--- a/contrib/natss/pkg/stanutil/stanutil_test.go
+++ b/contrib/natss/pkg/stanutil/stanutil_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 
 func TestConnectPublishClose(t *testing.T) {
 	// connect
-	natssConn, err := Connect(clusterId, clientId, natssUrl, logger)
+	natssConn, err := Connect(clusterId, clientId, natssUrl, logger, func(_ error) {})
 	if err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}


### PR DESCRIPTION
Currently if the NATS client disconnects subscriptions created with the client are neither cleaned up nor resubscribed. 

## Proposed Changes

- Add a reconcile channel which allows manually signaling for re-reconciliation of a channel
- Also properly handle disconnects using the natss client connection lost handler

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improve natss channel behavior on nats client disconnect.
```
