### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/trigger/resources/subscription.go
+++ b/pkg/reconciler/trigger/resources/subscription.go
@@ -18,8 +18,9 @@ package resources
 
 import (
 	"fmt"
-	"github.com/knative/pkg/kmeta"
 	"net/url"
+
+	"github.com/knative/pkg/kmeta"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
