### PR TITLE
Change the special value representing 'allow all events' from 'Any' to the empty string

### DIFF
--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -160,7 +160,7 @@ spec:
 The Webhook will default certain unspecified fields. For example if
 `spec.broker` is unspecified, it will default to `default`. If
 `spec.filter.sourceAndType.type` or `spec.filter.sourceAndType.Source` are
-unspecified, then they will default to the special value `Any`, which matches
+unspecified, then they will default to the special value empty string, which matches
 everything.
 
 The Webhook will default the YAML above to:
@@ -176,7 +176,7 @@ spec:
   filter:
     sourceAndType:
       type: dev.knative.foo.bar
-      source: Any # Defaulted by the Webhook.
+      source: "" # Defaulted by the Webhook.
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1

--- a/docs/broker/example_triggers.yaml
+++ b/docs/broker/example_triggers.yaml
@@ -65,8 +65,8 @@ spec:
 
 ---
 
-# We can filter on either the event's type, source, or both. The special value
-# 'Any' matches everything. If either is not specified, it defaults to 'Any'.
+# We can filter on either the event's type, source, or both. The special value,
+# empty string matches everything. If either is not specified, it defaults to ''.
 
 ---
 
@@ -101,7 +101,7 @@ spec:
     sourceAndType:
       source: dev.knative.bar
       # The Webhook will default this in, but it does not hurt to specify it.
-      type: Any
+      type: ""
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -101,7 +101,7 @@ const (
 	TriggerConditionSubscribed duckv1alpha1.ConditionType = "Subscribed"
 
 	// Constant to represent that we should allow anything.
-	TriggerAnyFilter = "Any"
+	TriggerAnyFilter = ""
 )
 
 // GetCondition returns the condition currently associated with the given type, or nil.

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -130,23 +130,23 @@ func TestReceiver(t *testing.T) {
 		},
 		"No TTL": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "Any"),
+				makeTrigger("", ""),
 			},
 			event: makeEventWithoutTTL(),
 		},
 		"Wrong type": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("some-other-type", "Any"),
+				makeTrigger("some-other-type", ""),
 			},
 		},
 		"Wrong source": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "some-other-source"),
+				makeTrigger("", "some-other-source"),
 			},
 		},
 		"Dispatch failed": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "Any"),
+				makeTrigger("", ""),
 			},
 			requestFails:     true,
 			expectedErr:      true,
@@ -154,7 +154,7 @@ func TestReceiver(t *testing.T) {
 		},
 		"Dispatch succeeded - Any": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "Any"),
+				makeTrigger("", ""),
 			},
 			expectedDispatch: true,
 		},
@@ -166,14 +166,14 @@ func TestReceiver(t *testing.T) {
 		},
 		"Returned Cloud Event": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "Any"),
+				makeTrigger("", ""),
 			},
 			expectedDispatch: true,
 			returnedEvent:    makeDifferentEvent(),
 		},
 		"Returned Cloud Event with custom headers": {
 			triggers: []*eventingv1alpha1.Trigger{
-				makeTrigger("Any", "Any"),
+				makeTrigger("", ""),
 			},
 			tctx: &cehttp.TransportContext{
 				Method: "POST",
@@ -371,19 +371,19 @@ func makeTrigger(t, s string) *eventingv1alpha1.Trigger {
 }
 
 func makeTriggerWithoutFilter() *eventingv1alpha1.Trigger {
-	t := makeTrigger("Any", "Any")
+	t := makeTrigger("", "")
 	t.Spec.Filter = nil
 	return t
 }
 
 func makeTriggerWithoutSubscriberURI() *eventingv1alpha1.Trigger {
-	t := makeTrigger("Any", "Any")
+	t := makeTrigger("", "")
 	t.Status = eventingv1alpha1.TriggerStatus{}
 	return t
 }
 
 func makeTriggerWithBadSubscriberURI() *eventingv1alpha1.Trigger {
-	t := makeTrigger("Any", "Any")
+	t := makeTrigger("", "")
 	// This should fail url.Parse(). It was taken from the unit tests for url.Parse(), it violates
 	// rfc3986 3.2.3, namely that the port must be digits.
 	t.Status.SubscriberURI = "http://[::1]:namedport"

--- a/test/e2e/broker_trigger_test.go
+++ b/test/e2e/broker_trigger_test.go
@@ -241,6 +241,12 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 // Helper function to create names for different objects (e.g., triggers, services, etc.).
 func name(obj, eventType, eventSource string) string {
 	// Pod names need to be lowercase. We might have an eventType as Any, that is why we lowercase them.
+	if eventType == "" {
+		eventType = "testany"
+	}
+	if eventSource == "" {
+		eventSource = "testany"
+	}
 	return strings.ToLower(fmt.Sprintf("%s-%s-%s", obj, eventType, eventSource))
 }
 


### PR DESCRIPTION
Fixes #968.

## Proposed Changes

- Change the special value representing 'allow all events' from 'Any' to the empty string

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Any existing Triggers with 'Any' will need to be updated to the empty string instead.
```
