### PR TITLE
Enable fail fast for resource creation functions used in E2E tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -93,11 +93,11 @@ go test -v -tags=e2e -count=1 ./test/e2e -clusterChannelProvisioners=in-memory,g
 
 #### One test case
 
-To run one e2e test case, e.g. `TestSingleBinaryEvents`, use
+To run one e2e test case, e.g. `TestSingleBinaryEventForChannel`, use
 [the `-run` flag with `go test`](https://golang.org/cmd/go/#hdr-Testing_flags):
 
 ```bash
-go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$
+go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEventForChannel$
 ```
 
 By default, it will run the test against the default
@@ -107,7 +107,7 @@ If you want to run it against another `ClusterChannelProvisioner`, you can
 specify it through `-clusterChannelProvisioners`.
 
 ```bash
-go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEvent$ -clusterChannelProvisioners=in-memory
+go test -v -tags=e2e -count=1 ./test/e2e -run ^TestSingleBinaryEventForChannel$ -clusterChannelProvisioners=in-memory
 ```
 
 ## Environment requirements

--- a/test/common/client.go
+++ b/test/common/client.go
@@ -20,9 +20,10 @@ limitations under the License.
 package common
 
 import (
+	"testing"
+
 	eventing "github.com/knative/eventing/pkg/client/clientset/versioned"
 	"github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/logging"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -33,13 +34,13 @@ type Client struct {
 	Dynamic  dynamic.Interface
 
 	Namespace string
-	Logf      logging.FormatLogger
+	T         *testing.T
 	Cleaner   *Cleaner
 }
 
 // NewClient instantiates and returns several clientsets required for making request to the
 // cluster specified by the combination of clusterName and configPath.
-func NewClient(configPath string, clusterName string, namespace string, logger logging.FormatLogger) (*Client, error) {
+func NewClient(configPath string, clusterName string, namespace string, t *testing.T) (*Client, error) {
 	client := &Client{}
 	cfg, err := test.BuildClientConfig(configPath, clusterName)
 	if err != nil {
@@ -61,7 +62,7 @@ func NewClient(configPath string, clusterName string, namespace string, logger l
 	}
 
 	client.Namespace = namespace
-	client.Logf = logger
-	client.Cleaner = NewCleaner(logger, client.Dynamic)
+	client.T = t
+	client.Cleaner = NewCleaner(t.Logf, client.Dynamic)
 	return client, nil
 }

--- a/test/common/operation.go
+++ b/test/common/operation.go
@@ -80,11 +80,9 @@ func (client *Client) sendFakeEventToAddress(
 	event *base.CloudEvent,
 ) error {
 	namespace := client.Namespace
-	client.Logf("Sending fake CloudEvent")
+	client.T.Logf("Sending fake CloudEvent")
 	pod := base.EventSenderPod(senderName, url, event)
-	if err := client.CreatePod(pod); err != nil {
-		return err
-	}
+	client.CreatePodOrFail(pod)
 	if err := pkgTest.WaitForPodRunning(client.Kube, senderName, namespace); err != nil {
 		return err
 	}

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -81,7 +81,7 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 		subscriptionName = "e2e-brokerchannel-subscription"
 	)
 
-	client := Setup(t, provisioner, true)
+	client := Setup(t, true)
 	defer TearDown(client)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -85,17 +85,11 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 	defer TearDown(client)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role
-	if err := client.CreateServiceAccountAndBinding(saIngressName, crIngressName); err != nil {
-		t.Fatalf("Failed to create the Ingress ServiceAccount and ServiceAccountRoleBinding: %v", err)
-	}
-	if err := client.CreateServiceAccountAndBinding(saFilterName, crFilterName); err != nil {
-		t.Fatalf("Failed to create the Filter ServiceAccount and ServiceAccountRoleBinding: %v", err)
-	}
+	client.CreateServiceAccountAndBindingOrFail(saIngressName, crIngressName)
+	client.CreateServiceAccountAndBindingOrFail(saFilterName, crFilterName)
 
 	// create a new broker
-	if err := client.CreateBroker(brokerName, provisioner); err != nil {
-		t.Fatalf("Failed to create the Broker: %q, %v", brokerName, err)
-	}
+	client.CreateBrokerOrFail(brokerName, provisioner)
 	client.WaitForBrokerReady(brokerName)
 
 	// create the event we want to transform to
@@ -109,40 +103,30 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 
 	// create the transformation service for trigger1
 	transformationPod := base.EventTransformationPod(transformationPodName, eventAfterTransformation)
-	if err := client.CreatePod(transformationPod, common.WithService(transformationPodName)); err != nil {
-		t.Fatalf("Failed to create transformation service %q: %v", transformationPodName, err)
-	}
+	client.CreatePodOrFail(transformationPod, common.WithService(transformationPodName))
 
 	// create trigger1 to receive the original event, and do event transformation
-	if err := client.CreateTrigger(
+	client.CreateTriggerOrFail(
 		triggerName1,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource1, eventType1),
 		base.WithSubscriberRefForTrigger(transformationPodName),
-	); err != nil {
-		t.Fatalf("Error creating trigger %q: %v", triggerName1, err)
-	}
+	)
 
 	// create logger pod and service for trigger2
 	loggerPod1 := base.EventLoggerPod(loggerPodName1)
-	if err := client.CreatePod(loggerPod1, common.WithService(loggerPodName1)); err != nil {
-		t.Fatalf("Failed to create logger service %q: %v", loggerPodName1, err)
-	}
+	client.CreatePodOrFail(loggerPod1, common.WithService(loggerPodName1))
 
 	// create trigger2 to receive all the events
-	if err := client.CreateTrigger(
+	client.CreateTriggerOrFail(
 		triggerName2,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(any, any),
 		base.WithSubscriberRefForTrigger(loggerPodName1),
-	); err != nil {
-		t.Fatalf("Error creating trigger %q: %v", triggerName2, err)
-	}
+	)
 
 	// create channel for trigger3
-	if err := client.CreateChannel(channelName, provisioner); err != nil {
-		t.Fatalf("Failed to create channel %q: %v", channelName, err)
-	}
+	client.CreateChannelOrFail(channelName, provisioner)
 	client.WaitForChannelReady(channelName)
 
 	// create trigger3 to receive the transformed event, and send it to the channel
@@ -150,29 +134,23 @@ func testBrokerChannelFlow(t *testing.T, provisioner string) {
 	if err != nil {
 		t.Fatalf("Failed to get the url for the channel %q: %v", channelName, err)
 	}
-	if err := client.CreateTrigger(
+	client.CreateTriggerOrFail(
 		triggerName3,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource2, eventType2),
 		base.WithSubscriberURIForTrigger(channelURL),
-	); err != nil {
-		t.Fatalf("Error creating trigger %q: %v", triggerName3, err)
-	}
+	)
 
 	// create logger pod and service for subscription
 	loggerPod2 := base.EventLoggerPod(loggerPodName2)
-	if err := client.CreatePod(loggerPod2, common.WithService(loggerPodName2)); err != nil {
-		t.Fatalf("Failed to create logger service %q: %v", loggerPodName2, err)
-	}
+	client.CreatePodOrFail(loggerPod2, common.WithService(loggerPodName2))
 
 	// create subscription
-	if err := client.CreateSubscription(
+	client.CreateSubscriptionOrFail(
 		subscriptionName,
 		channelName,
 		base.WithSubscriberForSubscription(loggerPodName2),
-	); err != nil {
-		t.Fatalf("Error creating subscription %q: %v", subscriptionName, err)
-	}
+	)
 
 	// wait for all test resources to be ready, so that we can start sending events
 	if err := client.WaitForAllTestResourcesReady(); err != nil {

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -55,7 +55,7 @@ type eventReceiver struct {
 // and sends different events to the broker's address. Finally, it verifies that only
 // the appropriate events are routed to the subscribers.
 func TestDefaultBrokerWithManyTriggers(t *testing.T) {
-	client := Setup(t, common.DefaultClusterChannelProvisioner, true)
+	client := Setup(t, true)
 	defer TearDown(client)
 
 	// Label namespace so that it creates the default broker.

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -81,21 +81,17 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 	for _, event := range eventsToReceive {
 		subscriberName := name("dumper", event.typeAndSource.Type, event.typeAndSource.Source)
 		pod := base.EventLoggerPod(subscriberName)
-		if err := client.CreatePod(pod, common.WithService(subscriberName)); err != nil {
-			t.Fatalf("Failed to create the subscriber %q: %v", subscriberName, err)
-		}
+		client.CreatePodOrFail(pod, common.WithService(subscriberName))
 	}
 
 	// Create triggers.
 	for _, event := range eventsToReceive {
 		triggerName := name("trigger", event.typeAndSource.Type, event.typeAndSource.Source)
 		subscriberName := name("dumper", event.typeAndSource.Type, event.typeAndSource.Source)
-		if err := client.CreateTrigger(triggerName,
+		client.CreateTriggerOrFail(triggerName,
 			base.WithSubscriberRefForTrigger(subscriberName),
 			base.WithTriggerFilter(event.typeAndSource.Source, event.typeAndSource.Type),
-		); err != nil {
-			t.Fatalf("Failed to create the trigger %q: %v", triggerName, err)
-		}
+		)
 	}
 
 	// Wait for all test resources to become ready before sending the events.

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -70,7 +70,7 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string) {
 		loggerPodName         = "logger-pod"
 	)
 
-	client := Setup(t, provisioner, true)
+	client := Setup(t, true)
 	defer TearDown(client)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -74,17 +74,11 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string) {
 	defer TearDown(client)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role
-	if err := client.CreateServiceAccountAndBinding(saIngressName, crIngressName); err != nil {
-		t.Fatalf("Failed to create the Ingress ServiceAccount and ServiceAccountRoleBinding: %v", err)
-	}
-	if err := client.CreateServiceAccountAndBinding(saFilterName, crFilterName); err != nil {
-		t.Fatalf("Failed to create the Filter ServiceAccount and ServiceAccountRoleBinding: %v", err)
-	}
+	client.CreateServiceAccountAndBindingOrFail(saIngressName, crIngressName)
+	client.CreateServiceAccountAndBindingOrFail(saFilterName, crFilterName)
 
 	// create a new broker
-	if err := client.CreateBroker(brokerName, provisioner); err != nil {
-		t.Fatalf("Failed to create the Broker: %q, %v", brokerName, err)
-	}
+	client.CreateBrokerOrFail(brokerName, provisioner)
 	client.WaitForBrokerReady(brokerName)
 
 	// create the event we want to transform to
@@ -98,35 +92,27 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string) {
 
 	// create the transformation service
 	transformationPod := base.EventTransformationPod(transformationPodName, eventAfterTransformation)
-	if err := client.CreatePod(transformationPod, common.WithService(transformationPodName)); err != nil {
-		t.Fatalf("Failed to create transformation service %q: %v", transformationPodName, err)
-	}
+	client.CreatePodOrFail(transformationPod, common.WithService(transformationPodName))
 
 	// create trigger1 for event transformation
-	if err := client.CreateTrigger(
+	client.CreateTriggerOrFail(
 		triggerName1,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource1, eventType1),
 		base.WithSubscriberRefForTrigger(transformationPodName),
-	); err != nil {
-		t.Fatalf("Error creating trigger %q: %v", triggerName1, err)
-	}
+	)
 
 	// create logger pod and service
 	loggerPod := base.EventLoggerPod(loggerPodName)
-	if err := client.CreatePod(loggerPod, common.WithService(loggerPodName)); err != nil {
-		t.Fatalf("Failed to create logger service %q: %v", loggerPodName, err)
-	}
+	client.CreatePodOrFail(loggerPod, common.WithService(loggerPodName))
 
 	// create trigger2 for event receiving
-	if err := client.CreateTrigger(
+	client.CreateTriggerOrFail(
 		triggerName2,
 		base.WithBroker(brokerName),
 		base.WithTriggerFilter(eventSource2, eventType2),
 		base.WithSubscriberRefForTrigger(loggerPodName),
-	); err != nil {
-		t.Fatalf("Error creating trigger %q: %v", triggerName2, err)
-	}
+	)
 
 	// wait for all test resources to be ready, so that we can start sending events
 	if err := client.WaitForAllTestResourcesReady(); err != nil {

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -48,7 +48,7 @@ func testChannelChain(t *testing.T, provisioner string) {
 	// subscriptionNames2 corresponds to Subscriptions on channelNames[1]
 	subscriptionNames2 := []string{"e2e-channelchain-subs21"}
 
-	client := Setup(t, provisioner, true)
+	client := Setup(t, true)
 	defer TearDown(client)
 
 	// create channels

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -52,25 +52,17 @@ func testChannelChain(t *testing.T, provisioner string) {
 	defer TearDown(client)
 
 	// create channels
-	if err := client.CreateChannels(channelNames, provisioner); err != nil {
-		t.Fatalf("Failed to create channels %q: %v", channelNames, err)
-	}
+	client.CreateChannelsOrFail(channelNames, provisioner)
 	client.WaitForChannelsReady()
 
 	// create loggerPod and expose it as a service
 	pod := base.EventLoggerPod(loggerPodName)
-	if err := client.CreatePod(pod, common.WithService(loggerPodName)); err != nil {
-		t.Fatalf("Failed to create logger service: %v", err)
-	}
+	client.CreatePodOrFail(pod, common.WithService(loggerPodName))
 
 	// create subscriptions that subscribe the first channel, and reply events directly to the second channel
-	if err := client.CreateSubscriptions(subscriptionNames1, channelNames[0], base.WithReply(channelNames[1])); err != nil {
-		t.Fatalf("Failed to create subscriptions %q for channel %q: %v", subscriptionNames1, channelNames[0], err)
-	}
+	client.CreateSubscriptionsOrFail(subscriptionNames1, channelNames[0], base.WithReply(channelNames[1]))
 	// create subscriptions that subscribe the second channel, and call the logging service
-	if err := client.CreateSubscriptions(subscriptionNames2, channelNames[1], base.WithSubscriberForSubscription(loggerPodName)); err != nil {
-		t.Fatalf("Failed to create subscriptions %q for channel %q: %v", subscriptionNames2, channelNames[1], err)
-	}
+	client.CreateSubscriptionsOrFail(subscriptionNames2, channelNames[1], base.WithSubscriberForSubscription(loggerPodName))
 
 	// wait for all test resources to be ready, so that we can start sending events
 	if err := client.WaitForAllTestResourcesReady(); err != nil {

--- a/test/e2e/channel_event_transformation_test.go
+++ b/test/e2e/channel_event_transformation_test.go
@@ -53,9 +53,7 @@ func TestEventTransformationForSubscription(t *testing.T) {
 		defer TearDown(client)
 
 		// create channels
-		if err := client.CreateChannels(channelNames, provisioner); err != nil {
-			st.Fatalf("Failed to create channels %q: %v", channelNames, err)
-		}
+		client.CreateChannelsOrFail(channelNames, provisioner)
 		client.WaitForChannelsReady()
 
 		// create transformation pod and service
@@ -67,33 +65,25 @@ func TestEventTransformationForSubscription(t *testing.T) {
 			Encoding: base.CloudEventDefaultEncoding,
 		}
 		transformationPod := base.EventTransformationPod(transformationPodName, eventAfterTransformation)
-		if err := client.CreatePod(transformationPod, common.WithService(transformationPodName)); err != nil {
-			st.Fatalf("Failed to create transformation service %q: %v", transformationPodName, err)
-		}
+		client.CreatePodOrFail(transformationPod, common.WithService(transformationPodName))
 
 		// create logger pod and service
 		loggerPod := base.EventLoggerPod(loggerPodName)
-		if err := client.CreatePod(loggerPod, common.WithService(loggerPodName)); err != nil {
-			st.Fatalf("Failed to create logger service %q: %v", loggerPodName, err)
-		}
+		client.CreatePodOrFail(loggerPod, common.WithService(loggerPodName))
 
 		// create subscriptions that subscribe the first channel, use the transformation service to transform the events and then forward the transformed events to the second channel
-		if err := client.CreateSubscriptions(
+		client.CreateSubscriptionsOrFail(
 			subscriptionNames1,
 			channelNames[0],
 			base.WithSubscriberForSubscription(transformationPodName),
 			base.WithReply(channelNames[1]),
-		); err != nil {
-			st.Fatalf("Failed to create subscriptions %q for channel %q: %v", subscriptionNames1, channelNames[0], err)
-		}
+		)
 		// create subscriptions that subscribe the second channel, and forward the received events to the logger service
-		if err := client.CreateSubscriptions(
+		client.CreateSubscriptionsOrFail(
 			subscriptionNames2,
 			channelNames[1],
 			base.WithSubscriberForSubscription(loggerPodName),
-		); err != nil {
-			st.Fatalf("Failed to create subscriptions %q for channel %q: %v", subscriptionNames2, channelNames[1], err)
-		}
+		)
 
 		// wait for all test resources to be ready, so that we can start sending events
 		if err := client.WaitForAllTestResourcesReady(); err != nil {

--- a/test/e2e/channel_event_transformation_test.go
+++ b/test/e2e/channel_event_transformation_test.go
@@ -49,7 +49,7 @@ func TestEventTransformationForSubscription(t *testing.T) {
 	loggerPodName := "e2e-eventtransformation-logger-pod"
 
 	RunTests(t, common.FeatureBasic, func(st *testing.T, provisioner string) {
-		client := Setup(st, provisioner, true)
+		client := Setup(st, true)
 		defer TearDown(client)
 
 		// create channels

--- a/test/e2e/channel_single_event_test.go
+++ b/test/e2e/channel_single_event_test.go
@@ -53,24 +53,18 @@ func singleEvent(t *testing.T, encoding string) {
 		defer TearDown(client)
 
 		// create channel
-		if err := client.CreateChannel(channelName, provisioner); err != nil {
-			st.Fatalf("Failed to create channel: %v", err)
-		}
+		client.CreateChannelOrFail(channelName, provisioner)
 
 		// create logger service as the subscriber
 		pod := base.EventLoggerPod(loggerPodName)
-		if err := client.CreatePod(pod, common.WithService(loggerPodName)); err != nil {
-			st.Fatalf("Failed to create logger service: %v", err)
-		}
+		client.CreatePodOrFail(pod, common.WithService(loggerPodName))
 
 		// create subscription to subscribe the channel, and forward the received events to the logger service
-		if err := client.CreateSubscription(
+		client.CreateSubscriptionOrFail(
 			subscriptionName,
 			channelName,
 			base.WithSubscriberForSubscription(loggerPodName),
-		); err != nil {
-			st.Fatalf("Failed to create subscription: %v", err)
-		}
+		)
 
 		// wait for all test resources to be ready, so that we can start sending events
 		if err := client.WaitForAllTestResourcesReady(); err != nil {

--- a/test/e2e/channel_single_event_test.go
+++ b/test/e2e/channel_single_event_test.go
@@ -49,7 +49,7 @@ func singleEvent(t *testing.T, encoding string) {
 
 	RunTests(t, common.FeatureBasic, func(st *testing.T, provisioner string) {
 		st.Logf("Run test with provisioner %q", provisioner)
-		client := Setup(st, provisioner, true)
+		client := Setup(st, true)
 		defer TearDown(client)
 
 		// create channel

--- a/test/e2e/test_runner.go
+++ b/test/e2e/test_runner.go
@@ -56,9 +56,8 @@ func RunTests(t *testing.T, feature common.Feature, testFunc func(st *testing.T,
 
 // Setup creates the client objects needed in the e2e tests,
 // and does other setups, like creating namespaces, run the test case in parallel, etc.
-func Setup(t *testing.T, provisioner string, runInParallel bool) *common.Client {
+func Setup(t *testing.T, runInParallel bool) *common.Client {
 	// Create a new namespace to run this test case.
-	// Combine the test name and CCP to avoid duplication.
 	baseFuncName := getBaseFuncName(t.Name())
 	namespace := makeK8sNamePrefix(baseFuncName)
 	t.Logf("namespace is : %q", namespace)

--- a/test/e2e/test_runner.go
+++ b/test/e2e/test_runner.go
@@ -66,7 +66,7 @@ func Setup(t *testing.T, provisioner string, runInParallel bool) *common.Client 
 		pkgTest.Flags.Kubeconfig,
 		pkgTest.Flags.Cluster,
 		namespace,
-		t.Logf)
+		t)
 	if err != nil {
 		t.Fatalf("Couldn't initialize clients: %v", err)
 	}
@@ -95,7 +95,7 @@ func Setup(t *testing.T, provisioner string, runInParallel bool) *common.Client 
 func TearDown(client *common.Client) {
 	client.Cleaner.Clean(true)
 	if err := DeleteNameSpace(client); err != nil {
-		client.Logf("Could not delete the namespace %q: %v", client.Namespace, err)
+		client.T.Logf("Could not delete the namespace %q: %v", client.Namespace, err)
 	}
 }
 
@@ -183,8 +183,8 @@ func logPodLogsForDebugging(client *common.Client, podName, containerName string
 	namespace := client.Namespace
 	logs, err := client.Kube.PodLogs(podName, containerName, namespace)
 	if err != nil {
-		client.Logf("Failed to get the logs for container %q of the pod %q in namespace %q: %v", containerName, podName, namespace, err)
+		client.T.Logf("Failed to get the logs for container %q of the pod %q in namespace %q: %v", containerName, podName, namespace, err)
 	} else {
-		client.Logf("Logs for the container %q of the pod %q in namespace %q:\n%s", containerName, podName, namespace, string(logs))
+		client.T.Logf("Logs for the container %q of the pod %q in namespace %q:\n%s", containerName, podName, namespace, string(logs))
 	}
 }


### PR DESCRIPTION
## Proposed Changes
- As discussed with Adam, it makes the code quite verbose if we handle every error in the test cases. So I changed all creation functions to `CreateXXOrFail` to make the test cases cleaner.
- Fix the example in `README` as `TestSingleBinaryEvents` doesn't exist anymore.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @Harwayne 
/cc @adrcunha 