### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_validation.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/pkg/apis"
 )
 

--- a/pkg/apis/eventing/v1alpha1/channel_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/channel_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_validation.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/pkg/apis"
 )
 

--- a/pkg/apis/eventing/v1alpha1/subscription_validation.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis"

--- a/pkg/apis/eventing/v1alpha1/trigger_validation.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 )

--- a/test/test_images/logevents/main.go
+++ b/test/test_images/logevents/main.go
@@ -16,9 +16,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"log"
 )
 
 func handler(event cloudevents.Event) {

--- a/test/test_images/sendevent/main.go
+++ b/test/test_images/sendevent/main.go
@@ -21,14 +21,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"log"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/cloudevents"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 )
 
 type Heartbeat struct {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
