### PR TITLE
Add a Deprecated condition on 'in-memory-channel' Channels.

### DIFF
--- a/pkg/provisioners/inmemory/channel/reconcile_test.go
+++ b/pkg/provisioners/inmemory/channel/reconcile_test.go
@@ -189,9 +189,9 @@ var (
 
 func init() {
 	// Add types to scheme.
-	eventingv1alpha1.AddToScheme(scheme.Scheme)
-	corev1.AddToScheme(scheme.Scheme)
-	istiov1alpha3.AddToScheme(scheme.Scheme)
+	_ = eventingv1alpha1.AddToScheme(scheme.Scheme)
+	_ = corev1.AddToScheme(scheme.Scheme)
+	_ = istiov1alpha3.AddToScheme(scheme.Scheme)
 }
 
 func TestInjectClient(t *testing.T) {
@@ -267,9 +267,6 @@ func TestReconcile(t *testing.T) {
 			Mocks: controllertesting.Mocks{
 				MockLists: errorListingK8sService(),
 			},
-			WantPresent: []runtime.Object{
-				makeChannel(),
-			},
 			WantErrMsg: testErrorMessage,
 			WantEvent: []corev1.Event{
 				events[k8sServiceCreateFailed],
@@ -283,11 +280,9 @@ func TestReconcile(t *testing.T) {
 			Mocks: controllertesting.Mocks{
 				MockCreates: errorCreatingK8sService(),
 			},
-			WantPresent: []runtime.Object{
-				// TODO: This should have a useful error message saying that the K8s Service failed.
-				makeChannel(),
-			},
-			WantErrMsg: testErrorMessage,
+			// TODO: This should have a useful error message saying that the K8s Service failed.
+			WantPresent: []runtime.Object{},
+			WantErrMsg:  testErrorMessage,
 			WantEvent: []corev1.Event{
 				events[k8sServiceCreateFailed],
 			},


### PR DESCRIPTION
Deprecation notice for #787.

## Proposed Changes

- Add a `Deprecated` condition to Channels. It does not affect `Ready`.
- Add a deprecation notice for `in-memory-channel`, which will be removed in 0.7.

Example:

```
status:
  conditions:
  - lastTransitionTime: 2019-04-17T20:40:05Z
    message: The `in-memory-channel` ClusterChannelProvisioner is deprecated and will
      be removed in 0.7. Recommended replacement is `in-memory`.
    reason: ClusterChannelProvisionerDeprecated
    severity: Warning
    status: "True"
    type: Deprecated
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The `in-memory-channel` ClusterChannelProvisioner will be deleted in the 0.7. Please migrate all Channels to a different provisioner.
```
