### PR TITLE
Fix webhook controller RBAC policy

### DIFF
--- a/config/200-webhook-clusterrole.yaml
+++ b/config/200-webhook-clusterrole.yaml
@@ -41,22 +41,23 @@ rules:
       - "apps"
     resources:
       - "deployments"
-    verbs:
-      - "get"
+      - "deployments/finalizers"
+    verbs: &everything
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
 
   # For actually registering our webhook.
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
       - "mutatingwebhookconfigurations"
-    verbs:
-      - "get"
-      - "list"
-      - "create"
-      - "update"
-      - "delete"
-      - "patch"
-      - "watch"
+    verbs: *everything
 
   # Our own resources and statuses we care about.
   - apiGroups:


### PR DESCRIPTION
Running on Openshift and injecting the namespace with `kubectl label namespace someNameSpace knative-eventing-injection=enabled` (for the broker), give the error below due to missing RBAC policy.

From the logs:

```
{
  "level": "error",
  "ts": "2019-04-19T10:15:04.327Z",
  "logger": "webhook",
  "caller": "webhook/webhook.go:322",
  "msg": "failed to register webhook",
  "knative.dev/controller": "webhook",
  "error": "failed to create a webhook: mutatingwebhookconfigurations.admissionregistration.k8s.io \"webhook.eventing.knative.dev\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>",
  "stacktrace": "github.com/knative/eventing/vendor/github.com/knative/pkg/webhook.(*AdmissionController).Run\n\t/go/src/github.com/knative/eventing/vendor/github.com/knative/pkg/webhook/webhook.go:322\nmain.main\n\t/go/src/github.com/knative/eventing/cmd/webhook/main.go:110\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"
}
{
  "level": "error",
  "ts": "2019-04-19T10:15:04.327Z",
  "logger": "webhook",
  "caller": "webhook/main.go:111",
  "msg": "controller.Run() failed",
  "knative.dev/controller": "webhook",
  "error": "failed to create a webhook: mutatingwebhookconfigurations.admissionregistration.k8s.io \"webhook.eventing.knative.dev\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>",
  "stacktrace": "main.main\n\t/go/src/github.com/knative/eventing/cmd/webhook/main.go:111\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"
}
```

can webhook controller is crashing

## Proposed Changes

- adding `finalizer` and definubg `&everything` as verbs

