### PR TITLE
Fix NATSS CCP flaky test "deleted_clusterChannelProvisioner"

### DIFF
--- a/contrib/natss/pkg/controller/clusterchannelprovisioner/reconcile_test.go
+++ b/contrib/natss/pkg/controller/clusterchannelprovisioner/reconcile_test.go
@@ -49,6 +49,7 @@ func init() {
 
 var (
 	truePointer = true
+	deletedTime = metav1.Now().Rfc3339Copy()
 )
 
 var mockFetchError = controllertesting.Mocks{
@@ -187,7 +188,6 @@ func getNewClusterChannelProvisioner(name string, reconcileKind string) *eventin
 
 func makeDeletedClusterChannelProvisioner() *eventingv1alpha1.ClusterChannelProvisioner {
 	c := makeClusterChannelProvisioner()
-	deletedTime := metav1.Now().Rfc3339Copy()
 	c.DeletionTimestamp = &deletedTime
 	return c
 }


### PR DESCRIPTION
Fixes #
Fix #1019

## Proposed Changes

- Avoid multiple generation of "DeletionTimestamp" during the tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
