### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/duck/v1alpha1/channelable_types.go
+++ b/pkg/apis/duck/v1alpha1/channelable_types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/apis/duck/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/apis/duck/v1alpha1/channelable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/channelable_types_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis/duck/v1alpha1"
 	"testing"
+
+	"github.com/knative/pkg/apis/duck/v1alpha1"
 
 	"github.com/google/go-cmp/cmp"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
