### PR TITLE
Create subscriber.uri and deprecate subscriber.dnsName

### DIFF
--- a/pkg/apis/eventing/v1alpha1/channel_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/channel_validation_test.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var dnsName = "example.com"
-
 func TestChannelValidation(t *testing.T) {
 	tests := []CRDTest{{
 		name: "valid",

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -138,11 +138,18 @@ type SubscriberSpec struct {
 	// +optional
 	Ref *corev1.ObjectReference `json:"ref,omitempty"`
 
+	// Deprecated: Use URI instead.
 	// Reference to a 'known' endpoint where no resolving is done.
 	// http://k8s-service for example
 	// http://myexternalhandler.example.com/foo/bar
 	// +optional
-	DNSName *string `json:"dnsName,omitempty"`
+	DeprecatedDNSName *string `json:"dnsName,omitempty"`
+
+	// Reference to a 'known' endpoint where no resolving is done.
+	// http://k8s-service for example
+	// http://myexternalhandler.example.com/foo/bar
+	// +optional
+	URI *string `json:"uri,omitempty"`
 }
 
 // ReplyStrategy specifies the handling of the SubscriberSpec's returned replies.

--- a/pkg/apis/eventing/v1alpha1/subscription_validation.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation.go
@@ -30,9 +30,10 @@ func (s *Subscription) Validate(ctx context.Context) *apis.FieldError {
 	return s.Spec.Validate(ctx).ViaField("spec")
 }
 
-// We require always Channel
-// Also at least one of 'subscriber' and 'reply' must be defined (non-nill and non-empty)
 func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
+	// We require always Channel.
+	// Also at least one of 'subscriber' and 'reply' must be defined (non-nil and non-empty).
+
 	var errs *apis.FieldError
 	if isChannelEmpty(ss.Channel) {
 		fe := apis.ErrMissingField("channel")
@@ -66,15 +67,34 @@ func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func isSubscriberSpecNilOrEmpty(s *SubscriberSpec) bool {
-	return s == nil || equality.Semantic.DeepEqual(s, &SubscriberSpec{}) ||
-		(equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) && s.DNSName == nil)
-
+	if s == nil || equality.Semantic.DeepEqual(s, &SubscriberSpec{}) {
+		return true
+	}
+	if equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) &&
+		s.DeprecatedDNSName == nil &&
+		s.URI == nil {
+		return true
+	}
+	return false
 }
 
 func isValidSubscriberSpec(s SubscriberSpec) *apis.FieldError {
 	var errs *apis.FieldError
-	if s.DNSName != nil && *s.DNSName != "" && s.Ref != nil && !equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) {
-		errs = errs.Also(apis.ErrMultipleOneOf("ref", "dnsName"))
+
+	fieldsSet := make([]string, 0, 0)
+	if s.Ref != nil && !equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) {
+		fieldsSet = append(fieldsSet, "ref")
+	}
+	if s.DeprecatedDNSName != nil && *s.DeprecatedDNSName != "" {
+		fieldsSet = append(fieldsSet, "dnsName")
+	}
+	if s.URI != nil && *s.URI != "" {
+		fieldsSet = append(fieldsSet, "uri")
+	}
+	if len(fieldsSet) == 0 {
+		errs = errs.Also(apis.ErrMissingOneOf("ref", "dnsName", "uri"))
+	} else if len(fieldsSet) > 1 {
+		errs = errs.Also(apis.ErrMultipleOneOf(fieldsSet...))
 	}
 
 	// If Ref given, check the fields.

--- a/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
@@ -509,7 +509,8 @@ func TestValidChannel(t *testing.T) {
 }
 
 func TestValidgetValidSubscriber(t *testing.T) {
-	dnsName := "example.com"
+	uri := "http://example.com"
+	empty := ""
 	tests := []struct {
 		name string
 		s    SubscriberSpec
@@ -521,7 +522,7 @@ func TestValidgetValidSubscriber(t *testing.T) {
 	}, {
 		name: "valid dnsName",
 		s: SubscriberSpec{
-			DNSName: &dnsName,
+			DeprecatedDNSName: &uri,
 		},
 		want: nil,
 	}, {
@@ -532,10 +533,66 @@ func TestValidgetValidSubscriber(t *testing.T) {
 				APIVersion: channelAPIVersion,
 				Kind:       channelKind,
 			},
-			DNSName: &dnsName,
+			DeprecatedDNSName: &uri,
 		},
 		want: func() *apis.FieldError {
 			fe := apis.ErrMultipleOneOf("ref", "dnsName")
+			return fe
+		}(),
+	}, {
+		name: "valid uri",
+		s: SubscriberSpec{
+			URI: &uri,
+		},
+		want: nil,
+	}, {
+		name: "both ref and uri given",
+		s: SubscriberSpec{
+			Ref: &corev1.ObjectReference{
+				Name:       channelName,
+				APIVersion: channelAPIVersion,
+				Kind:       channelKind,
+			},
+			URI: &uri,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMultipleOneOf("ref", "uri")
+			return fe
+		}(),
+	}, {
+		name: "both dnsName and uri given",
+		s: SubscriberSpec{
+			DeprecatedDNSName: &uri,
+			URI:               &uri,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMultipleOneOf("dnsName", "uri")
+			return fe
+		}(),
+	}, {
+		name: "ref, dnsName, and uri given",
+		s: SubscriberSpec{
+			Ref: &corev1.ObjectReference{
+				Name:       channelName,
+				APIVersion: channelAPIVersion,
+				Kind:       channelKind,
+			},
+			DeprecatedDNSName: &uri,
+			URI:               &uri,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMultipleOneOf("ref", "dnsName", "uri")
+			return fe
+		}(),
+	}, {
+		name: "empty ref, dnsName, and uri given",
+		s: SubscriberSpec{
+			Ref:               &corev1.ObjectReference{},
+			DeprecatedDNSName: &empty,
+			URI:               &empty,
+		},
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingOneOf("ref", "dnsName", "uri")
 			return fe
 		}(),
 	}, {

--- a/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -399,8 +399,17 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 			**out = **in
 		}
 	}
-	if in.DNSName != nil {
-		in, out := &in.DNSName, &out.DNSName
+	if in.DeprecatedDNSName != nil {
+		in, out := &in.DeprecatedDNSName, &out.DeprecatedDNSName
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(string)
+			**out = **in
+		}
+	}
+	if in.URI != nil {
+		in, out := &in.URI, &out.URI
 		if *in == nil {
 			*out = nil
 		} else {

--- a/pkg/reconciler/v1alpha1/broker/broker_test.go
+++ b/pkg/reconciler/v1alpha1/broker/broker_test.go
@@ -1063,7 +1063,7 @@ func makeDifferentSubscription() *v1alpha1.Subscription {
 	s := makeTestSubscription()
 	s.Spec.Subscriber.Ref = nil
 	url := "http://example.com/"
-	s.Spec.Subscriber.DNSName = &url
+	s.Spec.Subscriber.URI = &url
 	return s
 }
 

--- a/pkg/utils/resolve/subscriber.go
+++ b/pkg/utils/resolve/subscriber.go
@@ -72,8 +72,11 @@ func SubscriberSpec(ctx context.Context, dynamicClient dynamic.Interface, namesp
 	if isNilOrEmptySubscriber(s) {
 		return "", nil
 	}
-	if s.DNSName != nil && *s.DNSName != "" {
-		return *s.DNSName, nil
+	if s.URI != nil && *s.URI != "" {
+		return *s.URI, nil
+	}
+	if s.DeprecatedDNSName != nil && *s.DeprecatedDNSName != "" {
+		return *s.DeprecatedDNSName, nil
 	}
 
 	obj, err := ObjectReference(ctx, dynamicClient, namespace, s.Ref)

--- a/pkg/utils/resolve/subscriber_test.go
+++ b/pkg/utils/resolve/subscriber_test.go
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	dnsName = "dns-name"
+	uri = "http://example.com"
 
 	channelAddress = "test-channel.hostname"
 	channelURL     = fmt.Sprintf("http://%s/", channelAddress)
@@ -108,9 +108,15 @@ func TestSubscriberSpec(t *testing.T) {
 		},
 		"DNS Name": {
 			Sub: &v1alpha1.SubscriberSpec{
-				DNSName: &dnsName,
+				DeprecatedDNSName: &uri,
 			},
-			Expected: dnsName,
+			Expected: uri,
+		},
+		"URI": {
+			Sub: &v1alpha1.SubscriberSpec{
+				URI: &uri,
+			},
+			Expected: uri,
 		},
 		"Doesn't exist": {
 			Sub: &v1alpha1.SubscriberSpec{


### PR DESCRIPTION
Fixes #991

## Proposed Changes

- Create `subscriber.uri` and deprecate `subscriber.dnsName`.
    - The fields have identical semantics, both are used as a URI. We are simply giving the field the proper name. 
- #993 - In the following release, we will remove the deprecated `subscriber.dnsName` field.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch from using subscriber.dnsName to subscriber.uri. subscriber.dnsName will be removed in the next release.
```
