### PR TITLE
Fixing namespace reconciler bugs

### DIFF
--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	fakeclientset "github.com/knative/eventing/pkg/client/clientset/versioned/fake"
 	eventinginformers "github.com/knative/eventing/pkg/client/informers/externalversions"
@@ -92,154 +93,138 @@ func TestNew(t *testing.T) {
 }
 
 func TestAllCases(t *testing.T) {
-	table := TableTest{
-		{
-			Name: "bad workqueue key",
-			// Make sure Reconcile handles bad keys.
-			Key: "too/many/parts",
-		}, {
-			Name: "key not found",
-			// Make sure Reconcile handles good keys that don't exist.
-			Key: "foo/not-found",
-		}, {
-			Name: "Namespace is not labeled",
-			Objects: []runtime.Object{
-				NewNamespace(testNS),
-			},
-			Key: testNS,
-		}, {
-			Name: "Namespace is labeled disabled",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionDisabledLabels())),
-			},
-			Key: testNS,
-		}, {
-			Name: "Namespace is deleted, no resources",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-					WithNamespaceDeleted,
-				),
-			},
-			Key: testNS,
-		}, {
-			Name: "Namespace enabled",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-				),
-			},
-			Key:                     testNS,
-			SkipNamespaceValidation: true,
-			WantErr:                 false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
-				Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
-			},
-			WantCreates: []metav1.Object{
-				resources.MakeBroker(testNS),
-				resources.MakeServiceAccount(testNS),
-				resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
-			},
-		}, {
-			Name: "Namespace enabled, broker exists",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-				),
-				resources.MakeBroker(testNS),
-			},
-			Key:                     testNS,
-			SkipNamespaceValidation: true,
-			WantErr:                 false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
-			},
-			WantCreates: []metav1.Object{
-				resources.MakeServiceAccount(testNS),
-				resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
+	table := TableTest{{
+		Name: "bad workqueue key",
+		// Make sure Reconcile handles bad keys.
+		Key: "too/many/parts",
+	}, {
+		Name: "key not found",
+		// Make sure Reconcile handles good keys that don't exist.
+		Key: "foo/not-found",
+	}, {
+		Name: "Namespace is not labeled",
+		Objects: []runtime.Object{
+			NewNamespace(testNS),
+		},
+		Key: testNS,
+	}, {
+		Name: "Namespace is labeled disabled",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionDisabledLabels())),
+		},
+		Key: testNS,
+	}, {
+		Name: "Namespace is deleted no resources",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+				WithNamespaceDeleted,
+			),
+		},
+		Key: testNS,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\""),
+		},
+	}, {
+		Name: "Namespace enabled",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+			),
+		},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
+			Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\""),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeBroker(testNS),
+			resources.MakeServiceAccount(testNS),
+			resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
+		},
+	}, {
+		Name: "Namespace enabled, broker exists",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+			),
+			resources.MakeBroker(testNS),
+		},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\""),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeServiceAccount(testNS),
+			resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
+		},
+	}, {
+		Name: "Namespace enabled, broker exists with no label",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionDisabledLabels()),
+			),
+			&v1alpha1.Broker{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNS,
+					Name:      resources.DefaultBrokerName,
+				},
 			},
 		},
-		{
-			Name: "Namespace enabled, service account exists",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-				),
-				resources.MakeServiceAccount(testNS),
-			},
-			Key:                     testNS,
-			SkipNamespaceValidation: true,
-			WantErr:                 false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
-				Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
-			},
-			WantCreates: []metav1.Object{
-				resources.MakeBroker(testNS),
-				resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
-			},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+	}, {
+		Name: "Namespace enabled, service account exists",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+			),
+			resources.MakeServiceAccount(testNS),
 		},
-		{
-			Name: "Namespace enabled, role binding exists",
-			Objects: []runtime.Object{
-				NewNamespace(testNS,
-					WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-				),
-				resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
-			},
-			Key:                     testNS,
-			SkipNamespaceValidation: true,
-			WantErr:                 false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
-				Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
-			},
-			WantCreates: []metav1.Object{
-				resources.MakeBroker(testNS),
-				resources.MakeServiceAccount(testNS),
-			},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountRBACCreated", "Service account RBAC created for the Broker Filter 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
+			Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\""),
 		},
-		//{  TODO: this test should work but there is no clean-up in the controller.
-		//	Name: "Namespace disabled, cleanup",
-		//	Objects: []runtime.Object{
-		//		NewNamespace(testNS,
-		//			WithNamespaceLabeled(resources.InjectionDisabledLabels()),
-		//		),
-		//		resources.MakeBroker(testNS),
-		//		resources.MakeServiceAccount(testNS),
-		//		resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
-		//	},
-		//	Key:                     testNS,
-		//	SkipNamespaceValidation: true,
-		//	WantErr:                 false,
-		//	WantDeletes: []clientgotesting.DeleteActionImpl{{
-		//		ActionImpl: clientgotesting.ActionImpl{
-		//			Namespace: testNS,
-		//			Verb:      "delete",
-		//			Resource:  brokerGVR,
-		//		},
-		//		Name: resources.DefaultBrokerName,
-		//	}, {
-		//		ActionImpl: clientgotesting.ActionImpl{
-		//			Namespace: testNS,
-		//			Verb:      "delete",
-		//			Resource:  roleBindingGVR,
-		//		},
-		//		Name: resources.RoleBindingName,
-		//	}, {
-		//		ActionImpl: clientgotesting.ActionImpl{
-		//			Namespace: testNS,
-		//			Verb:      "delete",
-		//			Resource:  serviceAccountGVR,
-		//		},
-		//		Name: resources.DefaultBrokerName,
-		//	}},
-		//},
-		// TODO: we need a existing default un-owned test.
+		WantCreates: []metav1.Object{
+			resources.MakeBroker(testNS),
+			resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
+		},
+	}, {
+		Name: "Namespace enabled, role binding exists",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+			),
+			resources.MakeRoleBinding(resources.MakeServiceAccount(testNS)),
+		},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "BrokerFilterServiceAccountCreated", "Service account created for the Broker 'eventing-broker-filter'"),
+			Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created."),
+			Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\""),
+		},
+		WantCreates: []metav1.Object{
+			resources.MakeBroker(testNS),
+			resources.MakeServiceAccount(testNS),
+		},
+	},
+	// TODO: we need a existing default un-owned test.
 	}
 
 	defer logtesting.ClearAll()

--- a/pkg/reconciler/namespace/resources/labels.go
+++ b/pkg/reconciler/namespace/resources/labels.go
@@ -21,12 +21,13 @@ const (
 	InjectionLabelKey           = "knative-eventing-injection"
 	InjectionEnabledLabelValue  = "enabled"
 	InjectionDisabledLabelValue = "disabled"
+	InjectedResourceLabel       = "eventing.knative.dev/namespaceInjected"
 )
 
 // OwnedLabels generates the labels present on injected broker resources.
 func OwnedLabels() map[string]string {
 	return map[string]string{
-		"eventing.knative.dev/namespaceInjected": "true",
+		InjectedResourceLabel: "true",
 	}
 }
 


### PR DESCRIPTION
Addressed few issues mentioned in #1080 

## Proposed Changes
- produces reconciliation successs/failure events
- unit test for cleaning up resources and default broker in namespace

cc @n3wscott 

