### PR TITLE
Pickup runtime.Object change

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:0a8d273e9d38c7da3b2352a05f803b3bc543e7f0d8aefd5f0e913b3ec2a8c209"
+  digest = "1:a759cce98b97e3fecea0a9ff2bf06600136f8a8d25bbac26863e628f0a1e42de"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -481,7 +481,7 @@
     "webhook",
   ]
   pruneopts = "NUT"
-  revision = "985bff446d4e8da3ed9afaa2cefe9d91d03ae7e2"
+  revision = "15b1aa79be0b927a9e62d1738b03ef3efb2745f3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,8 +73,8 @@ required = [
 # This controls when we upgrade apis independently of Serving.
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-05-28
-  revision = "985bff446d4e8da3ed9afaa2cefe9d91d03ae7e2"
+  # HEAD as of 2019-05-29
+  revision = "15b1aa79be0b927a9e62d1738b03ef3efb2745f3"
 
 # TODO why is this overridden?
 [[override]]

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -148,7 +148,7 @@ func TestReconcile(t *testing.T) {
 					WithApiServerSourceEventTypes,
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeReceiveAdapter(),
 			},
 		},
@@ -198,7 +198,7 @@ func TestReconcile(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{
 				{Name: "name-1"},
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeReceiveAdapter(),
 			},
 		},
@@ -244,7 +244,7 @@ func TestReconcile(t *testing.T) {
 					WithApiServerSourceEventTypes,
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateEventType),
@@ -299,7 +299,7 @@ func TestReconcile(t *testing.T) {
 					WithApiServerSourceEventTypes,
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
@@ -357,7 +357,7 @@ func TestReconcile(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{
 				{Name: "name-1"},
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateEventType),

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -122,7 +122,7 @@ func TestReconcile(t *testing.T) {
 					WithBrokerChannelProvisioner(channelProvisioner("my-provisioner")),
 					WithInitBrokerConditions),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewChannel("", testNS,
 					WithChannelGenerateName(channelGenerateName),
 					WithChannelLabels(TriggerChannelLabels(brokerName)),
@@ -183,7 +183,7 @@ func TestReconcile(t *testing.T) {
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "deployments"),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewDeployment(filterDeploymentName, testNS,
 					WithDeploymentOwnerReferences(ownerReferences()),
 					WithDeploymentLabels(resources.FilterLabels(brokerName)),
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "services"),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewService(filterServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
 					WithServiceLabels(resources.FilterLabels(brokerName)),
@@ -357,7 +357,7 @@ func TestReconcile(t *testing.T) {
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "deployments"),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewDeployment(ingressDeploymentName, testNS,
 					WithDeploymentOwnerReferences(ownerReferences()),
 					WithDeploymentLabels(resources.IngressLabels(brokerName)),
@@ -462,7 +462,7 @@ func TestReconcile(t *testing.T) {
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "services"),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewService(ingressServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
 					WithServiceLabels(resources.IngressLabels(brokerName)),
@@ -572,7 +572,7 @@ func TestReconcile(t *testing.T) {
 			WithReactors: []clientgotesting.ReactionFunc{
 				InduceFailure("create", "channels"),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewChannel("", testNS,
 					WithChannelGenerateName(channelGenerateName),
 					WithChannelLabels(IngressChannelLabels(brokerName)),
@@ -636,7 +636,7 @@ func TestReconcile(t *testing.T) {
 					WithChannelReady,
 					WithChannelAddress(ingressChannelHostname)),
 			},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewSubscription("", testNS,
 					WithSubscriptionGenerateName(ingressSubscriptionGenerateName),
 					WithSubscriptionOwnerReferences(ownerReferences()),
@@ -787,7 +787,7 @@ func TestReconcile(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				Name: "subs",
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewSubscription("", testNS,
 					WithSubscriptionGenerateName(ingressSubscriptionGenerateName),
 					WithSubscriptionOwnerReferences(ownerReferences()),

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -253,7 +253,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceDeploying(`Created deployment ""`),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeDeployment(NewContainerSource(sourceName, testNS,
 					WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 						Image: image,
@@ -339,7 +339,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceDeploying(`Created deployment ""`),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeDeployment(NewContainerSource(sourceName, testNS,
 					WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 						Image: image,
@@ -382,7 +382,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceDeployFailed(`Could not create deployment: inducing failure for create deployments`),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeDeployment(NewContainerSource(sourceName, testNS,
 					WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 						Image: image,
@@ -420,7 +420,7 @@ func TestAllCases(t *testing.T) {
 		//			WithContainerSourceDeploying(`Created deployment ""`),
 		//		),
 		//	}},
-		//	WantCreates: []metav1.Object{
+		//	WantCreates: []runtime.Object{
 		//		makeDeployment(NewContainerSource(sourceName, testNS,
 		//			WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 		//				Image: image,

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -187,7 +187,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceEventType,
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeReceiveAdapter(),
 			},
 		}, {
@@ -225,7 +225,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceSink(sinkURI),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewEventType("", testNS,
 					WithEventTypeGenerateName(fmt.Sprintf("%s-", utils.ToDNS1123Subdomain(sourcesv1alpha1.CronJobEventType))),
 					WithEventTypeLabels(resources.Labels(sourceName)),
@@ -279,7 +279,7 @@ func TestAllCases(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				Name: "name-1",
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				NewEventType("", testNS,
 					WithEventTypeGenerateName(fmt.Sprintf("%s-", utils.ToDNS1123Subdomain(sourcesv1alpha1.CronJobEventType))),
 					WithEventTypeLabels(resources.Labels(sourceName)),

--- a/pkg/reconciler/inmemorychannel/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/inmemorychannel_test.go
@@ -219,7 +219,7 @@ func TestAllCases(t *testing.T) {
 				reconciletesting.NewInMemoryChannel(imcName, testNS),
 			},
 			WantErr: false,
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeChannelService(reconciletesting.NewInMemoryChannel(imcName, testNS)),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -304,7 +304,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithInMemoryChannelChannelServicetNotReady("ChannelServiceFailed", "Channel Service failed: inducing failure for create services"),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeChannelService(reconciletesting.NewInMemoryChannel(imcName, testNS)),
 			},
 			WantEvents: []string{

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -159,7 +159,7 @@ func TestAllCases(t *testing.T) {
 			brokerEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			broker,
 			saIngress,
 			rbIngress,
@@ -184,7 +184,7 @@ func TestAllCases(t *testing.T) {
 			rbFilterEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			saIngress,
 			rbIngress,
 			saFilter,
@@ -224,7 +224,7 @@ func TestAllCases(t *testing.T) {
 			brokerEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			broker,
 			rbIngress,
 			saFilter,
@@ -248,7 +248,7 @@ func TestAllCases(t *testing.T) {
 			brokerEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			broker,
 			saIngress,
 			saFilter,
@@ -272,7 +272,7 @@ func TestAllCases(t *testing.T) {
 			brokerEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			broker,
 			saIngress,
 			rbIngress,
@@ -296,7 +296,7 @@ func TestAllCases(t *testing.T) {
 			brokerEvent,
 			nsEvent,
 		},
-		WantCreates: []metav1.Object{
+		WantCreates: []runtime.Object{
 			broker,
 			saIngress,
 			rbIngress,

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -302,7 +302,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithTriggerStatusSubscriberURI(subscriberURI),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeIngressSubscription(),
 			},
 		}, {
@@ -381,7 +381,7 @@ func TestAllCases(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				Name: "",
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeIngressSubscription(),
 			},
 		}, {
@@ -419,7 +419,7 @@ func TestAllCases(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				Name: "",
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeIngressSubscription(),
 			},
 		}, {
@@ -451,7 +451,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithTriggerStatusSubscriberURI(subscriberURI),
 				),
 			}},
-			WantCreates: []metav1.Object{
+			WantCreates: []runtime.Object{
 				makeIngressSubscription(),
 			},
 		}, {

--- a/vendor/github.com/knative/pkg/reconciler/testing/table.go
+++ b/vendor/github.com/knative/pkg/reconciler/testing/table.go
@@ -29,7 +29,6 @@ import (
 	"github.com/knative/pkg/kmeta"
 	_ "github.com/knative/pkg/system/testing" // Setup system.Namespace()
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -54,7 +53,7 @@ type TableRow struct {
 	WantErr bool
 
 	// WantCreates holds the ordered list of Create calls we expect during reconciliation.
-	WantCreates []metav1.Object
+	WantCreates []runtime.Object
 
 	// WantUpdates holds the ordered list of Update calls we expect during reconciliation.
 	WantUpdates []clientgotesting.UpdateActionImpl


### PR DESCRIPTION
We allow a more permissive type for WantCreates, which requires a change to most existing table tests which use a different slice type.

