### PR TITLE
Remove the deprecated 'in-memory-channel' ClusterChannelProvisioner.

### DIFF
--- a/cmd/in_memory/dispatcher/main.go
+++ b/cmd/in_memory/dispatcher/main.go
@@ -51,7 +51,7 @@ var (
 	readTimeout         = 1 * time.Minute
 	writeTimeout        = 1 * time.Minute
 	port                = 8080
-	channelProvisioners = []string{"in-memory", "in-memory-channel"}
+	channelProvisioners = []string{"in-memory"}
 )
 
 func main() {

--- a/config/provisioners/in-memory-channel/README.md
+++ b/config/provisioners/in-memory-channel/README.md
@@ -18,12 +18,12 @@ They differ from most Channels in that they have:
 ### Deployment steps:
 
 1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
-1. Apply the 'in-memory-channel' ClusterChannelProvisioner, Controller, and
+1. Apply the 'in-memory' ClusterChannelProvisioner, Controller, and
    Dispatcher.
    ```shell
    ko apply -f config/provisioners/in-memory-channel/in-memory-channel.yaml
    ```
-1. Create Channels that reference the 'in-memory-channel'.
+1. Create Channels that reference the 'in-memory'.
 
    ```yaml
    apiVersion: eventing.knative.dev/v1alpha1
@@ -34,7 +34,7 @@ They differ from most Channels in that they have:
      provisioner:
        apiVersion: eventing.knative.dev/v1alpha1
        kind: ClusterChannelProvisioner
-       name: in-memory-channel
+       name: in-memory
    ```
 
 ### Components
@@ -58,11 +58,4 @@ Dispatcher for all in-memory Channels.
 
 ```shell
 kubectl get deployment -n knative-eventing in-memory-channel-dispatcher
-```
-
-The Channel Dispatcher Config Map is used to send information about Channels and
-Subscriptions from the Channel Controller to the Channel Dispatcher.
-
-```shell
-kubectl get configmap -n knative-eventing in-memory-channel-dispatcher-config-map
 ```

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -20,14 +20,6 @@ spec: {}
 
 ---
 
-apiVersion: eventing.knative.dev/v1alpha1
-kind: ClusterChannelProvisioner
-metadata:
-  name: in-memory-channel
-spec: {}
-
----
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -69,14 +61,6 @@ rules:
       - list
       - watch
       - create
-  - apiGroups:
-        - "" # Core API group.
-    resources:
-      - services
-    resourceNames:
-      - in-memory-channel-clusterbus
-    verbs:
-      - delete
   - apiGroups:
       - "" # Core API group.
     resources:

--- a/pkg/provisioners/inmemory/channel/controller.go
+++ b/pkg/provisioners/inmemory/channel/controller.go
@@ -32,7 +32,7 @@ const (
 	controllerAgentName = "in-memory-channel-controller"
 )
 
-// ProvideController returns a Controller that represents the in-memory-channel Provisioner.
+// ProvideController returns a Controller that represents the in-memory Provisioner.
 func ProvideController(mgr manager.Manager, logger *zap.Logger) (controller.Controller, error) {
 	// Setup a new controller to Reconcile Channels that belong to this Cluster Provisioner
 	// (in-memory channels).

--- a/pkg/provisioners/inmemory/channel/reconcile.go
+++ b/pkg/provisioners/inmemory/channel/reconcile.go
@@ -128,10 +128,6 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 
 	c.Status.InitializeConditions()
 
-	if usesDeprecatedProvisioner(c) {
-		c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", "The `in-memory-channel` ClusterChannelProvisioner is deprecated and will be removed in 0.7. Recommended replacement is `in-memory`.")
-	}
-
 	// We are syncing K8s Service to talk to this Channel.
 	svc, err := util.CreateK8sService(ctx, r.client, c, util.ExternalService(c))
 	if err != nil {
@@ -144,10 +140,4 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 
 	c.Status.MarkProvisioned()
 	return nil
-}
-
-func usesDeprecatedProvisioner(c *eventingv1alpha1.Channel) bool {
-	return c.Spec.Provisioner != nil &&
-		c.Spec.Provisioner.Namespace == "" &&
-		c.Spec.Provisioner.Name == "in-memory-channel"
 }

--- a/pkg/provisioners/inmemory/channel/reconcile_test.go
+++ b/pkg/provisioners/inmemory/channel/reconcile_test.go
@@ -44,8 +44,7 @@ import (
 )
 
 const (
-	ccpName      = "in-memory-channel"
-	asyncCCPName = "in-memory"
+	ccpName = "in-memory"
 
 	cNamespace = "test-namespace"
 	cName      = "test-channel"

--- a/pkg/provisioners/multichannelfanout/config.go
+++ b/pkg/provisioners/multichannelfanout/config.go
@@ -44,18 +44,9 @@ func NewConfigFromChannels(channels []v1alpha1.Channel) *Config {
 			Name:      c.Name,
 			HostName:  c.Status.Address.Hostname,
 		}
-
-		asyncHandler := true
-		// This is fairly hacky, but this is expected to change from a generic fanout sidecar to the
-		// in-memory dispatcher. And `in-memory-channel` is to be deleted in 0.7, so this shouldn't
-		// be here for long.
-		if c.Spec.Provisioner != nil && c.Spec.Provisioner.Name == "in-memory-channel" {
-			asyncHandler = false
-		}
-
 		if c.Spec.Subscribable != nil {
 			channelConfig.FanoutConfig = fanout.Config{
-				AsyncHandler:  asyncHandler,
+				AsyncHandler:  true,
 				Subscriptions: c.Spec.Subscribable.Subscribers,
 			}
 		}

--- a/pkg/provisioners/multichannelfanout/config_test.go
+++ b/pkg/provisioners/multichannelfanout/config_test.go
@@ -110,30 +110,6 @@ func TestNewConfigFromChannels(t *testing.T) {
 					},
 				},
 			},
-		}, {
-			name: "in-memory-channel provisioner -- synchronous",
-			channels: []v1alpha1.Channel{
-				withProvisioner(
-					makeChannel("chan-1", "ns-1", "a.b.c.d", makeSubscribable(makeSubscriber("sub1"))),
-					&v1.ObjectReference{
-						Name: "in-memory-channel",
-					}),
-			},
-			expected: &Config{
-				ChannelConfigs: []ChannelConfig{
-					{
-						Name:      "chan-1",
-						Namespace: "ns-1",
-						HostName:  "a.b.c.d",
-						FanoutConfig: fanout.Config{
-							AsyncHandler: false,
-							Subscriptions: []eventingduck.ChannelSubscriberSpec{
-								makeSubscriber("sub1"),
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 
@@ -168,9 +144,9 @@ func withProvisioner(c v1alpha1.Channel, p *v1.ObjectReference) v1alpha1.Channel
 	return c
 }
 
-func makeSubscribable(subsriberSpec ...eventingduck.ChannelSubscriberSpec) *eventingduck.Subscribable {
+func makeSubscribable(subscriberSpec ...eventingduck.ChannelSubscriberSpec) *eventingduck.Subscribable {
 	return &eventingduck.Subscribable{
-		Subscribers: subsriberSpec,
+		Subscribers: subscriberSpec,
 	}
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -88,7 +88,7 @@ If you want to run tests against other `ClusterChannelProvisioners`, you can
 specify them through `-clusterChannelProvisioners`.
 
 ```bash
-go test -v -tags=e2e -count=1 ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory-channel,gcp-pubsub
+go test -v -tags=e2e -count=1 ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory,gcp-pubsub
 ```
 
 #### One test case
@@ -108,7 +108,7 @@ specify it through `-clusterChannelProvisioners`. Note that you can only specify
 one `ClusterChannelProvisioner` if you are not running from `TestMain`.
 
 ```bash
-go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$ -clusterChannelProvisioners=in-memory-channel
+go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$ -clusterChannelProvisioners=in-memory
 ```
 
 ## Environment requirements

--- a/test/constants.go
+++ b/test/constants.go
@@ -22,10 +22,6 @@ const (
 	// DefaultClusterChannelProvisioner is the default ClusterChannelProvisioner we will run tests against.
 	DefaultClusterChannelProvisioner = InMemoryProvisioner
 
-	// InMemoryChannelProvisioner is the in-memory-channel provisioner.
-	// It will be delete in 0.7, see https://github.com/knative/eventing/pull/1062 for more info.
-	InMemoryChannelProvisioner = "in-memory-channel"
-
 	// InMemoryProvisioner is the in-memory provisioner, which is also the default one.
 	InMemoryProvisioner = "in-memory"
 	// GCPPubSubProvisioner is the gcp-pubsub provisioner, which is under contrib/gcppubsub.
@@ -38,7 +34,6 @@ const (
 
 // validProvisioners is a list of provisioners that Eventing currently support.
 var validProvisioners = []string{
-	InMemoryChannelProvisioner,
 	InMemoryProvisioner,
 	GCPPubSubProvisioner,
 	KafkaProvisioner,

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -211,6 +211,6 @@ function dump_extra_cluster_state() {
 
 initialize $@ --skip-istio-addon
 
-go_test_e2e -timeout=20m ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory-channel,in-memory,natss,kafka || fail_test
+go_test_e2e -timeout=20m ./test/e2e -run ^TestMain$ -runFromMain=true -clusterChannelProvisioners=in-memory,natss,kafka || fail_test
 
 success

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -36,13 +36,6 @@ var channelTestMap = map[string][]func(t *testing.T){
 		TestDefaultBrokerWithManyTriggers,
 		TestEventTransformationForTrigger,
 	},
-	test.InMemoryChannelProvisioner: {
-		TestSingleBinaryEvent,
-		TestSingleStructuredEvent,
-		TestEventTransformation,
-		TestChannelChain,
-		TestEventTransformationForTrigger,
-	},
 	test.GCPPubSubProvisioner: {
 		TestSingleBinaryEvent,
 		TestSingleStructuredEvent,


### PR DESCRIPTION
Fixes #787

## Proposed Changes

- Remove the deprecated 'in-memory-channel' ClusterChannelProvisioner.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The `in-memory-channel` ClusterChannelProvisioner has been removed. The recommended replacement is `in-memory`.
```
