### PR TITLE
golang format tools

### DIFF
--- a/pkg/duck/sinks_test.go
+++ b/pkg/duck/sinks_test.go
@@ -111,7 +111,7 @@ func TestGetSinkURI(t *testing.T) {
 				reconciler.Options{
 					DynamicClientSet: fake.NewSimpleDynamicClient(scheme.Scheme, tc.objects...),
 				},
-				func(string){},
+				func(string) {},
 			)
 			sourceName := "nilRef"
 			if tc.ref != nil {

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -893,7 +893,7 @@ func TestReconcile(t *testing.T) {
 			ingressServiceAccountName: ingressSA,
 		}
 	},
-	false,
+		false,
 	))
 }
 

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -156,7 +156,7 @@ func TestAllCases(t *testing.T) {
 			channelLister: listers.GetChannelLister(),
 		}
 	},
-	false,
+		false,
 	))
 }
 

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -32,9 +32,9 @@ import (
 	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	fakeclientset "github.com/knative/eventing/pkg/client/clientset/versioned/fake"
 	informers "github.com/knative/eventing/pkg/client/informers/externalversions"
+	"github.com/knative/eventing/pkg/duck"
 	"github.com/knative/eventing/pkg/reconciler"
 	"github.com/knative/eventing/pkg/utils"
-	"github.com/knative/eventing/pkg/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
@@ -438,10 +438,10 @@ func TestAllCases(t *testing.T) {
 			containerSourceLister: listers.GetContainerSourceLister(),
 			deploymentLister:      listers.GetDeploymentLister(),
 		}
-		r.sinkReconciler = duck.NewSinkReconciler(opt, func(string){})
+		r.sinkReconciler = duck.NewSinkReconciler(opt, func(string) {})
 		return r
 	},
-	true,
+		true,
 	))
 }
 

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -161,6 +161,6 @@ func TestReconcile(t *testing.T) {
 			tracker:         tracker.New(func(string) {}, 0),
 		}
 	},
-	false,
+		false,
 	))
 }

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -239,6 +239,6 @@ func TestAllCases(t *testing.T) {
 		}
 
 	},
-	false,
+		false,
 	))
 }

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -616,7 +616,7 @@ func TestAllCases(t *testing.T) {
 			addressableInformer: &fakeAddressableInformer{},
 		}
 	},
-	false,
+		false,
 	))
 }
 

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-        "k8s.io/apimachinery/pkg/api/meta"
-        "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -532,7 +532,7 @@ func TestAllCases(t *testing.T) {
 			tracker:             tracker.New(func(string) {}, 0),
 		}
 	},
-	false,
+		false,
 	))
 }
 


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
