### PR TITLE
Adding CRD to the yaml artifacts, and release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,7 +20,8 @@ source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 declare -A COMPONENTS
 COMPONENTS=(
   ["eventing.yaml"]="config"
-  ["in-memory-channel.yaml"]="config/provisioners/in-memory-channel"
+  ["in-memory-channel-crd.yaml"]="config/channels/in-memory-channel"
+  ["in-memory-channel-provisioner.yaml"]="config/provisioners/in-memory-channel"
   ["kafka.yaml"]="contrib/kafka/config"
   ["gcp-pubsub.yaml"]="contrib/gcppubsub/config"
   ["natss.yaml"]="contrib/natss/config"
@@ -29,7 +30,7 @@ readonly COMPONENTS
 
 declare -A RELEASES
 RELEASES=(
-  ["release.yaml"]="eventing.yaml in-memory-channel.yaml"
+  ["release.yaml"]="eventing.yaml in-memory-channel-crd.yaml in-memory-channel-provisioner.yaml"
 )
 readonly RELEASES
 


### PR DESCRIPTION
## Proposed Changes

- adding In-Mem channel CRD to a separate yaml file
- including it in the `release.yaml` file
- renaming the current one to `-provisioner`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
the in-memory-channel.yaml is replaced by the in-memory-channel-provisioner.yaml, and there is an new in-memory-channel-crd.yaml file that contains the new CRD for the in-mem channel
```
