### PR TITLE
#1251 Duck type user info annotation logic

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/broker_defaults.go
@@ -18,34 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-
-	"github.com/knative/eventing/pkg/apis/eventing"
-
-	"github.com/knative/pkg/apis"
-	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func (b *Broker) SetDefaults(ctx context.Context) {
 	b.Spec.SetDefaults(ctx)
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := b.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			defer b.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Broker)
-			if equality.Semantic.DeepEqual(old.Spec, b.Spec) {
-				return
-			}
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[eventing.CreatorAnnotation] = ui.Username
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		}
-	}
+	setUserInfoAnnotations(b, ctx)
 }
 
 func (bs *BrokerSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -93,3 +93,8 @@ type BrokerList struct {
 func (t *Broker) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Broker")
 }
+
+// GetSpec returns the spec of the Broker.
+func (b *Broker) GetSpec() interface{} {
+	return b.Spec
+}

--- a/pkg/apis/eventing/v1alpha1/channel_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/channel_defaults.go
@@ -19,10 +19,6 @@ package v1alpha1
 import (
 	"context"
 
-	"github.com/knative/eventing/pkg/apis/eventing"
-	"github.com/knative/pkg/apis"
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -52,25 +48,7 @@ func (c *Channel) SetDefaults(ctx context.Context) {
 		}
 	}
 	c.Spec.SetDefaults(ctx)
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := c.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			defer c.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Channel)
-			if equality.Semantic.DeepEqual(old.Spec, c.Spec) {
-				return
-			}
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[eventing.CreatorAnnotation] = ui.Username
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		}
-	}
+	setUserInfoAnnotations(c, ctx)
 }
 
 func (cs *ChannelSpec) SetDefaults(ctx context.Context) {}

--- a/pkg/apis/eventing/v1alpha1/channel_types.go
+++ b/pkg/apis/eventing/v1alpha1/channel_types.go
@@ -117,3 +117,8 @@ type ChannelList struct {
 func (c *Channel) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Channel")
 }
+
+// GetSpec returns the spec of the Channel.
+func (c *Channel) GetSpec() interface{} {
+	return c.Spec
+}

--- a/pkg/apis/eventing/v1alpha1/subscription_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_defaults.go
@@ -18,33 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-
-	"github.com/knative/eventing/pkg/apis/eventing"
-	"github.com/knative/pkg/apis"
-	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func (s *Subscription) SetDefaults(ctx context.Context) {
 	s.Spec.SetDefaults(ctx)
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := s.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			defer s.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Subscription)
-			if equality.Semantic.DeepEqual(old.Spec, s.Spec) {
-				return
-			}
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[eventing.CreatorAnnotation] = ui.Username
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		}
-	}
+	setUserInfoAnnotations(s, ctx)
 }
 
 func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/eventing/v1alpha1/subscription_types.go
+++ b/pkg/apis/eventing/v1alpha1/subscription_types.go
@@ -200,3 +200,8 @@ type SubscriptionList struct {
 func (t *Subscription) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Subscription")
 }
+
+// GetSpec returns the spec of the Subscription.
+func (s *Subscription) GetSpec() interface{} {
+	return s.Spec
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults.go
@@ -18,33 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-
-	"github.com/knative/eventing/pkg/apis/eventing"
-	"github.com/knative/pkg/apis"
-	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 func (t *Trigger) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
-
-	if ui := apis.GetUserInfo(ctx); ui != nil {
-		ans := t.GetAnnotations()
-		if ans == nil {
-			ans = map[string]string{}
-			defer t.SetAnnotations(ans)
-		}
-
-		if apis.IsInUpdate(ctx) {
-			old := apis.GetBaseline(ctx).(*Trigger)
-			if equality.Semantic.DeepEqual(old.Spec, t.Spec) {
-				return
-			}
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		} else {
-			ans[eventing.CreatorAnnotation] = ui.Username
-			ans[eventing.UpdaterAnnotation] = ui.Username
-		}
-	}
+	setUserInfoAnnotations(t, ctx)
 }
 
 func (ts *TriggerSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -108,3 +108,8 @@ type TriggerList struct {
 func (t *Trigger) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Trigger")
 }
+
+// GetSpec returns the spec of the Trigger.
+func (t *Trigger) GetSpec() interface{} {
+	return t.Spec
+}

--- a/pkg/apis/eventing/v1alpha1/user_info.go
+++ b/pkg/apis/eventing/v1alpha1/user_info.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"github.com/knative/eventing/pkg/apis/eventing"
+	"github.com/knative/pkg/apis"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HasSpec interface {
+	// GetSpec returns the spec of the resource.
+	GetSpec() interface{}
+}
+
+// setUserInfoAnnotations sets creator and updater annotations on a resource.
+func setUserInfoAnnotations(resource HasSpec, ctx context.Context) {
+	if ui := apis.GetUserInfo(ctx); ui != nil {
+		objectMetaAccessor, ok := resource.(metav1.ObjectMetaAccessor)
+		if !ok {
+			return
+		}
+
+		annotations := objectMetaAccessor.GetObjectMeta().GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+			defer objectMetaAccessor.GetObjectMeta().SetAnnotations(annotations)
+		}
+
+		if apis.IsInUpdate(ctx) {
+			old := apis.GetBaseline(ctx).(HasSpec)
+			if equality.Semantic.DeepEqual(old.GetSpec(), resource.GetSpec()) {
+				return
+			}
+			annotations[eventing.UpdaterAnnotation] = ui.Username
+		} else {
+			annotations[eventing.CreatorAnnotation] = ui.Username
+			annotations[eventing.UpdaterAnnotation] = ui.Username
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1251

## Proposed Changes
- Reduce multiple implementations of code that adds user info annotations

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

I think this task can be done in a proper way when some of the changes are moved to <https://github.com/knative/pkg>.

Some notes:
* The interface I introduced (`HasSpec`) could/should be defined in <https://github.com/knative/pkg> so that it is used in other modules as well.
* Also, if it was defined in <https://github.com/knative/pkg>, we would be able to call `setUserInfoAnnotations` directly for a resource within the webhook [here](https://github.com/knative/pkg/blob/365d80ec5bf8ec9fc0f6be429e1969f368a942c3/webhook/webhook.go#L551) like this:
```golang
oldObj = oldObj.DeepCopyObject().(GenericCRD)
oldObj.SetDefaults(ctx)
s, ok := oldObj.(HasSpec)  # type assertion
if ok {
    setUserInfoAnnotations(sj, ctx)
}
```
* This would reduce multiple calls to `setUserInfoAnnotations` in one place (or 2).
* The reason for `HasSpec` interface is, in the CRD using the `spec` field for specification of a resource is a convention but following also would work if the operator is designed to read the specs from `LeSpecification` field:
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
spec:
  ...
  validation:
    openAPIV3Schema:
      properties:
        LeSpecification:
          properties:
            ...
```

Didn't check any tests yet as I wanted some feedback first.