### PR TITLE
Support TLS encrypted connection between brokers and kafka channel

### DIFF
--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
@@ -18,6 +19,12 @@ import (
 	"github.com/knative/eventing/contrib/kafka/pkg/controller/channel"
 	eventingv1alpha "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
+)
+
+const (
+	// These are Environment variable names.
+	kafkaTLSENnabled = "KAFKA_TLS_ENABLE"
+	kafkaCAEnv       = "KAFKA_CA_CERT"
 )
 
 // SchemeFunc adds types to a Scheme.
@@ -66,6 +73,17 @@ func _main() int {
 	if err != nil {
 		logger.Error(err, "unable to run controller manager")
 		return 1
+	}
+
+	TlsEnabled := os.Getenv(kafkaTLSENnabled)
+	if strings.ToLower(TlsEnabled) == "true" {
+		ca := os.Getenv(kafkaCAEnv)
+		provisionerConfig.TlsConfig, err = provisionerController.NewTLSConfig(ca)
+		if err != nil {
+			logger.Error(err, "unable to enable TLS")
+			return 1
+		}
+		logger.Info("successfully enabled TLS", zap.String("secret", kafkaTLSENnabled))
 	}
 
 	for _, provider := range providers {

--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"strings"
 
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
@@ -19,12 +18,6 @@ import (
 	"github.com/knative/eventing/contrib/kafka/pkg/controller/channel"
 	eventingv1alpha "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
-)
-
-const (
-	// These are Environment variable names.
-	kafkaTLSENnabled = "KAFKA_TLS_ENABLE"
-	kafkaCAEnv       = "KAFKA_CA_CERT"
 )
 
 // SchemeFunc adds types to a Scheme.
@@ -75,15 +68,14 @@ func _main() int {
 		return 1
 	}
 
-	TlsEnabled := os.Getenv(kafkaTLSENnabled)
-	if strings.ToLower(TlsEnabled) == "true" {
-		ca := os.Getenv(kafkaCAEnv)
+	ca, define := os.LookupEnv(provisionerController.KafkaCAEnv)
+	if define {
 		provisionerConfig.TlsConfig, err = provisionerController.NewTLSConfig(ca)
 		if err != nil {
 			logger.Error(err, "unable to enable TLS")
 			return 1
 		}
-		logger.Info("successfully enabled TLS", zap.String("secret", kafkaTLSENnabled))
+		logger.Info("successfully enabled TLS")
 	}
 
 	for _, provider := range providers {

--- a/contrib/kafka/config/SECURITY.md
+++ b/contrib/kafka/config/SECURITY.md
@@ -1,0 +1,38 @@
+# Security
+
+kafka channel controller and dispatcher connect to brokers without
+encryption and authentication by default. Encryption using SSL can be
+turned.
+
+## Connect over SSL(TLS)
+
+1. Create secret from Cluster CA public key to verify the identity of the Kafka brokers.
+
+   ```yaml
+   kubectl create secret generic kafka-certificates  --from-file=ca.crt -n knative-eventing
+   ```
+
+1. Define environmental variables KAFKA_TLS_ENABLE and KAFKA_CA_CERT in their Deployments.
+
+   ```yaml
+           - name: KAFKA_TLS_ENABLE
+             value: "true"
+           - name: KAFKA_CA_CERT
+             valueFrom:
+               secretKeyRef:
+                 key: ca.crt
+                 name: kafka-certificates
+   ```
+
+1. Change the value of `bootstrap_servers` in configmap for secure connection.
+
+   ```yaml
+   data:
+     bootstrap_servers: kafkabroker.kafka:9093
+   ```
+
+1. Apply the change to your deployments.
+
+   ```
+   ko apply -f contrib/kafka/config/kafka.yaml
+   ```

--- a/contrib/kafka/config/SECURITY.md
+++ b/contrib/kafka/config/SECURITY.md
@@ -1,22 +1,32 @@
 # Security
 
-kafka channel controller and dispatcher connect to brokers without
+Kafka channel controller and dispatcher connect to brokers without
 encryption and authentication by default. Encryption using SSL can be
-turned.
+turned on by adding certs.
 
 ## Connect over SSL(TLS)
 
-1. Create secret from Cluster CA public key to verify the identity of the Kafka brokers.
+1. Create secret from Cluster CA to verify the identity of the Kafka brokers.
 
    ```yaml
    kubectl create secret generic kafka-certificates  --from-file=ca.crt -n knative-eventing
    ```
 
-1. Define environmental variables KAFKA_TLS_ENABLE and KAFKA_CA_CERT in their Deployments.
+   > Note: The CA certificate is to validate the Kafka broker when connecting to Kafka brokers
+   > over TLS.
+   >
+   > If you are using Strimzi, you can create the secret from the same value in the secret
+   > `<cluster>-cluster-ca-cert`.
+   > e.g.
+   > ```
+   > kubectl get secret -n kafka my-cluster-clients-ca-cert -o json | jq -r '.data."ca.crt"' |base64 -d > ca.crt
+   > kubectl create secret generic kafka-certificates  --from-file=ca.crt -n knative-eventing
+   > ```
+
+
+1. Define environmental variables KAFKA_CA_CERT in their Deployments.
 
    ```yaml
-           - name: KAFKA_TLS_ENABLE
-             value: "true"
            - name: KAFKA_CA_CERT
              valueFrom:
                secretKeyRef:
@@ -24,7 +34,7 @@ turned.
                  name: kafka-certificates
    ```
 
-1. Change the value of `bootstrap_servers` in configmap for secure connection.
+1. Change the value of `bootstrap_servers` in configmap `kafka-channel-controller-config` for secure connection.
 
    ```yaml
    data:

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -373,15 +373,7 @@ func (r *reconciler) listAllChannels(ctx context.Context) ([]eventingv1alpha1.Ch
 }
 
 func createKafkaAdminClient(config *controller.KafkaProvisionerConfig) (sarama.ClusterAdmin, error) {
-	saramaConf := sarama.NewConfig()
-	saramaConf.Version = sarama.V1_1_0_0
-	saramaConf.ClientID = controllerAgentName
-
-	if config.TlsConfig != nil {
-		saramaConf.Net.TLS.Enable = true
-		saramaConf.Net.TLS.Config = config.TlsConfig
-	}
-
+	saramaConf := controller.InitSaramaConfig(controllerAgentName, config.TlsConfig)
 	return sarama.NewClusterAdmin(config.Brokers, saramaConf)
 }
 

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -376,6 +376,12 @@ func createKafkaAdminClient(config *controller.KafkaProvisionerConfig) (sarama.C
 	saramaConf := sarama.NewConfig()
 	saramaConf.Version = sarama.V1_1_0_0
 	saramaConf.ClientID = controllerAgentName
+
+	if config.TlsConfig != nil {
+		saramaConf.Net.TLS.Enable = true
+		saramaConf.Net.TLS.Config = config.TlsConfig
+	}
+
 	return sarama.NewClusterAdmin(config.Brokers, saramaConf)
 }
 

--- a/contrib/kafka/pkg/controller/secure.go
+++ b/contrib/kafka/pkg/controller/secure.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const KafkaCAEnv = "KAFKA_CA_CERT"
+
 // NewTLSConfig configures TLS Config by adding ca cert.
 // If ca is passed by empty string, it returns &tls.Config object instead of nil.
 func NewTLSConfig(caCert string) (*tls.Config, error) {

--- a/contrib/kafka/pkg/controller/secure.go
+++ b/contrib/kafka/pkg/controller/secure.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+)
+
+// NewTLSConfig configures TLS Config by adding ca cert.
+// If ca is passed by empty string, it returns &tls.Config object instead of nil.
+func NewTLSConfig(caCert string) (*tls.Config, error) {
+	tlsConfig := tls.Config{}
+
+	if len(caCert) == 0 {
+		// No CA is passed, TLS uses the system's root CA set.
+		return &tlsConfig, nil
+	}
+
+	caCertPool := x509.NewCertPool()
+	ok := caCertPool.AppendCertsFromPEM([]byte(caCert))
+	if !ok {
+		return nil, fmt.Errorf("Unable to add ca cert.")
+	}
+	tlsConfig.RootCAs = caCertPool
+	tlsConfig.BuildNameToCertificate()
+
+	return &tlsConfig, nil
+}

--- a/contrib/kafka/pkg/controller/secure_test.go
+++ b/contrib/kafka/pkg/controller/secure_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	_ "github.com/knative/pkg/system/testing"
+)
+
+const testPEM = `
+-----BEGIN CERTIFICATE-----
+MIIEBDCCAuygAwIBAgIDAjppMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
+YWwgQ0EwHhcNMTMwNDA1MTUxNTU1WhcNMTUwNDA0MTUxNTU1WjBJMQswCQYDVQQG
+EwJVUzETMBEGA1UEChMKR29vZ2xlIEluYzElMCMGA1UEAxMcR29vZ2xlIEludGVy
+bmV0IEF1dGhvcml0eSBHMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AJwqBHdc2FCROgajguDYUEi8iT/xGXAaiEZ+4I/F8YnOIe5a/mENtzJEiaB0C1NP
+VaTOgmKV7utZX8bhBYASxF6UP7xbSDj0U/ck5vuR6RXEz/RTDfRK/J9U3n2+oGtv
+h8DQUB8oMANA2ghzUWx//zo8pzcGjr1LEQTrfSTe5vn8MXH7lNVg8y5Kr0LSy+rE
+ahqyzFPdFUuLH8gZYR/Nnag+YyuENWllhMgZxUYi+FOVvuOAShDGKuy6lyARxzmZ
+EASg8GF6lSWMTlJ14rbtCMoU/M4iarNOz0YDl5cDfsCx3nuvRTPPuj5xt970JSXC
+DTWJnZ37DhF5iR43xa+OcmkCAwEAAaOB+zCB+DAfBgNVHSMEGDAWgBTAephojYn7
+qwVkDBF9qn1luMrMTjAdBgNVHQ4EFgQUSt0GFhu89mi1dvWBtrtiGrpagS8wEgYD
+VR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAQYwOgYDVR0fBDMwMTAvoC2g
+K4YpaHR0cDovL2NybC5nZW90cnVzdC5jb20vY3Jscy9ndGdsb2JhbC5jcmwwPQYI
+KwYBBQUHAQEEMTAvMC0GCCsGAQUFBzABhiFodHRwOi8vZ3RnbG9iYWwtb2NzcC5n
+ZW90cnVzdC5jb20wFwYDVR0gBBAwDjAMBgorBgEEAdZ5AgUBMA0GCSqGSIb3DQEB
+BQUAA4IBAQA21waAESetKhSbOHezI6B1WLuxfoNCunLaHtiONgaX4PCVOzf9G0JY
+/iLIa704XtE7JW4S615ndkZAkNoUyHgN7ZVm2o6Gb4ChulYylYbc3GrKBIxbf/a/
+zG+FA1jDaFETzf3I93k9mTXwVqO94FntT0QJo544evZG0R0SnU++0ED8Vf4GXjza
+HFa9llF7b1cq26KqltyMdMKVvvBulRP/F/A8rLIQjcxz++iPAsbw+zOzlTvjwsto
+WHPbqCRiOwY1nQ2pM714A5AuTHhdUDqB1O6gyHA43LL5Z/qHQF1hwFGPa4NrzQU6
+yuGnBXj8ytqU0CwIPX4WecigUCAkVDNx
+-----END CERTIFICATE-----`
+
+func TestNewTLSConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		caCert   string
+		expected *tls.Config
+		addedCA  int
+	}{
+		{
+			name:     "New TLS config without ca cert",
+			caCert:   "",
+			addedCA:  0,
+			expected: &tls.Config{},
+		},
+		{
+			name:    "New TLS config with ca cert",
+			caCert:  testPEM,
+			addedCA: 1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Running %s", t.Name())
+			got, err := NewTLSConfig(tc.caCert)
+			opt := cmpopts.IgnoreUnexported(tls.Config{})
+			if err != nil {
+				t.Errorf("Unexpected UpdateConfig error: %v", err)
+			}
+			if tc.addedCA > 0 {
+				if diff := cmp.Diff(tc.addedCA, len(got.RootCAs.Subjects())); diff != "" {
+					t.Errorf("unexpected number of CAs (-want, +got) = %v", diff)
+				}
+			} else {
+				if diff := cmp.Diff(tc.expected, got, opt); diff != "" {
+					t.Errorf("unexpected tls.Config (-want, +got) = %v", diff)
+				}
+			}
+		})
+	}
+}

--- a/contrib/kafka/pkg/controller/types.go
+++ b/contrib/kafka/pkg/controller/types.go
@@ -1,8 +1,13 @@
 package controller
 
-import cluster "github.com/bsm/sarama-cluster"
+import (
+	"crypto/tls"
+
+	cluster "github.com/bsm/sarama-cluster"
+)
 
 type KafkaProvisionerConfig struct {
 	Brokers      []string
 	ConsumerMode cluster.ConsumerMode
+	TlsConfig    *tls.Config
 }

--- a/contrib/kafka/pkg/controller/util.go
+++ b/contrib/kafka/pkg/controller/util.go
@@ -1,9 +1,11 @@
 package controller
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 
+	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
 
 	"github.com/knative/pkg/configmap"
@@ -48,4 +50,17 @@ func GetProvisionerConfig(path string) (*KafkaProvisionerConfig, error) {
 		}
 	}
 	return config, nil
+}
+
+// InitSaramaConfig initializes sarama config by common settings.
+func InitSaramaConfig(agentName string, tlsConfig *tls.Config) *sarama.Config {
+	saramaConf := sarama.NewConfig()
+	saramaConf.Version = sarama.V1_1_0_0
+	saramaConf.ClientID = controllerAgentName
+
+	if tlsConfig != nil {
+		saramaConf.Net.TLS.Enable = true
+		saramaConf.Net.TLS.Config = tlsConfig
+	}
+	return saramaConf
 }

--- a/contrib/kafka/pkg/dispatcher/dispatcher.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher.go
@@ -267,14 +267,7 @@ func (d *KafkaDispatcher) setConfig(config *multichannelfanout.Config) {
 }
 
 func NewDispatcher(provisionerConf *controller.KafkaProvisionerConfig, logger *zap.Logger) (*KafkaDispatcher, error) {
-	conf := sarama.NewConfig()
-	conf.Version = sarama.V1_1_0_0
-	conf.ClientID = controller.Name + "-dispatcher"
-
-	if provisionerConf.TlsConfig != nil {
-		conf.Net.TLS.Enable = true
-		conf.Net.TLS.Config = provisionerConf.TlsConfig
-	}
+	conf := controller.InitSaramaConfig(controller.Name+"-dispatcher", provisionerConf.TlsConfig)
 
 	client, err := sarama.NewClient(provisionerConf.Brokers, conf)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/912

This patch supports SSL(TLS) connection between Broker and kafka channel.

## Proposed Changes
- Introduce ~~`KAFKA_TLS_ENABLE`~~ and `KAFKA_CA_CERT` to support SSL encryption.
- ~~Use TLS connection when `KAFKA_TLS_ENABLE` is set to `true`.~~
- Allow to use CA specified via `KAFKA_CA_CERT`.
- Once CA was specified, Kafka controller and dispatcher sue TLS connection.

**Release Note**

```release-note
Allow kafka controller and dispatcher to add CA public key for SSL(TLS) encrypted connection.
```