### PR TITLE
Add OpenAPI schema to Broker and Trigger.

### DIFF
--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -40,3 +40,32 @@ spec:
     - name: Hostname
       type: string
       JSONPath: .status.address.hostname
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            channelTemplate:
+              type: object
+              required:
+                - provisioner
+              properties:
+                provisioner:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
+                  properties:
+                    apiVersion:
+                      type: string
+                      minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    name:
+                      type: string
+                      minLength: 1
+            arguments:
+              type: object
+              additionalProperties: true

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -43,3 +43,44 @@ spec:
     - name: Subscriber_URI
       type: string
       JSONPath: .status.subscriberURI
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - subscriber
+          properties:
+            broker:
+              type: string
+            filter:
+              type: object
+              properties:
+                sourceAndType:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+            subscriber:
+              type: object
+              properties:
+                dnsName:
+                  type: string
+                  minLength: 1
+                ref:
+                  type: object
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
+                  properties:
+                    apiVersion:
+                      type: string
+                      minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    name:
+                      type: string
+                      minLength: 1


### PR DESCRIPTION
Fixes #894

## Proposed Changes

- Add OpenAPI schema to Broker and Trigger.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
