### PR TITLE
Passthrough the header 'b3'

### DIFF
--- a/pkg/broker/context.go
+++ b/pkg/broker/context.go
@@ -32,6 +32,9 @@ var (
 	forwardHeaders = sets.NewString(
 		// tracing
 		"x-request-id",
+		// Single header for b3 tracing. See
+		// https://github.com/openzipkin/b3-propagation#single-header.
+		"b3",
 	)
 	// These MUST be lowercase strings, as they will be compared against lowercase strings.
 	forwardPrefixes = []string{

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -176,19 +176,27 @@ func TestReceiver(t *testing.T) {
 					"foo": []string{"bar"},
 					// X-Request-Id will pass as an exact header match.
 					"X-Request-Id": []string{"123"},
-					// X-B3-Traceid will pass as a prefix match.
-					"X-B3-Traceid": []string{"abc"},
+					// b3 will pass as an exact header match.
+					"B3": []string{"0"},
+					// X-B3-Foo will pass as a prefix match.
+					"X-B3-Foo": []string{"abc"},
 					// Knative-Foo will pass as a prefix match.
 					"Knative-Foo": []string{"baz", "qux"},
+					// X-Ot-Foo will pass as a prefix match.
+					"X-Ot-Foo": []string{"haden"},
 				},
 			},
 			expectedHeaders: http.Header{
 				// X-Request-Id will pass as an exact header match.
 				"X-Request-Id": []string{"123"},
-				// X-B3-Traceid will pass as a prefix match.
-				"X-B3-Traceid": []string{"abc"},
+				// b3 will pass as an exact header match.
+				"B3": []string{"0"},
+				// X-B3-Foo will pass as a prefix match.
+				"X-B3-Foo": []string{"abc"},
 				// Knative-Foo will pass as a prefix match.
 				"Knative-Foo": []string{"baz", "qux"},
+				// X-Ot-Foo will pass as a prefix match.
+				"X-Ot-Foo": []string{"haden"},
 			},
 			expectedDispatch: true,
 			returnedEvent:    makeDifferentEvent(),


### PR DESCRIPTION
## Proposed Changes

- Passthrough the header `b3` to match https://github.com/openzipkin/b3-propagation#single-header.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
