### PR TITLE
Add OWNERS for the NATSS Channel

### DIFF
--- a/contrib/natss/OWNERS
+++ b/contrib/natss/OWNERS
@@ -1,0 +1,11 @@
+# These OWNERS are in addition to the repo level OWNERS.
+
+approvers:
+  - Abd4llA
+
+# Reviewers are suggested from the reviewers list first, then the approvers
+# list. To add reviewers while spreading the load among existing approvers,
+# copy the approvers to the reviewers list too.
+reviewers:
+  - Abd4llA
+


### PR DESCRIPTION
## Proposed Changes

- Add OWNERS for the NATSS Channel, based on those who volunteered during the WG call.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
