### PR TITLE
Add type godoc for Broker and Trigger

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -29,6 +29,11 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Broker collects a pool of events that are consumable using Triggers. Brokers
+// provide a well-known endpoint for event delivery that senders can use with
+// minimal knowledge of the event routing strategy. Receivers use Triggers to
+// request delivery of events from a Broker's pool to a specific URL or
+// Addressable endpoint.
 type Broker struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -29,6 +29,8 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Trigger represents a request to have events delivered to a consumer from a
+// Broker's event pool.
 type Trigger struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional


### PR DESCRIPTION
I noticed while combing through the API that `Broker` and `Trigger` don't have type-level godoc for what they are.
