### PR TITLE
fix minor quote issue for json tag.

### DIFF
--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -42,11 +42,9 @@ spec:
     - name: Broker
       type: string
       JSONPath: ".spec.broker"
-    # weird bug with Description, if it doesn't start with a capital letter,
-    # it is not rendered in the kubectl output.
     - name: Description
       type: string
-      JSONPath: ".spec.Description"
+      JSONPath: ".spec.description"
     - name: Ready
       type: string
       JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"

--- a/pkg/apis/eventing/v1alpha1/eventtype_types.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_types.go
@@ -61,7 +61,7 @@ type EventTypeSpec struct {
 	Broker string `json:"broker"`
 	// Description is an optional field used to describe the EventType, in any meaningful way.
 	// +optional
-	Description string `json:description,omitempty`
+	Description string `json:"description,omitempty"`
 }
 
 // EventTypeStatus represents the current state of a EventType.


### PR DESCRIPTION
## Proposed Changes

- the json tag needs internal double quotes. Added them.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nachocano 
