### PR TITLE
Include the Trigger's UID in the Trigger's path

### DIFF
--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -19,6 +19,7 @@ package broker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -201,7 +202,7 @@ func (r *Receiver) getTrigger(ctx context.Context, ref path.NamespacedNameUID) (
 		return nil, err
 	}
 	if t.UID != ref.UID {
-		return nil, errors.New("trigger had a different UID")
+		return nil, fmt.Errorf("trigger had a different UID. From ref '%s'. From Kubernetes '%s'", ref.UID, t.UID)
 	}
 	return t, nil
 }

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -43,6 +43,7 @@ import (
 const (
 	testNS      = "test-namespace"
 	triggerName = "test-trigger"
+	triggerUID  = "test-trigger-uid"
 	eventType   = `com.example.someevent`
 	eventSource = `/mycontext`
 
@@ -51,7 +52,7 @@ const (
 
 var (
 	host      = fmt.Sprintf("%s.%s.triggers.%s", triggerName, testNS, utils.GetClusterDomainName())
-	validPath = fmt.Sprintf("/triggers/%s/%s", testNS, triggerName)
+	validPath = fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID)
 )
 
 func init() {
@@ -371,6 +372,7 @@ func makeTrigger(t, s string) *eventingv1alpha1.Trigger {
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: testNS,
 			Name:      triggerName,
+			UID:       triggerUID,
 		},
 		Spec: eventingv1alpha1.TriggerSpec{
 			Filter: &eventingv1alpha1.TriggerFilter{

--- a/pkg/reconciler/testing/trigger.go
+++ b/pkg/reconciler/testing/trigger.go
@@ -23,6 +23,7 @@ import (
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // TriggerOption enables further configuration of a Trigger.
@@ -105,4 +106,10 @@ func WithTriggerStatusSubscriberURI(uri string) TriggerOption {
 func WithTriggerDeleted(t *v1alpha1.Trigger) {
 	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
 	t.ObjectMeta.SetDeletionTimestamp(&deleteTime)
+}
+
+func WithTriggerUID(uid string) TriggerOption {
+	return func(t *v1alpha1.Trigger) {
+		t.UID = types.UID(uid)
+	}
 }

--- a/pkg/reconciler/trigger/path/path.go
+++ b/pkg/reconciler/trigger/path/path.go
@@ -34,8 +34,8 @@ func Generate(t *v1alpha1.Trigger) string {
 }
 
 type NamespacedNameUID struct {
-	NamespacedName types.NamespacedName
-	UID            types.UID
+	types.NamespacedName
+	UID types.UID
 }
 
 // Parse parses the Path portion of a URI to determine which Trigger the request corresponds to. It

--- a/pkg/reconciler/trigger/path/path.go
+++ b/pkg/reconciler/trigger/path/path.go
@@ -30,24 +30,32 @@ const (
 
 // Generate generates the Path portion of a URI to send events to the given Trigger.
 func Generate(t *v1alpha1.Trigger) string {
-	return fmt.Sprintf("/%s/%s/%s", prefix, t.Namespace, t.Name)
+	return fmt.Sprintf("/%s/%s/%s/%s", prefix, t.Namespace, t.Name, t.UID)
+}
+
+type NamespacedNameUID struct {
+	NamespacedName types.NamespacedName
+	UID            types.UID
 }
 
 // Parse parses the Path portion of a URI to determine which Trigger the request corresponds to. It
-// is expected to be in the form "/triggers/namespace/name".
-func Parse(path string) (types.NamespacedName, error) {
+// is expected to be in the form "/triggers/namespace/name/uid".
+func Parse(path string) (NamespacedNameUID, error) {
 	parts := strings.Split(path, "/")
-	if len(parts) != 4 {
-		return types.NamespacedName{}, fmt.Errorf("incorrect number of parts in the path, expected 4, actual %d, '%s'", len(parts), path)
+	if len(parts) != 5 {
+		return NamespacedNameUID{}, fmt.Errorf("incorrect number of parts in the path, expected 5, actual %d, '%s'", len(parts), path)
 	}
 	if parts[0] != "" {
-		return types.NamespacedName{}, fmt.Errorf("text before the first slash, actual '%s'", path)
+		return NamespacedNameUID{}, fmt.Errorf("text before the first slash, actual '%s'", path)
 	}
 	if parts[1] != prefix {
-		return types.NamespacedName{}, fmt.Errorf("incorrect prefix, expected '%s', actual '%s'", prefix, path)
+		return NamespacedNameUID{}, fmt.Errorf("incorrect prefix, expected '%s', actual '%s'", prefix, path)
 	}
-	return types.NamespacedName{
-		Namespace: parts[2],
-		Name:      parts[3],
+	return NamespacedNameUID{
+		NamespacedName: types.NamespacedName{
+			Namespace: parts[2],
+			Name:      parts[3],
+		},
+		UID: types.UID(parts[4]),
 	}, nil
 }

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -47,6 +47,7 @@ import (
 const (
 	testNS      = "test-namespace"
 	triggerName = "test-trigger"
+	triggerUID  = "test-trigger-uid"
 	brokerName  = "test-broker"
 
 	subscriberAPIVersion = "v1"
@@ -115,6 +116,7 @@ func TestAllCases(t *testing.T) {
 			//			Name: "trigger key not found ",
 			//			Objects: []runtime.Object{
 			//				reconciletesting.NewTrigger(triggerName, testNS),
+			//					reconciletesting.WithTriggerUID(triggerUID),
 			//			},
 			//			Key:     "foo/incomplete",
 			//			WantErr: true,
@@ -126,6 +128,7 @@ func TestAllCases(t *testing.T) {
 			Key:  triggerKey,
 			Objects: []runtime.Object{
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI)),
 			},
 			WantErr: true,
@@ -134,6 +137,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -145,6 +149,7 @@ func TestAllCases(t *testing.T) {
 			Key:  triggerKey,
 			Objects: []runtime.Object{
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI)),
 			},
 			WantErr: true,
@@ -156,6 +161,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -167,6 +173,7 @@ func TestAllCases(t *testing.T) {
 			Key:  triggerKey,
 			Objects: []runtime.Object{
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 					reconciletesting.WithTriggerDeleted),
@@ -181,6 +188,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				makeReadyBroker(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -192,6 +200,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -205,6 +214,7 @@ func TestAllCases(t *testing.T) {
 				makeReadyBroker(),
 				makeTriggerChannel(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -216,6 +226,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -230,6 +241,7 @@ func TestAllCases(t *testing.T) {
 				makeTriggerChannel(),
 				makeIngressChannel(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -241,6 +253,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -256,6 +269,7 @@ func TestAllCases(t *testing.T) {
 				makeIngressChannel(),
 				makeBrokerFilterService(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -269,6 +283,7 @@ func TestAllCases(t *testing.T) {
 				Eventf(corev1.EventTypeWarning, "TriggerReconcileFailed", "Trigger reconciliation failed: inducing failure for create subscriptions")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -290,6 +305,7 @@ func TestAllCases(t *testing.T) {
 				makeBrokerFilterService(),
 				makeDifferentReadySubscription(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -303,6 +319,7 @@ func TestAllCases(t *testing.T) {
 				Eventf(corev1.EventTypeWarning, "TriggerReconcileFailed", "Trigger reconciliation failed: inducing failure for delete subscriptions")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -326,6 +343,7 @@ func TestAllCases(t *testing.T) {
 				makeBrokerFilterService(),
 				makeDifferentReadySubscription(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -339,6 +357,7 @@ func TestAllCases(t *testing.T) {
 				Eventf(corev1.EventTypeWarning, "TriggerReconcileFailed", "Trigger reconciliation failed: inducing failure for create subscriptions")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -365,6 +384,7 @@ func TestAllCases(t *testing.T) {
 				makeBrokerFilterService(),
 				makeDifferentReadySubscription(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -375,6 +395,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -400,6 +421,7 @@ func TestAllCases(t *testing.T) {
 				makeIngressChannel(),
 				makeBrokerFilterService(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -410,6 +432,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -431,6 +454,7 @@ func TestAllCases(t *testing.T) {
 				makeBrokerFilterService(),
 				makeNotReadySubscription(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -441,6 +465,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -459,6 +484,7 @@ func TestAllCases(t *testing.T) {
 				makeBrokerFilterService(),
 				makeReadySubscription(),
 				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
 				),
@@ -469,6 +495,7 @@ func TestAllCases(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
@@ -505,6 +532,7 @@ func makeTrigger() *v1alpha1.Trigger {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNS,
 			Name:      triggerName,
+			UID:       triggerUID,
 		},
 		Spec: v1alpha1.TriggerSpec{
 			Broker: brokerName,
@@ -615,7 +643,7 @@ func makeServiceURI() *url.URL {
 	return &url.URL{
 		Scheme: "http",
 		Host:   fmt.Sprintf("%s.%s.svc.%s", makeBrokerFilterService().Name, testNS, utils.GetClusterDomainName()),
-		Path:   fmt.Sprintf("/triggers/%s/%s", testNS, triggerName),
+		Path:   fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID),
 	}
 }
 


### PR DESCRIPTION


Fixes #1153

## Proposed Changes

- Include the Trigger's UID in the Trigger's path, to make sure the filter Deployment doesn't accidentally use an old, now deleted, Trigger's spec.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
