### PR TITLE
Fix envconfig tags by removing spaces

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 type envConfig struct {
-	Namespace string `envconfig: "NAMESPACE" required:"true"`
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
 }
 
 func main() {

--- a/contrib/gcppubsub/pkg/controller/cmd/main.go
+++ b/contrib/gcppubsub/pkg/controller/cmd/main.go
@@ -34,10 +34,10 @@ import (
 
 // These are Environment variable names.
 type envConfig struct {
-	DefaultGcpProject      string `envconfig: "DEFAULT_GCP_PROJECT" required: "true"`
-	DefaultSecretNamespace string `envconfig: "DEFAULT_SECRET_NAMESPACE" required: "true"`
-	DefaultSecretName      string `envconfig: "DEFAULT_SECRET_NAME" required: "true"`
-	DefaultSecretKey       string `envconfig: "DEFAULT_SECRET_KEY" required: "true"`
+	DefaultGcpProject      string `envconfig:"DEFAULT_GCP_PROJECT" required:"true"`
+	DefaultSecretNamespace string `envconfig:"DEFAULT_SECRET_NAMESPACE" required:"true"`
+	DefaultSecretName      string `envconfig:"DEFAULT_SECRET_NAME" required:"true"`
+	DefaultSecretKey       string `envconfig:"DEFAULT_SECRET_KEY" required:"true"`
 }
 
 // This is the main method for the GCP PubSub Channel controller. It reconciles the


### PR DESCRIPTION
## Proposed Changes

- Fix envconfig tags by removing spaces.
    - Spaces were accidentally added in #1305, leading to envconfig not working as expected.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
GCP PubSub dispatcher will need to redeployed, if it was released between #1305 and this PR.
```
