### PR TITLE
Polish GetGroupVersionKind for Broker/Channel/ClusterChannelProvisioner/Trigger

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -85,9 +85,5 @@ type BrokerList struct {
 
 // GetGroupVersionKind returns GroupVersionKind for Brokers
 func (t *Broker) GetGroupVersionKind() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "Broker",
-	}
+	return SchemeGroupVersion.WithKind("Broker")
 }

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -109,9 +109,5 @@ type ChannelList struct {
 
 // GetGroupVersionKind returns GroupVersionKind for Channels
 func (c *Channel) GetGroupVersionKind() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "Channel",
-	}
+	return SchemeGroupVersion.WithKind("Channel")
 }

--- a/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
+++ b/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go
@@ -127,9 +127,5 @@ type ClusterChannelProvisionerList struct {
 
 // GetGroupVersionKind return GroupVersionKind for ClusterChannelProvisioner
 func (ccp *ClusterChannelProvisioner) GetGroupVersionKind() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "ClusterChannelProvisioner",
-	}
+	return SchemeGroupVersion.WithKind("ClusterChannelProvisioner")
 }

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -100,9 +100,5 @@ type TriggerList struct {
 
 // GetGroupVersionKind returns GroupVersionKind for Triggers
 func (t *Trigger) GetGroupVersionKind() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    "Trigger",
-	}
+	return SchemeGroupVersion.WithKind("Trigger")
 }


### PR DESCRIPTION
Use `SchemeGroupVersion.WithKind()` to implement `GetGroupVersionKind`.

## Proposed Changes

-
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
