### PR TITLE
Use kmeta.NewControllerRef 

### DIFF
--- a/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -120,4 +121,13 @@ type ClusterChannelProvisionerList struct {
 	metav1.ListMeta `json:"metadata"`
 
 	Items []ClusterChannelProvisioner `json:"items"`
+}
+
+// GetGroupVersionKind return GroupVersionKind for ClusterChannelProvisioner
+func (ccp *ClusterChannelProvisioner) GetGroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    "ClusterChannelProvisioner",
+	}
 }

--- a/pkg/provisioners/provisioner_util.go
+++ b/pkg/provisioners/provisioner_util.go
@@ -3,12 +3,12 @@ package provisioners
 import (
 	"context"
 
+	"github.com/knative/pkg/kmeta"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,11 +67,7 @@ func newDispatcherService(ccp *eventingv1alpha1.ClusterChannelProvisioner, opts 
 			Namespace: system.Namespace(),
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(ccp, schema.GroupVersionKind{
-					Group:   eventingv1alpha1.SchemeGroupVersion.Group,
-					Version: eventingv1alpha1.SchemeGroupVersion.Version,
-					Kind:    "ClusterChannelProvisioner",
-				}),
+				*kmeta.NewControllerRef(ccp),
 			},
 		},
 		Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Fix [1160](https://github.com/knative/eventing/issues/1160)

## Proposed Changes

- Add function `GetGroupVersionKind()` for struct `ClusterChannelProvisioner`


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
