### PR TITLE
Refactor broker to move resource creation out of reconcile. Use resource subdir.

### DIFF
--- a/pkg/reconciler/v1alpha1/broker/broker.go
+++ b/pkg/reconciler/v1alpha1/broker/broker.go
@@ -25,7 +25,7 @@ import (
 	"github.com/knative/eventing/pkg/reconciler/names"
 	"github.com/knative/eventing/pkg/reconciler/v1alpha1/broker/resources"
 	"go.uber.org/zap"
-	"k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -105,7 +105,7 @@ func ProvideController(args ReconcilerArgs) func(manager.Manager, *zap.Logger) (
 		}
 
 		// Watch all the resources that the Broker reconciles.
-		for _, t := range []runtime.Object{&v1alpha1.Channel{}, &corev1.Service{}, &v1.Deployment{}} {
+		for _, t := range []runtime.Object{&v1alpha1.Channel{}, &corev1.Service{}, &appsv1.Deployment{}} {
 			err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.Broker{}, IsController: true})
 			if err != nil {
 				return nil, err
@@ -289,7 +289,7 @@ func (r *reconciler) updateStatus(broker *v1alpha1.Broker) (*v1alpha1.Broker, er
 }
 
 // reconcileFilterDeployment reconciles Broker's 'b' filter deployment.
-func (r *reconciler) reconcileFilterDeployment(ctx context.Context, b *v1alpha1.Broker) (*v1.Deployment, error) {
+func (r *reconciler) reconcileFilterDeployment(ctx context.Context, b *v1alpha1.Broker) (*appsv1.Deployment, error) {
 	expected := resources.MakeFilterDeployment(&resources.FilterArgs{
 		Broker:             b,
 		Image:              r.filterImage,
@@ -363,12 +363,12 @@ func (r *reconciler) getChannel(ctx context.Context, b *v1alpha1.Broker, ls labe
 }
 
 // reconcileDeployment reconciles the K8s Deployment 'd'.
-func (r *reconciler) reconcileDeployment(ctx context.Context, d *v1.Deployment) (*v1.Deployment, error) {
+func (r *reconciler) reconcileDeployment(ctx context.Context, d *appsv1.Deployment) (*appsv1.Deployment, error) {
 	name := types.NamespacedName{
 		Namespace: d.Namespace,
 		Name:      d.Name,
 	}
-	current := &v1.Deployment{}
+	current := &appsv1.Deployment{}
 	err := r.client.Get(ctx, name, current)
 	if k8serrors.IsNotFound(err) {
 		err = r.client.Create(ctx, d)
@@ -422,7 +422,7 @@ func (r *reconciler) reconcileService(ctx context.Context, svc *corev1.Service) 
 }
 
 // reconcileIngressDeployment reconciles the Ingress Deployment.
-func (r *reconciler) reconcileIngressDeployment(ctx context.Context, b *v1alpha1.Broker, c *v1alpha1.Channel) (*v1.Deployment, error) {
+func (r *reconciler) reconcileIngressDeployment(ctx context.Context, b *v1alpha1.Broker, c *v1alpha1.Channel) (*appsv1.Deployment, error) {
 	expected := resources.MakeIngress(&resources.IngressArgs{
 		Broker:             b,
 		Image:              r.ingressImage,

--- a/pkg/reconciler/v1alpha1/broker/broker_test.go
+++ b/pkg/reconciler/v1alpha1/broker/broker_test.go
@@ -162,7 +162,7 @@ func TestReconcile(t *testing.T) {
 				MockLists: []controllertesting.MockList{
 					func(_ client.Client, _ context.Context, opts *client.ListOptions, list runtime.Object) (controllertesting.MockHandled, error) {
 						// Only match the Trigger Channel labels.
-						ls := labels.FormatLabels(TriggerChannelLabels(makeBroker()))
+						ls := labels.FormatLabels(resources.TriggerChannelLabels(makeBroker()))
 						l, _ := labels.ConvertSelectorToLabelsMap(ls)
 
 						if _, ok := list.(*v1alpha1.ChannelList); ok && opts.LabelSelector.Matches(l) {
@@ -184,7 +184,7 @@ func TestReconcile(t *testing.T) {
 				MockCreates: []controllertesting.MockCreate{
 					func(_ client.Client, _ context.Context, obj runtime.Object) (controllertesting.MockHandled, error) {
 						if c, ok := obj.(*v1alpha1.Channel); ok {
-							if cmp.Equal(c.Labels, TriggerChannelLabels(makeBroker())) {
+							if cmp.Equal(c.Labels, resources.TriggerChannelLabels(makeBroker())) {
 								return controllertesting.Handled, errors.New("test error creating Trigger Channel")
 							}
 						}
@@ -490,7 +490,7 @@ func TestReconcile(t *testing.T) {
 				MockLists: []controllertesting.MockList{
 					func(_ client.Client, _ context.Context, opts *client.ListOptions, list runtime.Object) (controllertesting.MockHandled, error) {
 						// Only match the Ingress Channel labels.
-						ls := labels.FormatLabels(IngressChannelLabels(makeBroker()))
+						ls := labels.FormatLabels(resources.IngressChannelLabels(makeBroker()))
 						l, _ := labels.ConvertSelectorToLabelsMap(ls)
 
 						if _, ok := list.(*v1alpha1.ChannelList); ok && opts.LabelSelector.Matches(l) {
@@ -517,7 +517,7 @@ func TestReconcile(t *testing.T) {
 					func(innerClient client.Client, ctx context.Context, opts *client.ListOptions, list runtime.Object) (handled controllertesting.MockHandled, e error) {
 						if _, ok := list.(*v1alpha1.ChannelList); ok {
 							// Only match the Ingress Channel labels.
-							ls := labels.FormatLabels(IngressChannelLabels(makeBroker()))
+							ls := labels.FormatLabels(resources.IngressChannelLabels(makeBroker()))
 							l, _ := labels.ConvertSelectorToLabelsMap(ls)
 							if opts.LabelSelector.Matches(l) {
 								return controllertesting.Handled, nil
@@ -529,7 +529,7 @@ func TestReconcile(t *testing.T) {
 				MockCreates: []controllertesting.MockCreate{
 					func(_ client.Client, _ context.Context, obj runtime.Object) (controllertesting.MockHandled, error) {
 						if c, ok := obj.(*v1alpha1.Channel); ok {
-							if cmp.Equal(c.Labels, IngressChannelLabels(makeBroker())) {
+							if cmp.Equal(c.Labels, resources.IngressChannelLabels(makeBroker())) {
 								return controllertesting.Handled, errors.New("test error creating Ingress Channel")
 							}
 						}
@@ -555,7 +555,7 @@ func TestReconcile(t *testing.T) {
 					func(innerClient client.Client, ctx context.Context, opts *client.ListOptions, list runtime.Object) (handled controllertesting.MockHandled, e error) {
 						if cl, ok := list.(*v1alpha1.ChannelList); ok {
 							// Only match the Ingress Channel labels.
-							ls := labels.FormatLabels(IngressChannelLabels(makeBroker()))
+							ls := labels.FormatLabels(resources.IngressChannelLabels(makeBroker()))
 							l, _ := labels.ConvertSelectorToLabelsMap(ls)
 							if opts.LabelSelector.Matches(l) {
 								cl.Items = append(cl.Items, *makeDifferentIngressChannel())
@@ -595,7 +595,7 @@ func TestReconcile(t *testing.T) {
 					func(innerClient client.Client, ctx context.Context, opts *client.ListOptions, list runtime.Object) (handled controllertesting.MockHandled, e error) {
 						if cl, ok := list.(*v1alpha1.ChannelList); ok {
 							// Only match the Ingress Channel labels.
-							ls := labels.FormatLabels(IngressChannelLabels(makeBroker()))
+							ls := labels.FormatLabels(resources.IngressChannelLabels(makeBroker()))
 							l, _ := labels.ConvertSelectorToLabelsMap(ls)
 							if opts.LabelSelector.Matches(l) {
 								cl.Items = append(cl.Items, *makeNonAddressableIngressChannel())
@@ -794,7 +794,7 @@ func TestReconcile(t *testing.T) {
 					func(innerClient client.Client, ctx context.Context, opts *client.ListOptions, list runtime.Object) (handled controllertesting.MockHandled, e error) {
 						if cl, ok := list.(*v1alpha1.ChannelList); ok {
 							// Only match the Ingress Channel labels.
-							ls := labels.FormatLabels(IngressChannelLabels(makeBroker()))
+							ls := labels.FormatLabels(resources.IngressChannelLabels(makeBroker()))
 							l, _ := labels.ConvertSelectorToLabelsMap(ls)
 							if opts.LabelSelector.Matches(l) {
 								cl.Items = append(cl.Items, *makeIngressChannel())

--- a/pkg/reconciler/v1alpha1/broker/resources/channel.go
+++ b/pkg/reconciler/v1alpha1/broker/resources/channel.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewChannel creates a new Channel for Broker 'b'.
+func NewChannel(b *v1alpha1.Broker, l map[string]string) *v1alpha1.Channel {
+	var spec v1alpha1.ChannelSpec
+	if b.Spec.ChannelTemplate != nil {
+		spec = *b.Spec.ChannelTemplate
+	}
+
+	return &v1alpha1.Channel{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    b.Namespace,
+			GenerateName: fmt.Sprintf("%s-broker-", b.Name),
+			Labels:       l,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(b, schema.GroupVersionKind{
+					Group:   v1alpha1.SchemeGroupVersion.Group,
+					Version: v1alpha1.SchemeGroupVersion.Version,
+					Kind:    "Broker",
+				}),
+			},
+		},
+		Spec: spec,
+	}
+}
+
+func NewTriggerChannel(b *v1alpha1.Broker) *v1alpha1.Channel {
+	return NewChannel(b, TriggerChannelLabels(b))
+}
+
+func NewIngressChannel(b *v1alpha1.Broker) *v1alpha1.Channel {
+	return NewChannel(b, IngressChannelLabels(b))
+}

--- a/pkg/reconciler/v1alpha1/broker/resources/labels.go
+++ b/pkg/reconciler/v1alpha1/broker/resources/labels.go
@@ -1,0 +1,28 @@
+package resources
+
+import "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+
+// TriggerChannelLabels are all the labels placed on the Trigger Channel for the given Broker. This
+// should only be used by Broker and Trigger code.
+func TriggerChannelLabels(b *v1alpha1.Broker) map[string]string {
+	return map[string]string{
+		"eventing.knative.dev/broker":           b.Name,
+		"eventing.knative.dev/brokerEverything": "true",
+	}
+}
+
+// IngressChannelLabels are all the labels placed on the Ingress Channel for the given Broker. This
+// should only be used by Broker and Trigger code.
+func IngressChannelLabels(b *v1alpha1.Broker) map[string]string {
+	return map[string]string{
+		"eventing.knative.dev/broker":        b.Name,
+		"eventing.knative.dev/brokerIngress": "true",
+	}
+}
+
+func IngressSubscriptionLabels(b *v1alpha1.Broker) map[string]string {
+	return map[string]string{
+		"eventing.knative.dev/broker":        b.Name,
+		"eventing.knative.dev/brokerIngress": "true",
+	}
+}

--- a/pkg/reconciler/v1alpha1/broker/resources/subscription.go
+++ b/pkg/reconciler/v1alpha1/broker/resources/subscription.go
@@ -1,0 +1,42 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// NewSubscription returns a placeholder subscription for trigger 't', channel 'c', and service 'svc'.
+func NewSubscription(b *v1alpha1.Broker, c *v1alpha1.Channel, svc *corev1.Service) *v1alpha1.Subscription {
+	return &v1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    b.Namespace,
+			GenerateName: fmt.Sprintf("internal-ingress-%s-", b.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(b, schema.GroupVersionKind{
+					Group:   v1alpha1.SchemeGroupVersion.Group,
+					Version: v1alpha1.SchemeGroupVersion.Version,
+					Kind:    "Broker",
+				}),
+			},
+			Labels: IngressSubscriptionLabels(b),
+		},
+		Spec: v1alpha1.SubscriptionSpec{
+			Channel: corev1.ObjectReference{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       "Channel",
+				Name:       c.Name,
+			},
+			Subscriber: &v1alpha1.SubscriberSpec{
+				Ref: &corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       svc.Name,
+				},
+			},
+		},
+	}
+}

--- a/pkg/reconciler/v1alpha1/trigger/trigger.go
+++ b/pkg/reconciler/v1alpha1/trigger/trigger.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/logging"
-	"github.com/knative/eventing/pkg/reconciler/v1alpha1/broker"
+	brokerresources "github.com/knative/eventing/pkg/reconciler/v1alpha1/broker/resources"
 	"github.com/knative/eventing/pkg/utils/resolve"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
 	"go.uber.org/zap"
@@ -325,13 +325,13 @@ func (r *reconciler) getBroker(ctx context.Context, t *v1alpha1.Trigger) (*v1alp
 // getBrokerTriggerChannel return the Broker's Trigger Channel if it exists, otherwise it returns an
 // error.
 func (r *reconciler) getBrokerTriggerChannel(ctx context.Context, b *v1alpha1.Broker) (*v1alpha1.Channel, error) {
-	return r.getChannel(ctx, b, labels.SelectorFromSet(broker.TriggerChannelLabels(b)))
+	return r.getChannel(ctx, b, labels.SelectorFromSet(brokerresources.TriggerChannelLabels(b)))
 }
 
 // getBrokerIngressChannel return the Broker's Ingress Channel if it exists, otherwise it returns an
 // error.
 func (r *reconciler) getBrokerIngressChannel(ctx context.Context, b *v1alpha1.Broker) (*v1alpha1.Channel, error) {
-	return r.getChannel(ctx, b, labels.SelectorFromSet(broker.IngressChannelLabels(b)))
+	return r.getChannel(ctx, b, labels.SelectorFromSet(brokerresources.IngressChannelLabels(b)))
 }
 
 // getChannel returns the Broker's channel if it exists, otherwise it returns an error.

--- a/pkg/reconciler/v1alpha1/trigger/trigger_test.go
+++ b/pkg/reconciler/v1alpha1/trigger/trigger_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/reconciler/names"
 	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
-	"github.com/knative/eventing/pkg/reconciler/v1alpha1/broker"
+	brokerresources "github.com/knative/eventing/pkg/reconciler/v1alpha1/broker/resources"
 	"github.com/knative/eventing/pkg/utils"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	istiov1alpha3 "github.com/knative/pkg/apis/istio/v1alpha3"
@@ -195,7 +195,7 @@ func TestReconcile(t *testing.T) {
 				MockLists: []controllertesting.MockList{
 					func(_ client.Client, _ context.Context, opts *client.ListOptions, list runtime.Object) (controllertesting.MockHandled, error) {
 						// Only match the Trigger Channel labels.
-						ls := labels.FormatLabels(broker.TriggerChannelLabels(makeBroker()))
+						ls := labels.FormatLabels(brokerresources.TriggerChannelLabels(makeBroker()))
 						l, _ := labels.ConvertSelectorToLabelsMap(ls)
 
 						if _, ok := list.(*v1alpha1.ChannelList); ok && opts.LabelSelector.Matches(l) {
@@ -220,7 +220,7 @@ func TestReconcile(t *testing.T) {
 				MockLists: []controllertesting.MockList{
 					func(_ client.Client, _ context.Context, opts *client.ListOptions, list runtime.Object) (handled controllertesting.MockHandled, e error) {
 						// Only match the Ingress Channel labels.
-						ls := labels.FormatLabels(broker.IngressChannelLabels(makeBroker()))
+						ls := labels.FormatLabels(brokerresources.IngressChannelLabels(makeBroker()))
 						l, _ := labels.ConvertSelectorToLabelsMap(ls)
 
 						if _, ok := list.(*v1alpha1.ChannelList); ok && opts.LabelSelector.Matches(l) {


### PR DESCRIPTION
Follow-up to #1014 

Fixes https://github.com/knative/eventing/issues/1012

## Proposed Changes

- Use _reconciler_/resources to show clearly the resources that this controller can produce.

```release-note
NONE
```

/assign @Harwayne 