### PR TITLE
Changing Source in CronJob

### DIFF
--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -40,6 +40,9 @@ type envConfig struct {
 
 	// Environment variable containing the name of the cron job.
 	Name string `envconfig:"NAME" required:"true"`
+
+	// Environment variable containing the namespace of the cron job.
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
 }
 
 func main() {
@@ -59,10 +62,11 @@ func main() {
 	}
 
 	adapter := &cronjobevents.Adapter{
-		Schedule: env.Schedule,
-		Data:     env.Data,
-		SinkURI:  env.Sink,
-		Name:     env.Name,
+		Schedule:  env.Schedule,
+		Data:      env.Data,
+		SinkURI:   env.Sink,
+		Name:      env.Name,
+		Namespace: env.Namespace,
 	}
 
 	logger.Info("Starting Receive Adapter", zap.Reflect("adapter", adapter))

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -44,6 +44,9 @@ type Adapter struct {
 	// Name is the name of the Cron Job.
 	Name string
 
+	// Namespace is the namespace of the Cron Job.
+	Namespace string
+
 	// client sends cloudevents.
 	client cloudevents.Client
 }
@@ -87,7 +90,7 @@ func (a *Adapter) cronTick() {
 
 	event := cloudevents.NewEvent(cloudevents.VersionV02)
 	event.SetType(sourcesv1alpha1.CronJobEventType)
-	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Name))
+	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))
 
 	if _, err := a.client.Send(context.TODO(), event); err != nil {

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -87,9 +87,8 @@ func (a *Adapter) cronTick() {
 
 	event := cloudevents.NewEvent(cloudevents.VersionV02)
 	event.SetType(sourcesv1alpha1.CronJobEventType)
-	event.SetSource(sourcesv1alpha1.CronJobEventSource)
+	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Name))
 	event.SetData(message(a.Data))
-	event.SetSubject(a.Name)
 
 	if _, err := a.client.Send(context.TODO(), event); err != nil {
 		logger.Error("failed to send cloudevent", err)

--- a/pkg/apis/sources/v1alpha1/cron_job_types.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/kmeta"
@@ -55,13 +56,15 @@ var (
 const (
 	// CronJobEventType is the CronJob CloudEvent type.
 	CronJobEventType = "dev.knative.cronjob.event"
-	// CronJobEventSource is the CronJob CloudEvent source.
-	CronJobEventSource = "/CronJob"
 )
+
+// CronJobEventSource returns the CronJob CloudEvent source.
+func CronJobEventSource(cronJobName string) string {
+	return fmt.Sprintf("urn:cronjob:%s", cronJobName)
+}
 
 // CronJobSourceSpec defines the desired state of the CronJobSource.
 type CronJobSourceSpec struct {
-
 	// Schedule is the cronjob schedule.
 	// +required
 	Schedule string `json:"schedule"`

--- a/pkg/apis/sources/v1alpha1/cron_job_types.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_types.go
@@ -59,8 +59,8 @@ const (
 )
 
 // CronJobEventSource returns the CronJob CloudEvent source.
-func CronJobEventSource(cronJobName string) string {
-	return fmt.Sprintf("urn:cronjob:%s", cronJobName)
+func CronJobEventSource(namespace, cronJobName string) string {
+	return fmt.Sprintf("/apis/v1/namespaces/%s/cronjobsources/%s", namespace, cronJobName)
 }
 
 // CronJobSourceSpec defines the desired state of the CronJobSource.

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -226,10 +226,9 @@ func TestAllCases(t *testing.T) {
 					WithEventTypeGenerateName(fmt.Sprintf("%s-", utils.ToDNS1123Subdomain(sourcesv1alpha1.CronJobEventType))),
 					WithEventTypeLabels(resources.Labels(sourceName)),
 					WithEventTypeType(sourcesv1alpha1.CronJobEventType),
-					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource),
+					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource(sourceName)),
 					WithEventTypeBroker(sinkName),
-					WithEventTypeOwnerReference(ownerRef),
-					WithEventTypeDescription(sourceName)),
+					WithEventTypeOwnerReference(ownerRef)),
 				makeReceiveAdapterWithSink(brokerRef),
 			},
 		}, {

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -226,7 +226,7 @@ func TestAllCases(t *testing.T) {
 					WithEventTypeGenerateName(fmt.Sprintf("%s-", utils.ToDNS1123Subdomain(sourcesv1alpha1.CronJobEventType))),
 					WithEventTypeLabels(resources.Labels(sourceName)),
 					WithEventTypeType(sourcesv1alpha1.CronJobEventType),
-					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource(sourceName)),
+					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource(testNS, sourceName)),
 					WithEventTypeBroker(sinkName),
 					WithEventTypeOwnerReference(ownerRef)),
 				makeReceiveAdapterWithSink(brokerRef),

--- a/pkg/reconciler/cronjobsource/resources/eventtype.go
+++ b/pkg/reconciler/cronjobsource/resources/eventtype.go
@@ -40,7 +40,7 @@ func MakeEventType(src *v1alpha1.CronJobSource) *eventingv1alpha1.EventType {
 		},
 		Spec: eventingv1alpha1.EventTypeSpec{
 			Type:   v1alpha1.CronJobEventType,
-			Source: v1alpha1.CronJobEventSource(src.Name),
+			Source: v1alpha1.CronJobEventSource(src.Namespace, src.Name),
 			Broker: src.Spec.Sink.Name,
 		},
 	}

--- a/pkg/reconciler/cronjobsource/resources/eventtype.go
+++ b/pkg/reconciler/cronjobsource/resources/eventtype.go
@@ -39,10 +39,9 @@ func MakeEventType(src *v1alpha1.CronJobSource) *eventingv1alpha1.EventType {
 			},
 		},
 		Spec: eventingv1alpha1.EventTypeSpec{
-			Type:        v1alpha1.CronJobEventType,
-			Source:      v1alpha1.CronJobEventSource,
-			Broker:      src.Spec.Sink.Name,
-			Description: src.Name,
+			Type:   v1alpha1.CronJobEventType,
+			Source: v1alpha1.CronJobEventSource(src.Name),
+			Broker: src.Spec.Sink.Name,
 		},
 	}
 }

--- a/pkg/reconciler/cronjobsource/resources/receive_adapter.go
+++ b/pkg/reconciler/cronjobsource/resources/receive_adapter.go
@@ -82,6 +82,10 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 									Name:  "NAME",
 									Value: args.Source.Name,
 								},
+								{
+									Name:  "NAMESPACE",
+									Value: args.Source.Namespace,
+								},
 							},
 						},
 					},

--- a/pkg/reconciler/cronjobsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/cronjobsource/resources/receive_adapter_test.go
@@ -106,6 +106,10 @@ func TestMakeReceiveAdapter(t *testing.T) {
 									Name:  "NAME",
 									Value: "source-name",
 								},
+								{
+									Name:  "NAMESPACE",
+									Value: "source-namespace",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Helps fixing https://github.com/knative/eventing/issues/929

## Proposed Changes

- Change the CloudEvent source we are currently setting in CronJobSource. 
- /CronJob is somewhat useless to have as source, given that we have the CloudEvent type that indicates that. 
- As we are probably not going to include advanced filtering in 0.6 to, for example, filter on subject, then we should be more careful of what we put in source.
- Setting it to be:  /apis/v1/namespaces/<namespace>/cronjobsources/<cronjobname>

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Upon instantiation of a CronJobSource, it will register its EventType. This a breaking change in the sense that we were previously populating the CloudEvent source attribute with "/CronJob". Now we use "/apis/v1/namespaces/<namespace>/cronjobsources/<cronjobname>". If Triggers were created filtering on source "/CronJob", a equivalent solution now would be to filter only on type "dev.knative.cronjob.event".
```
