### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/eventing/pkg/reconciler/namespace/resources"
 	"github.com/knative/eventing/pkg/utils"
 	"github.com/knative/pkg/tracker"

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package namespace
 
 import (
-	"github.com/knative/pkg/tracker"
 	"testing"
+
+	"github.com/knative/pkg/tracker"
 
 	"github.com/knative/eventing/pkg/reconciler/namespace/resources"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
