### PR TITLE
Reconcile EventType upon Source change

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -263,14 +263,14 @@ func (r *Reconciler) createEventTypes(ctx context.Context, src *v1alpha1.ApiServ
 
 	for _, eventType := range extra {
 		if err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Delete(eventType.Name, &metav1.DeleteOptions{}); err != nil {
-			logging.FromContext(ctx).Info("Error deleting eventType", zap.Any("eventType", eventType))
+			logging.FromContext(ctx).Error("Error deleting eventType", zap.Any("eventType", eventType))
 			return err
 		}
 	}
 
 	for _, eventType := range missing {
 		if _, err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Create(&eventType); err != nil {
-			logging.FromContext(ctx).Info("Error creating eventType", zap.Any("eventType", eventType))
+			logging.FromContext(ctx).Error("Error creating eventType", zap.Any("eventType", eventType))
 			return err
 		}
 	}

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -254,6 +254,66 @@ func TestReconcile(t *testing.T) {
 				makeReceiveAdapter(),
 			},
 		},
+		{
+			Name: "valid with broker sink and event types to delete",
+			Objects: []runtime.Object{
+				NewApiServerSource(sourceName, testNS,
+					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
+						Resources: []sourcesv1alpha1.ApiServerResource{
+							{
+								APIVersion: "",
+								Kind:       "Namespace",
+							},
+						},
+						Sink: &brokerRef,
+					}),
+				),
+				NewBroker(sinkName, testNS,
+					WithInitBrokerConditions,
+					WithBrokerAddress(sinkDNS),
+				),
+				makeEventTypeWithName("type1", "name-1"),
+				makeEventTypeWithName("type2", "name-2"),
+				makeEventTypeWithName("type3", "name-3"),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceReconciled", `ApiServerSource reconciled: "%s/%s"`, testNS, sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewApiServerSource(sourceName, testNS,
+					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
+						Resources: []sourcesv1alpha1.ApiServerResource{
+							{
+								APIVersion: "",
+								Kind:       "Namespace",
+							},
+						},
+						Sink: &brokerRef,
+					}),
+					// Status Update:
+					WithInitApiServerSourceConditions,
+					WithApiServerSourceDeployed,
+					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceEventTypes,
+				),
+			}},
+			WantDeletes: []clientgotesting.DeleteActionImpl{
+				{Name: "name-1"},
+				{Name: "name-2"},
+				{Name: "name-3"},
+			},
+			WantCreates: []metav1.Object{
+				makeEventType(sourcesv1alpha1.ApiServerSourceAddEventType),
+				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteEventType),
+				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateEventType),
+				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
+				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
+				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
+				makeReceiveAdapter(),
+			},
+		},
 	}
 
 	defer logtesting.ClearAll()

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -289,11 +289,11 @@ func (r *Reconciler) createEventType(ctx context.Context, src *v1alpha1.CronJobS
 		if !equality.Semantic.DeepEqual(expected.Spec, current.Spec) {
 			// As is immutable, delete it and create it again.
 			if err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Delete(current.Name, &metav1.DeleteOptions{}); err != nil {
-				logging.FromContext(ctx).Debug("Error deleting existing event type", zap.Any("eventType", current))
+				logging.FromContext(ctx).Error("Error deleting existing event type", zap.Any("eventType", current))
 				return nil, err
 			}
 			if current, err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Create(expected); err != nil {
-				logging.FromContext(ctx).Debug("Error creating event type", zap.Any("eventType", current))
+				logging.FromContext(ctx).Error("Error creating event type", zap.Any("eventType", current))
 				return nil, err
 			}
 		}

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -284,12 +284,21 @@ func (r *Reconciler) createEventType(ctx context.Context, src *v1alpha1.CronJobS
 		logging.FromContext(ctx).Error("Unable to get an existing event type", zap.Error(err))
 		return nil, err
 	}
+	expected := resources.MakeEventType(src)
 	if current != nil {
-		// Not checking for spec changes as it is immutable. Only description is not, but we don't care if it is changed.
-		logging.FromContext(ctx).Debug("EventType already exists", zap.Any("eventType", current))
+		if !equality.Semantic.DeepEqual(expected.Spec, current.Spec) {
+			// As is immutable, delete it and create it again.
+			if err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Delete(current.Name, &metav1.DeleteOptions{}); err != nil {
+				logging.FromContext(ctx).Debug("Error deleting existing event type", zap.Any("eventType", current))
+				return nil, err
+			}
+			if current, err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Create(expected); err != nil {
+				logging.FromContext(ctx).Debug("Error creating event type", zap.Any("eventType", current))
+				return nil, err
+			}
+		}
 		return current, nil
 	}
-	expected := resources.MakeEventType(src)
 	if current, err = r.EventingClientSet.EventingV1alpha1().EventTypes(src.Namespace).Create(expected); err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -234,6 +234,60 @@ func TestAllCases(t *testing.T) {
 				makeReceiveAdapterWithSink(brokerRef),
 			},
 		}, {
+			Name: "valid with event type deletion and creation",
+			Objects: []runtime.Object{
+				NewCronSourceJob(sourceName, testNS,
+					WithCronJobSourceSpec(sourcesv1alpha1.CronJobSourceSpec{
+						Schedule: testSchedule,
+						Data:     testData,
+						Sink:     &brokerRef,
+					}),
+				),
+				NewBroker(sinkName, testNS,
+					WithInitBrokerConditions,
+					WithBrokerAddress(sinkDNS),
+				),
+				NewEventType("name-1", testNS,
+					WithEventTypeLabels(resources.Labels(sourceName)),
+					WithEventTypeType("type-1"),
+					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource(testNS, sourceName)),
+					WithEventTypeBroker(sinkName),
+					WithEventTypeOwnerReference(ownerRef)),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "CronJobSourceReconciled", `CronJobSource reconciled: "%s/%s"`, testNS, sourceName),
+				Eventf(corev1.EventTypeNormal, "CronJobSourceReadinessChanged", `CronJobSource %q became ready`, sourceName),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewCronSourceJob(sourceName, testNS,
+					WithCronJobSourceSpec(sourcesv1alpha1.CronJobSourceSpec{
+						Schedule: testSchedule,
+						Data:     testData,
+						Sink:     &brokerRef,
+					}),
+					// Status Update:
+					WithInitCronJobSourceConditions,
+					WithValidCronJobSourceSchedule,
+					WithCronJobSourceDeployed,
+					WithCronJobSourceEventType,
+					WithCronJobSourceSink(sinkURI),
+				),
+			}},
+			WantDeletes: []clientgotesting.DeleteActionImpl{{
+				Name: "name-1",
+			}},
+			WantCreates: []metav1.Object{
+				NewEventType("", testNS,
+					WithEventTypeGenerateName(fmt.Sprintf("%s-", utils.ToDNS1123Subdomain(sourcesv1alpha1.CronJobEventType))),
+					WithEventTypeLabels(resources.Labels(sourceName)),
+					WithEventTypeType(sourcesv1alpha1.CronJobEventType),
+					WithEventTypeSource(sourcesv1alpha1.CronJobEventSource(testNS, sourceName)),
+					WithEventTypeBroker(sinkName),
+					WithEventTypeOwnerReference(ownerRef)),
+				makeReceiveAdapterWithSink(brokerRef),
+			},
+		}, {
 			Name: "valid, existing ra",
 			Objects: []runtime.Object{
 				NewCronSourceJob(sourceName, testNS,


### PR DESCRIPTION
## Proposed Changes

- Bug found while editing the ApiServerSource or a CronJobSource source. E.g., changing its broker.
- Properly reconcile its EventTypes upon Event Source change, and also upon EventType change.
- Pending: if the Source sink changes to a non-Broker one, we are not properly removing the EventTypes. Will do in a follow up PR.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
