### PR TITLE
Add tracing to NATSS Channels, by watching the config-tracing ConfigMap.

### DIFF
--- a/contrib/natss/config/provisioner.yaml
+++ b/contrib/natss/config/provisioner.yaml
@@ -149,6 +149,39 @@ roleRef:
 
 ---
 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: natss-dispatcher
+  namespace: knative-eventing
+rules:
+  - apiGroups:
+      - "" # Core API group.
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: natss-channel-dispatcher
+  namespace: knative-eventing
+subjects:
+  - kind: ServiceAccount
+    name: natss-dispatcher
+    namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: natss-dispatcher
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Helps with #704.

## Proposed Changes

- Add Zipkin tracing support to the NATSS Channel dispatcher.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
An additional RBAC permission is needed by the `natss-dispatcher`. You need to apply `contrib/natss/config/provisioner.yaml` to grant it.
```
