### PR TITLE
Fix CI flow error for Eventing-0.5

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -420,14 +420,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a42211df7de241a39375cdd305887fc4415599bc684377eb2f35504d9bd093ee"
+  digest = "1:1bfc083da5bbeb7abaac53c56890eb14eb11bac9ec985bfe338c4bbb0540c9ba"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "c98ed95c2f812eb932a434752c715bdff6e0da1f"
+  revision = "1576da30069624094cf01719452da944b3046826"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -47,13 +47,13 @@ function knative_setup() {
 }
 
 function knative_teardown() {
-  uninstall_istio
-  
   ko delete --ignore-not-found=true -f config/
   wait_until_object_does_not_exist namespaces knative-eventing
 
   wait_until_object_does_not_exist customresourcedefinitions subscriptions.eventing.knative.dev
   wait_until_object_does_not_exist customresourcedefinitions channels.eventing.knative.dev
+
+  uninstall_istio
 }
 
 function install_istio() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -56,14 +56,14 @@ function knative_teardown() {
 }
 
 function install_istio() {
-  kubectl apply -f "${istio_crd_yaml}" || return 1
-  kubectl apply -f "${istio_yaml}" || return 1
+  kubectl apply -f "${ISTIO_CRD_YAML}" || return 1
+  kubectl apply -f "${ISTIO_YAML}" || return 1
   wait_until_pods_running istio-system || return 1
 }
 
 function uninstall_istio() {
-  kubectl delete -f "${istio_crd_yaml}" || return 1
-  kubectl delete -f "${istio_yaml}" || return 1
+  kubectl delete -f "${ISTIO_CRD_YAML}" || return 1
+  kubectl delete -f "${ISTIO_YAML}" || return 1
   wait_until_object_does_not_exist namespaces istio-system
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -47,8 +47,9 @@ function knative_setup() {
 }
 
 function knative_teardown() {
+  uninstall_istio
+  
   ko delete --ignore-not-found=true -f config/
-
   wait_until_object_does_not_exist namespaces knative-eventing
 
   wait_until_object_does_not_exist customresourcedefinitions subscriptions.eventing.knative.dev

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,10 +30,13 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.s
 # Currently this namespace must be the same as the namespace specified in
 # test/e2e/e2e.go.
 readonly E2E_TEST_NAMESPACE=e2etest-knative-eventing
+readonly ISTIO_CRD_YAML="${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio-crds.yaml"
+readonly ISTIO_YAML="${KNATIVE_BASE_YAML_SOURCE/@/serving}/istio.yaml"
 
 # Helper functions.
 
 function knative_setup() {
+  install_istio || return 1
   start_latest_knative_serving || return 1
   ko apply -f config/ || return 1
   wait_until_pods_running knative-eventing || fail_test "Eventing did not come up (1)"
@@ -50,6 +53,18 @@ function knative_teardown() {
 
   wait_until_object_does_not_exist customresourcedefinitions subscriptions.eventing.knative.dev
   wait_until_object_does_not_exist customresourcedefinitions channels.eventing.knative.dev
+}
+
+function install_istio() {
+  kubectl apply -f "${istio_crd_yaml}" || return 1
+  kubectl apply -f "${istio_yaml}" || return 1
+  wait_until_pods_running istio-system || return 1
+}
+
+function uninstall_istio() {
+  kubectl delete -f "${istio_crd_yaml}" || return 1
+  kubectl delete -f "${istio_yaml}" || return 1
+  wait_until_object_does_not_exist namespaces istio-system
 }
 
 # Setup resources common to all eventing tests
@@ -85,7 +100,8 @@ function dump_extra_cluster_state() {
 
 # Script entry point.
 
-initialize $@
+# Skip installing istio as an add-on
+initialize $@ --skip-istio-addon
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,9 +38,15 @@ function build_resource_name() {
 # Test cluster parameters
 
 # Configurable parameters
-readonly E2E_CLUSTER_REGION=${E2E_CLUSTER_REGION:-us-central1}
+# export E2E_CLUSTER_REGION and E2E_CLUSTER_ZONE as they're used in the cluster setup subprocess
+export E2E_CLUSTER_REGION=${E2E_CLUSTER_REGION:-us-central1}
 # By default we use regional clusters.
-readonly E2E_CLUSTER_ZONE=${E2E_CLUSTER_ZONE:-}
+export E2E_CLUSTER_ZONE=${E2E_CLUSTER_ZONE:-}
+
+# Default backup regions in case of stockouts; by default we don't fall back to a different zone in the same region
+readonly E2E_CLUSTER_BACKUP_REGIONS=${E2E_CLUSTER_BACKUP_REGIONS:-us-west1 us-east1}
+readonly E2E_CLUSTER_BACKUP_ZONES=${E2E_CLUSTER_BACKUP_ZONES:-}
+
 readonly E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-4}
 readonly E2E_GKE_ENVIRONMENT=${E2E_GKE_ENVIRONMENT:-prod}
 readonly E2E_GKE_COMMAND_GROUP=${E2E_GKE_COMMAND_GROUP:-beta}
@@ -61,6 +67,8 @@ IS_BOSKOS=0
 
 # Tear down the test resources.
 function teardown_test_resources() {
+  # On boskos, save time and don't teardown as the cluster will be destroyed anyway.
+  (( IS_BOSKOS )) && return
   header "Tearing down test environment"
   function_exists test_teardown && test_teardown
   (( ! SKIP_KNATIVE_SETUP )) && function_exists knative_teardown && knative_teardown
@@ -107,8 +115,7 @@ function save_metadata() {
     geo_key="Zone"
     geo_value="${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   fi
-  local gcloud_project="$(gcloud config get-value project)"
-  local cluster_version="$(gcloud container clusters list --project=${gcloud_project} --format='value(currentMasterVersion)')"
+  local cluster_version="$(gcloud container clusters list --project=${E2E_PROJECT_ID} --format='value(currentMasterVersion)')"
   cat << EOF > ${ARTIFACTS}/metadata.json
 {
   "E2E:${geo_key}": "${geo_value}",
@@ -120,26 +127,50 @@ function save_metadata() {
 EOF
 }
 
+# Delete target pools and health checks that might have leaked.
+# See https://github.com/knative/serving/issues/959 for details.
+# TODO(adrcunha): Remove once the leak issue is resolved.
+function delete_leaked_network_resources() {
+  # On boskos, don't bother with leaks as the janitor will delete everything in the project.
+  (( IS_BOSKOS )) && return
+  # Ensure we're using the GCP project used by kubetest
+  local gcloud_project="$(gcloud config get-value project)"
+  local http_health_checks="$(gcloud compute target-pools list \
+    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    grep httpHealthChecks | tr '\n' ' ')"
+  local target_pools="$(gcloud compute target-pools list \
+    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
+    tr '\n' ' ')"
+  if [[ -n "${target_pools}" ]]; then
+    echo "Found leaked target pools, deleting"
+    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
+  fi
+  if [[ -n "${http_health_checks}" ]]; then
+    echo "Found leaked health checks, deleting"
+    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
+  fi
+}
+
 # Create a test cluster with kubetest and call the current script again.
 function create_test_cluster() {
   # Fail fast during setup.
   set -o errexit
   set -o pipefail
 
-  header "Creating test cluster"
+  if function_exists cluster_setup; then
+    cluster_setup || fail_test "cluster setup failed"
+  fi
 
   echo "Cluster will have a minimum of ${E2E_MIN_CLUSTER_NODES} and a maximum of ${E2E_MAX_CLUSTER_NODES} nodes."
 
   # Smallest cluster required to run the end-to-end-tests
-  local geoflag="--gcp-region=${E2E_CLUSTER_REGION}"
-  [[ -n "${E2E_CLUSTER_ZONE}" ]] && geoflag="--gcp-zone=${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
+    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${GKE_ADDONS} ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
     --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
     --cluster="${E2E_CLUSTER_NAME}"
-    ${geoflag}
     --gcp-network="${E2E_NETWORK_NAME}"
     --gke-environment="${E2E_GKE_ENVIRONMENT}"
     --gke-command-group="${E2E_GKE_COMMAND_GROUP}"
@@ -158,6 +189,7 @@ function create_test_cluster() {
   local gcloud_project="${GCP_PROJECT}"
   [[ -z "${gcloud_project}" ]] && gcloud_project="$(gcloud config get-value project)"
   echo "gcloud project is ${gcloud_project}"
+  echo "gcloud user is $(gcloud config get-value core/account)"
   (( IS_BOSKOS )) && echo "Using boskos for the test cluster"
   [[ -n "${GCP_PROJECT}" ]] && echo "GCP project for test cluster is ${GCP_PROJECT}"
   echo "Test script is ${E2E_SCRIPT}"
@@ -167,46 +199,69 @@ function create_test_cluster() {
   (( SKIP_KNATIVE_SETUP )) && test_cmd_args+=" --skip-knative-setup"
   [[ -n "${GCP_PROJECT}" ]] && test_cmd_args+=" --gcp-project ${GCP_PROJECT}"
   [[ -n "${E2E_SCRIPT_CUSTOM_FLAGS[@]}" ]] && test_cmd_args+=" ${E2E_SCRIPT_CUSTOM_FLAGS[@]}"
-  # Don't fail test for kubetest, as it might incorrectly report test failure
-  # if teardown fails (for details, see success() below)
-  set +o errexit
-  run_go_tool k8s.io/test-infra/kubetest \
-    kubetest "${CLUSTER_CREATION_ARGS[@]}" \
+  local extra_flags=()
+  # If using boskos, save time and let it tear down the cluster
+  (( ! IS_BOSKOS )) && extra_flags+=(--down)
+  create_test_cluster_with_retries "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
-    --down \
     --extract "${E2E_CLUSTER_VERSION}" \
     --gcp-node-image "${SERVING_GKE_IMAGE}" \
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}" \
+    ${extra_flags[@]} \
     ${EXTRA_KUBETEST_FLAGS[@]}
   echo "Test subprocess exited with code $?"
   # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
   set +o errexit
-  # Ensure we're using the GCP project used by kubetest
-  gcloud_project="$(gcloud config get-value project)"
-  # Delete target pools and health checks that might have leaked.
-  # See https://github.com/knative/serving/issues/959 for details.
-  # TODO(adrcunha): Remove once the leak issue is resolved.
-  local http_health_checks="$(gcloud compute target-pools list \
-    --project=${gcloud_project} --format='value(healthChecks)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
-    grep httpHealthChecks | tr '\n' ' ')"
-  local target_pools="$(gcloud compute target-pools list \
-    --project=${gcloud_project} --format='value(name)' --filter="instances~-${E2E_CLUSTER_NAME}-" | \
-    tr '\n' ' ')"
-  if [[ -n "${target_pools}" ]]; then
-    echo "Found leaked target pools, deleting"
-    gcloud compute forwarding-rules delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
-    gcloud compute target-pools delete -q --project=${gcloud_project} --region=${E2E_CLUSTER_REGION} ${target_pools}
-  fi
-  if [[ -n "${http_health_checks}" ]]; then
-    echo "Found leaked health checks, deleting"
-    gcloud compute http-health-checks delete -q --project=${gcloud_project} ${http_health_checks}
-  fi
-  local result="$(cat ${TEST_RESULT_FILE})"
+  function_exists cluster_teardown && cluster_teardown
+  delete_leaked_network_resources
+  local result=$(get_test_return_code)
   echo "Artifacts were written to ${ARTIFACTS}"
   echo "Test result code is ${result}"
-
   exit ${result}
+}
+
+# Retry backup regions/zones if cluster creations failed due to stockout.
+# Parameters: $1..$n - any kubetest flags other than geo flag.
+function create_test_cluster_with_retries() {
+  local cluster_creation_log=/tmp/${E2E_BASE_NAME}-cluster_creation-log
+  # zone_not_provided is a placeholder for e2e_cluster_zone to make for loop below work
+  local zone_not_provided="zone_not_provided"
+
+  local e2e_cluster_regions=(${E2E_CLUSTER_REGION})
+  local e2e_cluster_zones=(${E2E_CLUSTER_ZONE})
+
+  if [[ -n "${E2E_CLUSTER_BACKUP_ZONES}" ]]; then
+    e2e_cluster_zones+=(${E2E_CLUSTER_BACKUP_ZONES})
+  elif [[ -n "${E2E_CLUSTER_BACKUP_REGIONS}" ]]; then
+    e2e_cluster_regions+=(${E2E_CLUSTER_BACKUP_REGIONS})
+    e2e_cluster_zones=(${zone_not_provided})
+  else
+    echo "No backup region/zone set, cluster creation will fail in case of stockout"
+  fi
+
+  for e2e_cluster_region in "${e2e_cluster_regions[@]}"; do
+    for e2e_cluster_zone in "${e2e_cluster_zones[@]}"; do
+      E2E_CLUSTER_REGION=${e2e_cluster_region}
+      E2E_CLUSTER_ZONE=${e2e_cluster_zone}
+      [[ "${E2E_CLUSTER_ZONE}" == "${zone_not_provided}" ]] && E2E_CLUSTER_ZONE=""
+
+      local geoflag="--gcp-region=${E2E_CLUSTER_REGION}"
+      [[ -n "${E2E_CLUSTER_ZONE}" ]] && geoflag="--gcp-zone=${E2E_CLUSTER_REGION}-${E2E_CLUSTER_ZONE}"
+
+      header "Creating test cluster in $E2E_CLUSTER_REGION $E2E_CLUSTER_ZONE"
+      # Don't fail test for kubetest, as it might incorrectly report test failure
+      # if teardown fails (for details, see success() below)
+      set +o errexit
+      { run_go_tool k8s.io/test-infra/kubetest \
+        kubetest "$@" ${geoflag}; } 2>&1 | tee ${cluster_creation_log}
+
+      # Exit if test succeeded
+      [[ "$(get_test_return_code)" == "0" ]] && return
+      # If test failed not because of cluster creation stockout, return
+      [[ -z "$(grep -Eio 'does not have enough resources available to fulfill' ${cluster_creation_log})" ]] && return
+    done
+  done
 }
 
 # Setup the test cluster for running the tests.
@@ -216,6 +271,11 @@ function setup_test_cluster() {
   set -o pipefail
 
   header "Setting up test cluster"
+
+  # Set the actual project the test cluster resides in
+  # It will be a project assigned by Boskos if test is running on Prow, 
+  # otherwise will be ${GCP_PROJECT} set up by user.
+  readonly export E2E_PROJECT_ID="$(gcloud config get-value project)"
 
   # Save some metadata about cluster creation for using in prow and testgrid
   save_metadata
@@ -228,9 +288,10 @@ function setup_test_cluster() {
   if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
     acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
     kubectl config set-context ${k8s_cluster} --namespace=default
-    export KO_DOCKER_REPO=gcr.io/$(gcloud config get-value project)/${E2E_BASE_NAME}-e2e-img
+    export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
 
+  echo "- Project is ${E2E_PROJECT_ID}"
   echo "- Cluster is ${k8s_cluster}"
   echo "- User is ${k8s_user}"
   echo "- Docker is ${KO_DOCKER_REPO}"
@@ -249,6 +310,12 @@ function setup_test_cluster() {
   if function_exists test_setup; then
     test_setup || fail_test "test setup failed"
   fi
+}
+
+# Gets the exit of the test script.
+# For more details, see set_test_return_code().
+function get_test_return_code() {
+  echo $(cat ${TEST_RESULT_FILE})
 }
 
 # Set the return code that the test script will return.
@@ -283,9 +350,11 @@ function fail_test() {
 RUN_TESTS=0
 EMIT_METRICS=0
 SKIP_KNATIVE_SETUP=0
+SKIP_ISTIO_ADDON=0
 GCP_PROJECT=""
 E2E_SCRIPT=""
 E2E_CLUSTER_VERSION=""
+GKE_ADDONS=""
 EXTRA_CLUSTER_CREATION_FLAGS=()
 EXTRA_KUBETEST_FLAGS=()
 E2E_SCRIPT_CUSTOM_FLAGS=()
@@ -317,6 +386,7 @@ function initialize() {
       --run-tests) RUN_TESTS=1 ;;
       --emit-metrics) EMIT_METRICS=1 ;;
       --skip-knative-setup) SKIP_KNATIVE_SETUP=1 ;;
+      --skip-istio-addon) SKIP_ISTIO_ADDON=1 ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -346,6 +416,8 @@ function initialize() {
   is_protected_gcr ${KO_DOCKER_REPO} && \
     abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
+  (( SKIP_ISTIO_ADDON )) || GKE_ADDONS="--addons=Istio"
+
   readonly RUN_TESTS
   readonly EMIT_METRICS
   readonly GCP_PROJECT
@@ -353,6 +425,7 @@ function initialize() {
   readonly EXTRA_CLUSTER_CREATION_FLAGS
   readonly EXTRA_KUBETEST_FLAGS
   readonly SKIP_KNATIVE_SETUP
+  readonly GKE_ADDONS
 
   if (( ! RUN_TESTS )); then
     create_test_cluster

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -22,6 +22,10 @@ source $(dirname ${BASH_SOURCE})/library.sh
 # GitHub upstream.
 readonly KNATIVE_UPSTREAM="https://github.com/knative/${REPO_NAME}"
 
+# GCRs for Knative releases.
+readonly NIGHTLY_GCR="gcr.io/knative-nightly/github.com/knative/${REPO_NAME}"
+readonly RELEASE_GCR="gcr.io/knative-releases/github.com/knative/${REPO_NAME}"
+
 # Georeplicate images to {us,eu,asia}.gcr.io
 readonly GEO_REPLICATION=(us eu asia)
 
@@ -33,14 +37,15 @@ function banner() {
 
 # Tag images in the yaml files if $TAG is not empty.
 # $KO_DOCKER_REPO is the registry containing the images to tag with $TAG.
-# Parameters: $1..$n - yaml files to parse for images.
+# Parameters: $1..$n - files to parse for images (non .yaml files are ignored).
 function tag_images_in_yamls() {
   [[ -z ${TAG} ]] && return 0
   local SRC_DIR="${GOPATH}/src/"
   local DOCKER_BASE="${KO_DOCKER_REPO}/${REPO_ROOT_DIR/$SRC_DIR}"
   local GEO_REGIONS="${GEO_REPLICATION[@]} "
-  echo "Tagging images under '${DOCKER_BASE}' with ${TAG}"
+  echo "Tagging any images under '${DOCKER_BASE}' with ${TAG}"
   for file in $@; do
+    [[ "${file##*.}" != "yaml" ]] && continue
     echo "Inspecting ${file}"
     for image in $(grep -o "${DOCKER_BASE}/[a-z\./-]\+@sha256:[0-9a-f]\+" ${file}); do
       for region in "" ${GEO_REGIONS// /. }; do
@@ -50,43 +55,62 @@ function tag_images_in_yamls() {
   done
 }
 
-# Copy the given yaml files to the $RELEASE_GCS_BUCKET bucket's "latest" directory.
+# Copy the given files to the $RELEASE_GCS_BUCKET bucket's "latest" directory.
 # If $TAG is not empty, also copy them to $RELEASE_GCS_BUCKET bucket's "previous" directory.
-# Parameters: $1..$n - yaml files to copy.
-function publish_yamls() {
+# Parameters: $1..$n - files to copy.
+function publish_to_gcs() {
   function verbose_gsutil_cp {
     local DEST="gs://${RELEASE_GCS_BUCKET}/$1/"
     shift
     echo "Publishing [$@] to ${DEST}"
-    gsutil cp $@ ${DEST}
+    gsutil -m cp $@ ${DEST}
   }
-  # Before publishing the YAML files, cleanup the `latest` dir.
-  echo "Cleaning up the 'latest' directory first"
-  gsutil -m rm gs://${RELEASE_GCS_BUCKET}/latest/**
+  # Before publishing the files, cleanup the `latest` dir if it exists.
+  local latest_dir="gs://${RELEASE_GCS_BUCKET}/latest"
+  if [[ -n "$(gsutil ls ${latest_dir} 2> /dev/null)" ]]; then
+    echo "Cleaning up '${latest_dir}' first"
+    gsutil -m rm ${latest_dir}/**
+  fi
   verbose_gsutil_cp latest $@
   [[ -n ${TAG} ]] && verbose_gsutil_cp previous/${TAG} $@
 }
 
 # These are global environment variables.
 SKIP_TESTS=0
+PRESUBMIT_TEST_FAIL_FAST=1
 TAG_RELEASE=0
 PUBLISH_RELEASE=0
 PUBLISH_TO_GITHUB=0
 TAG=""
+BUILD_COMMIT_HASH=""
+BUILD_YYYYMMDD=""
+BUILD_TIMESTAMP=""
+BUILD_TAG=""
 RELEASE_VERSION=""
 RELEASE_NOTES=""
 RELEASE_BRANCH=""
-RELEASE_GCS_BUCKET=""
-KO_FLAGS=""
+RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
+KO_FLAGS="-P"
 VALIDATION_TESTS="./test/presubmit-tests.sh"
 YAMLS_TO_PUBLISH=""
-export KO_DOCKER_REPO=""
+ARTIFACTS_TO_PUBLISH=""
+FROM_NIGHTLY_RELEASE=""
+FROM_NIGHTLY_RELEASE_GCS=""
+export KO_DOCKER_REPO="gcr.io/knative-nightly"
 export GITHUB_TOKEN=""
 
 # Convenience function to run the hub tool.
 # Parameters: $1..$n - arguments to hub.
 function hub_tool() {
   run_go_tool github.com/github/hub hub $@
+}
+
+# Shortcut to "git push" that handles authentication.
+# Parameters: $1..$n - arguments to "git push <repo>".
+function git_push() {
+  local repo_url="${KNATIVE_UPSTREAM}"
+  [[ -n "${GITHUB_TOKEN}}" ]] && repo_url="${repo_url/:\/\//:\/\/${GITHUB_TOKEN}@}"
+  git push ${repo_url} $@
 }
 
 # Return the master version of a release.
@@ -104,6 +128,13 @@ function master_version() {
 function release_build_number() {
   local tokens=(${1//\./ })
   echo "${tokens[2]}"
+}
+
+# Return the short commit SHA from a release tag.
+# For example, "v20010101-deadbeef" returns "deadbeef".
+function hash_from_tag() {
+  local tokens=(${1//-/ })
+  echo "${tokens[1]}"
 }
 
 # Setup the repository upstream, if not set.
@@ -130,30 +161,30 @@ function prepare_auto_release() {
   TAG_RELEASE=1
   PUBLISH_RELEASE=1
 
-  git fetch --all
+  git fetch --all || abort "error fetching branches/tags from remote"
   local tags="$(git tag | cut -d 'v' -f2 | cut -d '.' -f1-2 | sort | uniq)"
   local branches="$( { (git branch -r | grep upstream/release-) ; (git branch | grep release-); } | cut -d '-' -f2 | sort | uniq)"
-  RELEASE_VERSION=""
 
-  [[ -n "${tags}" ]] || abort "cannot obtain release tags for the repository"
-  [[ -n "${branches}" ]] || abort "cannot obtain release branches for the repository"
+  echo "Versions released (from tags): [" ${tags} "]"
+  echo "Versions released (from branches): [" ${branches} "]"
 
-  for i in $branches; do
-    RELEASE_NUMBER=$i
-    for j in $tags; do
-      if [[ "$i" == "$j" ]]; then
-        RELEASE_NUMBER=""
+  local release_number=""
+  for i in ${branches}; do
+    release_number="${i}"
+    for j in ${tags}; do
+      if [[ "${i}" == "${j}" ]]; then
+        release_number=""
       fi
     done
   done
 
-  if [ -z "$RELEASE_NUMBER" ]; then
+  if [[ -z "${release_number}" ]]; then
     echo "*** No new release will be generated, as no new branches exist"
     exit  0
   fi
 
-  RELEASE_VERSION="${RELEASE_NUMBER}.0"
-  RELEASE_BRANCH="release-${RELEASE_NUMBER}"
+  RELEASE_VERSION="${release_number}.0"
+  RELEASE_BRANCH="release-${release_number}"
   echo "Will create release ${RELEASE_VERSION} from branch ${RELEASE_BRANCH}"
   # If --release-notes not used, add a placeholder
   if [[ -z "${RELEASE_NOTES}" ]]; then
@@ -210,16 +241,88 @@ function prepare_dot_release() {
   fi
 }
 
+# Setup source nightly image for a release.
+function prepare_from_nightly_release() {
+  echo "Release from nightly requested"
+  SKIP_TESTS=1
+  if [[ "${FROM_NIGHTLY_RELEASE}" == "latest" ]]; then
+    echo "Finding the latest nightly release"
+    find_latest_nightly "${NIGHTLY_GCR}" || abort "cannot find the latest nightly release"
+    echo "Latest nightly is ${FROM_NIGHTLY_RELEASE}"
+  fi
+  readonly FROM_NIGHTLY_RELEASE_GCS="gs://knative-nightly/${REPO_NAME}/previous/${FROM_NIGHTLY_RELEASE}"
+  gsutil ls -d "${FROM_NIGHTLY_RELEASE_GCS}" > /dev/null \
+      || abort "nightly release ${FROM_NIGHTLY_RELEASE} doesn't exist"
+}
+
+# Build a release from an existing nightly one.
+function build_from_nightly_release() {
+  banner "Building the release"
+  echo "Fetching manifests from nightly"
+  local yamls_dir="$(mktemp -d)"
+  gsutil -m cp -r "${FROM_NIGHTLY_RELEASE_GCS}/*" "${yamls_dir}" || abort "error fetching manifests"
+  # Update references to release GCR
+  for yaml in ${yamls_dir}/*.yaml; do
+    sed -i -e "s#${NIGHTLY_GCR}#${RELEASE_GCR}#" "${yaml}"
+  done
+  ARTIFACTS_TO_PUBLISH="$(find ${yamls_dir} -name '*.yaml' -printf '%p ')"
+  echo "Copying nightly images"
+  copy_nightly_images_to_release_gcr "${NIGHTLY_GCR}" "${FROM_NIGHTLY_RELEASE}"
+  # Create a release branch from the nightly release tag.
+  local commit="$(hash_from_tag ${FROM_NIGHTLY_RELEASE})"
+  echo "Creating release branch ${RELEASE_BRANCH} at commit ${commit}"
+  git checkout -b ${RELEASE_BRANCH} ${commit} || abort "cannot create branch"
+  git_push upstream ${RELEASE_BRANCH} || abort "cannot push branch"
+}
+
+# Build a release from source.
+function build_from_source() {
+  run_validation_tests ${VALIDATION_TESTS}
+  banner "Building the release"
+  build_release
+  # Do not use `||` above or any error will be swallowed.
+  if [[ $? -ne 0 ]]; then
+    abort "error building the release"
+  fi
+}
+
+# Copy tagged images from the nightly GCR to the release GCR, tagging them 'latest'.
+# This is a recursive function, first call must pass $NIGHTLY_GCR as first parameter.
+# Parameters: $1 - GCR to recurse into.
+#             $2 - tag to be used to select images to copy.
+function copy_nightly_images_to_release_gcr() {
+  for entry in $(gcloud --format="value(name)" container images list --repository="$1"); do
+    copy_nightly_images_to_release_gcr "${entry}" "$2"
+    # Copy each image with the given nightly tag
+    for x in $(gcloud --format="value(tags)" container images list-tags "${entry}" --filter="tags=$2" --limit=1); do
+      local path="${entry/${NIGHTLY_GCR}}"  # Image "path" (remove GCR part)
+      local dst="${RELEASE_GCR}${path}:latest"
+      gcloud container images add-tag "${entry}:$2" "${dst}" || abort "error copying image"
+    done
+  done
+}
+
+# Recurse into GCR and find the nightly tag of the first `latest` image found.
+# Parameters: $1 - GCR to recurse into.
+function find_latest_nightly() {
+  for entry in $(gcloud --format="value(name)" container images list --repository="$1"); do
+    find_latest_nightly "${entry}" && return 0
+    for tag in $(gcloud --format="value(tags)" container images list-tags "${entry}" \
+        --filter="tags=latest" --limit=1); do
+      local tags=( ${tag//,/ } )
+      # Skip if more than one nightly tag, as we don't know what's the latest.
+      if [[ ${#tags[@]} -eq 2 ]]; then
+        local nightly_tag="${tags[@]/latest}"  # Remove 'latest' tag
+        FROM_NIGHTLY_RELEASE="${nightly_tag// /}"  # Remove spaces
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
 # Parses flags and sets environment variables accordingly.
 function parse_flags() {
-  TAG=""
-  RELEASE_VERSION=""
-  RELEASE_NOTES=""
-  RELEASE_BRANCH=""
-  KO_FLAGS="-P"
-  KO_DOCKER_REPO="gcr.io/knative-nightly"
-  RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
-  GITHUB_TOKEN=""
   local has_gcr_flag=0
   local has_gcs_flag=0
   local is_dot_release=0
@@ -236,6 +339,7 @@ function parse_flags() {
       --nopublish) PUBLISH_RELEASE=0 ;;
       --dot-release) is_dot_release=1 ;;
       --auto-release) is_auto_release=1 ;;
+      --from-latest-nightly) FROM_NIGHTLY_RELEASE=latest ;;
       *)
         [[ $# -ge 2 ]] || abort "missing parameter after $1"
         shift
@@ -266,6 +370,10 @@ function parse_flags() {
             [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
             RELEASE_NOTES=$1
             ;;
+          --from-nightly)
+            [[ $1 =~ ^v[0-9]+-[0-9a-f]+$ ]] || abort "nightly tag must be 'vYYYYMMDD-commithash'"
+            FROM_NIGHTLY_RELEASE=$1
+            ;;
           *) abort "unknown option ${parameter}" ;;
         esac
     esac
@@ -274,14 +382,24 @@ function parse_flags() {
 
   # Do auto release unless release is forced
   if (( is_auto_release )); then
-
     (( is_dot_release )) && abort "cannot have both --dot-release and --auto-release set simultaneously"
-    [[ -n "${RELEASE_VERSION}" ]] &&  abort "cannot have both --version and --auto-release set simultaneously"
-    [[ -n "${RELEASE_BRANCH}" ]] &&  abort "cannot have both --branch and --auto-release set simultaneously"
-
+    [[ -n "${RELEASE_VERSION}" ]] && abort "cannot have both --version and --auto-release set simultaneously"
+    [[ -n "${RELEASE_BRANCH}" ]] && abort "cannot have both --branch and --auto-release set simultaneously"
+    [[ -n "${FROM_NIGHTLY_RELEASE}" ]] && abort "cannot have --auto-release with a nightly source"
     setup_upstream
     prepare_auto_release
+  fi
 
+  # Setup source nightly image
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    (( is_dot_release )) && abort "dot releases are built from source"
+    [[ -z "${RELEASE_VERSION}" ]] && abort "release version must be specified with --version"
+    # TODO(adrcunha): "dot" releases from release branches require releasing nightlies
+    # for such branches, which we don't do yet.
+    [[ "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.0$ ]] || abort "version format must be 'X.Y.0'"
+    RELEASE_BRANCH="release-$(master_version ${RELEASE_VERSION})"
+    prepare_from_nightly_release
+    setup_upstream
   fi
 
   # Setup dot releases
@@ -299,20 +417,21 @@ function parse_flags() {
     RELEASE_GCS_BUCKET=""
   fi
 
-  if (( TAG_RELEASE )); then
-    # Get the commit, excluding any tags but keeping the "dirty" flag
-    local commit="$(git describe --always --dirty --match '^$')"
-    [[ -n "${commit}" ]] || abort "Error getting the current commit"
-    # Like kubernetes, image tag is vYYYYMMDD-commit
-    TAG="v$(date +%Y%m%d)-${commit}"
-  fi
+  # Get the commit, excluding any tags but keeping the "dirty" flag
+  BUILD_COMMIT_HASH="$(git describe --always --dirty --match '^$')"
+  [[ -n "${BUILD_COMMIT_HASH}" ]] || abort "error getting the current commit"
+  BUILD_YYYYMMDD="$(date -u +%Y%m%d)"
+  BUILD_TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  BUILD_TAG="v${BUILD_YYYYMMDD}-${BUILD_COMMIT_HASH}"
 
-  if [[ -n "${RELEASE_VERSION}" ]]; then
-    TAG="v${RELEASE_VERSION}"
-  fi
-
+  (( TAG_RELEASE )) && TAG="${BUILD_TAG}"
+  [[ -n "${RELEASE_VERSION}" ]] && TAG="v${RELEASE_VERSION}"
   [[ -n "${RELEASE_VERSION}" && -n "${RELEASE_BRANCH}" ]] && (( PUBLISH_RELEASE )) && PUBLISH_TO_GITHUB=1
 
+  readonly BUILD_COMMIT_HASH
+  readonly BUILD_YYYYMMDD
+  readonly BUILD_TIMESTAMP
+  readonly BUILD_TAG
   readonly SKIP_TESTS
   readonly TAG_RELEASE
   readonly PUBLISH_RELEASE
@@ -324,6 +443,7 @@ function parse_flags() {
   readonly RELEASE_GCS_BUCKET
   readonly KO_DOCKER_REPO
   readonly VALIDATION_TESTS
+  readonly FROM_NIGHTLY_RELEASE
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.
@@ -339,6 +459,16 @@ function run_validation_tests() {
   fi
 }
 
+# Publishes the generated artifacts to GCS, GitHub, etc.
+# Parameters: $1..$n - files to add to the release.
+function publish_artifacts() {
+  (( ! PUBLISH_RELEASE )) && return
+  tag_images_in_yamls ${ARTIFACTS_TO_PUBLISH}
+  publish_to_gcs ${ARTIFACTS_TO_PUBLISH}
+  publish_to_github ${ARTIFACTS_TO_PUBLISH}
+  banner "New release published successfully"
+}
+
 # Entry point for a release script.
 function main() {
   function_exists build_release || abort "function 'build_release()' not defined"
@@ -346,6 +476,9 @@ function main() {
   parse_flags $@
   # Log what will be done and where.
   banner "Release configuration"
+  echo "- gcloud user: $(gcloud config get-value core/account)"
+  echo "- Go path: ${GOPATH}"
+  echo "- Repository root: ${REPO_ROOT_DIR}"
   echo "- Destination GCR: ${KO_DOCKER_REPO}"
   (( SKIP_TESTS )) && echo "- Tests will NOT be run" || echo "- Tests will be run"
   if (( TAG_RELEASE )); then
@@ -361,38 +494,41 @@ function main() {
   if (( PUBLISH_TO_GITHUB )); then
     echo "- Release WILL BE published to GitHub"
   fi
-  [[ -n "${RELEASE_BRANCH}" ]] && echo "- Release will be built from branch '${RELEASE_BRANCH}'"
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    echo "- Release will be A COPY OF '${FROM_NIGHTLY_RELEASE}' nightly"
+  else
+    echo "- Release will be BUILT FROM SOURCE"
+    [[ -n "${RELEASE_BRANCH}" ]] && echo "- Release will be built from branch '${RELEASE_BRANCH}'"
+  fi
   [[ -n "${RELEASE_NOTES}" ]] && echo "- Release notes are generated from '${RELEASE_NOTES}'"
 
   # Checkout specific branch, if necessary
-  if [[ -n "${RELEASE_BRANCH}" ]]; then
+  if [[ -n "${RELEASE_BRANCH}" && -z "${FROM_NIGHTLY_RELEASE}" ]]; then
     setup_upstream
     setup_branch
     git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
   fi
 
-  set -o errexit
-  set -o pipefail
-
-  run_validation_tests ${VALIDATION_TESTS}
-  banner "Building the release"
-  build_release
-  # Do not use `||` above or any error will be swallowed.
-  if [[ $? -ne 0 ]]; then
-    abort "error building the release"
+  if [[ -n "${FROM_NIGHTLY_RELEASE}" ]]; then
+    build_from_nightly_release
+  else
+    set -e -o pipefail
+    build_from_source
+    set +e +o pipefail
   fi
-  [[ -z "${YAMLS_TO_PUBLISH}" ]] && abort "no manifests were generated"
+  # TODO(adrcunha): Remove once all repos use ARTIFACTS_TO_PUBLISH.
+  [[ -z "${ARTIFACTS_TO_PUBLISH}" ]] && ARTIFACTS_TO_PUBLISH="${YAMLS_TO_PUBLISH}"
+  [[ -z "${ARTIFACTS_TO_PUBLISH}" ]] && abort "no artifacts were generated"
+  # Ensure no empty file will be published.
+  for artifact in ${ARTIFACTS_TO_PUBLISH}; do
+    [[ -s ${artifact} ]] || abort "Artifact ${artifact} is empty"
+  done
   echo "New release built successfully"
-  if (( PUBLISH_RELEASE )); then
-    tag_images_in_yamls ${YAMLS_TO_PUBLISH}
-    publish_yamls ${YAMLS_TO_PUBLISH}
-    publish_to_github ${YAMLS_TO_PUBLISH}
-    echo "New release published successfully"
-  fi
+  publish_artifacts
 }
 
 # Publishes a new release on GitHub, also git tagging it (unless this is not a versioned release).
-# Parameters: $1..$n - YAML files to add to the release.
+# Parameters: $1..$n - files to add to the release.
 function publish_to_github() {
   (( PUBLISH_TO_GITHUB )) || return 0
   local title="${REPO_NAME_FORMATTED} release ${TAG}"
@@ -400,19 +536,17 @@ function publish_to_github() {
   local description="$(mktemp)"
   local attachments_dir="$(mktemp -d)"
   local commitish=""
-  # Copy each YAML to a separate dir
-  for yaml in $@; do
-    cp ${yaml} ${attachments_dir}/
-    attachments+=("--attach=${yaml}#$(basename ${yaml})")
+  # Copy files to a separate dir
+  for artifact in $@; do
+    cp ${artifact} ${attachments_dir}/
+    attachments+=("--attach=${artifact}#$(basename ${artifact})")
   done
   echo -e "${title}\n" > ${description}
   if [[ -n "${RELEASE_NOTES}" ]]; then
     cat ${RELEASE_NOTES} >> ${description}
   fi
   git tag -a ${TAG} -m "${title}"
-  local repo_url="${KNATIVE_UPSTREAM}"
-  [[ -n "${GITHUB_TOKEN}}" ]] && repo_url="${repo_url/:\/\//:\/\/${GITHUB_TOKEN}@}"
-  hub_tool push ${repo_url} tag ${TAG}
+  git_push tag ${TAG}
 
   [[ -n "${RELEASE_BRANCH}" ]] && commitish="--commitish=${RELEASE_BRANCH}"
   hub_tool release create \


### PR DESCRIPTION
Fixes https://github.com/knative/test-infra/issues/723

## Proposed Changes
Eventing 0.5 can only work with `Serving 0.5 + Istio 0.5 shipped by Serving`, but not `Serving 0.5 + GKE Istio Addon`, so we'll have to install `Istio 0.5` here.
Since `Istio 0.5` is only used by Eventing 0.5, and Serving release has stopped shipping Istio, I think it's better to add the function directly here instead of adding extra complexity to the test-infra. Please LMK if there's any other suggestion.

/cc @adrcunha 
/cc @chaodaiG 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
