### PR TITLE
Fix errors in test readme

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -19,8 +19,8 @@ You can run it simply with:
 test/presubmit-tests.sh
 ```
 
-By default, this script will run `build tests`, `unit tests` and
-`integration tests`. If you only want to run one type of tests, you can run this
+_By default, this script will run `build tests`, `unit tests` and
+`integration tests`._ If you only want to run one type of tests, you can run this
 script with corresponding flags like below:
 
 ```shell
@@ -29,7 +29,7 @@ test/presubmit-tests.sh --unit-tests
 test/presubmit-tests.sh --integration-tests
 ```
 
-_Note that if the tests you are running includes `integration tests`, it will
+_Note that if the tests you are running include `integration tests`, it will
 create a new GKE cluster in project `$PROJECT_ID`, start Knative Serving and
 Eventing system, upload test images to `$KO_DOCKER_REPO`, and run all
 `e2e-*tests.sh` scripts under [`test`](.). After the tests finish, it will
@@ -45,21 +45,21 @@ You can run it simply with:
 test/e2e-tests.sh
 ```
 
-By default, it will create a new GKE cluster in project `$PROJECT_ID`, install
+_By default, it will create a new GKE cluster in project `$PROJECT_ID`, install
 Knative Serving stack with Istio, upload test images to your Docker repo and run
 the end-to-end tests against the Knative Eventing built from source. After the
-tests finishes, it will delete the cluster.
+tests finishes, it will delete the cluster._
 
 If you have already created your own Kubernetes cluster but haven't installed
 Knative, you can run with `test/e2e-tests.sh --run-tests`.
 
 If you have set up a running environment that meets
 [the e2e test environment requirements](#environment-requirements), you can run
-with `./test/e2e-tests.sh --run-tests --skip-knative-setup`.
+with `test/e2e-tests.sh --run-tests --skip-knative-setup`.
 
 ## Running tests with `go test` command (recommended)
 
-## Running unit tests
+### Running unit tests
 
 You can also use `go test` command to run unit tests:
 
@@ -70,7 +70,7 @@ go test -v ./pkg/...
 _By default `go test` will not run [the e2e tests](#running-end-to-end-tests),
 which needs [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
-## Running end-to-end tests
+### Running end-to-end tests
 
 To run [the e2e tests](./e2e) with `go test` command, you need to have a running
 environment that meets
@@ -81,7 +81,7 @@ to specify the build tag `e2e`.
 go test -v -tags=e2e -count=1 ./test/e2e
 ```
 
-### One test case
+#### One test case
 
 To run one e2e test case, e.g. TestSingleBinaryEvent, use the
 [-run](https://golang.org/cmd/go/#hdr-Testing_flags) flag with `go test`:
@@ -107,9 +107,9 @@ There's couple of things you need to install before running e2e tests locally.
 
 ### Building the test images
 
-Note: this is only required when you run e2e tests locally with `go test`
+_Note: this is only required when you run e2e tests locally with `go test`
 commands. Running tests through e2e-tests.sh will publish the images
-automatically.
+automatically._
 
 The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to
 build and push the test images used by the e2e tests. It requires:
@@ -134,7 +134,7 @@ deployed in GCR.
 New test images should be placed in `./test/test_images`. For each image create
 a new sub-folder and include a Go file that will be an entry point to the
 application. This Go file should use the package `main` and include the function
-`main()`. It is a good practice to include a readme file as well. When uploading
+`main()`. It is a good practice to include a `readme` file as well. When uploading
 test images, `ko` will build an image from this folder.
 
 ## Flags

--- a/test/README.md
+++ b/test/README.md
@@ -2,14 +2,16 @@
 
 This directory contains tests and testing docs for `Knative Eventing`.
 
-- [Unit tests](#running-unit-tests) reside in the codebase alongside the code they test
+- [Unit tests](#running-unit-tests) reside in the codebase alongside the code
+  they test
 - [End-to-end tests](#running-end-to-end-tests) reside in [`/test/e2e`](./e2e)
 
 ## Running tests with scripts (not recommended)
 
 ### Presubmit tests
 
-[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the tests before code submission.
+[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the tests
+before code submission.
 
 You can run it simply with:
 
@@ -17,8 +19,9 @@ You can run it simply with:
 test/presubmit-tests.sh
 ```
 
-By default, this script will run `build tests`, `unit tests` and `integration tests`.
-If you only want to run one type of tests, you can run this script with corresponding flags like below:
+By default, this script will run `build tests`, `unit tests` and
+`integration tests`. If you only want to run one type of tests, you can run this
+script with corresponding flags like below:
 
 ```shell
 test/presubmit-tests.sh --build-tests
@@ -26,7 +29,11 @@ test/presubmit-tests.sh --unit-tests
 test/presubmit-tests.sh --integration-tests
 ```
 
-_Note that if the tests you are running includes `integration tests`, it will create a new GKE cluster in project `$PROJECT_ID`, start Knative Serving and Eventing system, upload test images to `$KO_DOCKER_REPO`, and run all `e2e-*tests.sh` scripts under [`test`](.). After the tests finish, it will delete the cluster._
+_Note that if the tests you are running includes `integration tests`, it will
+create a new GKE cluster in project `$PROJECT_ID`, start Knative Serving and
+Eventing system, upload test images to `$KO_DOCKER_REPO`, and run all
+`e2e-*tests.sh` scripts under [`test`](.). After the tests finish, it will
+delete the cluster._
 
 ### E2E tests
 
@@ -38,11 +45,17 @@ You can run it simply with:
 test/e2e-tests.sh
 ```
 
-By default, it will create a new GKE cluster in project `$PROJECT_ID`, install Knative Serving stack with Istio, upload test images to your Docker repo and run the end-to-end tests against the Knative Eventing built from source. After the tests finishes, it will delete the cluster.
+By default, it will create a new GKE cluster in project `$PROJECT_ID`, install
+Knative Serving stack with Istio, upload test images to your Docker repo and run
+the end-to-end tests against the Knative Eventing built from source. After the
+tests finishes, it will delete the cluster.
 
-If you have already created your own Kubernetes cluster but haven't installed Knative, you can run with `test/e2e-tests.sh --run-tests`.
+If you have already created your own Kubernetes cluster but haven't installed
+Knative, you can run with `test/e2e-tests.sh --run-tests`.
 
-If you have set up a running environment that meets [the e2e test environment requirements](#environment-requirements), you can run with `./test/e2e-tests.sh --run-tests --skip-knative-setup`.
+If you have set up a running environment that meets
+[the e2e test environment requirements](#environment-requirements), you can run
+with `./test/e2e-tests.sh --run-tests --skip-knative-setup`.
 
 ## Running tests with `go test` command (recommended)
 
@@ -54,11 +67,15 @@ You can also use `go test` command to run unit tests:
 go test -v ./pkg/...
 ```
 
-_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which needs [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests),
+which needs [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
 ## Running end-to-end tests
 
-To run [the e2e tests](./e2e) with `go test` command, you need to have a running environment that meets [the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
+To run [the e2e tests](./e2e) with `go test` command, you need to have a running
+environment that meets
+[the e2e test environment requirements](#environment-requirements), and you need
+to specify the build tag `e2e`.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e
@@ -66,7 +83,8 @@ go test -v -tags=e2e -count=1 ./test/e2e
 
 ### One test case
 
-To run one e2e test case, e.g. TestSingleBinaryEvent, use the [-run](https://golang.org/cmd/go/#hdr-Testing_flags) flag with `go test`:
+To run one e2e test case, e.g. TestSingleBinaryEvent, use the
+[-run](https://golang.org/cmd/go/#hdr-Testing_flags) flag with `go test`:
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$
@@ -89,11 +107,15 @@ There's couple of things you need to install before running e2e tests locally.
 
 ### Building the test images
 
-Note: this is only required when you run e2e tests locally with `go test` commands. Running tests through e2e-tests.sh will publish the images automatically.
+Note: this is only required when you run e2e tests locally with `go test`
+commands. Running tests through e2e-tests.sh will publish the images
+automatically.
 
-The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to build and push the test images used by the e2e tests. It requires:
+The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to
+build and push the test images used by the e2e tests. It requires:
 
-- [`KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup) to be set
+- [`KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
+  to be set
 - You to be
   [authenticated with your `KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
 - [`docker`](https://docs.docker.com/install/) to be installed
@@ -104,12 +126,18 @@ To run the script for all end to end test images:
 ./test/upload-test-images.sh e2e
 ```
 
-A docker tag is mandatory to avoid issues with using `latest` tag for images deployed in GCR.
+A docker tag is mandatory to avoid issues with using `latest` tag for images
+deployed in GCR.
 
 ### Adding new test images
 
-New test images should be placed in `./test/test_images`. For each image create a new sub-folder and include a Go file that will be an entry point to the application. This Go file should use the package `main` and include the function `main()`. It is a good practice to include a readme file as well. When uploading test images, `ko` will build an image from this folder.
+New test images should be placed in `./test/test_images`. For each image create
+a new sub-folder and include a Go file that will be an entry point to the
+application. This Go file should use the package `main` and include the function
+`main()`. It is a good practice to include a readme file as well. When uploading
+test images, `ko` will build an image from this folder.
 
 ## Flags
 
-Flags are similar to those in [`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)
+Flags are similar to those in
+[`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)

--- a/test/README.md
+++ b/test/README.md
@@ -95,7 +95,7 @@ go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$
 There's couple of things you need to install before running e2e tests locally.
 
 1. A running [Knative](https://www.knative.dev/docs/install/) cluster
-2. A docker repo containing [the test images](#test-images)
+1. A docker repo containing [the test images](#test-images)
 
 ## Test images
 

--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@ This directory contains tests and testing docs for `Knative Eventing`.
   they test
 - [End-to-end tests](#running-end-to-end-tests) reside in [`/test/e2e`](./e2e)
 
-## Running tests with scripts (not recommended)
+## Running tests with scripts
 
 ### Presubmit tests
 
@@ -20,8 +20,8 @@ test/presubmit-tests.sh
 ```
 
 _By default, this script will run `build tests`, `unit tests` and
-`integration tests`._ If you only want to run one type of tests, you can run this
-script with corresponding flags like below:
+`integration tests`._ If you only want to run one type of tests, you can run
+this script with corresponding flags like below:
 
 ```shell
 test/presubmit-tests.sh --build-tests
@@ -45,10 +45,10 @@ You can run it simply with:
 test/e2e-tests.sh
 ```
 
-_By default, it will create a new GKE cluster in project `$PROJECT_ID`, install
-Knative Serving stack with Istio, upload test images to your Docker repo and run
-the end-to-end tests against the Knative Eventing built from source. After the
-tests finishes, it will delete the cluster._
+_By default, it will create a new GKE cluster in project `$PROJECT_ID`, start
+Knative Serving and Eventing system, upload test images to `$KO_DOCKER_REPO`,
+and run the end-to-end tests. After the tests finishes, it will delete the
+cluster._
 
 If you have already created your own Kubernetes cluster but haven't installed
 Knative, you can run with `test/e2e-tests.sh --run-tests`.
@@ -57,7 +57,7 @@ If you have set up a running environment that meets
 [the e2e test environment requirements](#environment-requirements), you can run
 with `test/e2e-tests.sh --run-tests --skip-knative-setup`.
 
-## Running tests with `go test` command (recommended)
+## Running tests with `go test` command
 
 ### Running unit tests
 
@@ -94,14 +94,8 @@ go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$
 
 There's couple of things you need to install before running e2e tests locally.
 
-1. `kubetest` installed:
-
-   ```bash
-   go get -u k8s.io/test-infra/kubetest
-   ```
-
-2. A running [Knative](https://www.knative.dev/docs/install/) cluster
-3. A docker repo containing [the test images](#test-images)
+1. A running [Knative](https://www.knative.dev/docs/install/) cluster
+2. A docker repo containing [the test images](#test-images)
 
 ## Test images
 
@@ -134,8 +128,8 @@ deployed in GCR.
 New test images should be placed in `./test/test_images`. For each image create
 a new sub-folder and include a Go file that will be an entry point to the
 application. This Go file should use the package `main` and include the function
-`main()`. It is a good practice to include a `readme` file as well. When uploading
-test images, `ko` will build an image from this folder.
+`main()`. It is a good practice to include a `readme` file as well. When
+uploading test images, `ko` will build an image from this folder.
 
 ## Flags
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,42 +2,63 @@
 
 This directory contains tests and testing docs for `Knative Eventing`.
 
-- [Unit tests](#running-unit-tests) reside in the codebase alongside the code
-  they test
+- [Unit tests](#running-unit-tests) reside in the codebase alongside the code they test
 - [End-to-end tests](#running-end-to-end-tests) reside in [`/test/e2e`](./e2e)
 
-## Running unit tests
+## Running tests with scripts (not recommended)
 
-Use `go test`:
+### Presubmit tests
 
-```shell
-go test -v ./pkg/...
-```
+[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the tests before code submission.
 
-_By default `go test` will not run [the e2e tests](#running-end-to-end-tests),
-which need [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
-
-## Presubmit tests
-
-[`presubmit-tests.sh`](./presubmit-tests.sh) is the entry point for the
-[end-to-end tests](/test/e2e).
-
-This script, and consequently, the e2e tests will be run before every code
-submission. You can run these tests manually with:
+You can run it simply with:
 
 ```shell
 test/presubmit-tests.sh
 ```
 
-_Note that to run `presubmit-tests.sh` or `e2e-tests.sh` scripts, you need to
-have a running environment that meets
-[the e2e test environment requirements](#environment-requirements)_
+By default, this script will run `build tests`, `unit tests` and `integration tests`.
+If you only want to run one type of tests, you can run this script with corresponding flags like below:
+
+```shell
+test/presubmit-tests.sh --build-tests
+test/presubmit-tests.sh --unit-tests
+test/presubmit-tests.sh --integration-tests
+```
+
+_Note that if the tests you are running includes `integration tests`, it will create a new GKE cluster in project `$PROJECT_ID`, start Knative Serving and Eventing system, upload test images to `$KO_DOCKER_REPO`, and run all `e2e-*tests.sh` scripts under [`test`](.). After the tests finish, it will delete the cluster._
+
+### E2E tests
+
+[`e2e-tests.sh`](./e2e-tests.sh) is the entry point for running all e2e tests.
+
+You can run it simply with:
+
+```shell
+test/e2e-tests.sh
+```
+
+By default, it will create a new GKE cluster in project `$PROJECT_ID`, install Knative Serving stack with Istio, upload test images to your Docker repo and run the end-to-end tests against the Knative Eventing built from source. After the tests finishes, it will delete the cluster.
+
+If you have already created your own Kubernetes cluster but haven't installed Knative, you can run with `test/e2e-tests.sh --run-tests`.
+
+If you have set up a running environment that meets [the e2e test environment requirements](#environment-requirements), you can run with `./test/e2e-tests.sh --run-tests --skip-knative-setup`.
+
+## Running tests with `go test` command (recommended)
+
+## Running unit tests
+
+You can also use `go test` command to run unit tests:
+
+```shell
+go test -v ./pkg/...
+```
+
+_By default `go test` will not run [the e2e tests](#running-end-to-end-tests), which needs [`-tags=e2e`](#running-end-to-end-tests) to be enabled._
 
 ## Running end-to-end tests
 
-To run [the e2e tests](./e2e), you need to have a running environment that meets
-[the e2e test environment requirements](#environment-requirements), and you need
-to specify the build tag `e2e`.
+To run [the e2e tests](./e2e) with `go test` command, you need to have a running environment that meets [the e2e test environment requirements](#environment-requirements), and you need to specify the build tag `e2e`.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e
@@ -45,14 +66,13 @@ go test -v -tags=e2e -count=1 ./test/e2e
 
 ### One test case
 
-To run one e2e test case, e.g. TestKubernetesEvents, use
-[the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
+To run one e2e test case, e.g. TestSingleBinaryEvent, use the [-run](https://golang.org/cmd/go/#hdr-Testing_flags) flag with `go test`:
 
 ```bash
-go test -v -tags=e2e -count=1 ./test/e2e -run ^TestKubernetesEvents$
+go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$
 ```
 
-### Environment requirements
+## Environment requirements
 
 There's couple of things you need to install before running e2e tests locally.
 
@@ -62,37 +82,18 @@ There's couple of things you need to install before running e2e tests locally.
    go get -u k8s.io/test-infra/kubetest
    ```
 
-1. [A running `Knative Serving` cluster.]
-1. A docker repo containing [the test images](#test-images)
-
-Simply run the `./test/e2e-tests.sh` script. It will create a GKE cluster,
-install Knative Serving stack with Istio, upload test images to your Docker repo
-and run the end-to-end tests against the Knative Eventing built from source.
-
-If you already have the `*_OVERRIDE` environment variables set, call the script
-with the `--run-tests` argument and it will use the cluster and run the tests.
-Note that this requires you to have Serving and Istio installed and configured
-to your particular configuration setup. Knative Eventing will still built and
-deployed from source.
-
-Otherwise, calling this script without arguments will create a new cluster in
-project `$PROJECT_ID`, start Knative Serving and the eventing system, upload
-test images, run the tests and delete the cluster. In this case, it's required
-that `$KO_DOCKER_REPO` points to a valid writable docker repo.
+2. A running [Knative](https://www.knative.dev/docs/install/) cluster
+3. A docker repo containing [the test images](#test-images)
 
 ## Test images
 
 ### Building the test images
 
-Note: this is only required when you run e2e tests locally with `go test`
-commands. Running tests through e2e-tests.sh will publish the images
-automatically.
+Note: this is only required when you run e2e tests locally with `go test` commands. Running tests through e2e-tests.sh will publish the images automatically.
 
-The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to
-build and push the test images used by the e2e tests. It requires:
+The [`upload-test-images.sh`](./upload-test-images.sh) script can be used to build and push the test images used by the e2e tests. It requires:
 
-- [`KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
-  to be set
+- [`KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup) to be set
 - You to be
   [authenticated with your `KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
 - [`docker`](https://docs.docker.com/install/) to be installed
@@ -103,18 +104,12 @@ To run the script for all end to end test images:
 ./test/upload-test-images.sh e2e
 ```
 
-A docker tag is mandatory to avoid issues with using `latest` tag for images
-deployed in GCR.
+A docker tag is mandatory to avoid issues with using `latest` tag for images deployed in GCR.
 
 ### Adding new test images
 
-New test images should be placed in `./test/test_images`. For each image create
-a new sub-folder and include a Go file that will be an entry point to the
-application. This Go file should use the package "main" and include the function
-main(). It is a good practice to include a readme file as well. When uploading
-test images, `ko` will build an image from this folder.
+New test images should be placed in `./test/test_images`. For each image create a new sub-folder and include a Go file that will be an entry point to the application. This Go file should use the package `main` and include the function `main()`. It is a good practice to include a readme file as well. When uploading test images, `ko` will build an image from this folder.
 
 ## Flags
 
-Flags are similar to those in
-[`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)
+Flags are similar to those in [`Knative Serving`](https://github.com/knative/serving/blob/master/test/README.md#flags-1)


### PR DESCRIPTION
There are several errors in the `README` file for test, which is misleading when people try to run the tests locally.