### PR TITLE
golang format tools

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/broker"
 	"github.com/knative/eventing/pkg/provisioners"

--- a/cmd/pong/main.go
+++ b/cmd/pong/main.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/google/uuid"
 )
 

--- a/cmd/sendevent/main.go
+++ b/cmd/sendevent/main.go
@@ -25,7 +25,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/knative/eventing/pkg/utils"
 )
 

--- a/cmd/sources-controller/main.go
+++ b/cmd/sources-controller/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/knative/eventing/pkg/reconciler/containersource"
 	"k8s.io/client-go/tools/clientcmd"
-	"log"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/contrib/gcppubsub/pkg/controller/channel/names_test.go
+++ b/contrib/gcppubsub/pkg/controller/channel/names_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package channel
 
 import (
-	v1 "k8s.io/api/core/v1"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"

--- a/contrib/gcppubsub/pkg/dispatcher/receiver/receiver_test.go
+++ b/contrib/gcppubsub/pkg/dispatcher/receiver/receiver_test.go
@@ -201,8 +201,8 @@ func TestUpdateHostToChannelMap(t *testing.T) {
 				makeChannel(withName("chan2"), withNamespace("ns2"), withStatusReady("host.name2")),
 			},
 			expectedMap: map[string]provisioners.ChannelReference{
-				"host.name1": provisioners.ChannelReference{Name: "chan1", Namespace: "ns1"},
-				"host.name2": provisioners.ChannelReference{Name: "chan2", Namespace: "ns2"},
+				"host.name1": {Name: "chan1", Namespace: "ns1"},
+				"host.name2": {Name: "chan2", Namespace: "ns2"},
 			},
 		},
 	}

--- a/contrib/gcppubsub/pkg/util/status.go
+++ b/contrib/gcppubsub/pkg/util/status.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"

--- a/contrib/kafka/pkg/dispatcher/dispatcher_test.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher_test.go
@@ -220,7 +220,7 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 			},
 			oldHostToChanMap: map[string]provisioners.ChannelReference{},
 			newHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel", Namespace: "default"},
 			},
 		},
 		{
@@ -250,7 +250,7 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 			subscribes:       []string{"subscription-1", "subscription-2"},
 			oldHostToChanMap: map[string]provisioners.ChannelReference{},
 			newHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel", Namespace: "default"},
 			},
 		},
 		{
@@ -296,10 +296,10 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 			subscribes:   []string{"subscription-2", "subscription-3"},
 			unsubscribes: []string{"subscription-1"},
 			oldHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel", Namespace: "default"},
 			},
 			newHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel", Namespace: "default"},
 			},
 		},
 		{
@@ -359,11 +359,11 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 			subscribes:   []string{"subscription-1", "subscription-3", "subscription-4"},
 			unsubscribes: []string{"subscription-2"},
 			oldHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel-1", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel-1", Namespace: "default"},
 			},
 			newHostToChanMap: map[string]provisioners.ChannelReference{
-				"a.b.c.d": provisioners.ChannelReference{Name: "test-channel-1", Namespace: "default"},
-				"e.f.g.h": provisioners.ChannelReference{Name: "test-channel-2", Namespace: "default"},
+				"a.b.c.d": {Name: "test-channel-1", Namespace: "default"},
+				"e.f.g.h": {Name: "test-channel-2", Namespace: "default"},
 			},
 		},
 		{

--- a/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher/dispatcher_test.go
@@ -228,9 +228,9 @@ func TestUpdateHostToChannelMap(t *testing.T) {
 				*makechannel("chan3", "ns3", "host3"),
 			},
 			expected: map[string]provisioners.ChannelReference{
-				"host1": provisioners.ChannelReference{Name: "chan1", Namespace: "ns1"},
-				"host2": provisioners.ChannelReference{Name: "chan2", Namespace: "ns2"},
-				"host3": provisioners.ChannelReference{Name: "chan3", Namespace: "ns3"},
+				"host1": {Name: "chan1", Namespace: "ns1"},
+				"host2": {Name: "chan2", Namespace: "ns2"},
+				"host3": {Name: "chan3", Namespace: "ns3"},
 			},
 		},
 	}

--- a/pkg/broker/context.go
+++ b/pkg/broker/context.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -23,7 +23,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/reconciler/trigger/path"
 	"go.uber.org/zap"

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -17,7 +17,7 @@
 package broker
 
 import (
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 )
 
 const (

--- a/pkg/kncloudevents/good_client.go
+++ b/pkg/kncloudevents/good_client.go
@@ -1,7 +1,7 @@
 package kncloudevents
 
 import (
-	"github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 )
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -19,6 +19,7 @@ package logging
 
 import (
 	"context"
+
 	"github.com/knative/pkg/logging"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/containersource/resources/deployment.go
+++ b/pkg/reconciler/containersource/resources/deployment.go
@@ -18,8 +18,9 @@ package resources
 
 import (
 	"fmt"
-	"github.com/knative/pkg/kmeta"
 	"strings"
+
+	"github.com/knative/pkg/kmeta"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/containersource/resources/deployment_test.go
+++ b/pkg/reconciler/containersource/resources/deployment_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"testing"
+
+	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/cronjobsource/resources/receive_adapter.go
+++ b/pkg/reconciler/cronjobsource/resources/receive_adapter.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/pkg/kmeta"
 
 	v1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/eventing/pkg/reconciler/namespace/resources"
 	"k8s.io/client-go/tools/cache"
 

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package namespace
 
 import (
+	"testing"
+
 	"github.com/knative/eventing/pkg/reconciler/namespace/resources"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	fakeclientset "github.com/knative/eventing/pkg/client/clientset/versioned/fake"

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -17,9 +17,10 @@ limitations under the License.
 package reconciler
 
 import (
+	"time"
+
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/system"
-	"time"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/testing/containersource.go
+++ b/pkg/reconciler/testing/containersource.go
@@ -17,8 +17,9 @@ limitations under the License.
 package testing
 
 import (
-	"k8s.io/apimachinery/pkg/types"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -18,8 +18,9 @@ package testing
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"

--- a/pkg/reconciler/testing/namespace.go
+++ b/pkg/reconciler/testing/namespace.go
@@ -17,9 +17,10 @@ limitations under the License.
 package testing
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // NamespaceOption enables further configuration of a Namespace.

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -28,20 +28,20 @@ import (
 
 // channelTestMap indicates which test cases we want to run for a given CCP.
 var channelTestMap = map[string][]func(t *testing.T){
-	test.InMemoryProvisioner: []func(t *testing.T){
+	test.InMemoryProvisioner: {
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,
 		TestChannelChain,
 		TestDefaultBrokerWithManyTriggers,
 	},
-	test.InMemoryChannelProvisioner: []func(t *testing.T){
+	test.InMemoryChannelProvisioner: {
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,
 		TestChannelChain,
 	},
-	test.GCPPubSubProvisioner: []func(t *testing.T){
+	test.GCPPubSubProvisioner: {
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,
 		TestEventTransformation,


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
