### PR TITLE
Change webhook rbac permission to use apps.deployments instead of extensions.deployments. Remove create for eventing.knative.dev resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -370,7 +370,7 @@
   revision = "dd3ceb3323922b899a0a913f885fcf59943e7b59"
 
 [[projects]]
-  digest = "1:a5df88e05f523f7b7a16b4a9c44508c91605be6fa647dab8a9674022ad5fca1c"
+  digest = "1:dc35c3341a255e7c944c45c996ebadea2a0c2eef86537d8d2e2a2ccf00e096a1"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -389,6 +389,7 @@
     "system",
     "system/testing",
     "test",
+    "test/ingress",
     "test/logging",
     "test/monitoring",
     "test/spoof",
@@ -396,7 +397,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "60fdcbcabd2faeb34328d8b2725dc76c59189453"
+  revision = "b032768e6dee2ccec842e338b8590c0838a73639"
 
 [[projects]]
   digest = "1:edcf99e561b63d758646ca9d9dee0f6c81c3eed617af1120645c9d5c0d80d8c7"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,8 +100,8 @@ required = [
 # This controls when we upgrade apis independently of Serving.
 [[constraint]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-03-21
-  revision = "60fdcbcabd2faeb34328d8b2725dc76c59189453"
+  # HEAD as of 2019-03-27
+  revision = "b032768e6dee2ccec842e338b8590c0838a73639"
 
 [[constraint]]
   name = "github.com/knative/serving"

--- a/config/200-webhook-clusterrole.yaml
+++ b/config/200-webhook-clusterrole.yaml
@@ -26,7 +26,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "create"]
   # For getting our Deployment so we can decorate with ownerref
-  - apiGroups: ["extensions"]
+  - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get"]
   # For actually registering our webhook

--- a/config/200-webhook-clusterrole.yaml
+++ b/config/200-webhook-clusterrole.yaml
@@ -36,4 +36,4 @@ rules:
   # Our own resources and statuses we care about
   - apiGroups: ["eventing.knative.dev"]
     resources: ["brokers", "brokers/status", "channels", "channels/status", "clusterchannelprovisioners", "clusterchannelprovisioners/status", "subscriptions", "subscriptions/status", "triggers", "triggers/status",]
-    verbs: ["get", "list", "create", "watch"]
+    verbs: ["get", "list", "watch"]

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -163,6 +163,16 @@ func (_ *Conditions) GetFullType() duck.Populatable {
 	return &KResource{}
 }
 
+// GetCondition fetches the condition of the specified type.
+func (s *Status) GetCondition(t ConditionType) *Condition {
+	for _, cond := range s.Conditions {
+		if cond.Type == t {
+			return &cond
+		}
+	}
+	return nil
+}
+
 // Populate implements duck.Populatable
 func (t *KResource) Populate() {
 	t.Status.ObservedGeneration = 42

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -91,7 +91,7 @@ func (fe *FieldError) ViaFieldIndex(field string, index int) *FieldError {
 
 // ViaKey is used to attach a key to the next ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
-//  for k, v := range spec.Bag. {
+//  for k, v := range spec.Bag {
 //    if err := doValidation(v); err != nil {
 //      return err.ViaKey(k).ViaField("bag")
 //    }

--- a/vendor/github.com/knative/pkg/test/ingress/ingress.go
+++ b/vendor/github.com/knative/pkg/test/ingress/ingress.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// TODO(tcnghia): These probably shouldn't be hard-coded here?
+	istioIngressNamespace = "istio-system"
+	istioIngressName      = "istio-ingressgateway"
+)
+
+// GetIngressEndpoint gets the endpoint IP or hostname to use for the service.
+func GetIngressEndpoint(kubeClientset *kubernetes.Clientset) (*string, error) {
+	ingressName := istioIngressName
+	if gatewayOverride := os.Getenv("GATEWAY_OVERRIDE"); gatewayOverride != "" {
+		ingressName = gatewayOverride
+	}
+	ingressNamespace := istioIngressNamespace
+	if gatewayNsOverride := os.Getenv("GATEWAY_NAMESPACE_OVERRIDE"); gatewayNsOverride != "" {
+		ingressNamespace = gatewayNsOverride
+	}
+
+	ingress, err := kubeClientset.CoreV1().Services(ingressNamespace).Get(ingressName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := EndpointFromService(ingress)
+	if err != nil {
+		return nil, err
+	}
+	return &endpoint, nil
+}
+
+// EndpointFromService extracts the endpoint from the service's ingress.
+func EndpointFromService(svc *v1.Service) (string, error) {
+	ingresses := svc.Status.LoadBalancer.Ingress
+	if len(ingresses) != 1 {
+		return "", fmt.Errorf("Expected exactly one ingress load balancer, instead had %d: %v", len(ingresses), ingresses)
+	}
+	itu := ingresses[0]
+
+	switch {
+	case itu.IP != "":
+		return itu.IP, nil
+	case itu.Hostname != "":
+		return itu.Hostname, nil
+	default:
+		return "", fmt.Errorf("Expected ingress loadbalancer IP or hostname for %s to be set, instead was empty", svc.Name)
+	}
+}

--- a/vendor/github.com/knative/pkg/test/kube_checks.go
+++ b/vendor/github.com/knative/pkg/test/kube_checks.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/knative/pkg/test/logging"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8styped "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -43,8 +43,8 @@ const (
 // from client every interval until inState returns `true` indicating it
 // is done, returns an error or timeout. desc will be used to name the metric
 // that is emitted to track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(client *KubeClient, name string, inState func(d *apiv1beta1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
-	d := client.Kube.ExtensionsV1beta1().Deployments(namespace)
+func WaitForDeploymentState(client *KubeClient, name string, inState func(d *appsv1.Deployment) (bool, error), desc string, namespace string, timeout time.Duration) error {
+	d := client.Kube.AppsV1().Deployments(namespace)
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc))
 	defer span.End()
 
@@ -81,8 +81,8 @@ func GetConfigMap(client *KubeClient, namespace string) k8styped.ConfigMapInterf
 }
 
 // DeploymentScaledToZeroFunc returns a func that evaluates if a deployment has scaled to 0 pods
-func DeploymentScaledToZeroFunc() func(d *apiv1beta1.Deployment) (bool, error) {
-	return func(d *apiv1beta1.Deployment) (bool, error) {
+func DeploymentScaledToZeroFunc() func(d *appsv1.Deployment) (bool, error) {
+	return func(d *appsv1.Deployment) (bool, error) {
 		return d.Status.ReadyReplicas == 0, nil
 	}
 }


### PR DESCRIPTION
Fixes #984 

## Proposed Changes

- We changed the knative/pkg/webhook to use apps.deployments instead extensions.deployments, so change the rbac rule to talk about that.
- remove create verb for knative/eventing resources

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
knative-eventing-webhook uses apps.deployment
knative-eventing-webhook does not have create rule anymore for eventing.knative.dev resources.
```
