### PR TITLE
Add the knative.dev/crd-install=true label in eventtype.yaml

### DIFF
--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -15,6 +15,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
   version: v1alpha1


### PR DESCRIPTION
Fixes #1285 

## Proposed Changes
While installing the Eventing 0.6.0 CRD by '--selector knative.dev/crd-install=true', the `EventType` will not be installed.
- Add the `knative.dev/crd-install=true` label in `config/300-eventtype.yaml` .

**Release Note**

```release-note

```
