### PR TITLE
Using a larger default TTL until we make it settable.

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	defaultTTL = 10
+	defaultTTL = 1000
 
 	metricsPort = 9090
 

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	defaultTTL = 1000
+	defaultTTL = 255
 
 	metricsPort = 9090
 


### PR DESCRIPTION
## Proposed Changes

- TTL was blocking me to make a cool app. Bumping TTL to a large number until we make it configurable.

Related to: #1011 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increase TTL from 10 to 255.
```
