### PR TITLE
rename webhook to be eventing-webhook to avoid potential clash

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -88,7 +88,7 @@ func main() {
 		DeploymentName: logconfig.WebhookName(),
 		Namespace:      system.Namespace(),
 		Port:           8443,
-		SecretName:     "webhook-certs",
+		SecretName:     "eventing-webhook-certs",
 		WebhookName:    "webhook.eventing.knative.dev",
 	}
 	controller := webhook.AdmissionController{

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -16,12 +16,12 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    role: webhook
-  name: webhook
+    role: eventing-webhook
+  name: eventing-webhook
   namespace: knative-eventing
 spec:
   ports:
     - port: 443
       targetPort: 8443
   selector:
-    role: webhook
+    role: eventing-webhook

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -15,10 +15,56 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webhook
+  name: eventing-webhook
   namespace: knative-eventing
 spec:
   replicas: 1
+  selector:
+    matchLabels: &labels
+      app: eventing-webhook
+      role: eventing-webhook
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels: *labels
+    spec:
+      serviceAccountName: eventing-webhook
+      containers:
+      - name: eventing-webhook
+        terminationMessagePolicy: FallbackToLogsOnError
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: github.com/knative/eventing/cmd/webhook
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: WEBHOOK_NAME
+          value: eventing-webhook
+        resources:
+          limits:
+            memory: 1000Mi   # An initial guess, but consistent with serving
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-eventing
+spec:
+  replicas: 0
   selector:
     matchLabels: &labels
       app: webhook


### PR DESCRIPTION
Fixes #1260

## Proposed Changes

- rename `webhook` to be `eventing-webhook`
- keep old `webhook` deployment, but with `replicas: 0`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
the webhook has been renamed to eventing-webhook, and the old webhook will scale to 0
```
