### PR TITLE
Updating Subscription Ready status on Failed conditions

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -106,7 +106,6 @@ func main() {
 		subscription.NewController(
 			opt,
 			subscriptionInformer,
-			channelInformer,
 			addressableInformer,
 		),
 		namespace.NewController(

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -106,6 +106,7 @@ func main() {
 		subscription.NewController(
 			opt,
 			subscriptionInformer,
+			channelInformer,
 			addressableInformer,
 		),
 		namespace.NewController(

--- a/pkg/apis/eventing/v1alpha1/subscription_lifecycle.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_lifecycle.go
@@ -18,6 +18,10 @@ package v1alpha1
 
 import duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 
+// subCondSet is a condition set with Ready as the happy condition and
+// ReferencesResolved and ChannelReady as the dependent conditions.
+var subCondSet = duckv1alpha1.NewLivingConditionSet(SubscriptionConditionReferencesResolved, SubscriptionConditionChannelReady)
+
 const (
 	// SubscriptionConditionReady has status True when all subconditions below have been set to True.
 	SubscriptionConditionReady = duckv1alpha1.ConditionReady
@@ -53,4 +57,14 @@ func (ss *SubscriptionStatus) MarkReferencesResolved() {
 // MarkChannelReady sets the ChannelReady condition to True state.
 func (ss *SubscriptionStatus) MarkChannelReady() {
 	subCondSet.Manage(ss).MarkTrue(SubscriptionConditionChannelReady)
+}
+
+// MarkReferencesNotResolved sets the ReferencesResolved condition to False state.
+func (ss *SubscriptionStatus) MarkReferencesNotResolved(reason, messageFormat string, messageA ...interface{}) {
+	subCondSet.Manage(ss).MarkFalse(SubscriptionConditionReferencesResolved, reason, messageFormat, messageA...)
+}
+
+// MarkChannelNotReady sets the ChannelReady condition to False state.
+func (ss *SubscriptionStatus) MarkChannelNotReady(reason, messageFormat string, messageA ...interface{}) {
+	subCondSet.Manage(ss).MarkFalse(SubscriptionConditionChannelReady, reason, messageFormat, messageA)
 }

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -165,10 +165,6 @@ type ReplyStrategy struct {
 	Channel *corev1.ObjectReference `json:"channel,omitempty"`
 }
 
-// subCondSet is a condition set with Ready as the happy condition and
-// ReferencesResolved and ChannelReady as the dependent conditions.
-var subCondSet = duckv1alpha1.NewLivingConditionSet(SubscriptionConditionReferencesResolved, SubscriptionConditionChannelReady)
-
 // SubscriptionStatus (computed) for a subscription
 type SubscriptionStatus struct {
 	// inherits duck/v1alpha1 Status, which currently provides:

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -82,7 +82,6 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 func NewController(
 	opt reconciler.Options,
 	subscriptionInformer eventinginformers.SubscriptionInformer,
-	channelInformer eventinginformers.ChannelInformer,
 	addressableInformer eventingduck.AddressableInformer,
 ) *controller.Impl {
 
@@ -99,14 +98,6 @@ func NewController(
 	// Tracker is used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
 	r.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
-	channelInformer.Informer().AddEventHandler(reconciler.Handler(
-		// Call the tracker's OnChanged method, but we've seen the objects coming through this path
-		// missing TypeMeta, so ensure it is properly populated.
-		controller.EnsureTypeMeta(
-			r.tracker.OnChanged,
-			v1alpha1.SchemeGroupVersion.WithKind("Channel"),
-		),
-	))
 
 	return impl
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -176,6 +176,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 			zap.Error(err),
 			zap.Any("channel", subscription.Spec.Channel))
 		r.Recorder.Eventf(subscription, corev1.EventTypeWarning, channelReferenceFetchFailed, "Failed to validate spec.channel exists: %v", err)
+		subscription.Status.MarkReferencesNotResolved(channelReferenceFetchFailed, "Failed to validate spec.channel exists: %v", err)
 		return err
 	}
 
@@ -191,6 +192,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 			zap.Error(err),
 			zap.Any("subscriber", subscription.Spec.Subscriber))
 		r.Recorder.Eventf(subscription, corev1.EventTypeWarning, subscriberResolveFailed, "Failed to resolve spec.subscriber: %v", err)
+		subscription.Status.MarkReferencesNotResolved(subscriberResolveFailed, "Failed to resolve spec.subscriber: %v", err)
 		return err
 	}
 
@@ -203,6 +205,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 			zap.Error(err),
 			zap.Any("reply", subscription.Spec.Reply))
 		r.Recorder.Eventf(subscription, corev1.EventTypeWarning, resultResolveFailed, "Failed to resolve spec.reply: %v", err)
+		subscription.Status.MarkReferencesNotResolved(resultResolveFailed, "Failed to resolve spec.reply: %v", err)
 		return err
 	}
 
@@ -221,6 +224,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 	if err := r.syncPhysicalChannel(ctx, subscription, false); err != nil {
 		logging.FromContext(ctx).Warn("Failed to sync physical Channel", zap.Error(err))
 		r.Recorder.Eventf(subscription, corev1.EventTypeWarning, physicalChannelSyncFailed, "Failed to sync physical Channel: %v", err)
+		subscription.Status.MarkChannelNotReady(physicalChannelSyncFailed, "Failed to sync physical Channel: %v", err)
 		return err
 	}
 	// Everything went well, set the fact that subscriptions have been modified

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -82,6 +82,7 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 func NewController(
 	opt reconciler.Options,
 	subscriptionInformer eventinginformers.SubscriptionInformer,
+	channelInformer eventinginformers.ChannelInformer,
 	addressableInformer eventingduck.AddressableInformer,
 ) *controller.Impl {
 
@@ -98,6 +99,14 @@ func NewController(
 	// Tracker is used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
 	r.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
+	channelInformer.Informer().AddEventHandler(reconciler.Handler(
+		// Call the tracker's OnChanged method, but we've seen the objects coming through this path
+		// missing TypeMeta, so ensure it is properly populated.
+		controller.EnsureTypeMeta(
+			r.tracker.OnChanged,
+			v1alpha1.SchemeGroupVersion.WithKind("Channel"),
+		),
+	))
 
 	return impl
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -99,6 +99,7 @@ func NewController(
 	// Tracker is used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
 	r.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
+	// TODO further analyze if this informer can be removed.
 	channelInformer.Informer().AddEventHandler(reconciler.Handler(
 		// Call the tracker's OnChanged method, but we've seen the objects coming through this path
 		// missing TypeMeta, so ensure it is properly populated.

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -627,13 +627,12 @@ func TestNew(t *testing.T) {
 	eventingInformer := informers.NewSharedInformerFactory(eventingClient, 0)
 
 	subscriptionInformer := eventingInformer.Eventing().V1alpha1().Subscriptions()
-	channelInformer := eventingInformer.Eventing().V1alpha1().Channels()
 	addressableInformer := &fakeAddressableInformer{}
 	c := NewController(reconciler.Options{
 		KubeClientSet:     kubeClient,
 		EventingClientSet: eventingClient,
 		Logger:            logtesting.TestLogger(t),
-	}, subscriptionInformer, channelInformer, addressableInformer)
+	}, subscriptionInformer, addressableInformer)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -656,12 +656,13 @@ func TestNew(t *testing.T) {
 	eventingInformer := informers.NewSharedInformerFactory(eventingClient, 0)
 
 	subscriptionInformer := eventingInformer.Eventing().V1alpha1().Subscriptions()
+	channelInformer := eventingInformer.Eventing().V1alpha1().Channels()
 	addressableInformer := &fakeAddressableInformer{}
 	c := NewController(reconciler.Options{
 		KubeClientSet:     kubeClient,
 		EventingClientSet: eventingClient,
 		Logger:            logtesting.TestLogger(t),
-	}, subscriptionInformer, addressableInformer)
+	}, subscriptionInformer, channelInformer, addressableInformer)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -143,6 +143,12 @@ func MarkSubscriptionReady(s *v1alpha1.Subscription) {
 	s.Status.MarkReferencesResolved()
 }
 
+func WithSubscriptionReferencesNotResolved(reason, msg string) SubscriptionOption {
+	return func(s *v1alpha1.Subscription) {
+		s.Status.MarkReferencesNotResolved(reason, msg)
+	}
+}
+
 func WithSubscriptionReply(gvk metav1.GroupVersionKind, name string) SubscriptionOption {
 	return func(s *v1alpha1.Subscription) {
 		s.Spec.Reply = &v1alpha1.ReplyStrategy{


### PR DESCRIPTION
Found this while investigation the changes for Channel CRDs

## Proposed Changes

- Marking subscription as not ready in the different failure conditions that can occur.
- Updated UTs.
- Still not entirely sure if we can remove the channel informer. Will further discuss with @Harwayne 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
