### PR TITLE
Kafka dispatcher no need for a statefulset

### DIFF
--- a/contrib/kafka/config/README.md
+++ b/contrib/kafka/config/README.md
@@ -80,7 +80,7 @@ kubectl get configmap -n knative-eventing kafka-channel-controller-config
 The Channel Dispatcher receives and distributes all events:
 
 ```shell
-kubectl get statefulset -n knative-eventing kafka-channel-dispatcher
+kubectl get deployment -n knative-eventing kafka-channel-dispatcher
 ```
 
 The Channel Dispatcher Config Map is used to send information about Channels and

--- a/contrib/kafka/config/kafka.yaml
+++ b/contrib/kafka/config/kafka.yaml
@@ -185,7 +185,7 @@ roleRef:
 ---
 
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: kafka-channel-dispatcher
   namespace: knative-eventing
@@ -195,7 +195,6 @@ spec:
     matchLabels: &labels
       clusterChannelProvisioner: kafka
       role: dispatcher
-  serviceName: kafka-channel-dispatcher-service
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The broker itself needs to be a stateful set, but the dispatcher is just a client/consumer.

hence a deployment is good.

@grantr  I guess we need some release notes :smile: 

locally tested w/ a 0.4.0 installation and this branch (and Strimzi 0.11 release). messages are distributed from the dispatcher