### PR TITLE
golang format tools

### DIFF
--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -67,7 +67,7 @@ type testCase struct {
 
 func TestReconcile(t *gotesting.T) {
 	table := []testCase{
-		testCase{
+		{
 			Name: "Receive Pod creation event",
 			InitialState: []runtime.Object{
 				getPod(),

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -101,7 +101,7 @@ func TestReconcile(t *testing.T) {
 				NewApiServerSource(sourceName, testNS,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
-							sourcesv1alpha1.ApiServerResource{
+							{
 								APIVersion: "",
 								Kind:       "Namespace",
 							},
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 				Object: NewApiServerSource(sourceName, testNS,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
-							sourcesv1alpha1.ApiServerResource{
+							{
 								APIVersion: "",
 								Kind:       "Namespace",
 							},
@@ -178,7 +178,7 @@ func makeReceiveAdapter() *appsv1.Deployment {
 	source := NewApiServerSource(sourceName, testNS,
 		WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 			Resources: []sourcesv1alpha1.ApiServerResource{
-				sourcesv1alpha1.ApiServerResource{
+				{
 					APIVersion: "",
 					Kind:       "Namespace",
 				},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -35,11 +35,11 @@ func TestMakeReceiveAdapter(t *testing.T) {
 		Spec: v1alpha1.ApiServerSourceSpec{
 			ServiceAccountName: "source-svc-acct",
 			Resources: []v1alpha1.ApiServerResource{
-				v1alpha1.ApiServerResource{
+				{
 					APIVersion: "",
 					Kind:       "Namespace",
 				},
-				v1alpha1.ApiServerResource{
+				{
 					APIVersion: "",
 					Kind:       "Pod",
 					Controller: true,


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
