### PR TITLE
Add more logs, try to find the reason for e2e test flakiness

### DIFF
--- a/test/e2e/broker_trigger_test.go
+++ b/test/e2e/broker_trigger_test.go
@@ -218,6 +218,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 		subscriberContainerName := subscriberPod.Spec.Containers[0].Name
 		t.Logf("Dumper %q expecting %q", subscriberPodName, strings.Join(expectedEvents[subscriberPodName], ","))
 		if err := WaitForLogContents(clients, t.Logf, subscriberPodName, subscriberContainerName, ns, expectedEvents[subscriberPodName]); err != nil {
+			logPodLogsForDebugging(clients, subscriberPodName, subscriberContainerName, ns, t.Logf)
 			t.Fatalf("Event(s) not found in logs of subscriber pod %q: %v", subscriberPodName, err)
 		}
 		// At this point all the events should have been received in the pod.

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -98,6 +98,7 @@ func TestChannelChain(t *testing.T) {
 	// check if the logging service receives the correct number of event messages
 	expectedContentCount := len(subscriptionNames1) * len(subscriptionNames2)
 	if err := WaitForLogContentCount(clients, loggerPodName, loggerPod.Spec.Containers[0].Name, ns, body, expectedContentCount); err != nil {
+		logPodLogsForDebugging(clients, loggerPodName, loggerPod.Spec.Containers[0].Name, ns, t.Logf)
 		t.Fatalf("String %q does not appear %d times in logs of logger pod %q: %v", body, expectedContentCount, loggerPodName, err)
 	}
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -489,3 +489,13 @@ func DeleteNameSpace(clients *test.Clients, namespace string) error {
 	}
 	return err
 }
+
+// logPodLogsForDebugging add the pod logs in the testing log for further debugging.
+func logPodLogsForDebugging(clients *test.Clients, podName, containerName, namespace string, logf logging.FormatLogger) {
+	logs, err := clients.Kube.PodLogs(podName, containerName, namespace)
+	if err != nil {
+		logf("Failed to get the logs for container %q of the pod %q in namespace %q: %v", containerName, podName, namespace, err)
+	} else {
+		logf("Logs for the container %q of the pod % in namespace %q:\n%s", containerName, podName, namespace, string(logs))
+	}
+}

--- a/test/e2e/event_transformation_test.go
+++ b/test/e2e/event_transformation_test.go
@@ -120,9 +120,7 @@ func TestEventTransformation(t *testing.T) {
 	podName := loggerPod.Name
 	containerName := loggerPod.Spec.Containers[0].Name
 	if err := WaitForLogContentCount(clients, podName, containerName, ns, expectedContent, expectedContentCount); err != nil {
-		if logs, err := clients.Kube.PodLogs(podName, containerName, ns); err != nil {
-			t.Logf("Log content: %s\n", string(logs))
-		}
+		logPodLogsForDebugging(clients, podName, containerName, ns, t.Logf)
 		t.Fatalf("String %q does not appear %d times in logs of logger pod %q: %v", expectedContent, expectedContentCount, loggerPod.Name, err)
 	}
 }

--- a/test/e2e/single_event_test.go
+++ b/test/e2e/single_event_test.go
@@ -83,12 +83,9 @@ func singleEvent(t *testing.T, encoding string) {
 	}
 
 	if err := pkgTest.WaitForLogContent(clients.Kube, loggerPodName, loggerPod.Spec.Containers[0].Name, ns, body); err != nil {
-		if logs, err := clients.Kube.PodLogs(senderName, "sendevent", ns); err != nil {
-			t.Logf("Logs for sendevent container of the sender pod:\n %s", string(logs))
-		}
-		if logs, err := clients.Kube.PodLogs(senderName, "istio-proxy", ns); err != nil {
-			t.Logf("Logs for istio-proxy container of the sender pod:\n %s", string(logs))
-		}
+		logPodLogsForDebugging(clients, loggerPodName, loggerPod.Spec.Containers[0].Name, ns, t.Logf)
+		logPodLogsForDebugging(clients, senderName, "sendevent", ns, t.Logf)
+		logPodLogsForDebugging(clients, senderName, "istio-proxy", ns, t.Logf)
 		t.Fatalf("String %q not found in logs of logger pod %q: %v", body, loggerPodName, err)
 	}
 }


### PR DESCRIPTION
## Proposed Changes
A couple of current E2E tests are flaky and fail intermittently.
This PR is adding more logs to collect more information when the test fails.