### PR TITLE
Broker Filter tracing

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -23,14 +23,18 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/broker"
 	"github.com/knative/eventing/pkg/provisioners"
+	"github.com/knative/eventing/pkg/tracing"
+	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 type envConfig struct {
+	Broker    string `envconfig:"BROKER" required:"true"`
 	Namespace string `envconfig:"NAMESPACE" required:"true"`
 }
 
@@ -60,6 +64,17 @@ func main() {
 		logger.Fatal("Unable to add eventingv1alpha1 scheme", zap.Error(err))
 	}
 
+	kc := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	configMapWatcher := configmap.NewInformedWatcher(kc, env.Namespace)
+
+	zipkinServiceName := tracing.BrokerFilterName(tracing.BrokerFilterNameArgs{
+		Namespace:  env.Namespace,
+		BrokerName: env.Broker,
+	})
+	if err = tracing.SetupDynamicZipkinPublishing(logger.Sugar(), configMapWatcher, zipkinServiceName); err != nil {
+		logger.Fatal("Error setting up Zipkin publishing", zap.Error(err))
+	}
+
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
 	receiver, err := broker.New(logger, mgr.GetClient())
@@ -73,6 +88,11 @@ func main() {
 
 	// Set up signals so we handle the first shutdown signal gracefully.
 	stopCh := signals.SetupSignalHandler()
+
+	// configMapWatcher does not block, so start it first.
+	if err = configMapWatcher.Start(stopCh); err != nil {
+		logger.Fatal("Failed to start ConfigMap watcher", zap.Error(err))
+	}
 
 	// Start blocks forever.
 	logger.Info("Manager starting...")

--- a/config/200-broker-clusterrole.yaml
+++ b/config/200-broker-clusterrole.yaml
@@ -18,6 +18,14 @@ metadata:
   name: eventing-broker-filter
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
       - "eventing.knative.dev"
     resources:
       - "triggers"

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -927,6 +927,10 @@ func envVars(containerName string) []corev1.EnvVar {
 					},
 				},
 			},
+			{
+				Name:  "BROKER",
+				Value: brokerName,
+			},
 		}
 	case ingressContainerName:
 		return []corev1.EnvVar{

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -70,6 +70,10 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 										},
 									},
 								},
+								{
+									Name:  "BROKER",
+									Value: args.Broker.Name,
+								},
 							},
 						},
 					},

--- a/pkg/tracing/names.go
+++ b/pkg/tracing/names.go
@@ -29,3 +29,14 @@ type BrokerIngressNameArgs struct {
 func BrokerIngressName(args BrokerIngressNameArgs) string {
 	return fmt.Sprintf("%s-broker-ingress.%s", args.BrokerName, args.Namespace)
 }
+
+// BrokerFilterNameArgs are the arguments needed to generate the BrokerFilterName.
+type BrokerFilterNameArgs struct {
+	Namespace  string
+	BrokerName string
+}
+
+// BrokerFilterName creates the service name for Broker Filters to use when writing Zipkin traces.
+func BrokerFilterName(args BrokerFilterNameArgs) string {
+	return fmt.Sprintf("%s-broker-filter.%s", args.BrokerName, args.Namespace)
+}

--- a/pkg/tracing/names_test.go
+++ b/pkg/tracing/names_test.go
@@ -29,3 +29,15 @@ func TestBrokerIngressName(t *testing.T) {
 		t.Errorf("BrokerIngressName = %q, want %q", got, want)
 	}
 }
+
+func TestBrokerFilterName(t *testing.T) {
+	const testNS = "test-namespace"
+	const broker = "my-broker"
+	args := BrokerFilterNameArgs{
+		Namespace:  testNS,
+		BrokerName: broker,
+	}
+	if got, want := BrokerFilterName(args), "my-broker-broker-filter.test-namespace"; got != want {
+		t.Errorf("BrokerFilterName = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Helps with #704.

## Proposed Changes

- Add dynamic Zipkin Tracing to the Broker Filter component (e.g. triggers).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The `eventing-broker-filter` ClusterRole in `200-broker-clusterrole.yaml` needs to be re-applied.
```
