### PR TITLE
Cleanup the gke import lines. Used for off cluster gke connections.

### DIFF
--- a/cmd/apiserver_receive_adapter/main.go
+++ b/cmd/apiserver_receive_adapter/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
+
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/knative/eventing/pkg/adapter/apiserver"

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	informers "github.com/knative/eventing/pkg/client/informers/externalversions"
 	"github.com/knative/eventing/pkg/logconfig"

--- a/cmd/in_memory/controller/main.go
+++ b/cmd/in_memory/controller/main.go
@@ -19,8 +19,10 @@ package main
 import (
 	"flag"
 
-	"github.com/knative/eventing/pkg/provisioners/inmemory/channel"
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
+	"github.com/knative/eventing/pkg/provisioners/inmemory/channel"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"
 	"github.com/knative/eventing/pkg/provisioners/inmemory/clusterchannelprovisioner"
@@ -28,8 +30,6 @@ import (
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {

--- a/cmd/in_memory/dispatcher/main.go
+++ b/cmd/in_memory/dispatcher/main.go
@@ -25,6 +25,9 @@ import (
 	"strings"
 	"time"
 
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/channelwatcher"
 	"github.com/knative/eventing/pkg/provisioners/swappable"
@@ -38,8 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 const (

--- a/cmd/sources_controller/main.go
+++ b/cmd/sources_controller/main.go
@@ -21,11 +21,9 @@ import (
 	"github.com/knative/eventing/pkg/metrics"
 	"log"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
-	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/rest"
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	informers "github.com/knative/eventing/pkg/client/informers/externalversions"
 	"github.com/knative/eventing/pkg/logconfig"
 	"github.com/knative/eventing/pkg/logging"
@@ -39,6 +37,8 @@ import (
 	pkgmetrics "github.com/knative/pkg/metrics"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"os"
 
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	provisionerController "github.com/knative/eventing/contrib/kafka/pkg/controller"
 	"github.com/knative/eventing/contrib/kafka/pkg/controller/channel"
 	eventingv1alpha "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
@@ -15,8 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // SchemeFunc adds types to a Scheme.

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -50,10 +50,10 @@ type ObservabilityConfig struct {
 	// collect logs under /var/log/.
 	EnableVarLogCollection bool
 
-	// TODO(#818): Use the fluentd daemon set to collect /var/log.
-	// FluentdSidecarImage is the name of the image used for the fluentd sidecar
-	// injected into the revision pod. It is used only when enableVarLogCollection
-	// is true.
+	// TODO(https://github.com/knative/serving/issues/818): Use the fluentd
+	//  daemon set to collect /var/log. FluentdSidecarImage is the name of the
+	//  image used for the fluentd sidecar injected into the revision pod. It
+	//  is used only when enableVarLogCollection is true.
 	FluentdSidecarImage string
 
 	// FluentdSidecarOutputConfig is the config for fluentd sidecar to specify


### PR DESCRIPTION
Follow-up to #1200 

## Proposed Changes

- Cleanup the gke import lines. Used for off cluster gke connections. (Clean up the nits added to #1200)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
