### PR TITLE
Consistency is king, use "" for the filter

### DIFF
--- a/config/200-broker-clusterrole.yaml
+++ b/config/200-broker-clusterrole.yaml
@@ -18,11 +18,11 @@ metadata:
   name: eventing-broker-filter
 rules:
   - apiGroups:
-      - eventing.knative.dev
+      - "eventing.knative.dev"
     resources:
-      - triggers
-      - triggers/status
+      - "triggers"
+      - "triggers/status"
     verbs:
-      - get
-      - list
-      - watch
+      - "get"
+      - "list"
+      - "watch"


### PR DESCRIPTION
the other 200- files are using quotes (`"..."`) for groups, verbs and rules.  Doing the same for the broker-clusterrole 