### PR TITLE
Update CloudEvents SDK to 0.6.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -58,7 +58,7 @@
   version = "v2.1.15"
 
 [[projects]]
-  digest = "1:f616892b62757b2dcd70957602981d4f05c4d75017138cea02b3845d07c18785"
+  digest = "1:fa1c3e6de410f74eb102fd927c838a66feb5b825fdf63d0e82cbbfd1a16db8a1"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     "pkg/cloudevents",
@@ -74,8 +74,8 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "e00e75c8a1befe895cc00def1f88adb611195159"
-  version = "0.4.4"
+  revision = "51b1fb67ea02b6edb9c158592f4c996d6edd1493"
+  version = "0.6.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -130,4 +130,4 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  version = "=0.4.4"
+  version = "=0.6.0"

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -400,7 +400,7 @@ func makeEventWithoutTTL() *cloudevents.Event {
 				},
 			},
 			ContentType: cloudevents.StringOfApplicationJSON(),
-		},
+		}.AsV02(),
 	}
 }
 
@@ -425,6 +425,6 @@ func makeDifferentEvent() *cloudevents.Event {
 				},
 			},
 			ContentType: cloudevents.StringOfApplicationJSON(),
-		},
+		}.AsV02(),
 	}
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
@@ -102,6 +102,7 @@ func (c *ceClient) obsSend(ctx context.Context, event cloudevents.Event) (*cloud
 			event = fn(event)
 		}
 	}
+
 	// Validate the event conforms to the CloudEvents Spec.
 	if err := event.Validate(); err != nil {
 		return nil, err

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"github.com/google/uuid"
 	"time"
 )
@@ -15,25 +14,9 @@ type EventDefaulter func(event cloudevents.Event) cloudevents.Event
 // context.ID if it is found to be empty.
 func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
-		switch event.Context.GetSpecVersion() {
-		case cloudevents.CloudEventsVersionV01:
-			ec := event.Context.AsV01()
-			if ec.EventID == "" {
-				ec.EventID = uuid.New().String()
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV02:
-			ec := event.Context.AsV02()
-			if ec.ID == "" {
-				ec.ID = uuid.New().String()
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV03:
-			ec := event.Context.AsV03()
-			if ec.ID == "" {
-				ec.ID = uuid.New().String()
-				event.Context = ec
-			}
+		if event.ID() == "" {
+			event.Context = event.Context.Clone()
+			event.SetID(uuid.New().String())
 		}
 	}
 	return event
@@ -43,25 +26,9 @@ func DefaultIDToUUIDIfNotSet(event cloudevents.Event) cloudevents.Event {
 // Timestamp to context.Time if it is found to be nil or zero.
 func DefaultTimeToNowIfNotSet(event cloudevents.Event) cloudevents.Event {
 	if event.Context != nil {
-		switch event.Context.GetSpecVersion() {
-		case cloudevents.CloudEventsVersionV01:
-			ec := event.Context.AsV01()
-			if ec.EventTime == nil || ec.EventTime.IsZero() {
-				ec.EventTime = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV02:
-			ec := event.Context.AsV02()
-			if ec.Time == nil || ec.Time.IsZero() {
-				ec.Time = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
-		case cloudevents.CloudEventsVersionV03:
-			ec := event.Context.AsV03()
-			if ec.Time == nil || ec.Time.IsZero() {
-				ec.Time = &types.Timestamp{Time: time.Now()}
-				event.Context = ec
-			}
+		if event.Time().IsZero() {
+			event.Context = event.Context.Clone()
+			event.SetTime(time.Now())
 		}
 	}
 	return event

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/codec/jsoncodec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/codec/jsoncodec.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
-	"log"
 	"strconv"
 )
 
@@ -28,7 +27,11 @@ func obsJsonEncodeV01(e cloudevents.Event) ([]byte, error) {
 	if ctx.ContentType == nil {
 		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
-	return jsonEncode(ctx, e.Data)
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
 // JsonEncodeV02 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
@@ -49,7 +52,11 @@ func obsJsonEncodeV02(e cloudevents.Event) ([]byte, error) {
 	if ctx.ContentType == nil {
 		ctx.ContentType = cloudevents.StringOfApplicationJSON()
 	}
-	return jsonEncode(ctx, e.Data)
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
 // JsonEncodeV03 takes in a cloudevent.Event and outputs the byte representation of that event using CloudEvents
@@ -70,10 +77,15 @@ func obsJsonEncodeV03(e cloudevents.Event) ([]byte, error) {
 	if ctx.DataContentType == nil {
 		ctx.DataContentType = cloudevents.StringOfApplicationJSON()
 	}
-	return jsonEncode(ctx, e.Data)
+
+	data, err := e.DataBytes()
+	if err != nil {
+		return nil, err
+	}
+	return jsonEncode(ctx, data)
 }
 
-func jsonEncode(ctx cloudevents.EventContext, data interface{}) ([]byte, error) {
+func jsonEncode(ctx cloudevents.EventContextReader, data []byte) ([]byte, error) {
 	ctxb, err := marshalEvent(ctx)
 	if err != nil {
 		return nil, err
@@ -86,19 +98,26 @@ func jsonEncode(ctx cloudevents.EventContext, data interface{}) ([]byte, error) 
 		return nil, err
 	}
 
-	mediaType := ctx.GetDataMediaType()
-	datab, err := marshalEventData(mediaType, data)
-	if err != nil {
-		return nil, err
-	}
 	if data != nil {
-		if mediaType == "" || mediaType == cloudevents.ApplicationJSON {
-			b["data"] = datab
-		} else if datab[0] != byte('"') {
-			b["data"] = []byte(strconv.QuoteToASCII(string(datab)))
+		// data is passed in as an encoded []byte. That slice might be any
+		// number of things but for json encoding of the envelope all we care
+		// is if the payload is either a string or a json object. If it is a
+		// json object, it can be inserted into the body without modification.
+		// Otherwise we need to quote it if not already quoted.
+		mediaType, err := ctx.GetDataMediaType()
+		if err != nil {
+			return nil, err
+		}
+		isBase64 := ctx.GetDataContentEncoding() == cloudevents.Base64
+		isJson := mediaType == "" || mediaType == cloudevents.ApplicationJSON || mediaType == cloudevents.TextJSON
+		// TODO(#60): we do not support json values at the moment, only objects and lists.
+		if isJson && !isBase64 {
+			b["data"] = data
+		} else if data[0] != byte('"') {
+			b["data"] = []byte(strconv.QuoteToASCII(string(data)))
 		} else {
 			// already quoted
-			b["data"] = datab
+			b["data"] = data
 		}
 	}
 
@@ -140,8 +159,9 @@ func obsJsonDecodeV01(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -175,8 +195,9 @@ func obsJsonDecodeV02(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -210,16 +231,13 @@ func obsJsonDecodeV03(body []byte) (*cloudevents.Event, error) {
 	}
 
 	return &cloudevents.Event{
-		Context: ec,
-		Data:    data,
+		Context:     &ec,
+		Data:        data,
+		DataEncoded: true,
 	}, nil
 }
 
 func marshalEvent(event interface{}) ([]byte, error) {
-	if b, ok := event.([]byte); ok {
-		log.Printf("json.marshalEvent asked to encode bytes... wrong? %s", string(b))
-	}
-
 	b, err := json.Marshal(event)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/content_type.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/content_type.go
@@ -1,6 +1,7 @@
 package cloudevents
 
 const (
+	TextJSON                        = "text/json"
 	ApplicationJSON                 = "application/json"
 	ApplicationXML                  = "application/xml"
 	ApplicationCloudEventsJSON      = "application/cloudevents+json"

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/context/logger.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/context/logger.go
@@ -1,0 +1,42 @@
+package context
+
+import (
+	"context"
+	"go.uber.org/zap"
+)
+
+// Opaque key type used to store logger
+type loggerKeyType struct{}
+
+var loggerKey = loggerKeyType{}
+
+// fallbackLogger is the logger is used when there is no logger attached to the context.
+var fallbackLogger *zap.SugaredLogger
+
+func init() {
+	if logger, err := zap.NewProduction(); err != nil {
+		// We failed to create a fallback logger.
+		fallbackLogger = zap.NewNop().Sugar()
+	} else {
+		fallbackLogger = logger.Named("fallback").Sugar()
+	}
+}
+
+// WithLogger returns a new context with the logger injected into the given context.
+func WithLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context {
+	if logger == nil {
+		return context.WithValue(ctx, loggerKey, fallbackLogger)
+	}
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// LoggerFrom returns the logger stored in context.
+func LoggerFrom(ctx context.Context) *zap.SugaredLogger {
+	l := ctx.Value(loggerKey)
+	if l != nil {
+		if logger, ok := l.(*zap.SugaredLogger); ok {
+			return logger
+		}
+	}
+	return fallbackLogger
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/data_content_encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/data_content_encoding.go
@@ -1,0 +1,11 @@
+package cloudevents
+
+const (
+	Base64 = "base64"
+)
+
+// StringOfBase64 returns a string pointer to "Base64"
+func StringOfBase64() *string {
+	a := Base64
+	return &a
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/codec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec/codec.go
@@ -26,11 +26,15 @@ func init() {
 
 	AddDecoder("", json.Decode)
 	AddDecoder("application/json", json.Decode)
+	AddDecoder("text/json", json.Decode)
 	AddDecoder("application/xml", xml.Decode)
+	AddDecoder("text/xml", xml.Decode)
 
 	AddEncoder("", json.Encode)
 	AddEncoder("application/json", json.Encode)
+	AddEncoder("text/json", json.Encode)
 	AddEncoder("application/xml", xml.Encode)
+	AddEncoder("text/xml", xml.Encode)
 }
 
 // AddDecoder registers a decoder for a given content type. The codecs will use

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
@@ -4,51 +4,35 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
-	"sort"
 	"strings"
 )
 
 // Event represents the canonical representation of a CloudEvent.
 type Event struct {
-	Context EventContext
-	Data    interface{}
+	Context     EventContext
+	Data        interface{}
+	DataEncoded bool
 }
 
-// DataAs attempts to populate the provided data object with the event payload.
-// data should be a pointer type.
-func (e Event) DataAs(data interface{}) error {
-	return datacodec.Decode(e.Context.GetDataMediaType(), e.Data, data)
-}
+const (
+	defaultEventVersion = CloudEventsVersionV02
+)
 
-// SpecVersion returns Context.GetSpecVersion()
-func (e Event) SpecVersion() string {
-	return e.Context.GetSpecVersion()
-}
-
-// Type returns Context.GetType()
-func (e Event) Type() string {
-	return e.Context.GetType()
-}
-
-// Source returns Context.GetSource()
-func (e Event) Source() string {
-	return e.Context.GetSource()
-}
-
-// SchemaURL returns Context.GetSchemaURL()
-func (e Event) SchemaURL() string {
-	return e.Context.GetSchemaURL()
+// New returns a new Event, an optional version can be passed to change the
+// default spec version from 0.2 to the provided version.
+func New(version ...string) Event {
+	specVersion := defaultEventVersion // TODO: should there be a default? or set a default?
+	if len(version) >= 1 {
+		specVersion = version[0]
+	}
+	e := &Event{}
+	e.SetSpecVersion(specVersion)
+	return *e
 }
 
 // ExtensionAs returns Context.ExtensionAs(name, obj)
 func (e Event) ExtensionAs(name string, obj interface{}) error {
 	return e.Context.ExtensionAs(name, obj)
-}
-
-// DataContentType returns Context.getDataContentType()
-func (e Event) DataContentType() string {
-	return e.Context.GetDataContentType()
 }
 
 // Validate performs a spec based validation on this event.
@@ -83,90 +67,22 @@ func (e Event) String() string {
 		b.WriteString(fmt.Sprintf("Validation Error: \n%s\n", valid.Error()))
 	}
 
-	b.WriteString("Context Attributes,\n")
-
-	var extensions map[string]interface{}
-
-	// TODO: This impl detail should be pushed into the impl structs.
-
-	switch e.SpecVersion() {
-	case CloudEventsVersionV01:
-		if ec, ok := e.Context.(EventContextV01); ok {
-			b.WriteString("  cloudEventsVersion: " + ec.CloudEventsVersion + "\n")
-			b.WriteString("  eventType: " + ec.EventType + "\n")
-			if ec.EventTypeVersion != nil {
-				b.WriteString("  eventTypeVersion: " + *ec.EventTypeVersion + "\n")
-			}
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			b.WriteString("  eventID: " + ec.EventID + "\n")
-			if ec.EventTime != nil {
-				b.WriteString("  eventTime: " + ec.EventTime.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaURL: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.ContentType != nil {
-				b.WriteString("  contentType: " + *ec.ContentType + "\n")
-			}
-			extensions = ec.Extensions
-		}
-
-	case CloudEventsVersionV02:
-		if ec, ok := e.Context.(EventContextV02); ok {
-			b.WriteString("  specversion: " + ec.SpecVersion + "\n")
-			b.WriteString("  type: " + ec.Type + "\n")
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			b.WriteString("  id: " + ec.ID + "\n")
-			if ec.Time != nil {
-				b.WriteString("  time: " + ec.Time.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.ContentType != nil {
-				b.WriteString("  contenttype: " + *ec.ContentType + "\n")
-			}
-			extensions = ec.Extensions
-		}
-
-	case CloudEventsVersionV03:
-		if ec, ok := e.Context.(EventContextV03); ok {
-			b.WriteString("  specversion: " + ec.SpecVersion + "\n")
-			b.WriteString("  type: " + ec.Type + "\n")
-			b.WriteString("  source: " + ec.Source.String() + "\n")
-			b.WriteString("  id: " + ec.ID + "\n")
-			if ec.Time != nil {
-				b.WriteString("  time: " + ec.Time.String() + "\n")
-			}
-			if ec.SchemaURL != nil {
-				b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
-			}
-			if ec.DataContentType != nil {
-				b.WriteString("  datacontenttype: " + *ec.DataContentType + "\n")
-			}
-			extensions = ec.Extensions
-		}
-	default:
-		b.WriteString(e.String() + "\n")
-	}
-
-	if extensions != nil && len(extensions) > 0 {
-		b.WriteString("Extensions,\n")
-		keys := make([]string, 0, len(extensions))
-		for k := range extensions {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			b.WriteString(fmt.Sprintf("  %s: %v\n", key, extensions[key]))
-		}
-	}
+	b.WriteString(e.Context.String())
 
 	if e.Data != nil {
 		b.WriteString("Data,\n  ")
 		if strings.HasPrefix(e.DataContentType(), "application/json") {
 			var prettyJSON bytes.Buffer
-			err := json.Indent(&prettyJSON, e.Data.([]byte), "  ", "  ")
+
+			data, ok := e.Data.([]byte)
+			if !ok {
+				var err error
+				data, err = json.Marshal(e.Data)
+				if err != nil {
+					data = []byte(err.Error())
+				}
+			}
+			err := json.Indent(&prettyJSON, data, "  ", "  ")
 			if err != nil {
 				b.Write(e.Data.([]byte))
 			} else {

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_data.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_data.go
@@ -1,0 +1,96 @@
+package cloudevents
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/datacodec"
+	"strconv"
+)
+
+// Data is special. Break it out into it's own file.
+
+// SetData implements EventWriter.SetData
+func (e *Event) SetData(obj interface{}) error {
+	data, err := datacodec.Encode(e.DataMediaType(), obj)
+	if err != nil {
+		return err
+	}
+	if e.DataContentEncoding() == Base64 {
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+		base64.StdEncoding.Encode(buf, data)
+		e.Data = string(buf)
+	} else {
+		e.Data = data
+	}
+	e.DataEncoded = true
+	return nil
+}
+
+func (e *Event) DataBytes() ([]byte, error) {
+	if !e.DataEncoded {
+		if err := e.SetData(e.Data); err != nil {
+			return nil, err
+		}
+	}
+
+	b, ok := e.Data.([]byte)
+	if !ok {
+		if s, ok := e.Data.(string); ok {
+			b = []byte(s)
+		} else {
+			return nil, errors.New("data was not a byte slice or string")
+		}
+	}
+	return b, nil
+}
+
+const (
+	quotes = `"'`
+)
+
+// DataAs attempts to populate the provided data object with the event payload.
+// data should be a pointer type.
+func (e Event) DataAs(data interface{}) error { // TODO: Clean this function up
+	if e.Data == nil {
+		return nil
+	}
+	obj, ok := e.Data.([]byte)
+	if !ok {
+		if s, ok := e.Data.(string); ok {
+			obj = []byte(s)
+		} else {
+			return errors.New("data was not a byte slice or string")
+		}
+	}
+	if len(obj) == 0 {
+		// no data.
+		return nil
+	}
+	if e.Context.GetDataContentEncoding() == Base64 {
+		var bs []byte
+		// test to see if we need to unquote the data.
+		if obj[0] == quotes[0] || obj[0] == quotes[1] {
+			str, err := strconv.Unquote(string(obj))
+			if err != nil {
+				return err
+			}
+			bs = []byte(str)
+		} else {
+			bs = obj
+		}
+
+		buf := make([]byte, base64.StdEncoding.DecodedLen(len(bs)))
+		n, err := base64.StdEncoding.Decode(buf, bs)
+		if err != nil {
+			return fmt.Errorf("failed to decode data from base64: %s", err.Error())
+		}
+		obj = buf[:n]
+	}
+
+	mediaType, err := e.Context.GetDataMediaType()
+	if err != nil {
+		return err
+	}
+	return datacodec.Decode(mediaType, obj, data)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_interface.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_interface.go
@@ -1,0 +1,72 @@
+package cloudevents
+
+import (
+	"time"
+)
+
+// EventWriter is the interface for reading through an event from attributes.
+type EventReader interface {
+	// SpecVersion returns event.Context.GetSpecVersion().
+	SpecVersion() string
+	// Type returns event.Context.GetType().
+	Type() string
+	// Source returns event.Context.GetSource().
+	Source() string
+	// Subject returns event.Context.GetSubject().
+	Subject() string
+	// ID returns event.Context.GetID().
+	ID() string
+	// Time returns event.Context.GetTime().
+	Time() time.Time
+	// SchemaURL returns event.Context.GetSchemaURL().
+	SchemaURL() string
+	// DataContentType returns event.Context.GetDataContentType().
+	DataContentType() string
+	// DataMediaType returns event.Context.GetDataMediaType().
+	DataMediaType() string
+	// DataContentEncoding returns event.Context.GetDataContentEncoding().
+	DataContentEncoding() string
+
+	// Extension Attributes
+
+	// ExtensionAs returns event.Context.ExtensionAs(name, obj).
+	ExtensionAs(string, interface{}) error
+
+	// Data Attribute
+
+	// ExtensionAs returns event.Context.ExtensionAs(name, obj).
+	DataAs(interface{}) error
+}
+
+// EventWriter is the interface for writing through an event onto attributes.
+// If an error is thrown by a sub-component, EventWriter panics.
+type EventWriter interface {
+	// Context Attributes
+
+	// SetSpecVersion performs event.Context.SetSpecVersion.
+	SetSpecVersion(string)
+	// SetType performs event.Context.SetType.
+	SetType(string)
+	// SetSource performs event.Context.SetSource.
+	SetSource(string)
+	// SetSubject( performs event.Context.SetSubject.
+	SetSubject(string)
+	// SetID performs event.Context.SetID.
+	SetID(string)
+	// SetTime performs event.Context.SetTime.
+	SetTime(time.Time)
+	// SetSchemaURL performs event.Context.SetSchemaURL.
+	SetSchemaURL(string)
+	// SetDataContentType performs event.Context.SetDataContentType.
+	SetDataContentType(string)
+	// SetDataContentEncoding performs event.Context.SetDataContentEncoding.
+	SetDataContentEncoding(string)
+
+	// Extension Attributes
+
+	// SetExtension performs event.Context.SetExtension.
+	SetExtension(string, interface{})
+
+	// SetData encodes the given payload with the current encoding settings.
+	SetData(interface{}) error
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_reader.go
@@ -1,0 +1,58 @@
+package cloudevents
+
+import (
+	"time"
+)
+
+var _ EventReader = (*Event)(nil)
+
+// SpecVersion implements EventReader.SpecVersion
+func (e Event) SpecVersion() string {
+	return e.Context.GetSpecVersion()
+}
+
+// Type implements EventReader.Type
+func (e Event) Type() string {
+	return e.Context.GetType()
+}
+
+// Source implements EventReader.Source
+func (e Event) Source() string {
+	return e.Context.GetSource()
+}
+
+// Subject implements EventReader.Subject
+func (e Event) Subject() string {
+	return e.Context.GetSubject()
+}
+
+// ID implements EventReader.ID
+func (e Event) ID() string {
+	return e.Context.GetID()
+}
+
+// Time implements EventReader.Time
+func (e Event) Time() time.Time {
+	return e.Context.GetTime()
+}
+
+// SchemaURL implements EventReader.SchemaURL
+func (e Event) SchemaURL() string {
+	return e.Context.GetSchemaURL()
+}
+
+// DataContentType implements EventReader.DataContentType
+func (e Event) DataContentType() string {
+	return e.Context.GetDataContentType()
+}
+
+// DataMediaType implements EventReader.DataMediaType
+func (e Event) DataMediaType() string {
+	mediaType, _ := e.Context.GetDataMediaType()
+	return mediaType
+}
+
+// DataContentEncoding implements EventReader.DataContentEncoding
+func (e Event) DataContentEncoding() string {
+	return e.Context.GetDataContentEncoding()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_writer.go
@@ -1,0 +1,92 @@
+package cloudevents
+
+import (
+	"fmt"
+	"time"
+)
+
+var _ EventWriter = (*Event)(nil)
+
+// SetSpecVersion implements EventWriter.SetSpecVersion
+func (e *Event) SetSpecVersion(v string) {
+	if e.Context == nil {
+		switch v {
+		case CloudEventsVersionV01:
+			e.Context = EventContextV01{}.AsV01()
+		case CloudEventsVersionV02:
+			e.Context = EventContextV02{}.AsV02()
+		case CloudEventsVersionV03:
+			e.Context = EventContextV03{}.AsV03()
+		default:
+			panic(fmt.Errorf("a valid spec version is required: [%s, %s, %s]",
+				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03))
+		}
+		return
+	}
+	if err := e.Context.SetSpecVersion(v); err != nil {
+		panic(err)
+	}
+}
+
+// SetType implements EventWriter.SetType
+func (e *Event) SetType(t string) {
+	if err := e.Context.SetType(t); err != nil {
+		panic(err)
+	}
+}
+
+// SetSource implements EventWriter.SetSource
+func (e *Event) SetSource(s string) {
+	if err := e.Context.SetSource(s); err != nil {
+		panic(err)
+	}
+}
+
+// SetSubject implements EventWriter.SetSubject
+func (e *Event) SetSubject(s string) {
+	if err := e.Context.SetSubject(s); err != nil {
+		panic(err)
+	}
+}
+
+// SetID implements EventWriter.SetID
+func (e *Event) SetID(id string) {
+	if err := e.Context.SetID(id); err != nil {
+		panic(err)
+	}
+}
+
+// SetTime implements EventWriter.SetTime
+func (e *Event) SetTime(t time.Time) {
+	if err := e.Context.SetTime(t); err != nil {
+		panic(err)
+	}
+}
+
+// SetSchemaURL implements EventWriter.SetSchemaURL
+func (e *Event) SetSchemaURL(s string) {
+	if err := e.Context.SetSchemaURL(s); err != nil {
+		panic(err)
+	}
+}
+
+// SetDataContentType implements EventWriter.SetDataContentType
+func (e *Event) SetDataContentType(ct string) {
+	if err := e.Context.SetDataContentType(ct); err != nil {
+		panic(err)
+	}
+}
+
+// SetDataContentEncoding implements EventWriter.SetDataContentEncoding
+func (e *Event) SetDataContentEncoding(enc string) {
+	if err := e.Context.SetDataContentEncoding(enc); err != nil {
+		panic(err)
+	}
+}
+
+// SetDataContentEncoding implements EventWriter.SetDataContentEncoding
+func (e *Event) SetExtension(name string, obj interface{}) {
+	if err := e.Context.SetExtension(name, obj); err != nil {
+		panic(err)
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
@@ -1,48 +1,105 @@
 package cloudevents
 
-// EventContext is conical interface for a CloudEvents Context.
-type EventContext interface {
+import "time"
+
+// EventContextReader are the methods required to be a reader of context
+// attributes.
+type EventContextReader interface {
+	// GetSpecVersion returns the native CloudEvents Spec version of the event
+	// context.
+	GetSpecVersion() string
+	// GetType returns the CloudEvents type from the context.
+	GetType() string
+	// GetSource returns the CloudEvents source from the context.
+	GetSource() string
+	// GetSubject returns the CloudEvents subject from the context.
+	GetSubject() string
+	// GetID returns the CloudEvents ID from the context.
+	GetID() string
+	// GetTime returns the CloudEvents creation time from the context.
+	GetTime() time.Time
+	// GetSchemaURL returns the CloudEvents schema URL (if any) from the
+	// context.
+	GetSchemaURL() string
+	// GetDataContentType returns content type on the context.
+	GetDataContentType() string
+	// GetDataContentEncoding returns content encoding on the context.
+	GetDataContentEncoding() string
+
+	// GetDataMediaType returns the MIME media type for encoded data, which is
+	// needed by both encoding and decoding. This is a processed form of
+	// GetDataContentType and it may return an error.
+	GetDataMediaType() (string, error)
+
+	// ExtensionAs populates the given interface with the CloudEvents extension
+	// of the given name from the extension attributes. It returns an error if
+	// the extension does not exist, the extension's type does not match the
+	// provided type, or if the type is not a supported.
+	ExtensionAs(string, interface{}) error
+}
+
+// EventContextWriter are the methods required to be a writer of context
+// attributes.
+type EventContextWriter interface {
+	// SetSpecVersion sets the spec version of the context.
+	SetSpecVersion(string) error
+	// SetType sets the type of the context.
+	SetType(string) error
+	// SetSource sets the source of the context.
+	SetSource(string) error
+	// SetSubject sets the subject of the context.
+	SetSubject(string) error
+	// SetID sets the ID of the context.
+	SetID(string) error
+	// SetTime sets the time of the context.
+	SetTime(time time.Time) error
+	// SetSchemaURL sets the schema url of the context.
+	SetSchemaURL(string) error
+	// SetDataContentType sets the data content type of the context.
+	SetDataContentType(string) error
+	// SetDataContentEncoding sets the data context encoding of the context.
+	SetDataContentEncoding(string) error
+
+	// SetExtension sets the given interface onto the extension attributes
+	// determined by the provided name.
+	SetExtension(string, interface{}) error
+}
+
+type EventContextConverter interface {
 	// AsV01 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.1 field names, moving fields to or
 	// from extensions as necessary.
-	AsV01() EventContextV01
+	AsV01() *EventContextV01
 
 	// AsV02 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.2 field names, moving fields to or
 	// from extensions as necessary.
-	AsV02() EventContextV02
+	AsV02() *EventContextV02
 
 	// AsV03 provides a translation from whatever the "native" encoding of the
 	// CloudEvent was to the equivalent in v0.3 field names, moving fields to or
 	// from extensions as necessary.
-	AsV03() EventContextV03
+	AsV03() *EventContextV03
+}
 
-	// GetDataContentType returns content type on the context.
-	GetDataContentType() string
+// EventContext is conical interface for a CloudEvents Context.
+type EventContext interface {
+	// EventContextConverter allows for conversion between versions.
+	EventContextConverter
 
-	// GetDataMediaType returns the MIME media type for encoded data, which is
-	// needed by both encoding and decoding.
-	GetDataMediaType() string
+	// EventContextReader adds methods for reading context.
+	EventContextReader
 
-	// GetSpecVersion returns the native CloudEvents Spec version of the event
-	// context.
-	GetSpecVersion() string
-
-	// GetType returns the CloudEvents type from the context.
-	GetType() string
-
-	// GetSource returns the CloudEvents source from the context.
-	GetSource() string
-
-	// GetSchemaURL returns the CloudEvents schema URL (if any) from the context.
-	GetSchemaURL() string
-
-	// ExtensionAs populates 'obj' with the CloudEvents extension 'name' from the context.
-	// It returns an error if the extension 'name' does not exist, the extension's type
-	// does not match the 'obj' type, or if the 'obj' type is not a supported.
-	ExtensionAs(name string, obj interface{}) error
+	// EventContextWriter adds methods for writing to context.
+	EventContextWriter
 
 	// Validate the event based on the specifics of the CloudEvents spec version
 	// represented by this event context.
 	Validate() error
+
+	// Clone clones the event context.
+	Clone() EventContext
+
+	// String returns a pretty-printed representation of the EventContext.
+	String() string
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01_reader.go
@@ -1,0 +1,86 @@
+package cloudevents
+
+import (
+	"mime"
+	"time"
+)
+
+// Adhere to EventContextReader
+var _ EventContextReader = (*EventContextV01)(nil)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV01) GetSpecVersion() string {
+	if ec.CloudEventsVersion != "" {
+		return ec.CloudEventsVersion
+	}
+	return CloudEventsVersionV01
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV01) GetDataContentType() string {
+	if ec.ContentType != nil {
+		return *ec.ContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV01) GetDataMediaType() (string, error) {
+	if ec.ContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
+		if err != nil {
+			return "", err
+		}
+		return mediaType, nil
+	}
+	return "", nil
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV01) GetType() string {
+	return ec.EventType
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV01) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV01) GetSubject() string {
+	var sub string
+	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
+		return ""
+	}
+	return sub
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV01) GetID() string {
+	return ec.EventID
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV01) GetTime() time.Time {
+	if ec.EventTime != nil {
+		return ec.EventTime.Time
+	}
+	return time.Time{}
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV01) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV01) GetDataContentEncoding() string {
+	var enc string
+	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
+		return ""
+	}
+	return enc
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v01_writer.go
@@ -1,0 +1,103 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV01)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV01) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV01 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV01)
+	}
+	ec.CloudEventsVersion = CloudEventsVersionV01
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV01) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.ContentType = nil
+	} else {
+		ec.ContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV01) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.EventType = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV01) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV01) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ec.SetExtension(SubjectKey, nil)
+	}
+	return ec.SetExtension(SubjectKey, s)
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV01) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("event id is required to be a non-empty string")
+	}
+	ec.EventID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV01) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.EventTime = nil
+	} else {
+		ec.EventTime = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV01) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV01) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		return ec.SetExtension(DataContentEncodingKey, nil)
+	}
+	return ec.SetExtension(DataContentEncodingKey, e)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02.go
@@ -3,8 +3,7 @@ package cloudevents
 import (
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
-	"mime"
+	"sort"
 	"strings"
 )
 
@@ -38,53 +37,6 @@ type EventContextV02 struct {
 // Adhere to EventContext
 var _ EventContext = (*EventContextV02)(nil)
 
-// GetSpecVersion implements EventContext.GetSpecVersion
-func (ec EventContextV02) GetSpecVersion() string {
-	if ec.SpecVersion != "" {
-		return ec.SpecVersion
-	}
-	return CloudEventsVersionV02
-}
-
-// GetDataContentType implements EventContext.GetDataContentType
-func (ec EventContextV02) GetDataContentType() string {
-	if ec.ContentType != nil {
-		return *ec.ContentType
-	}
-	return ""
-}
-
-// GetDataMediaType implements EventContext.GetDataMediaType
-func (ec EventContextV02) GetDataMediaType() string {
-	if ec.ContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
-		if err != nil {
-			log.Printf("failed to parse media type from ContentType: %s", err)
-			return ""
-		}
-		return mediaType
-	}
-	return ""
-}
-
-// GetType implements EventContext.GetType
-func (ec EventContextV02) GetType() string {
-	return ec.Type
-}
-
-// GetSource implements EventContext.GetSource
-func (ec EventContextV02) GetSource() string {
-	return ec.Source.String()
-}
-
-// GetSchemaURL implements EventContext.GetSchemaURL
-func (ec EventContextV02) GetSchemaURL() string {
-	if ec.SchemaURL != nil {
-		return ec.SchemaURL.String()
-	}
-	return ""
-}
-
 // ExtensionAs implements EventContext.ExtensionAs
 func (ec EventContextV02) ExtensionAs(name string, obj interface{}) error {
 	value, ok := ec.Extensions[name]
@@ -106,15 +58,25 @@ func (ec EventContextV02) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
-func (ec *EventContextV02) SetExtension(name string, value interface{}) {
+func (ec *EventContextV02) SetExtension(name string, value interface{}) error {
 	if ec.Extensions == nil {
 		ec.Extensions = make(map[string]interface{})
 	}
-	ec.Extensions[name] = value
+	if value == nil {
+		delete(ec.Extensions, name)
+	} else {
+		ec.Extensions[name] = value
+	}
+	return nil
 }
 
-// AsV01 implements EventContext.AsV01
-func (ec EventContextV02) AsV01() EventContextV01 {
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV02) Clone() EventContext {
+	return ec.AsV02()
+}
+
+// AsV01 implements EventContextConverter.AsV01
+func (ec EventContextV02) AsV01() *EventContextV01 {
 	ret := EventContextV01{
 		CloudEventsVersion: CloudEventsVersionV01,
 		EventID:            ec.ID,
@@ -128,7 +90,7 @@ func (ec EventContextV02) AsV01() EventContextV01 {
 
 	for k, v := range ec.Extensions {
 		// eventTypeVersion was retired in v0.2
-		if strings.EqualFold(k, "eventTypeVersion") {
+		if strings.EqualFold(k, EventTypeVersionKey) {
 			etv, ok := v.(string)
 			if ok && etv != "" {
 				ret.EventTypeVersion = &etv
@@ -140,17 +102,17 @@ func (ec EventContextV02) AsV01() EventContextV01 {
 	if len(ret.Extensions) == 0 {
 		ret.Extensions = nil
 	}
-	return ret
+	return &ret
 }
 
-// AsV02 implements EventContext.AsV02
-func (ec EventContextV02) AsV02() EventContextV02 {
+// AsV02 implements EventContextConverter.AsV02
+func (ec EventContextV02) AsV02() *EventContextV02 {
 	ec.SpecVersion = CloudEventsVersionV02
-	return ec
+	return &ec
 }
 
-// AsV03 implements EventContext.AsV03
-func (ec EventContextV02) AsV03() EventContextV03 {
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV02) AsV03() *EventContextV03 {
 	ret := EventContextV03{
 		SpecVersion:     CloudEventsVersionV03,
 		ID:              ec.ID,
@@ -159,9 +121,33 @@ func (ec EventContextV02) AsV03() EventContextV03 {
 		SchemaURL:       ec.SchemaURL,
 		DataContentType: ec.ContentType,
 		Source:          ec.Source,
-		Extensions:      ec.Extensions,
+		Extensions:      make(map[string]interface{}),
 	}
-	return ret
+
+	for k, v := range ec.Extensions {
+		// Subject was introduced in 0.3
+		if strings.EqualFold(k, SubjectKey) {
+			sub, ok := v.(string)
+			if ok && sub != "" {
+				ret.Subject = &sub
+			}
+			continue
+		}
+		// DataContentEncoding was introduced in 0.3
+		if strings.EqualFold(k, DataContentEncodingKey) {
+			etv, ok := v.(string)
+			if ok && etv != "" {
+				ret.DataContentEncoding = &etv
+			}
+			continue
+		}
+		ret.Extensions[k] = v
+	}
+	if len(ret.Extensions) == 0 {
+		ret.Extensions = nil
+	}
+
+	return &ret
 }
 
 // Validate returns errors based on requirements from the CloudEvents spec.
@@ -249,4 +235,39 @@ func (ec EventContextV02) Validate() error {
 		return fmt.Errorf(strings.Join(errors, "\n"))
 	}
 	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV02) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  specversion: " + ec.SpecVersion + "\n")
+	b.WriteString("  type: " + ec.Type + "\n")
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	b.WriteString("  id: " + ec.ID + "\n")
+	if ec.Time != nil {
+		b.WriteString("  time: " + ec.Time.String() + "\n")
+	}
+	if ec.SchemaURL != nil {
+		b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
+	}
+	if ec.ContentType != nil {
+		b.WriteString("  contenttype: " + *ec.ContentType + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02_reader.go
@@ -1,0 +1,86 @@
+package cloudevents
+
+import (
+	"mime"
+	"time"
+)
+
+// Adhere to EventContextReader
+var _ EventContextReader = (*EventContextV02)(nil)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV02) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV02
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV02) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV02) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV02) GetSubject() string {
+	var sub string
+	if err := ec.ExtensionAs(SubjectKey, &sub); err != nil {
+		return ""
+	}
+	return sub
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV02) GetID() string {
+	return ec.ID
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV02) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV02) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV02) GetDataContentType() string {
+	if ec.ContentType != nil {
+		return *ec.ContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV02) GetDataMediaType() (string, error) {
+	if ec.ContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.ContentType)
+		if err != nil {
+			return "", err
+		}
+		return mediaType, nil
+	}
+	return "", nil
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV02) GetDataContentEncoding() string {
+	var enc string
+	if err := ec.ExtensionAs(DataContentEncodingKey, &enc); err != nil {
+		return ""
+	}
+	return enc
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v02_writer.go
@@ -1,0 +1,103 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV02)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV02) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV02 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV02)
+	}
+	ec.SpecVersion = CloudEventsVersionV02
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV02) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.ContentType = nil
+	} else {
+		ec.ContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV02) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV02) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV02) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ec.SetExtension(SubjectKey, nil)
+	}
+	return ec.SetExtension(SubjectKey, s)
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV02) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV02) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV02) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV02) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		return ec.SetExtension(DataContentEncodingKey, nil)
+	}
+	return ec.SetExtension(DataContentEncodingKey, e)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03.go
@@ -3,8 +3,7 @@ package cloudevents
 import (
 	"fmt"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
-	"mime"
+	"sort"
 	"strings"
 )
 
@@ -24,6 +23,9 @@ type EventContextV03 struct {
 	Type string `json:"type"`
 	// Source - A URI describing the event producer.
 	Source types.URLRef `json:"source"`
+	// Subject - The subject of the event in the context of the event producer
+	// (identified by `source`).
+	Subject *string `json:"subject,omitempty"`
 	// ID of the event; must be non-empty and unique within the scope of the producer.
 	ID string `json:"id"`
 	// Time - A Timestamp when the event happened.
@@ -33,59 +35,14 @@ type EventContextV03 struct {
 	// GetDataMediaType - A MIME (RFC2046) string describing the media type of `data`.
 	// TODO: Should an empty string assume `application/json`, `application/octet-stream`, or auto-detect the content?
 	DataContentType *string `json:"datacontenttype,omitempty"`
+	// DataContentEncoding describes the content encoding for the `data` attribute. Valid: nil, `Base64`.
+	DataContentEncoding *string `json:"datacontentencoding,omitempty"`
 	// Extensions - Additional extension metadata beyond the base spec.
 	Extensions map[string]interface{} `json:"-,omitempty"` // TODO: decide how we want extensions to be inserted
 }
 
 // Adhere to EventContext
 var _ EventContext = (*EventContextV03)(nil)
-
-// GetSpecVersion implements EventContext.GetSpecVersion
-func (ec EventContextV03) GetSpecVersion() string {
-	if ec.SpecVersion != "" {
-		return ec.SpecVersion
-	}
-	return CloudEventsVersionV03
-}
-
-// GetDataContentType implements EventContext.GetDataContentType
-func (ec EventContextV03) GetDataContentType() string {
-	if ec.DataContentType != nil {
-		return *ec.DataContentType
-	}
-	return ""
-}
-
-// GetDataMediaType implements EventContext.GetDataMediaType
-func (ec EventContextV03) GetDataMediaType() string {
-	if ec.DataContentType != nil {
-		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
-		if err != nil {
-			log.Printf("failed to parse media type from DataContentType: %s", err)
-			return ""
-		}
-		return mediaType
-	}
-	return ""
-}
-
-// GetType implements EventContext.GetType
-func (ec EventContextV03) GetType() string {
-	return ec.Type
-}
-
-// GetSource implements EventContext.GetSource
-func (ec EventContextV03) GetSource() string {
-	return ec.Source.String()
-}
-
-// GetSchemaURL implements EventContext.GetSchemaURL
-func (ec EventContextV03) GetSchemaURL() string {
-	if ec.SchemaURL != nil {
-		return ec.SchemaURL.String()
-	}
-	return ""
-}
 
 // ExtensionAs implements EventContext.ExtensionAs
 func (ec EventContextV03) ExtensionAs(name string, obj interface{}) error {
@@ -108,21 +65,31 @@ func (ec EventContextV03) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
-func (ec *EventContextV03) SetExtension(name string, value interface{}) {
+func (ec *EventContextV03) SetExtension(name string, value interface{}) error {
 	if ec.Extensions == nil {
 		ec.Extensions = make(map[string]interface{})
 	}
-	ec.Extensions[name] = value
+	if value == nil {
+		delete(ec.Extensions, name)
+	} else {
+		ec.Extensions[name] = value
+	}
+	return nil
 }
 
-// AsV01 implements EventContext.AsV01
-func (ec EventContextV03) AsV01() EventContextV01 {
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV03) Clone() EventContext {
+	return ec.AsV03()
+}
+
+// AsV01 implements EventContextConverter.AsV01
+func (ec EventContextV03) AsV01() *EventContextV01 {
 	ecv2 := ec.AsV02()
 	return ecv2.AsV01()
 }
 
-// AsV02 implements EventContext.AsV02
-func (ec EventContextV03) AsV02() EventContextV02 {
+// AsV02 implements EventContextConverter.AsV02
+func (ec EventContextV03) AsV02() *EventContextV02 {
 	ret := EventContextV02{
 		SpecVersion: CloudEventsVersionV02,
 		ID:          ec.ID,
@@ -131,20 +98,38 @@ func (ec EventContextV03) AsV02() EventContextV02 {
 		SchemaURL:   ec.SchemaURL,
 		ContentType: ec.DataContentType,
 		Source:      ec.Source,
-		Extensions:  ec.Extensions,
+		Extensions:  make(map[string]interface{}),
 	}
-	return ret
+	// Subject was introduced in 0.3, so put it in an extension for 0.2.
+	if ec.Subject != nil {
+		ret.SetExtension(SubjectKey, *ec.Subject)
+	}
+	// DataContentEncoding was introduced in 0.3, so put it in an extension for 0.2.
+	if ec.DataContentEncoding != nil {
+		ret.SetExtension(DataContentEncodingKey, *ec.DataContentEncoding)
+	}
+	if ec.Extensions != nil {
+		for k, v := range ec.Extensions {
+			ret.Extensions[k] = v
+		}
+	}
+	if len(ret.Extensions) == 0 {
+		ret.Extensions = nil
+	}
+	return &ret
 }
 
-// AsV03 implements EventContext.AsV03
-func (ec EventContextV03) AsV03() EventContextV03 {
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV03) AsV03() *EventContextV03 {
 	ec.SpecVersion = CloudEventsVersionV03
-	return ec
+	return &ec
 }
 
 // Validate returns errors based on requirements from the CloudEvents spec.
 // For more details, see https://github.com/cloudevents/spec/blob/master/spec.md
 // As of Feb 26, 2019, commit 17c32ea26baf7714ad027d9917d03d2fff79fc7e
+// + https://github.com/cloudevents/spec/pull/387 -> datacontentencoding
+// + https://github.com/cloudevents/spec/pull/406 -> subject
 func (ec EventContextV03) Validate() error {
 	errors := []string(nil)
 
@@ -176,6 +161,18 @@ func (ec EventContextV03) Validate() error {
 	source := strings.TrimSpace(ec.Source.String())
 	if source == "" {
 		errors = append(errors, "source: REQUIRED")
+	}
+
+	// subject
+	// Type: String
+	// Constraints:
+	//  OPTIONAL
+	//  MUST be a non-empty string
+	if ec.Subject != nil {
+		subject := strings.TrimSpace(*ec.Subject)
+		if subject == "" {
+			errors = append(errors, "subject: if present, MUST be a non-empty string")
+		}
 	}
 
 	// id
@@ -224,8 +221,63 @@ func (ec EventContextV03) Validate() error {
 		}
 	}
 
+	// datacontentencoding
+	// Type: String per RFC 2045 Section 6.1
+	// Constraints:
+	//  The attribute MUST be set if the data attribute contains string-encoded binary data.
+	//    Otherwise the attribute MUST NOT be set.
+	//  If present, MUST adhere to RFC 2045 Section 6.1
+	if ec.DataContentEncoding != nil {
+		dataContentEncoding := strings.ToLower(strings.TrimSpace(*ec.DataContentEncoding))
+		if dataContentEncoding != Base64 {
+			// TODO: need to test for RFC 2046
+			errors = append(errors, "datacontentencoding: if present, MUST adhere to RFC 2045 Section 6.1")
+		}
+	}
+
 	if len(errors) > 0 {
 		return fmt.Errorf(strings.Join(errors, "\n"))
 	}
 	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV03) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  specversion: " + ec.SpecVersion + "\n")
+	b.WriteString("  type: " + ec.Type + "\n")
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	if ec.Subject != nil {
+		b.WriteString("  subject: " + *ec.Subject + "\n")
+	}
+	b.WriteString("  id: " + ec.ID + "\n")
+	if ec.Time != nil {
+		b.WriteString("  time: " + ec.Time.String() + "\n")
+	}
+	if ec.SchemaURL != nil {
+		b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
+	}
+	if ec.DataContentType != nil {
+		b.WriteString("  datacontenttype: " + *ec.DataContentType + "\n")
+	}
+	if ec.DataContentEncoding != nil {
+		b.WriteString("  datacontentencoding: " + *ec.DataContentEncoding + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03_reader.go
@@ -1,0 +1,81 @@
+package cloudevents
+
+import (
+	"mime"
+	"time"
+)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV03) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV03
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV03) GetDataContentType() string {
+	if ec.DataContentType != nil {
+		return *ec.DataContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV03) GetDataMediaType() (string, error) {
+	if ec.DataContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
+		if err != nil {
+			return "", err
+		}
+		return mediaType, nil
+	}
+	return "", nil
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV03) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV03) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV03) GetSubject() string {
+	if ec.Subject != nil {
+		return *ec.Subject
+	}
+	return ""
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV03) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV03) GetID() string {
+	return ec.ID
+}
+
+// GetSchemaURL implements EventContextReader.GetSchemaURL
+func (ec EventContextV03) GetSchemaURL() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// GetDataContentEncoding implements EventContextReader.GetDataContentEncoding
+func (ec EventContextV03) GetDataContentEncoding() string {
+	if ec.DataContentEncoding != nil {
+		return *ec.DataContentEncoding
+	}
+	return ""
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v03_writer.go
@@ -1,0 +1,107 @@
+package cloudevents
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV03)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV03) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV03 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV03)
+	}
+	ec.SpecVersion = CloudEventsVersionV03
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV03) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.DataContentType = nil
+	} else {
+		ec.DataContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV03) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV03) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV03) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		ec.Subject = nil
+	} else {
+		ec.Subject = &s
+	}
+	return nil
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV03) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV03) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetSchemaURL implements EventContextWriter.SetSchemaURL
+func (ec *EventContextV03) SetSchemaURL(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URLRef{URL: *pu}
+	return nil
+}
+
+// SetDataContentEncoding implements EventContextWriter.SetDataContentEncoding
+func (ec *EventContextV03) SetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		ec.DataContentEncoding = nil
+	} else {
+		ec.DataContentEncoding = &e
+	}
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/extensions.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/extensions.go
@@ -1,0 +1,13 @@
+package cloudevents
+
+const (
+	// DataContentEncodingKey is the key to DataContentEncoding for versions that do not support data content encoding
+	// directly.
+	DataContentEncodingKey = "datacontentencoding"
+
+	// EventTypeVersionKey is the key to EventTypeVersion for versions that do not support event type version directly.
+	EventTypeVersionKey = "eventTypeVersion"
+
+	// SubjectKey is the key to Subject for versions that do not support subject directly.
+	SubjectKey = "subject"
+)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec.go
@@ -131,7 +131,7 @@ func (c *Codec) Decode(msg transport.Message) (*cloudevents.Event, error) {
 			return c.convertEvent(event), nil
 		}
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec_v01.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec_v01.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
-	"log"
 	"net/http"
 	"net/textproto"
 	"strings"
@@ -69,7 +68,7 @@ func (v CodecV01) obsDecode(msg transport.Message) (*cloudevents.Event, error) {
 	case StructuredV01:
 		return v.decodeStructured(msg)
 	default:
-		return nil, fmt.Errorf("unknown encoding for message %v", msg)
+		return nil, fmt.Errorf("unknown encoding")
 	}
 }
 
@@ -79,9 +78,9 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 		return nil, err
 	}
 
-	body, err := marshalEventData(e.Context.GetDataMediaType(), e.Data)
+	body, err := e.DataBytes()
 	if err != nil {
-		return nil, err
+		panic("encode")
 	}
 
 	msg := &Message{
@@ -92,7 +91,7 @@ func (v CodecV01) encodeBinary(e cloudevents.Event) (transport.Message, error) {
 	return msg, nil
 }
 
-func (v CodecV01) toHeaders(ec cloudevents.EventContextV01) (http.Header, error) {
+func (v CodecV01) toHeaders(ec *cloudevents.EventContextV01) (http.Header, error) {
 	// Preserve case in v0.1, even though HTTP headers are case-insensitive.
 	h := http.Header{}
 	h["CE-CloudEventsVersion"] = []string{ec.CloudEventsVersion}
@@ -161,8 +160,9 @@ func (v CodecV01) decodeBinary(msg transport.Message) (*cloudevents.Event, error
 		body = m.Body
 	}
 	return &cloudevents.Event{
-		Context: ctx,
-		Data:    body,
+		Context:     &ctx,
+		Data:        body,
+		DataEncoded: true,
 	}, nil
 }
 
@@ -171,25 +171,31 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 	for k, v := range h {
 		ck := textproto.CanonicalMIMEHeaderKey(k)
 		if k != ck {
-			log.Printf("[warn] received header with non-canonical form; canonical: %q, got %q", ck, k)
 			h[ck] = v
 		}
 	}
 
 	ec := cloudevents.EventContextV01{}
 	ec.CloudEventsVersion = h.Get("CE-CloudEventsVersion")
+	h.Del("CE-CloudEventsVersion")
 	ec.EventID = h.Get("CE-EventID")
+	h.Del("CE-EventID")
 	ec.EventType = h.Get("CE-EventType")
+	h.Del("CE-EventType")
 	source := types.ParseURLRef(h.Get("CE-Source"))
+	h.Del("CE-Source")
 	if source != nil {
 		ec.Source = *source
 	}
 	ec.EventTime = types.ParseTimestamp(h.Get("CE-EventTime"))
+	h.Del("CE-EventTime")
 	etv := h.Get("CE-EventTypeVersion")
+	h.Del("CE-EventTypeVersion")
 	if etv != "" {
 		ec.EventTypeVersion = &etv
 	}
 	ec.SchemaURL = types.ParseURLRef(h.Get("CE-SchemaURL"))
+	h.Del("CE-SchemaURL")
 	et := h.Get("Content-Type")
 	ec.ContentType = &et
 
@@ -204,6 +210,7 @@ func (v CodecV01) fromHeaders(h http.Header) (cloudevents.EventContextV01, error
 				// If we can't unmarshal the data, treat it as a string.
 				extensions[key] = v[0]
 			}
+			h.Del(k)
 		}
 	}
 	if len(extensions) > 0 {

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
@@ -4,17 +4,19 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents"
 	cecontext "github.com/cloudevents/sdk-go/pkg/cloudevents/context"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport"
 )
 
@@ -32,6 +34,7 @@ const (
 type Transport struct {
 	// The encoding used to select the codec for outbound events.
 	Encoding Encoding
+
 	// DefaultEncodingSelectionFn allows for other encoding selection strategies to be injected.
 	DefaultEncodingSelectionFn EncodingSelector
 
@@ -45,7 +48,7 @@ type Transport struct {
 	// If nil, the Transport will create a one.
 	Client *http.Client
 	// Req is the base http request that is used for http.Do.
-	// Only .Method, .URL, and .Header is considered.
+	// Only .Method, .URL, .Close, and .Header is considered.
 	// If not set, Req.Method defaults to POST.
 	// Req.URL or context.WithTarget(url) are required for sending.
 	Req *http.Request
@@ -93,15 +96,21 @@ func (t *Transport) applyOptions(opts ...Option) error {
 	return nil
 }
 
-func (t *Transport) loadCodec() bool {
+func (t *Transport) loadCodec(ctx context.Context) bool {
 	if t.codec == nil {
 		t.crMu.Lock()
 		if t.DefaultEncodingSelectionFn != nil && t.Encoding != Default {
-			log.Printf("[warn] Transport has a DefaultEncodingSelectionFn set but Encoding is not Default. DefaultEncodingSelectionFn will be ignored.")
-		}
-		t.codec = &Codec{
-			Encoding:                   t.Encoding,
-			DefaultEncodingSelectionFn: t.DefaultEncodingSelectionFn,
+			logger := cecontext.LoggerFrom(ctx)
+			logger.Warn("transport has a DefaultEncodingSelectionFn set but Encoding is not Default. DefaultEncodingSelectionFn will be ignored.")
+
+			t.codec = &Codec{
+				Encoding: t.Encoding,
+			}
+		} else {
+			t.codec = &Codec{
+				Encoding:                   t.Encoding,
+				DefaultEncodingSelectionFn: t.DefaultEncodingSelectionFn,
+			}
 		}
 		t.crMu.Unlock()
 	}
@@ -144,6 +153,7 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 	if t.Req != nil {
 		req.Method = t.Req.Method
 		req.URL = t.Req.URL
+		req.Close = t.Req.Close
 		copyHeaders(t.Req.Header, req.Header)
 	}
 
@@ -152,7 +162,7 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 		req.URL = target
 	}
 
-	if ok := t.loadCodec(); !ok {
+	if ok := t.loadCodec(ctx); !ok {
 		return nil, fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
 	}
 
@@ -166,9 +176,9 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(m.Body))
 		req.ContentLength = int64(len(m.Body))
-		req.Close = true
 
 		return httpDo(ctx, t.Client, &req, func(resp *http.Response, err error) (*cloudevents.Event, error) {
+			logger := cecontext.LoggerFrom(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -182,19 +192,19 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (*clou
 
 			var respEvent *cloudevents.Event
 			if msg.CloudEventsVersion() != "" {
-				if ok := t.loadCodec(); !ok {
+				if ok := t.loadCodec(ctx); !ok {
 					err := fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
-					log.Printf("failed to load codec: %s", err)
+					logger.Error("failed to load codec", zap.Error(err))
 				}
 				if respEvent, err = t.codec.Decode(msg); err != nil {
-					log.Printf("failed to decode message: %s %v", err, resp)
+					logger.Error("failed to decode message", zap.Error(err))
 				}
 			}
 
 			if accepted(resp) {
 				return respEvent, nil
 			}
-			return respEvent, fmt.Errorf("error sending cloudevent: %s", status(resp))
+			return respEvent, fmt.Errorf("error sending cloudevent: %s", resp.Status)
 		})
 	}
 	return nil, fmt.Errorf("failed to encode Event into a Message")
@@ -290,16 +300,6 @@ func accepted(resp *http.Response) bool {
 	return false
 }
 
-// status is a helper method to read the response of the target.
-func status(resp *http.Response) string {
-	status := resp.Status
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Sprintf("Status[%s] error reading response body: %v", status, err)
-	}
-	return fmt.Sprintf("Status[%s] %s", status, body)
-}
-
 func (t *Transport) invokeReceiver(ctx context.Context, event cloudevents.Event) (*Response, error) {
 	ctx, r := observability.NewReporter(ctx, reportReceive)
 	resp, err := t.obsInvokeReceiver(ctx, event)
@@ -312,6 +312,7 @@ func (t *Transport) invokeReceiver(ctx context.Context, event cloudevents.Event)
 }
 
 func (t *Transport) obsInvokeReceiver(ctx context.Context, event cloudevents.Event) (*Response, error) {
+	logger := cecontext.LoggerFrom(ctx)
 	if t.Receiver != nil {
 		// Note: http does not use eventResp.Reason
 		eventResp := cloudevents.EventResponse{}
@@ -319,21 +320,21 @@ func (t *Transport) obsInvokeReceiver(ctx context.Context, event cloudevents.Eve
 
 		err := t.Receiver.Receive(ctx, event, &eventResp)
 		if err != nil {
-			log.Printf("got an error from receiver fn: %s", err.Error())
+			logger.Warnw("got an error from receiver fn: %s", zap.Error(err))
 			resp.StatusCode = http.StatusInternalServerError
 			return &resp, err
 		}
 
 		if eventResp.Event != nil {
-			if t.loadCodec() {
+			if t.loadCodec(ctx) {
 				if m, err := t.codec.Encode(*eventResp.Event); err != nil {
-					log.Printf("failed to encode response from receiver fn: %s", err.Error())
+					logger.Errorw("failed to encode response from receiver fn", zap.Error(err))
 				} else if msg, ok := m.(*Message); ok {
 					resp.Header = msg.Header
 					resp.Body = msg.Body
 				}
 			} else {
-				log.Printf("failed to load codec")
+				logger.Error("failed to load codec")
 				resp.StatusCode = http.StatusInternalServerError
 				return &resp, err
 			}
@@ -365,10 +366,11 @@ func (t *Transport) obsInvokeReceiver(ctx context.Context, event cloudevents.Eve
 // ServeHTTP implements http.Handler
 func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx, r := observability.NewReporter(req.Context(), reportServeHTTP)
+	logger := cecontext.LoggerFrom(ctx)
 
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		log.Printf("failed to handle request: %s %v", err, req)
+		logger.Errorw("failed to handle request", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(`{"error":"Invalid request"}`))
 		r.Error()
@@ -379,9 +381,9 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Body:   body,
 	}
 
-	if ok := t.loadCodec(); !ok {
+	if ok := t.loadCodec(ctx); !ok {
 		err := fmt.Errorf("unknown encoding set on transport: %d", t.Encoding)
-		log.Printf("failed to load codec: %s", err)
+		logger.Errorw("failed to load codec", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 		r.Error()
@@ -389,7 +391,7 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	event, err := t.codec.Decode(msg)
 	if err != nil {
-		log.Printf("failed to decode message: %s %v", err, req)
+		logger.Errorw("failed to decode message", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 		r.Error()
@@ -402,11 +404,13 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	resp, err := t.invokeReceiver(ctx, *event)
 	if err != nil {
+		logger.Warnw("error returned from invokeReceiver", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 		r.Error()
 		return
 	}
+
 	if resp != nil {
 		if t.Req != nil {
 			copyHeaders(t.Req.Header, w.Header())
@@ -414,17 +418,18 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if len(resp.Header) > 0 {
 			copyHeaders(resp.Header, w.Header())
 		}
-		status := http.StatusAccepted
-		if resp.StatusCode >= 200 && resp.StatusCode < 600 {
-			status = resp.StatusCode
-		}
-		w.WriteHeader(status)
+		w.Header().Add("Content-Length", strconv.Itoa(len(resp.Body)))
 		if len(resp.Body) > 0 {
 			if _, err := w.Write(resp.Body); err != nil {
 				r.Error()
 				return
 			}
 		}
+		status := http.StatusAccepted
+		if resp.StatusCode >= 200 && resp.StatusCode < 600 {
+			status = resp.StatusCode
+		}
+		w.WriteHeader(status)
 
 		r.OK()
 		return


### PR DESCRIPTION
## Proposed Changes

- Bring in latest version of CloudEvents Golang SDK 0.6.0

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
