### PR TITLE
Remove Knative Serving installation step

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,9 +50,6 @@ readonly NATSS_CONFIG="contrib/natss/config/provisioner.yaml"
 
 # Setup the Knative environment for running tests.
 function knative_setup() {
-  # Install the latest stable Knative/serving in the current cluster.
-  start_latest_knative_serving || return 1
-
   # Install the latest Knative/eventing in the current cluster.
   echo ">> Starting Knative Eventing"
   echo "Installing Knative Eventing"
@@ -88,7 +85,7 @@ function test_setup() {
   # Publish test images.
   echo ">> Publishing test images"
   $(dirname $0)/upload-test-images.sh e2e || fail_test "Error uploading test images"
-}
+}   
 
 # Tear down resources used in the eventing tests.
 function test_teardown() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -85,7 +85,7 @@ function test_setup() {
   # Publish test images.
   echo ">> Publishing test images"
   $(dirname $0)/upload-test-images.sh e2e || fail_test "Error uploading test images"
-}   
+}
 
 # Tear down resources used in the eventing tests.
 function test_teardown() {


### PR DESCRIPTION
## Proposed Changes
We do not need to install Knative Serving for the e2e tests anymore after completely getting rid of Istio dependency.