### PR TITLE
add system integrator persona

### DIFF
--- a/docs/personas.md
+++ b/docs/personas.md
@@ -31,6 +31,16 @@ User stories:
 - Publish events
 - Control who can create Feeds
 
+### System Integrator
+
+System Integrators are typically of two varieties. They are producing new Channel
+implmmentations or new Event Source implementations.
+
+User stories:
+
+- Create a new Event Source (creating a bridge between an existing system and Knative Eventing)
+- Create a new CHannel implementation
+
 ## Contributors
 
 Contributors are an important part of the Knative project. As such, we will also


### PR DESCRIPTION

## Proposed Changes

- Add System Integrator persona. Quite often I find myself thinking of a person that's creating a new Channel type, or a new Event source and they feel like a distinct personal that's currently missing from the personal document. So, here's one proposal to fix that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add 'System Integrator' as a persona.
```
