### PR TITLE
Rename the ClusterRoleBindings, as they no longer give admin privileges.

### DIFF
--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: eventing-controller-admin
+  name: eventing-controller
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -23,11 +24,13 @@ roleRef:
   kind: ClusterRole
   name: knative-eventing-controller
   apiGroup: rbac.authorization.k8s.io
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: eventing-webhook-admin
+  name: eventing-webhook
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook


### PR DESCRIPTION
## Proposed Changes

- Rename the ClusterRoleBindings, as they no longer give admin privileges.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Manually delete the old `eventing-controller-admin` ClusterRoleBinding.
```
