### PR TITLE
Format markdown

### DIFF
--- a/contrib/natss/config/README.md
+++ b/contrib/natss/config/README.md
@@ -9,9 +9,9 @@ They offer:
   - If the Channel's Pod goes down, all events already ACKed by the Channel will
     persist and be retransmitted when the Pod restarts.
 - Redelivery attempts
-  - If downstream rejects an event, that request is attempted again. NOTE: downstream must
-    successfully process the event within one minute or the delivery is assumed to have failed 
-    and will be reattempted.
+  - If downstream rejects an event, that request is attempted again. NOTE:
+    downstream must successfully process the event within one minute or the
+    delivery is assumed to have failed and will be reattempted.
 
 They do not offer:
 
@@ -66,17 +66,20 @@ Dispatcher for all natss Channels.
 kubectl get deployment -n knative-eventing natss-dispatcher
 ```
 
-By default the components are configured to connect to NATS at `nats://nats-streaming.natss.svc:4222` with NATS Streaming cluster ID `knative-nats-streaming`. This may be overridden by configuring both the `natss-channel-controller` and `natss-dispatcher` deployments with
-environment variables:
+By default the components are configured to connect to NATS at
+`nats://nats-streaming.natss.svc:4222` with NATS Streaming cluster ID
+`knative-nats-streaming`. This may be overridden by configuring both the
+`natss-channel-controller` and `natss-dispatcher` deployments with environment
+variables:
 
-  ```yaml
-          env:
-          - name: DEFAULT_NATSS_URL
-            value: nats://natss.custom-namespace.svc.cluster.local:4222
-          - name: DEFAULT_CLUSTER_ID
-            value: custom-cluster-id
-          - name: SYSTEM_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace  
-  ```
+```yaml
+env:
+  - name: DEFAULT_NATSS_URL
+    value: nats://natss.custom-namespace.svc.cluster.local:4222
+  - name: DEFAULT_CLUSTER_ID
+    value: custom-cluster-id
+  - name: SYSTEM_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+```

--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -259,9 +259,9 @@ Namespaces are reconciled by the
 [Broker Reconciler](../../pkg/reconciler/v1alpha1/broker). For each `Broker`, it
 reconciles:
 
-1. The 'trigger' `Channel`. This is a `Channel` that all events in the
-   `Broker` are sent to. Anything that passes the `Broker`'s Ingress is sent to
-   this `Channel`. All `Trigger`s subscribe to this `Channel`.
+1. The 'trigger' `Channel`. This is a `Channel` that all events in the `Broker`
+   are sent to. Anything that passes the `Broker`'s Ingress is sent to this
+   `Channel`. All `Trigger`s subscribe to this `Channel`.
 1. The 'filter' `Deployment`. The `Deployment` runs
    [cmd/broker/filter](../../cmd/broker/filter). Its purpose is the data plane
    for all `Trigger`s related to this `Broker`.
@@ -277,8 +277,8 @@ reconciles:
    events that are entering the `Broker`.
 1. The 'ingress' Kubernetes `Service`. This `Service` points to the 'ingress'
    `Deployment`. This `Service`'s address is the address given for the `Broker`.
-1. The 'ingress' `Channel`. This is a `Channel` for replies from `Trigger`s.
-   It should not be used by anything else.
+1. The 'ingress' `Channel`. This is a `Channel` for replies from `Trigger`s. It
+   should not be used by anything else.
 1. The 'ingress' `Subscription` which subscribes from the 'ingress' `Channel` to
    the 'ingress' `Service`.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,7 +4,7 @@ This is a list of metrics exported by Knative Eventing components.
 
 ## Broker ingress
 
-| Name | Type | Description | Tags
-| ---- | ---- | ---- | ---- |
-| `messages_total` | count | Number of messages received. | `result`, `broker` |
-| `dispatch_time` | histogram | Time to dispatch a message. | `result`, `broker` |
+| Name             | Type      | Description                  | Tags               |
+| ---------------- | --------- | ---------------------------- | ------------------ |
+| `messages_total` | count     | Number of messages received. | `result`, `broker` |
+| `dispatch_time`  | histogram | Time to dispatch a message.  | `result`, `broker` |


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`