### PR TITLE
k8s forces additionalProperties to true, hence no need to set it ourselves

### DIFF
--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -73,4 +73,3 @@ spec:
                       minLength: 1
                 arguments:
                   type: object
-                  additionalProperties: true

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -66,7 +66,6 @@ spec:
                   minLength: 1
             arguments:
               type: object
-              additionalProperties: true
             subscribable:
               type: object
               properties:


### PR DESCRIPTION
with `additionalProperties:true`, I am getting the following error:

```
cannot unmarshal bool into Go struct field JSONSchemaProps.AdditionalProperties of type apiextensions.JSONSchemaPropsOrBool
```

Since k8s forces it (defaults) to be `true`, we don't need to explicitly set it to true!