### PR TITLE
Remove receive adapter images that are not needed

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -50,10 +50,6 @@ spec:
             value: github.com/knative/eventing/cmd/broker/filter
           - name: BROKER_FILTER_SERVICE_ACCOUNT
             value: eventing-broker-filter
-          - name: CRONJOB_RA_IMAGE
-            value: github.com/knative/eventing/cmd/cronjob_receive_adapter
-          - name: APISERVER_RA_IMAGE
-            value: github.com/knative/eventing/cmd/apiserver_receiver_adapter
         ports:
           - containerPort: 9090
             name: metrics


### PR DESCRIPTION
## Proposed Changes

- Remove receive adapter images that are only relevant for the eventing-sources controller, not the eventing controller.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
