### PR TITLE
Format markdown

### DIFF
--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -321,8 +321,8 @@ reconciles:
 ### Trigger
 
 `Trigger`s are reconciled by the
-[Trigger Reconciler](../../pkg/reconciler/trigger). For each `Trigger`,
-it reconciles:
+[Trigger Reconciler](../../pkg/reconciler/trigger). For each `Trigger`, it
+reconciles:
 
 1. Verify the Broker Exists
 1. Get the Broker's:
@@ -333,5 +333,6 @@ it reconciles:
    - Currently uses the same logic as the `Subscription` Reconciler, so supports
      Addressables and Kubernetes `Service`s.
 1. Creates a `Subscription` from the `Broker`'s 'trigger' `Channel` to the
-   `Trigger`'s Kubernetes `Service` using the HTTP path `/triggers/{namespace}/{name}`. Replies are sent to the `Broker`'s
-   'ingress' `Channel`.
+   `Trigger`'s Kubernetes `Service` using the HTTP path
+   `/triggers/{namespace}/{name}`. Replies are sent to the `Broker`'s 'ingress'
+   `Channel`.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -243,11 +243,11 @@ a Channel system that receives and delivers events._
 
 ### ChannelSubscriberSpec
 
-| Field         | Type            | Description                                                    | Constraints    |
-| ------------- | --------------- | -------------------------------------------------------------- | -------------- |
+| Field         | Type   | Description                                                        | Constraints    |
+| ------------- | ------ | ------------------------------------------------------------------ | -------------- |
 | uid           | String | The Subscription UID this ChannelSubscriberSpec was resolved from. |                |
-| subscriberURI | String          | The URI name of the endpoint for the subscriber.               | Must be a URL. |
-| replyURI      | String          | The URI name of the endpoint for the reply.                    | Must be a URL. |
+| subscriberURI | String | The URI name of the endpoint for the subscriber.                   | Must be a URL. |
+| replyURI      | String | The URI name of the endpoint for the reply.                        | Must be a URL. |
 
 ### ReplyStrategy
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`