### PR TITLE
Add e2e testing support for gcp-pubsub CCP

### DIFF
--- a/test/builders.go
+++ b/test/builders.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/clients.go
+++ b/test/clients.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/constants.go
+++ b/test/constants.go
@@ -19,13 +19,28 @@ package test
 const (
 	// DefaultBrokerName is the name of the Broker that is automatically created after the current namespace is labeled.
 	DefaultBrokerName = "default"
+	// DefaultClusterChannelProvisioner is the default ClusterChannelProvisioner we will run tests against.
+	DefaultClusterChannelProvisioner = InMemoryProvisioner
 
 	// InMemoryChannelProvisioner is the in-memory-channel provisioner.
+	// It will be delete in 0.7, see https://github.com/knative/eventing/pull/1062 for more info.
 	InMemoryChannelProvisioner = "in-memory-channel"
-	// GCPPubSubChannelProvisioner is the gcp-pubsub provisioner, which is under contrib/gcppubsub.
-	GCPPubSubChannelProvisioner = "gcp-pubsub"
-	// KafkaChannelProvisioner is the kafka provisioner, which is under contrib/kafka.
-	KafkaChannelProvisioner = "kafka"
-	// NatssChannelProvisioner is the natss provisioner, which is under contrib/natss
-	NatssChannelProvisioner = "natss"
+
+	// InMemoryProvisioner is the in-memory provisioner, which is also the default one.
+	InMemoryProvisioner = "in-memory"
+	// GCPPubSubProvisioner is the gcp-pubsub provisioner, which is under contrib/gcppubsub.
+	GCPPubSubProvisioner = "gcp-pubsub"
+	// KafkaProvisioner is the kafka provisioner, which is under contrib/kafka.
+	KafkaProvisioner = "kafka"
+	// NatssProvisioner is the natss provisioner, which is under contrib/natss
+	NatssProvisioner = "natss"
 )
+
+// validProvisioners is a list of provisioners that Eventing currently support.
+var validProvisioners = []string{
+	InMemoryChannelProvisioner,
+	InMemoryProvisioner,
+	GCPPubSubProvisioner,
+	KafkaProvisioner,
+	NatssProvisioner,
+}

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+const (
+	// DefaultBrokerName is the name of the Broker that is automatically created after the current namespace is labeled.
+	DefaultBrokerName = "default"
+
+	// InMemoryChannelProvisioner is the in-memory-channel provisioner.
+	InMemoryChannelProvisioner = "in-memory-channel"
+	// GCPPubSubChannelProvisioner is the gcp-pubsub provisioner, which is under contrib/gcppubsub.
+	GCPPubSubChannelProvisioner = "gcp-pubsub"
+	// KafkaChannelProvisioner is the kafka provisioner, which is under contrib/kafka.
+	KafkaChannelProvisioner = "kafka"
+	// NatssChannelProvisioner is the natss provisioner, which is under contrib/natss
+	NatssChannelProvisioner = "natss"
+)

--- a/test/crd.go
+++ b/test/crd.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -114,7 +114,6 @@ function gcppubsub_teardown() {
       --role roles/pubsub.editor
     gcloud iam service-accounts delete -q ${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
   fi
-
   kubectl -n knative-eventing delete secret gcppubsub-channel-key
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -45,7 +45,7 @@ function knative_setup() {
 
   echo "Installing GCPPubSub ClusterChannelProvisioner"
   kubectl -n knative-eventing create secret generic gcppubsub-channel-key --from-file=key.json=${GOOGLE_APPLICATION_CREDENTIALS}
-  gcloud_project="$(gcloud config get-value project)"
+  local gcloud_project="$(gcloud config get-value project)"
   sed "s/REPLACE_WITH_GCP_PROJECT/${gcloud_project}/" contrib/gcppubsub/config/gcppubsub.yaml | ko apply -f -
   wait_until_pods_running knative-eventing || fail_test "Failed to install the GCPPubSub ClusterChannelProvisioner"
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,7 +95,7 @@ function gcppubsub_setup() {
     gcloud iam service-accounts create ${PUBSUB_SERVICE_ACCOUNT}
     gcloud projects add-iam-policy-binding ${PROJECT_ID} \
       --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
-    --role roles/pubsub.editor
+      --role roles/pubsub.editor
     gcloud iam service-accounts keys create ${PUBSUB_SERVICE_ACCOUNT_KEY} \
     --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     service_account_key="${PUBSUB_SERVICE_ACCOUNT_KEY}"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -109,7 +109,7 @@ function gcppubsub_teardown() {
   if (( ! IS_PROW )); then
     echo "Tear down ServiceAccount for GCP PubSub provisioner"
     gcloud iam service-accounts keys delete -q ${PUBSUB_SERVICE_ACCOUNT_KEY} \
-    --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
+      --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
       --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
       --role roles/pubsub.editor

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,7 +32,7 @@ readonly EVENTING_CONFIG=config/
 readonly IN_MEMORY_CHANNEL_CONFIG=config/provisioners/in-memory-channel/in-memory-channel.yaml
 readonly GCP_PUBSUB_CHANNEL_CONFIG=contrib/gcppubsub/config/gcppubsub.yaml
 
-E2E_CLUSTER_PROJECT = ""
+E2E_CLUSTER_PROJECT=""
 
 # Setup the Knative environment for running tests
 function knative_setup() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -112,7 +112,7 @@ function gcppubsub_teardown() {
     --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
       --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
-    --role roles/pubsub.editor
+      --role roles/pubsub.editor
     gcloud iam service-accounts delete -q ${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
   fi
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -94,7 +94,7 @@ function gcppubsub_setup() {
     gcloud services enable pubsub.googleapis.com
     gcloud iam service-accounts create ${PUBSUB_SERVICE_ACCOUNT}
     gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-    --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+      --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
     --role roles/pubsub.editor
     gcloud iam service-accounts keys create ${PUBSUB_SERVICE_ACCOUNT_KEY} \
     --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -100,7 +100,6 @@ function gcppubsub_setup() {
       --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     service_account_key="${PUBSUB_SERVICE_ACCOUNT_KEY}"
   fi
-
   kubectl -n knative-eventing create secret generic gcppubsub-channel-key --from-file=key.json=${service_account_key}
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -88,7 +88,7 @@ readonly PUBSUB_SERVICE_ACCOUNT_KEY="knative-gcppubsub-channel.json"
 
 # Create resources required for GCP PubSub provisioner setup
 function gcppubsub_setup() {
-  local service_account_key=${GOOGLE_APPLICATION_CREDENTIALS}
+  local service_account_key="${GOOGLE_APPLICATION_CREDENTIALS}"
   if (( ! IS_PROW )); then
     echo "Set up ServiceAccount for GCP PubSub provisioner"
     gcloud services enable pubsub.googleapis.com

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,6 +37,9 @@ readonly GCP_PUBSUB_CONFIG_TEMPLATE="contrib/gcppubsub/config/gcppubsub.yaml"
 # Real GCP PubSub config, generated from the template.
 readonly GCP_PUBSUB_CONFIG="$(mktemp)"
 
+# TODO(Fredy-Z): delete this flag after https://github.com/knative/test-infra/pull/692 is merged and updated
+E2E_PROJECT_ID=""
+
 # Constants used for creating ServiceAccount for GCP PubSub provisioner setup if it's not running on Prow.
 readonly PUBSUB_SERVICE_ACCOUNT="eventing_pubsub_test"
 readonly PUBSUB_SERVICE_ACCOUNT_KEY="$(mktemp)"
@@ -57,7 +60,6 @@ function knative_setup() {
   ko apply -f ${IN_MEMORY_CHANNEL_CONFIG} || return 1
   wait_until_pods_running knative-eventing || fail_test "Failed to install the In-Memory ClusterChannelProvisioner"
 
-  # TODO(Fredy-Z): delete this flag after https://github.com/knative/test-infra/pull/692 is merged and updated
   E2E_PROJECT_ID="$(gcloud config get-value project)"
   echo "Installing GCPPubSub ClusterChannelProvisioner"
   gcppubsub_setup

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -111,7 +111,7 @@ function gcppubsub_teardown() {
     gcloud iam service-accounts keys delete -q ${PUBSUB_SERVICE_ACCOUNT_KEY} \
     --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
-    --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+      --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
     --role roles/pubsub.editor
     gcloud iam service-accounts delete -q ${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
   fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -97,7 +97,7 @@ function gcppubsub_setup() {
       --member=serviceAccount:${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
       --role roles/pubsub.editor
     gcloud iam service-accounts keys create ${PUBSUB_SERVICE_ACCOUNT_KEY} \
-    --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
+      --iam-account=${PUBSUB_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
     service_account_key="${PUBSUB_SERVICE_ACCOUNT_KEY}"
   fi
 

--- a/test/e2e/broker_trigger_test.go
+++ b/test/e2e/broker_trigger_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/test"
@@ -82,7 +83,7 @@ func Setup(t *testing.T, runInParallel bool, logf logging.FormatLogger) (*test.C
 	// Create a new namespace to run this test case.
 	// Combine the test name and CCP to avoid duplication.
 	baseFuncName := GetBaseFuncName(t.Name())
-	ns := strings.ToLower(baseFuncName) + "-" + ccpToTest
+	ns := makeK8sNamePrefix(baseFuncName)
 	CreateNamespaceIfNeeded(t, clients, ns, t.Logf)
 
 	// Run the test case in parallel if needed.
@@ -91,6 +92,26 @@ func Setup(t *testing.T, runInParallel bool, logf logging.FormatLogger) (*test.C
 	}
 
 	return clients, ns, ccpToTest, cleaner
+}
+
+// TODO(Fredy-Z): Borrowed this function from Knative/Serving, will delete it after we move it to Knative/pkg/test.
+// makeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash
+// and also convert camelcase tokens into dash-delimited lowercase tokens.
+func makeK8sNamePrefix(s string) string {
+	var sb strings.Builder
+	newToken := false
+	for _, c := range s {
+		if !(unicode.IsLetter(c) || unicode.IsNumber(c)) {
+			newToken = true
+			continue
+		}
+		if sb.Len() > 0 && (newToken || unicode.IsUpper(c)) {
+			sb.WriteRune('-')
+		}
+		sb.WriteRune(unicode.ToLower(c))
+		newToken = false
+	}
+	return sb.String()
 }
 
 // GetBaseFuncName returns the baseFuncName parsed from the fullFuncName.

--- a/test/e2e/event_transformation_test.go
+++ b/test/e2e/event_transformation_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/event_transformation_test.go
+++ b/test/e2e/event_transformation_test.go
@@ -117,7 +117,12 @@ func TestEventTransformation(t *testing.T) {
 	// check if the logging service receives the correct number of event messages
 	expectedContent := body + msgPostfix
 	expectedContentCount := len(subscriptionNames1) * len(subscriptionNames2)
-	if err := WaitForLogContentCount(clients, loggerPod.Name, loggerPod.Spec.Containers[0].Name, ns, expectedContent, expectedContentCount); err != nil {
+	podName := loggerPod.Name
+	containerName := loggerPod.Spec.Containers[0].Name
+	if err := WaitForLogContentCount(clients, podName, containerName, ns, expectedContent, expectedContentCount); err != nil {
+		if logs, err := clients.Kube.PodLogs(podName, containerName, ns); err != nil {
+			t.Logf("Log content: %s\n", string(logs))
+		}
 		t.Fatalf("String %q does not appear %d times in logs of logger pod %q: %v", expectedContent, expectedContentCount, loggerPod.Name, err)
 	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -28,19 +28,18 @@ import (
 
 // channelTestMap indicates which test cases we want to run for a given CCP.
 var channelTestMap = map[string][]func(t *testing.T){
-	test.InMemoryChannelProvisioner: []func(t *testing.T){
-		TestSingleBinaryEvent,
-		TestSingleStructuredEvent,
-		TestEventTransformation,
-		TestChannelChain,
-		TestDefaultBrokerWithManyTriggers,
-	},
 	test.InMemoryProvisioner: []func(t *testing.T){
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,
 		TestChannelChain,
 		TestDefaultBrokerWithManyTriggers,
+	},
+	test.InMemoryChannelProvisioner: []func(t *testing.T){
+		TestSingleBinaryEvent,
+		TestSingleStructuredEvent,
+		TestEventTransformation,
+		TestChannelChain,
 	},
 	test.GCPPubSubProvisioner: []func(t *testing.T){
 		TestSingleBinaryEvent,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -34,6 +34,12 @@ var channelTestMap = map[string][]func(t *testing.T){
 		TestChannelChain,
 		TestDefaultBrokerWithManyTriggers,
 	},
+	"gcp-pubsub": []func(t *testing.T){
+		TestSingleBinaryEvent,
+		TestSingleStructuredEvent,
+		TestEventTransformation,
+		TestChannelChain,
+	},
 }
 
 func TestMain(t *testing.T) {
@@ -50,7 +56,7 @@ func TestMain(t *testing.T) {
 			funcName := runtime.FuncForPC(reflect.ValueOf(testFunc).Pointer()).Name()
 			baseFuncName := GetBaseFuncName(funcName)
 			t.Logf("Running %q with %q ClusterChannelProvisioner", baseFuncName, provisioner)
-			t.Run(baseFuncName, testFunc)
+			t.Run(baseFuncName+"-"+provisioner, testFunc)
 		}
 	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -35,7 +35,14 @@ var channelTestMap = map[string][]func(t *testing.T){
 		TestChannelChain,
 		TestDefaultBrokerWithManyTriggers,
 	},
-	test.GCPPubSubChannelProvisioner: []func(t *testing.T){
+	test.InMemoryProvisioner: []func(t *testing.T){
+		TestSingleBinaryEvent,
+		TestSingleStructuredEvent,
+		TestEventTransformation,
+		TestChannelChain,
+		TestDefaultBrokerWithManyTriggers,
+	},
+	test.GCPPubSubProvisioner: []func(t *testing.T){
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,14 +27,14 @@ import (
 
 // channelTestMap indicates which test cases we want to run for a given CCP.
 var channelTestMap = map[string][]func(t *testing.T){
-	"in-memory-channel": []func(t *testing.T){
+	test.InMemoryChannelProvisioner: []func(t *testing.T){
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,
 		TestChannelChain,
 		TestDefaultBrokerWithManyTriggers,
 	},
-	"gcp-pubsub": []func(t *testing.T){
+	test.GCPPubSubChannelProvisioner: []func(t *testing.T){
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -2,6 +2,7 @@
 
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -30,29 +30,7 @@ import (
 	testLogging "github.com/knative/pkg/test/logging"
 )
 
-const (
-	// DefaultClusterChannelProvisioner is the default ClusterChannelProvisioner we will run tests against.
-	DefaultClusterChannelProvisioner = InMemoryChannelProvisioner
-)
-
 var logger = logging.FromContext(context.Background()).Named("eventing-e2e-testing")
-
-// validProvisioners is a list of provisioners that Eventing currently support.
-var validProvisioners = []string{
-	InMemoryChannelProvisioner,
-	GCPPubSubChannelProvisioner,
-	KafkaChannelProvisioner,
-	NatssChannelProvisioner,
-}
-
-func isValid(provisioner string) bool {
-	for i := range validProvisioners {
-		if provisioner == validProvisioners[i] {
-			return true
-		}
-	}
-	return false
-}
 
 // EventingFlags holds the command line flags specific to knative/eventing.
 var EventingFlags = initializeEventingFlags()
@@ -76,6 +54,16 @@ func (ps *Provisioners) Set(value string) error {
 		*ps = append(*ps, provisioner)
 	}
 	return nil
+}
+
+// Check if the provisioner is a valid one.
+func isValid(provisioner string) bool {
+	for i := range validProvisioners {
+		if provisioner == validProvisioners[i] {
+			return true
+		}
+	}
+	return false
 }
 
 // EventingEnvironmentFlags holds the e2e flags needed only by the eventing repo.

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -30,18 +30,19 @@ import (
 )
 
 const (
-	// E2ETestNamespacePrefix is the namespace prefix used for running all e2e tests.
-	E2ETestNamespacePrefix = "e2e-ns"
 	// DefaultClusterChannelProvisioner is the default ClusterChannelProvisioner we will run tests against.
-	DefaultClusterChannelProvisioner = "in-memory-channel"
-	// DefaultBrokerName is the name of the Broker that is automatically created after the current namespace is labeled.
-	DefaultBrokerName = "default"
+	DefaultClusterChannelProvisioner = InMemoryChannelProvisioner
 )
 
 var logger = logging.FromContext(context.Background()).Named("eventing-e2e-testing")
 
 // validProvisioners is a list of provisioners that Eventing currently support.
-var validProvisioners = []string{DefaultClusterChannelProvisioner}
+var validProvisioners = []string{
+	InMemoryChannelProvisioner,
+	GCPPubSubChannelProvisioner,
+	KafkaChannelProvisioner,
+	NatssChannelProvisioner,
+}
 
 func isValid(provisioner string) bool {
 	for i := range validProvisioners {

--- a/test/states.go
+++ b/test/states.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/test_images/logevents/main.go
+++ b/test/test_images/logevents/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,7 +20,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 )
 
 func handler(event cloudevents.Event) {

--- a/test/test_images/sendevent/main.go
+++ b/test/test_images/sendevent/main.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 )
 

--- a/test/test_images/transformevents/main.go
+++ b/test/test_images/transformevents/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,7 +22,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 )
 
 type example struct {


### PR DESCRIPTION
Fixes #1041 

Proposed changes:
1. Add e2e testing support for gcp-pubsub CCP;
2. Refactor some constants to `constants.go`