### PR TITLE
Adding back statefulSet w/ 0 replicas

### DIFF
--- a/contrib/kafka/config/kafka.yaml
+++ b/contrib/kafka/config/kafka.yaml
@@ -212,3 +212,32 @@ spec:
         - name: kafka-channel-controller-config
           configMap:
             name: kafka-channel-controller-config
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-channel-dispatcher
+  namespace: knative-eventing
+spec:
+  replicas: 0
+  selector:
+    matchLabels: &labels
+      clusterChannelProvisioner: kafka
+      role: dispatcher
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: kafka-channel-dispatcher
+      containers:
+        - name: dispatcher
+          image: github.com/knative/eventing/contrib/kafka/cmd/dispatcher
+          volumeMounts:
+            - name: kafka-channel-controller-config
+              mountPath: /etc/config-provisioner
+      volumes:
+        - name: kafka-channel-controller-config
+          configMap:
+            name: kafka-channel-controller-config


### PR DESCRIPTION
Fixes #

## Proposed Changes

- deprecated kafka statefulset for the dispatcher
- temporarily scaling down to 0 replicas

**Release Note**

```release-note
The `StatefulSet` is now **deprecated** and will go away in 0.7.0 release. In this release it's replaced by a `Deployment` and the `StatefulSet` is scaled down to 0 replicas

Action Required: It is recommended to delete your old dispatcher
```
