### PR TITLE
Adding finalizers for a more constraint RBAC

### DIFF
--- a/config/200-controller-clusterrole.yaml
+++ b/config/200-controller-clusterrole.yaml
@@ -67,6 +67,15 @@ rules:
       - "eventtypes/status"
     verbs: *everything
 
+  # Eventing resources and finalizers we care about.
+  - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "brokers/finalizers"
+      - "triggers/finalizers"
+    verbs:
+      - "update"
+
   # Source resources and statuses we care about.
   - apiGroups:
       - "sources.eventing.knative.dev"

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -57,6 +57,7 @@ rules:
     - eventing.knative.dev
     resources:
     - channels/finalizers
+    - clusterchannelprovisioners/finalizers
     verbs:
     - update
   - apiGroups:


### PR DESCRIPTION
At least on OpenShift, which has fairly restrictive RBAC out of the box, a few rules are missing for `/finalizers` sub-resource