### PR TITLE
Format markdown

### DIFF
--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -3,7 +3,6 @@
 The `Broker` and `Trigger` CRDs are documented in the
 [docs repo](https://github.com/knative/docs/blob/master/docs/eventing/broker-trigger.md).
 
-
 ## Implementation
 
 Broker and Trigger are intended to be black boxes. How they are implemented


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`