### PR TITLE
remove the DeprecatedGeneration from Trigger/Broker

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -49,15 +49,6 @@ var _ runtime.Object = (*Broker)(nil)
 var _ webhook.GenericCRD = (*Broker)(nil)
 
 type BrokerSpec struct {
-	// TODO By enabling the status subresource metadata.generation should increment
-	// thus making this property obsolete.
-	//
-	// We should be able to drop this property with a CRD conversion webhook
-	// in the future
-	//
-	// +optional
-	DeprecatedGeneration int64 `json:"generation,omitempty"`
-
 	// ChannelTemplate, if specified will be used to create all the Channels used internally by the
 	// Broker. Only Provisioner and Arguments may be specified. If left unspecified, the default
 	// Channel for the namespace will be used.

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -49,15 +49,6 @@ var _ runtime.Object = (*Trigger)(nil)
 var _ webhook.GenericCRD = (*Trigger)(nil)
 
 type TriggerSpec struct {
-	// TODO By enabling the status subresource metadata.generation should increment
-	// thus making this property obsolete.
-	//
-	// We should be able to drop this property with a CRD conversion webhook
-	// in the future
-	//
-	// +optional
-	DeprecatedGeneration int64 `json:"generation,omitempty"`
-
 	// Broker is the broker that this trigger receives events from. If not specified, will default
 	// to 'default'.
 	Broker string `json:"broker,omitempty"`


### PR DESCRIPTION
Fixes #938 

## Proposed Changes

- Remove DeprecatedGeneration from Broker / Trigger. This unnecessarily adds future tech debt because no releases have been made with these, so let's remove them asap.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove DeprecatedGeneration from Broker / Trigger

```
