### PR TITLE
in-memory Channels are asynchronous

### DIFF
--- a/cmd/fanoutsidecar/main.go
+++ b/cmd/fanoutsidecar/main.go
@@ -124,14 +124,17 @@ func main() {
 func setupChannelWatcher(logger *zap.Logger, configUpdated swappable.UpdateConfig) (manager.Manager, error) {
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
-		logger.Error("Error creating new maanger.", zap.Error(err))
+		logger.Error("Error creating new manager.", zap.Error(err))
 		return nil, err
 	}
 	if err = v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
 		logger.Error("Error while adding eventing scheme to manager.", zap.Error(err))
 		return nil, err
 	}
-	channelwatcher.New(mgr, logger, channelwatcher.UpdateConfigWatchHandler(configUpdated, shouldWatch))
+	if err = channelwatcher.New(mgr, logger, channelwatcher.UpdateConfigWatchHandler(configUpdated, shouldWatch)); err != nil {
+		logger.Error("Error making the channel watcher: %s", zap.Error(err))
+		return nil, err
+	}
 
 	return mgr, nil
 }

--- a/pkg/channelwatcher/channel_watcher.go
+++ b/pkg/channelwatcher/channel_watcher.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package channelwatcher
 
 import (

--- a/pkg/channelwatcher/channel_watcher_test.go
+++ b/pkg/channelwatcher/channel_watcher_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	controllertesting "github.com/knative/eventing/pkg/reconciler/testing"
 	"github.com/knative/eventing/pkg/sidecar/fanout"
@@ -31,8 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 )
 
 func init() {
@@ -73,6 +72,7 @@ func TestUpdateConfigWatchHandler(t *testing.T) {
 						Namespace: "ns-1",
 						HostName:  "e.f.g.h",
 						FanoutConfig: fanout.Config{
+							AsyncHandler: true,
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								makeSubscriber("sub1"),
 								makeSubscriber("sub2"),
@@ -83,6 +83,7 @@ func TestUpdateConfigWatchHandler(t *testing.T) {
 						Namespace: "ns-2",
 						HostName:  "i.j.k.l",
 						FanoutConfig: fanout.Config{
+							AsyncHandler: true,
 							Subscriptions: []eventingduck.ChannelSubscriberSpec{
 								makeSubscriber("sub3"),
 								makeSubscriber("sub4"),

--- a/pkg/sidecar/multichannelfanout/config.go
+++ b/pkg/sidecar/multichannelfanout/config.go
@@ -44,8 +44,18 @@ func NewConfigFromChannels(channels []v1alpha1.Channel) *Config {
 			Name:      c.Name,
 			HostName:  c.Status.Address.Hostname,
 		}
+
+		asyncHandler := true
+		// This is fairly hacky, but this is expected to change from a generic fanout sidecar to the
+		// in-memory dispatcher. And `in-memory-channel` is to be deleted in 0.7, so this shouldn't
+		// be here for long.
+		if c.Spec.Provisioner != nil && c.Spec.Provisioner.Name == "in-memory-channel" {
+			asyncHandler = false
+		}
+
 		if c.Spec.Subscribable != nil {
 			channelConfig.FanoutConfig = fanout.Config{
+				AsyncHandler:  asyncHandler,
 				Subscriptions: c.Spec.Subscribable.Subscribers,
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

- `in-memory` Channels are asynchronous.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
