### PR TITLE
Updating links to docs repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Contributor Covenant Code of Conduct
 
 Please see the Knative Community
-[Contributor Covenant Code of Conduct](https://github.com/knative/docs/blob/master/contributing/CODE-OF-CONDUCT.md).
+[Contributor Covenant Code of Conduct](https://www.knative.dev/contributing/code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution guidelines
 
 So you want to hack on Knative Eventing? Yay! Please refer to Knative's overall
-[contribution guidelines](https://github.com/knative/docs/blob/master/contributing/CONTRIBUTING.md)
+[contribution guidelines](https://www.knative.dev/contributing/)
 to find out how you can help.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,6 +127,6 @@ ko delete -f config/
 
 To access Telemetry see:
 
-- [Accessing Metrics](https://github.com/knative/docs/blob/master/docs/serving/accessing-metrics.md)
-- [Accessing Logs](https://github.com/knative/docs/blob/master/docs/serving/accessing-logs.md)
-- [Accessing Traces](https://github.com/knative/docs/blob/master/docs/serving/accessing-traces.md)
+- [Accessing Metrics](https://www.knative.dev/docs/serving/accessing-metrics/)
+- [Accessing Logs](https://www.knative.dev/docs/serving/accessing-logs/)
+- [Accessing Traces](https://www.knative.dev/docs/serving/accessing-traces/)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ address a common need for cloud native development:
      producer.
 
 For complete Knative Eventing documentation, see
-[Knative eventing](https://github.com/knative/docs/tree/master/docs/eventing) or
-[Knative docs](https://github.com/knative/docs/) to learn about Knative.
+[Knative eventing](https://www.knative.dev/docs/eventing/) or
+[Knative docs](https://www.knative.dev/docs/) to learn about Knative.
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
-[Knative WORKING-GROUPS.md](https://github.com/knative/docs/blob/master/contributing/WORKING-GROUPS.md#eventing).
+[Knative WORKING-GROUPS.md](https://www.knative.dev/contributing/working-groups/#eventing).
 
 Please join
 [knative-users](https://groups.google.com/forum/#!forum/knative-users) to view

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -19,7 +19,7 @@ Docs in this directory:
 <!-- TODO(n3wscott): * [Sample API usage](normative_examples.md) -->
 
 See the
-[Knative Eventing Docs Architecture](https://github.com/knative/docs/blob/master/docs/eventing/README.md#architecture)
+[Knative Eventing Docs Architecture](https://www.knative.dev/docs/eventing/#architecture)
 for more high level details.
 
 <!-- TODO(#498): Update the docs/Architecture page. -->

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,4 +1,4 @@
 # Samples
 
 _Knative eventing_ samples have moved to
-[the docs repository](https://github.com/knative/docs/tree/master/eventing/samples).
+[the docs repository](https://github.com/knative/docs/tree/master/docs/eventing/samples).


### PR DESCRIPTION
Work towards fixing https://github.com/knative/docs/issues/1038

## Proposed Changes

* Updates all links in the Eventing repo that began with github.com/knative/docs
* Most links updated to point to the content on knative.dev, but kept the link to the samples pointing to the new location of the samples folder on Github