### PR TITLE
Add E2E test case for cron job source

### DIFF
--- a/test/base/generics.go
+++ b/test/base/generics.go
@@ -31,8 +31,18 @@ type MetaResource struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
+// MetaEventing returns a MetaResource that can represent a Knative Eventing resource.
+func MetaEventing(name, namespace, kind string) *MetaResource {
+	return Meta(name, namespace, kind, eventingAPIVersion)
+}
+
+// MetaSource returns a MetaResource that can represent a Knative Sources resource.
+func MetaSource(name, namespace, kind string) *MetaResource {
+	return Meta(name, namespace, kind, sourcesAPIVersion)
+}
+
 // Meta returns a MetaResource built from the given name, namespace and kind.
-func Meta(name, namespace, kind string) *MetaResource {
+func Meta(name, namespace, kind, apiVersion string) *MetaResource {
 	return &MetaResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -40,7 +50,7 @@ func Meta(name, namespace, kind string) *MetaResource {
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       kind,
-			APIVersion: EventingAPIVersion,
+			APIVersion: apiVersion,
 		},
 	}
 }

--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -51,7 +51,11 @@ func (client *Client) CreateChannelsOrFail(names []string, provisionerName strin
 }
 
 // CreateSubscriptionOrFail will create a Subscription or fail the test if there is an error.
-func (client *Client) CreateSubscriptionOrFail(name, channelName string, options ...func(*eventingv1alpha1.Subscription)) {
+func (client *Client) CreateSubscriptionOrFail(
+	name,
+	channelName string,
+	options ...func(*eventingv1alpha1.Subscription),
+) {
 	namespace := client.Namespace
 	subscription := base.Subscription(name, channelName, options...)
 
@@ -65,7 +69,11 @@ func (client *Client) CreateSubscriptionOrFail(name, channelName string, options
 }
 
 // CreateSubscriptionsOrFail will create a list of Subscriptions with the same configuration except the name.
-func (client *Client) CreateSubscriptionsOrFail(names []string, channelName string, options ...func(*eventingv1alpha1.Subscription)) {
+func (client *Client) CreateSubscriptionsOrFail(
+	names []string,
+	channelName string,
+	options ...func(*eventingv1alpha1.Subscription),
+) {
 	for _, name := range names {
 		client.CreateSubscriptionOrFail(name, channelName, options...)
 	}

--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -17,7 +17,8 @@ limitations under the License.
 package common
 
 import (
-	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing/test/base"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -28,7 +29,7 @@ var coreAPIVersion = corev1.SchemeGroupVersion.Version
 var rbacAPIGroup = rbacv1.SchemeGroupVersion.Group
 var rbacAPIVersion = rbacv1.SchemeGroupVersion.Version
 
-// CreateChannelOrFail will create a Channel Resource in Eventing.
+// CreateChannelOrFail will create a Channel or fail the test if there is an error.
 func (client *Client) CreateChannelOrFail(name, provisonerName string) {
 	namespace := client.Namespace
 	channel := base.Channel(name, provisonerName)
@@ -49,8 +50,8 @@ func (client *Client) CreateChannelsOrFail(names []string, provisionerName strin
 	}
 }
 
-// CreateSubscriptionOrFail will create a Subscription.
-func (client *Client) CreateSubscriptionOrFail(name, channelName string, options ...func(*v1alpha1.Subscription)) {
+// CreateSubscriptionOrFail will create a Subscription or fail the test if there is an error.
+func (client *Client) CreateSubscriptionOrFail(name, channelName string, options ...func(*eventingv1alpha1.Subscription)) {
 	namespace := client.Namespace
 	subscription := base.Subscription(name, channelName, options...)
 
@@ -64,13 +65,13 @@ func (client *Client) CreateSubscriptionOrFail(name, channelName string, options
 }
 
 // CreateSubscriptionsOrFail will create a list of Subscriptions with the same configuration except the name.
-func (client *Client) CreateSubscriptionsOrFail(names []string, channelName string, options ...func(*v1alpha1.Subscription)) {
+func (client *Client) CreateSubscriptionsOrFail(names []string, channelName string, options ...func(*eventingv1alpha1.Subscription)) {
 	for _, name := range names {
 		client.CreateSubscriptionOrFail(name, channelName, options...)
 	}
 }
 
-// CreateBrokerOrFail will create a Broker.
+// CreateBrokerOrFail will create a Broker or fail the test if there is an error.
 func (client *Client) CreateBrokerOrFail(name, provisionerName string) {
 	namespace := client.Namespace
 	broker := base.Broker(name, provisionerName)
@@ -91,8 +92,8 @@ func (client *Client) CreateBrokersOrFail(names []string, provisionerName string
 	}
 }
 
-// CreateTriggerOrFail will create a Trigger.
-func (client *Client) CreateTriggerOrFail(name string, options ...func(*v1alpha1.Trigger)) {
+// CreateTriggerOrFail will create a Trigger or fail the test if there is an error.
+func (client *Client) CreateTriggerOrFail(name string, options ...func(*eventingv1alpha1.Trigger)) {
 	namespace := client.Namespace
 	trigger := base.Trigger(name, options...)
 
@@ -103,6 +104,25 @@ func (client *Client) CreateTriggerOrFail(name string, options ...func(*v1alpha1
 		client.T.Fatalf("Failed to create trigger %q: %v", name, err)
 	}
 	client.Cleaner.AddObj(trigger)
+}
+
+// CreateCronJobSourceOrFail will create a CronJobSource or fail the test if there is an error.
+func (client *Client) CreateCronJobSourceOrFail(
+	name,
+	schedule,
+	data string,
+	options ...func(*sourcesv1alpha1.CronJobSource),
+) {
+	namespace := client.Namespace
+	cronJobSource := base.CronJobSource(name, schedule, data, options...)
+
+	cronJobSources := client.Eventing.SourcesV1alpha1().CronJobSources(namespace)
+	// update cronJobSource with the new reference
+	cronJobSource, err := cronJobSources.Create(cronJobSource)
+	if err != nil {
+		client.T.Fatalf("Failed to create cronjobsource %q: %v", name, err)
+	}
+	client.Cleaner.AddObj(cronJobSource)
 }
 
 // WithService returns an option that creates a Service binded with the given pod.
@@ -120,7 +140,7 @@ func WithService(name string) func(*corev1.Pod, *Client) error {
 	}
 }
 
-// CreatePodOrFail will create a Pod.
+// CreatePodOrFail will create a Pod or fail the test if there is an error.
 func (client *Client) CreatePodOrFail(pod *corev1.Pod, options ...func(*corev1.Pod, *Client) error) {
 	// set namespace for the pod in case it's empty
 	namespace := client.Namespace

--- a/test/common/validation.go
+++ b/test/common/validation.go
@@ -27,7 +27,7 @@ import (
 const (
 	// The interval and timeout used for polling pod logs.
 	interval = 1 * time.Second
-	timeout  = 2 * time.Minute
+	timeout  = 4 * time.Minute
 )
 
 // CheckLog waits until logs for the logger Pod satisfy the checker.
@@ -66,7 +66,7 @@ func CheckerContainsAll(contents []string) func(string) bool {
 	}
 }
 
-// CheckerContainsCount returns a checker functions to check if the log contains the count number of given content.
+// CheckerContainsCount returns a checker function to check if the log contains the count number of given content.
 func CheckerContainsCount(content string, count int) func(string) bool {
 	return func(log string) bool {
 		return strings.Count(log, content) == count

--- a/test/e2e/source_cron_job_test.go
+++ b/test/e2e/source_cron_job_test.go
@@ -1,0 +1,59 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/knative/eventing/test/base"
+	"github.com/knative/eventing/test/common"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+func TestCronJobSource(t *testing.T) {
+	const (
+		cronJobSourceName = "e2e-cron-job-source"
+		// Every 1 minute starting from now
+		schedule = "*/1 * * * *"
+
+		loggerPodName = "e2e-cron-job-source-logger-pod"
+	)
+
+	client := Setup(t, true)
+	defer TearDown(client)
+
+	// create event logger pod and service
+	loggerPod := base.EventLoggerPod(loggerPodName)
+	client.CreatePodOrFail(loggerPod, common.WithService(loggerPodName))
+
+	// create cron job source
+	data := fmt.Sprintf("TestCronJobSource %s", uuid.NewUUID())
+	sinkOption := base.WithSinkServiceForCronJobSource(loggerPodName)
+	client.CreateCronJobSourceOrFail(cronJobSourceName, schedule, data, sinkOption)
+
+	// wait for all test resources to be ready
+	if err := client.WaitForAllTestResourcesReady(); err != nil {
+		t.Fatalf("Failed to get all test resources ready: %v", err)
+	}
+
+	// verify the logger service receives the event
+	if err := client.CheckLog(loggerPodName, common.CheckerContains(data)); err != nil {
+		t.Fatalf("String %q not found in logs of logger pod %q: %v", data, loggerPodName, err)
+	}
+}


### PR DESCRIPTION
## Proposed Changes
I revisited the [samples of eventing sources](https://github.com/knative/docs/tree/master/docs/eventing/samples), and I think there is no need to have a separate testing framework for eventing sources now. We can just create the EventSource resource, add a Kubernetes Service sink for it (we can just use the existed logger pod), and check if the Service can receive the events.

Probably in the future when we have an eventing sources framework, we can design a corresponding testing framework. But for now since we have decided to put `CronJobSource` under eventing repo, I think it would be good to have E2E test coverage for it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
 
/cc @adrcunha 
