### PR TITLE
Disable gcp pubsub e2e tests until we fix the flaky tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -145,6 +145,6 @@ function dump_extra_cluster_state() {
 
 initialize $@
 
-go_test_e2e -timeout=20m ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory-channel,in-memory,gcp-pubsub || fail_test
+go_test_e2e -timeout=20m ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory-channel,in-memory || fail_test
 
 success


### PR DESCRIPTION
Since the current tests for GCP PubSub provisioner are quite flaky, we disable the tests for now until we fix them.

/cc @grantr 