### PR TITLE
Natss broker doesn't require istio injectin enabled

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -164,7 +164,6 @@ function gcppubsub_teardown() {
 function natss_setup() {
   echo "Installing NATS Streaming"
   kubectl create namespace natss || return 1
-  kubectl label namespace natss istio-injection=enabled || return 1
   kubectl apply -n natss -f ${NATSS_INSTALLATION_CONFIG} || return 1
   wait_until_pods_running natss || fail_test "Failed to start up a NATSS cluster"
 }


### PR DESCRIPTION
## Proposed Changes

- Quick fix to remove istio injection in namespace that has the natss instance. This was fixed as part of removing istio dependency in Eventing, and documentation was updated. But I guess it slipped into tests around the same time
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
