### PR TITLE
Check that ClusterChannelProvisioner is OwnerRefable

### DIFF
--- a/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/kmeta"
 	"github.com/knative/pkg/webhook"
 )
 
@@ -50,6 +51,7 @@ var _ apis.Validatable = (*ClusterChannelProvisioner)(nil)
 var _ apis.Defaultable = (*ClusterChannelProvisioner)(nil)
 var _ runtime.Object = (*ClusterChannelProvisioner)(nil)
 var _ webhook.GenericCRD = (*ClusterChannelProvisioner)(nil)
+var _ kmeta.OwnerRefable = (*ClusterChannelProvisioner)(nil)
 
 // ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.
 type ClusterChannelProvisionerSpec struct {


### PR DESCRIPTION
Follow [1168](https://github.com/knative/eventing/pull/1168)

## Proposed Changes

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
