### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/broker_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 
 	"github.com/knative/pkg/apis"

--- a/pkg/apis/eventing/v1alpha1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_lifecycle_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"

--- a/pkg/apis/eventing/v1alpha1/channel_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/channel_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/apis/eventing/v1alpha1/channel_lifecycle_test.go
+++ b/pkg/apis/eventing/v1alpha1/channel_lifecycle_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/apis/eventing/v1alpha1/subscription_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/apis/eventing/v1alpha1/subscription_lifecycle_test.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_lifecycle_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/apis/eventing/v1alpha1/trigger_lifecycle_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_lifecycle_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
