### PR TITLE
Add openAPIV3Schema to EventType CRD

### DIFF
--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -53,3 +53,25 @@ spec:
     - name: Reason
       type: string
       JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - type
+            - source
+            - broker
+          properties:
+            type:
+              type: string
+              minLength: 1
+            source:
+              type: string
+              minLength: 1
+            schema:
+              type: string
+            broker:
+              type: string
+              minLength: 1
+            description:
+              type: string


### PR DESCRIPTION
Fixes #1307 

## Proposed Changes
- Add openAPIV3Schema to EventType CRD

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
N/A
```
