### PR TITLE
Format markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution guidelines
 
 So you want to hack on Knative Eventing? Yay! Please refer to Knative's overall
-[contribution guidelines](https://www.knative.dev/contributing/)
-to find out how you can help.
+[contribution guidelines](https://www.knative.dev/contributing/) to find out how
+you can help.

--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -44,16 +44,17 @@ spec:
       type: dev.knative.foo.bar
   subscriber:
     ref:
-     apiVersion: serving.knative.dev/v1alpha1
-     kind: Service
-     name: my-service
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: my-service
 ```
 
 ## Usage
 
 ### Broker
 
-There are two ways to create a Broker, via [namespace annotation](#annotation) or [manual setup](#manual-setup).
+There are two ways to create a Broker, via [namespace annotation](#annotation)
+or [manual setup](#manual-setup).
 
 Normally the [namespace annotation](#annotation) is used to do this setup.
 
@@ -149,9 +150,9 @@ spec:
       type: dev.knative.foo.bar
   subscriber:
     ref:
-     apiVersion: serving.knative.dev/v1alpha1
-     kind: Service
-     name: my-service
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: my-service
 ```
 
 #### Defaulting
@@ -178,9 +179,9 @@ spec:
       source: Any # Defaulted by the Webhook.
   subscriber:
     ref:
-     apiVersion: serving.knative.dev/v1alpha1
-     kind: Service
-     name: my-service
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: my-service
 ```
 
 You can make multiple `Trigger`s on the same `Broker` corresponding to different
@@ -241,14 +242,14 @@ implmentation**.
 ### Namespace
 
 Namespaces are reconciled by the
-[Namespace Reconciler](../../pkg/reconciler/v1alpha1/namespace). The `Namespace
-Reconciler` looks for all `namespace`s that have the label
+[Namespace Reconciler](../../pkg/reconciler/v1alpha1/namespace). The
+`Namespace Reconciler` looks for all `namespace`s that have the label
 `knative-eventing-injection: enabled`. If that label is present, then the
 `Namespace Reconciler` reconciles:
 
 1. Creates the Broker Filter's `ServiceAccount`, `eventing-broker-filter`.
-1. Ensures that `ServiceAccount` has the requisite RBAC permissions by giving
-   it the [`eventing-broker-filter`](../../config/200-broker-clusterrole.yaml)
+1. Ensures that `ServiceAccount` has the requisite RBAC permissions by giving it
+   the [`eventing-broker-filter`](../../config/200-broker-clusterrole.yaml)
    `Role`.
 1. Creates a `Broker` named `default`.
 
@@ -264,19 +265,18 @@ reconciles:
 1. The 'filter' `Deployment`. The `Deployment` runs
    [cmd/broker/filter](../../cmd/broker/filter). Its purpose is the data plane
    for all `Trigger`s related to this `Broker`.
-   - This piece is very similar to the existing Channel dispatchers, in that
-     all `Trigger`s for a given `Broker` route to this single `Deployment`.
-     The code inspects the Host header to determine which `Trigger` the
-     request is related to and then carries it out.
+   - This piece is very similar to the existing Channel dispatchers, in that all
+     `Trigger`s for a given `Broker` route to this single `Deployment`. The code
+     inspects the Host header to determine which `Trigger` the request is
+     related to and then carries it out.
    - Internally this binary uses the [pkg/broker](../../pkg/broker) library.
 1. The 'filter' Kubernetes `Service`. This `Service` points to the 'filter'
    `Deployment`.
 1. The 'ingress' `Deployment`. The `Deployment` runs
-   [cmd/broker/ingress](../../cmd/broker/ingress). Its purpose is to inspect
-   all events that are entering the `Broker`.
+   [cmd/broker/ingress](../../cmd/broker/ingress). Its purpose is to inspect all
+   events that are entering the `Broker`.
 1. The 'ingress' Kubernetes `Service`. This `Service` points to the 'ingress'
-   `Deployment`. This `Service`'s address is the address given for the
-   `Broker`.
+   `Deployment`. This `Service`'s address is the address given for the `Broker`.
 
 ### Trigger
 
@@ -285,13 +285,12 @@ reconciles:
 it reconciles:
 
 1. Determines the subscriber's URI.
-   - Currently uses the same logic as the `Subscription` Reconciler, so
-     supports Addressables and Kubernetes `Service`s.
+   - Currently uses the same logic as the `Subscription` Reconciler, so supports
+     Addressables and Kubernetes `Service`s.
 1. Creates a Kubernetes `Service` and Istio `VirtualService` pair. This allows
    all Istio enabled `Pod`s to send to the `Trigger`'s address.
    - This is the same as the current `Channel` implementation. The `Service`
-     points nowhere. The `VirtualService` reroutes requests that originally
-     went to the `Service`, to instead go to the `Broker`'s 'filter'
-     `Service`.
+     points nowhere. The `VirtualService` reroutes requests that originally went
+     to the `Service`, to instead go to the `Broker`'s 'filter' `Service`.
 1. Creates `Subscription` from the `Broker`'s 'everything' `Channel` to the
    `Trigger`'s Kubernetes `Service`.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`