### PR TITLE
Add one E2E test case that uses both broker and channel

### DIFF
--- a/test/base/generics.go
+++ b/test/base/generics.go
@@ -54,7 +54,10 @@ func GetGenericObject(dynamicClient dynamic.Interface, obj *MetaResource, rtype 
 	gvk := obj.GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	// use the helper functions to convert the resource to the given duck-type
-	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype}
+	stopChannel := make(chan struct{})
+	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype, StopChannel: stopChannel}
+	// defer close the stopChannel to stop the informer created in tif.Get(gvr)
+	defer close(stopChannel)
 	_, lister, err := tif.Get(gvr)
 	if err != nil {
 		return nil, err

--- a/test/base/generics.go
+++ b/test/base/generics.go
@@ -53,11 +53,12 @@ func GetGenericObject(dynamicClient dynamic.Interface, obj *MetaResource, rtype 
 	namespace := obj.Namespace
 	gvk := obj.GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	// use the helper functions to convert the resource to the given duck-type
+
 	stopChannel := make(chan struct{})
-	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype, StopChannel: stopChannel}
 	// defer close the stopChannel to stop the informer created in tif.Get(gvr)
 	defer close(stopChannel)
+	// use the helper functions to convert the resource to the given duck-type
+	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype, StopChannel: stopChannel}
 	_, lister, err := tif.Get(gvr)
 	if err != nil {
 		return nil, err

--- a/test/base/generics.go
+++ b/test/base/generics.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// MetaResource includes necessary meta data to retrieve the duck-type KResource.
+// MetaResource includes necessary meta data to retrieve the generic Kubernetes resource.
 type MetaResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ func GetGenericObject(dynamicClient dynamic.Interface, obj *MetaResource, rtype 
 	namespace := obj.Namespace
 	gvk := obj.GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	// use the helper functions to convert the resource to a KResource duck
+	// use the helper functions to convert the resource to the given duck-type
 	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype}
 	_, lister, err := tif.Get(gvr)
 	if err != nil {

--- a/test/base/generics.go
+++ b/test/base/generics.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"github.com/knative/pkg/apis"
+	"github.com/knative/pkg/apis/duck"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+)
+
+// MetaResource includes necessary meta data to retrieve the duck-type KResource.
+type MetaResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// Meta returns a MetaResource built from the given name, namespace and kind.
+func Meta(name, namespace, kind string) *MetaResource {
+	return &MetaResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kind,
+			APIVersion: EventingAPIVersion,
+		},
+	}
+}
+
+// GetGenericObject returns a generic object representing a Kubernetes resource.
+// Callers can cast this returned object to other objects that implement the corresponding duck-type.
+func GetGenericObject(dynamicClient dynamic.Interface, obj *MetaResource, rtype apis.Listable) (runtime.Object, error) {
+	// get the resource's name, namespace and gvr
+	name := obj.Name
+	namespace := obj.Namespace
+	gvk := obj.GroupVersionKind()
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	// use the helper functions to convert the resource to a KResource duck
+	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: rtype}
+	_, lister, err := tif.Get(gvr)
+	if err != nil {
+		return nil, err
+	}
+	return lister.ByNamespace(namespace).Get(name)
+}

--- a/test/base/resource_checks.go
+++ b/test/base/resource_checks.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// crdpolling contains functions which poll Knative Serving CRDs until they
+// resource_checks.go contains functions which check resources until they
 // get into the state desired by the caller or time out.
 
 package base
@@ -24,35 +24,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/knative/pkg/apis/duck"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"go.opencensus.io/trace"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 )
-
-// MetaResource includes necessary meta data to retrieve the duck-type KResource.
-type MetaResource struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-}
-
-// Meta returns a MetaResource built from the given name, namespace and kind.
-func Meta(name, namespace, kind string) *MetaResource {
-	return &MetaResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       kind,
-			APIVersion: EventingAPIVersion,
-		},
-	}
-}
 
 const (
 	// The interval and timeout used for polling in checking resource states.
@@ -77,19 +54,7 @@ func WaitForResourceReady(dynamicClient dynamic.Interface, obj *MetaResource) er
 
 // isResourceReady leverage duck-type to check if the given MetaResource is in ready state
 func isResourceReady(dynamicClient dynamic.Interface, obj *MetaResource) (bool, error) {
-	// get the resource's name, namespace and gvr
-	name := obj.Name
-	namespace := obj.Namespace
-	gvk := obj.GroupVersionKind()
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	// use the helper functions to convert the resource to a KResource duck
-	tif := &duck.TypedInformerFactory{Client: dynamicClient, Type: &duckv1alpha1.KResource{}}
-	_, lister, err := tif.Get(gvr)
-	if err != nil {
-		// Return error to stop the polling.
-		return false, err
-	}
-	untyped, err := lister.ByNamespace(namespace).Get(name)
+	untyped, err := GetGenericObject(dynamicClient, obj, &duckv1alpha1.KResource{})
 	if k8serrors.IsNotFound(err) {
 		// Return false as we are not done yet.
 		// We swallow the error to keep on polling.
@@ -99,6 +64,7 @@ func isResourceReady(dynamicClient dynamic.Interface, obj *MetaResource) (bool, 
 		// Return error to stop the polling.
 		return false, err
 	}
+
 	kr := untyped.(*duckv1alpha1.KResource)
 	return kr.Status.GetCondition(duckv1alpha1.ConditionReady).IsTrue(), nil
 }

--- a/test/base/resource_inspectors.go
+++ b/test/base/resource_inspectors.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// GetAddressableURI returns the uri for the given resource that implements Addressable duck.
+// GetAddressableURI returns the uri for the given resource that implements Addressable duck-type.
 func GetAddressableURI(dynamicClient dynamic.Interface, obj *MetaResource) (string, error) {
 	untyped, err := GetGenericObject(dynamicClient, obj, &duckv1alpha1.AddressableType{})
 	if err != nil {

--- a/test/base/resource_inspectors.go
+++ b/test/base/resource_inspectors.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// resource_inspectors.go contains functions which get property values for
+// resources provided by the caller.
+
+package base
+
+import (
+	"fmt"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"k8s.io/client-go/dynamic"
+)
+
+// GetAddressableURI returns the uri for the given resource that implements Addressable duck.
+func GetAddressableURI(dynamicClient dynamic.Interface, obj *MetaResource) (string, error) {
+	untyped, err := GetGenericObject(dynamicClient, obj, &duckv1alpha1.AddressableType{})
+	if err != nil {
+		return "", err
+	}
+
+	at := untyped.(*duckv1alpha1.AddressableType)
+	uri := fmt.Sprintf("http://%s", at.Status.Address.Hostname)
+	return uri, nil
+}

--- a/test/base/resources.go
+++ b/test/base/resources.go
@@ -140,6 +140,15 @@ func WithSubscriberForTrigger(name string) func(*v1alpha1.Trigger) {
 	}
 }
 
+// WithURIForTrigger returns an option that adds a uri for the given Trigger.
+func WithURIForTrigger(uri string) func(*v1alpha1.Trigger) {
+	return func(t *v1alpha1.Trigger) {
+		t.Spec.Subscriber = &v1alpha1.SubscriberSpec{
+			URI: &uri,
+		}
+	}
+}
+
 // Trigger returns a Trigger.
 func Trigger(name string, options ...func(*v1alpha1.Trigger)) *v1alpha1.Trigger {
 	trigger := &v1alpha1.Trigger{

--- a/test/base/resources.go
+++ b/test/base/resources.go
@@ -129,8 +129,8 @@ func WithBroker(brokerName string) func(*v1alpha1.Trigger) {
 	}
 }
 
-// WithSubscriberForTrigger returns an option that adds a Subscriber for the given Trigger.
-func WithSubscriberForTrigger(name string) func(*v1alpha1.Trigger) {
+// WithSubscriberRefForTrigger returns an option that adds a Subscriber Ref for the given Trigger.
+func WithSubscriberRefForTrigger(name string) func(*v1alpha1.Trigger) {
 	return func(t *v1alpha1.Trigger) {
 		if name != "" {
 			t.Spec.Subscriber = &v1alpha1.SubscriberSpec{
@@ -140,8 +140,8 @@ func WithSubscriberForTrigger(name string) func(*v1alpha1.Trigger) {
 	}
 }
 
-// WithURIForTrigger returns an option that adds a uri for the given Trigger.
-func WithURIForTrigger(uri string) func(*v1alpha1.Trigger) {
+// WithSubscriberURIForTrigger returns an option that adds a Subscriber URI for the given Trigger.
+func WithSubscriberURIForTrigger(uri string) func(*v1alpha1.Trigger) {
 	return func(t *v1alpha1.Trigger) {
 		t.Spec.Subscriber = &v1alpha1.SubscriberSpec{
 			URI: &uri,

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -1,0 +1,203 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	"github.com/knative/eventing/test/base"
+	"github.com/knative/eventing/test/common"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+/*
+TestEventTransformationForTrigger tests the following topology:
+
+                   ------------- ----------------------
+                   |           | |                    |
+                   v	       | v                    |
+EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
+                   |
+                   |
+				   |-------> Trigger2 -------> Service(Logger)
+				   |
+				   |
+				   |-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger)
+
+Explanation:
+Trigger1 filters the orignal event and tranforms it to a new event,
+Trigger2 filters all events,
+Trigger3 filters the transformed event and send it to Channel.
+
+*/
+func TestBrokerChannelFlow(t *testing.T) {
+	RunTests(t, common.FeatureBasic, testBrokerChannelFlow)
+}
+
+func testBrokerChannelFlow(t *testing.T, provisioner string) {
+	const (
+		senderName    = "e2e-brokerchannel-sender"
+		brokerName    = "e2e-brokerchannel-broker"
+		saIngressName = "eventing-broker-ingress"
+		saFilterName  = "eventing-broker-filter"
+
+		// This ClusterRole is installed in Knative Eventing setup, see https://github.com/knative/eventing/tree/master/docs/broker#manual-setup.
+		crIngressName = "eventing-broker-ingress"
+		crFilterName  = "eventing-broker-filter"
+
+		any          = v1alpha1.TriggerAnyFilter
+		eventType1   = "type1"
+		eventType2   = "type2"
+		eventSource1 = "source1"
+		eventSource2 = "source2"
+		eventBody    = "e2e-brokerchannel-body"
+
+		triggerName1 = "e2e-brokerchannel-trigger1"
+		triggerName2 = "e2e-brokerchannel-trigger2"
+		triggerName3 = "e2e-brokerchannel-trigger3"
+
+		transformationPodName = "e2e-brokerchannel-trans-pod"
+		loggerPodName1        = "e2e-brokerchannel-logger-pod1"
+		loggerPodName2        = "e2e-brokerchannel-logger-pod2"
+
+		channelName      = "e2e-brokerchannel-channel"
+		subscriptionName = "e2e-brokerchannel-subscription"
+	)
+
+	client := Setup(t, provisioner, true)
+	defer TearDown(client)
+
+	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role
+	if err := client.CreateServiceAccountAndBinding(saIngressName, crIngressName); err != nil {
+		t.Fatalf("Failed to create the Ingress ServiceAccount and ServiceAccountRoleBinding: %v", err)
+	}
+	if err := client.CreateServiceAccountAndBinding(saFilterName, crFilterName); err != nil {
+		t.Fatalf("Failed to create the Filter ServiceAccount and ServiceAccountRoleBinding: %v", err)
+	}
+
+	// create a new broker
+	if err := client.CreateBroker(brokerName, provisioner); err != nil {
+		t.Fatalf("Failed to create the Broker: %q, %v", brokerName, err)
+	}
+	client.WaitForBrokerReady(brokerName)
+
+	// create the event we want to transform to
+	transformedEventBody := fmt.Sprintf("%s %s", eventBody, string(uuid.NewUUID()))
+	eventAfterTransformation := &base.CloudEvent{
+		Source:   eventSource2,
+		Type:     eventType2,
+		Data:     fmt.Sprintf(`{"msg":%q}`, transformedEventBody),
+		Encoding: base.CloudEventDefaultEncoding,
+	}
+
+	// create the transformation service for trigger1
+	transformationPod := base.EventTransformationPod(transformationPodName, eventAfterTransformation)
+	if err := client.CreatePod(transformationPod, common.WithService(transformationPodName)); err != nil {
+		t.Fatalf("Failed to create transformation service %q: %v", transformationPodName, err)
+	}
+
+	// create trigger1 to receive the original event, and do event transformation
+	if err := client.CreateTrigger(
+		triggerName1,
+		base.WithBroker(brokerName),
+		base.WithTriggerFilter(eventSource1, eventType1),
+		base.WithSubscriberForTrigger(transformationPodName),
+	); err != nil {
+		t.Fatalf("Error creating trigger %q: %v", triggerName1, err)
+	}
+
+	// create logger pod and service for trigger2
+	loggerPod1 := base.EventLoggerPod(loggerPodName1)
+	if err := client.CreatePod(loggerPod1, common.WithService(loggerPodName1)); err != nil {
+		t.Fatalf("Failed to create logger service %q: %v", loggerPodName1, err)
+	}
+
+	// create trigger2 to receive all the events
+	if err := client.CreateTrigger(
+		triggerName2,
+		base.WithBroker(brokerName),
+		base.WithTriggerFilter(any, any),
+		base.WithSubscriberForTrigger(loggerPodName1),
+	); err != nil {
+		t.Fatalf("Error creating trigger %q: %v", triggerName2, err)
+	}
+
+	// create channel for trigger3
+	if err := client.CreateChannel(channelName, provisioner); err != nil {
+		t.Fatalf("Failed to create channel %q: %v", channelName, err)
+	}
+	client.WaitForChannelReady(channelName)
+
+	// create trigger3 to receive the transformed event, and send it to the channel
+	channelURL, err := client.GetChannelURL(channelName)
+	if err != nil {
+		t.Fatalf("Failed to get the url for the channel %q: %v", channelName, err)
+	}
+	if err := client.CreateTrigger(
+		triggerName3,
+		base.WithBroker(brokerName),
+		base.WithTriggerFilter(eventSource2, eventType2),
+		base.WithURIForTrigger(channelURL),
+	); err != nil {
+		t.Fatalf("Error creating trigger %q: %v", triggerName3, err)
+	}
+
+	// create logger pod and service for subscription
+	loggerPod2 := base.EventLoggerPod(loggerPodName2)
+	if err := client.CreatePod(loggerPod2, common.WithService(loggerPodName2)); err != nil {
+		t.Fatalf("Failed to create logger service %q: %v", loggerPodName2, err)
+	}
+
+	// create subscription
+	if err := client.CreateSubscription(
+		subscriptionName,
+		channelName,
+		base.WithSubscriberForSubscription(loggerPodName2),
+	); err != nil {
+		t.Fatalf("Error creating subscription %q: %v", subscriptionName, err)
+	}
+
+	// wait for all test resources to be ready, so that we can start sending events
+	if err := client.WaitForAllTestResourcesReady(); err != nil {
+		t.Fatalf("Failed to get all test resources ready: %v", err)
+	}
+
+	// send fake CloudEvent to the broker
+	eventToSend := &base.CloudEvent{
+		Source:   eventSource1,
+		Type:     eventType1,
+		Data:     fmt.Sprintf(`{"msg":%q}`, eventBody),
+		Encoding: base.CloudEventDefaultEncoding,
+	}
+	if err := client.SendFakeEventToBroker(senderName, brokerName, eventToSend); err != nil {
+		t.Fatalf("Failed to send fake CloudEvent to the broker %q", brokerName)
+	}
+
+	// check if trigger2's logging service receives both events
+	eventBodies := []string{transformedEventBody, eventBody}
+	if err := client.CheckLog(loggerPodName1, common.CheckerContainsAll([]string{transformedEventBody, eventBody})); err != nil {
+		t.Fatalf("Strings %v not found in logs of logger pod %q: %v", eventBodies, loggerPodName1, err)
+	}
+
+	// check if subscription's logging service receives the transformed event
+	if err := client.CheckLog(loggerPodName2, common.CheckerContains(transformedEventBody)); err != nil {
+		t.Fatalf("Strings %q not found in logs of logger pod %q: %v", transformedEventBody, loggerPodName2, err)
+	}
+}

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -118,7 +118,7 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 		triggerName1,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource1, eventType1),
-		base.WithSubscriberForTrigger(transformationPodName),
+		base.WithSubscriberRefForTrigger(transformationPodName),
 	); err != nil {
 		t.Fatalf("Error creating trigger %q: %v", triggerName1, err)
 	}

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -134,7 +134,7 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 		triggerName2,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(any, any),
-		base.WithSubscriberForTrigger(loggerPodName1),
+		base.WithSubscriberRefForTrigger(loggerPodName1),
 	); err != nil {
 		t.Fatalf("Error creating trigger %q: %v", triggerName2, err)
 	}
@@ -154,7 +154,7 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 		triggerName3,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource2, eventType2),
-		base.WithURIForTrigger(channelURL),
+		base.WithSubscriberURIForTrigger(channelURL),
 	); err != nil {
 		t.Fatalf("Error creating trigger %q: %v", triggerName3, err)
 	}

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -36,15 +36,15 @@ TestEventTransformationForTrigger tests the following topology:
 EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
                    |
                    |
-				   |-------> Trigger2 -------> Service(Logger)
-				   |
-				   |
-				   |-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger)
+                   |-------> Trigger2 -------> Service(Logger1)
+                   |
+                   |
+                   |-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger2)
 
 Explanation:
 Trigger1 filters the orignal event and tranforms it to a new event,
-Trigger2 filters all events,
-Trigger3 filters the transformed event and send it to Channel.
+Trigger2 logs all events,
+Trigger3 filters the transformed event and sends it to Channel.
 
 */
 func TestBrokerChannelFlow(t *testing.T) {

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -91,7 +91,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 		triggerName := name("trigger", event.typeAndSource.Type, event.typeAndSource.Source)
 		subscriberName := name("dumper", event.typeAndSource.Type, event.typeAndSource.Source)
 		if err := client.CreateTrigger(triggerName,
-			base.WithSubscriberForTrigger(subscriberName),
+			base.WithSubscriberRefForTrigger(subscriberName),
 			base.WithTriggerFilter(event.typeAndSource.Source, event.typeAndSource.Type),
 		); err != nil {
 			t.Fatalf("Failed to create the trigger %q: %v", triggerName, err)

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -123,7 +123,7 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string) {
 		triggerName2,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource2, eventType2),
-		base.WithSubscriberForTrigger(loggerPodName),
+		base.WithSubscriberRefForTrigger(loggerPodName),
 	); err != nil {
 		t.Fatalf("Error creating trigger %q: %v", triggerName2, err)
 	}

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -107,7 +107,7 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string) {
 		triggerName1,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource1, eventType1),
-		base.WithSubscriberForTrigger(transformationPodName),
+		base.WithSubscriberRefForTrigger(transformationPodName),
 	); err != nil {
 		t.Fatalf("Error creating trigger %q: %v", triggerName1, err)
 	}


### PR DESCRIPTION
Fixes #1273 

The PR involves the following changes:
1. Split generic methods for operating on duck-type into three files: `generics.go` provides function to get the raw object for a given duck-type; `resource_checks.go` contains functions to check the duck resource status; `resource_inspectors.go` contains functions that can return status of a duck resource.
2. Add one E2E test case to test the scenario that uses both `Broker` and `Channel`.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
