### PR TITLE
golang format tools

### DIFF
--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package apiserver
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	kncetesting "github.com/knative/eventing/pkg/kncloudevents/testing"
 	rectesting "github.com/knative/eventing/pkg/reconciler/testing"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"testing"
 )
 
 func TestNewAdaptor(t *testing.T) {

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package events_test
 
 import (
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/adapter/apiserver/ref.go
+++ b/pkg/adapter/apiserver/ref.go
@@ -18,11 +18,12 @@ package apiserver
 
 import (
 	"context"
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
-	"reflect"
 
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/knative/eventing/pkg/adapter/apiserver/events"

--- a/pkg/adapter/apiserver/ref_test.go
+++ b/pkg/adapter/apiserver/ref_test.go
@@ -1,9 +1,10 @@
 package apiserver
 
 import (
+	"testing"
+
 	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 func TestRefAddEvent(t *testing.T) {

--- a/pkg/adapter/apiserver/resource.go
+++ b/pkg/adapter/apiserver/resource.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+
 	cloudevents "github.com/cloudevents/sdk-go"
 	"github.com/knative/eventing/pkg/adapter/apiserver/events"
 	"go.uber.org/zap"

--- a/pkg/adapter/apiserver/resource_test.go
+++ b/pkg/adapter/apiserver/resource_test.go
@@ -1,9 +1,10 @@
 package apiserver
 
 import (
+	"testing"
+
 	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"testing"
 )
 
 func TestResourceAddEvent(t *testing.T) {

--- a/pkg/kncloudevents/testing/test_client.go
+++ b/pkg/kncloudevents/testing/test_client.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+
 	cloudevents "github.com/cloudevents/sdk-go"
 )
 

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -18,10 +18,11 @@ package apiserversource
 
 import (
 	"fmt"
-	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"testing"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/tracing/setup.go
+++ b/pkg/tracing/setup.go
@@ -22,7 +22,7 @@ import (
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/tracing"
 	tracingconfig "github.com/knative/pkg/tracing/config"
-	"github.com/openzipkin/zipkin-go"
+	zipkin "github.com/openzipkin/zipkin-go"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
