### PR TITLE
Add a label knative.dev/crd-install to CRDs to allow installing CRDs in a separate pass.

### DIFF
--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -15,6 +15,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: channels.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1

--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -15,6 +15,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterchannelprovisioners.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -15,6 +15,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: subscriptions.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1


### PR DESCRIPTION
## Proposed Changes

- Label CRDs so that they can be installed first with `kubectl -l knative.dev/crd-install=true YAML_FILE`

**Release Note**

```release-note
- CRDs are now labelled with knative.dev/crd-install=true to allow installing without race conditions or kubectl errors.
```
