### PR TITLE
Remove subscriber.dnsName which is a deprecated field in subscriber

### DIFF
--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -69,9 +69,6 @@ spec:
             subscriber:
               type: object
               properties:
-                dnsName:
-                  type: string
-                  minLength: 1
                 uri:
                   type: string
                   minLength: 1

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -70,9 +70,6 @@ spec:
             subscriber:
               type: object
               properties:
-                dnsName:
-                  type: string
-                  minLength: 1
                 uri:
                   type: string
                   minLength: 1

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -237,9 +237,9 @@ a Channel system that receives and delivers events._
 | Field               | Type            | Description | Constraints              |
 | ------------------- | --------------- | ----------- | ------------------------ |
 | ref<sup>1</sup>     | ObjectReference |             | Must adhere to Callable. |
-| dnsName<sup>1</sup> | String          |             |                          |
+| uri<sup>1</sup> | String          |             |                          |
 
-1: One of (ref, dnsName), Required.
+1: One of (ref, uri), Required.
 
 ### ChannelSubscriberSpec
 

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -138,13 +138,6 @@ type SubscriberSpec struct {
 	// +optional
 	Ref *corev1.ObjectReference `json:"ref,omitempty"`
 
-	// Deprecated: Use URI instead.
-	// Reference to a 'known' endpoint where no resolving is done.
-	// http://k8s-service for example
-	// http://myexternalhandler.example.com/foo/bar
-	// +optional
-	DeprecatedDNSName *string `json:"dnsName,omitempty"`
-
 	// Reference to a 'known' endpoint where no resolving is done.
 	// http://k8s-service for example
 	// http://myexternalhandler.example.com/foo/bar

--- a/pkg/apis/eventing/v1alpha1/subscription_validation.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation.go
@@ -71,7 +71,6 @@ func isSubscriberSpecNilOrEmpty(s *SubscriberSpec) bool {
 		return true
 	}
 	if equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) &&
-		s.DeprecatedDNSName == nil &&
 		s.URI == nil {
 		return true
 	}
@@ -85,14 +84,11 @@ func isValidSubscriberSpec(s SubscriberSpec) *apis.FieldError {
 	if s.Ref != nil && !equality.Semantic.DeepEqual(s.Ref, &corev1.ObjectReference{}) {
 		fieldsSet = append(fieldsSet, "ref")
 	}
-	if s.DeprecatedDNSName != nil && *s.DeprecatedDNSName != "" {
-		fieldsSet = append(fieldsSet, "dnsName")
-	}
 	if s.URI != nil && *s.URI != "" {
 		fieldsSet = append(fieldsSet, "uri")
 	}
 	if len(fieldsSet) == 0 {
-		errs = errs.Also(apis.ErrMissingOneOf("ref", "dnsName", "uri"))
+		errs = errs.Also(apis.ErrMissingOneOf("ref", "uri"))
 	} else if len(fieldsSet) > 1 {
 		errs = errs.Also(apis.ErrMultipleOneOf(fieldsSet...))
 	}

--- a/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_validation_test.go
@@ -520,26 +520,6 @@ func TestValidgetValidSubscriber(t *testing.T) {
 		s:    *getValidSubscriberSpec(),
 		want: nil,
 	}, {
-		name: "valid dnsName",
-		s: SubscriberSpec{
-			DeprecatedDNSName: &uri,
-		},
-		want: nil,
-	}, {
-		name: "both ref and dnsName given",
-		s: SubscriberSpec{
-			Ref: &corev1.ObjectReference{
-				Name:       channelName,
-				APIVersion: channelAPIVersion,
-				Kind:       channelKind,
-			},
-			DeprecatedDNSName: &uri,
-		},
-		want: func() *apis.FieldError {
-			fe := apis.ErrMultipleOneOf("ref", "dnsName")
-			return fe
-		}(),
-	}, {
 		name: "valid uri",
 		s: SubscriberSpec{
 			URI: &uri,
@@ -560,39 +540,27 @@ func TestValidgetValidSubscriber(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "both dnsName and uri given",
-		s: SubscriberSpec{
-			DeprecatedDNSName: &uri,
-			URI:               &uri,
-		},
-		want: func() *apis.FieldError {
-			fe := apis.ErrMultipleOneOf("dnsName", "uri")
-			return fe
-		}(),
-	}, {
-		name: "ref, dnsName, and uri given",
+		name: "ref and uri given",
 		s: SubscriberSpec{
 			Ref: &corev1.ObjectReference{
 				Name:       channelName,
 				APIVersion: channelAPIVersion,
 				Kind:       channelKind,
 			},
-			DeprecatedDNSName: &uri,
-			URI:               &uri,
+			URI: &uri,
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMultipleOneOf("ref", "dnsName", "uri")
+			fe := apis.ErrMultipleOneOf("ref", "uri")
 			return fe
 		}(),
 	}, {
-		name: "empty ref, dnsName, and uri given",
+		name: "empty ref, and uri given",
 		s: SubscriberSpec{
-			Ref:               &corev1.ObjectReference{},
-			DeprecatedDNSName: &empty,
-			URI:               &empty,
+			Ref: &corev1.ObjectReference{},
+			URI: &empty,
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingOneOf("ref", "dnsName", "uri")
+			fe := apis.ErrMissingOneOf("ref", "uri")
 			return fe
 		}(),
 	}, {

--- a/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -371,11 +371,6 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
-	if in.DeprecatedDNSName != nil {
-		in, out := &in.DeprecatedDNSName, &out.DeprecatedDNSName
-		*out = new(string)
-		**out = **in
-	}
 	if in.URI != nil {
 		in, out := &in.URI, &out.URI
 		*out = new(string)

--- a/pkg/utils/resolve/subscriber.go
+++ b/pkg/utils/resolve/subscriber.go
@@ -75,9 +75,6 @@ func SubscriberSpec(ctx context.Context, dynamicClient dynamic.Interface, namesp
 	if s.URI != nil && *s.URI != "" {
 		return *s.URI, nil
 	}
-	if s.DeprecatedDNSName != nil && *s.DeprecatedDNSName != "" {
-		return *s.DeprecatedDNSName, nil
-	}
 
 	obj, err := ObjectReference(ctx, dynamicClient, namespace, s.Ref)
 	if err != nil {

--- a/pkg/utils/resolve/subscriber_test.go
+++ b/pkg/utils/resolve/subscriber_test.go
@@ -106,12 +106,6 @@ func TestSubscriberSpec(t *testing.T) {
 			Sub:      &v1alpha1.SubscriberSpec{},
 			Expected: "",
 		},
-		"DNS Name": {
-			Sub: &v1alpha1.SubscriberSpec{
-				DeprecatedDNSName: &uri,
-			},
-			Expected: uri,
-		},
 		"URI": {
 			Sub: &v1alpha1.SubscriberSpec{
 				URI: &uri,


### PR DESCRIPTION
Fixes #993 


**Release Note**

```release-note
Remove deprecated subscriber field `subscriber.dnsName`
```
