### PR TITLE
Remove unneeded log keys.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/knative/eventing/pkg/reconciler/v1alpha1/broker"
 	"github.com/knative/pkg/configmap"
 	kncontroller "github.com/knative/pkg/controller"
-	"github.com/knative/pkg/logging/logkey"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
 	controllerruntime "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -57,7 +56,6 @@ func main() {
 
 	logger, atomicLevel := setupLogger()
 	defer logger.Sync()
-	logger = logger.With(zap.String(logkey.ControllerType, logconfig.Controller))
 
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.channelLister.Channels(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logging.FromContext(ctx).Error("channel key in work queue no longer exists", zap.Any("key", key))
+		logging.FromContext(ctx).Error("channel key in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err
@@ -106,12 +106,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		logging.FromContext(ctx).Warn("Error reconciling Channel", zap.Error(err))
 	} else {
-		logging.FromContext(ctx).Debug("Successfully reconciled Channel", zap.Any("key", key))
+		logging.FromContext(ctx).Debug("Successfully reconciled Channel")
 		r.Recorder.Eventf(channel, corev1.EventTypeNormal, channelReconciled, "Channel reconciled: %s", key)
 	}
 
 	if _, updateStatusErr := r.updateStatus(ctx, channel.DeepCopy()); updateStatusErr != nil {
-		logging.FromContext(ctx).Warn("Error updating Channel status", zap.Any("key", key), zap.Error(updateStatusErr))
+		logging.FromContext(ctx).Warn("Error updating Channel status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(channel, corev1.EventTypeWarning, channelUpdateStatusFailed, "Failed to update channel status: %s", key)
 		return updateStatusErr
 	}

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.channelLister.Channels(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logging.FromContext(ctx).Error("channel key in work queue no longer exists")
+		logging.FromContext(ctx).Error("Channel key in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// updates regardless of whether the reconcile error out.
 	err = r.reconcile(ctx, channel)
 	if err != nil {
-		logging.FromContext(ctx).Warn("Error reconciling Channel", zap.Error(err))
+		logging.FromContext(ctx).Error("Error reconciling Channel", zap.Error(err))
 	} else {
 		logging.FromContext(ctx).Debug("Successfully reconciled Channel")
 		r.Recorder.Eventf(channel, corev1.EventTypeNormal, channelReconciled, "Channel reconciled: %s", key)

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -106,7 +106,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-	ctx = logging.WithLogger(ctx, r.Logger.Desugar().With(zap.String("key", key)))
 
 	// Get the EventType resource with this namespace/name
 	original, err := r.eventTypeLister.EventTypes(namespace).Get(name)

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -130,7 +130,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.namespaceLister.Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logging.FromContext(ctx).Error("namespace key in work queue no longer exists", zap.Any("key", key))
+		logging.FromContext(ctx).Error("namespace key in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err
@@ -149,9 +149,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// whether the reconcile error out.
 	err = r.reconcile(ctx, ns)
 	if err != nil {
-		logging.FromContext(ctx).Error("Error reconciling Namespace", zap.Error(err), zap.Any("key", key))
+		logging.FromContext(ctx).Error("Error reconciling Namespace", zap.Error(err))
 	} else {
-		logging.FromContext(ctx).Debug("Namespace reconciled", zap.Any("key", key))
+		logging.FromContext(ctx).Debug("Namespace reconciled")
 	}
 
 	// Requeue if the resource is not ready:

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -107,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	original, err := r.subscriptionLister.Subscriptions(namespace).Get(name)
 	if apierrs.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logging.FromContext(ctx).Error("subscription key in work queue no longer exists", zap.Any("key", key))
+		logging.FromContext(ctx).Error("subscription key in work queue no longer exists")
 		return nil
 	} else if err != nil {
 		return err

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -135,8 +135,6 @@ func NewController(
 // converge the two. It then updates the Status block of the Trigger resource
 // with the current status of the resource.
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
-	ctx = logging.WithLogger(ctx, r.Logger.Desugar().With(zap.String("key", key)))
-
 	// Convert the namespace/name string into a distinct namespace and name.
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {

--- a/pkg/reconciler/v1alpha1/broker/broker.go
+++ b/pkg/reconciler/v1alpha1/broker/broker.go
@@ -146,7 +146,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-	ctx = logging.WithLogger(ctx, r.Logger.Desugar().With(zap.String("key", key)))
 
 	// Get the Broker resource with this namespace/name
 	original, err := r.brokerLister.Brokers(namespace).Get(name)


### PR DESCRIPTION
knative.dev/controller is set by pkg/reconciler just before calling our reconciler, so adding a second one in main is redundant and produced entries with:
{
    "knative.dev/controller": "controller",
    "knative.dev/controller": "trigger-controller",
}


Fixes #

## Proposed Changes

- Remove unneeded log keys.
  - knative.dev/controller is set by pkg/reconciler just before calling our reconciler, so adding a second one in main is redundant and produced entries with:
    ```json
    {
      "knative.dev/controller": "controller",
      "knative.dev/controller": "trigger-controller",
    }
    ```
  - The reconcile key is already saved as 'knative.dev/key' by pkg/reconciler, so we don't need to add 'key' as well.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
