### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/cmd/channel_controller/main.go
+++ b/contrib/kafka/cmd/channel_controller/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"log"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	clientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned"
 	eventingScheme "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/scheme"

--- a/contrib/kafka/cmd/channel_dispatcher/main.go
+++ b/contrib/kafka/cmd/channel_dispatcher/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"log"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	clientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned"
 	eventingScheme "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/scheme"

--- a/contrib/kafka/cmd/controller/main.go
+++ b/contrib/kafka/cmd/controller/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"os"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 )
 

--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
@@ -15,8 +15,9 @@ package v1alpha1
 
 import (
 	"context"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"testing"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_validation.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/pkg/apis"
 )
 

--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_validation_test.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_validation_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/webhook"
-	"testing"
 
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/apis"

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	"github.com/Shopify/sarama"

--- a/contrib/kafka/pkg/controller/reconcile_test.go
+++ b/contrib/kafka/pkg/controller/reconcile_test.go
@@ -19,8 +19,9 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"testing"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/provisioners"

--- a/contrib/kafka/pkg/dispatcher/dispatcher.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher.go
@@ -18,12 +18,13 @@ package dispatcher
 import (
 	"errors"
 	"fmt"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"sync"
 	"sync/atomic"
 
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
+
 	"github.com/Shopify/sarama"
-	"github.com/bsm/sarama-cluster"
+	cluster "github.com/bsm/sarama-cluster"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 

--- a/contrib/kafka/pkg/dispatcher/dispatcher_test.go
+++ b/contrib/kafka/pkg/dispatcher/dispatcher_test.go
@@ -3,13 +3,14 @@ package dispatcher
 import (
 	"errors"
 	"fmt"
-	"github.com/knative/eventing/pkg/provisioners/utils"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/knative/eventing/pkg/provisioners/utils"
 
 	cluster "github.com/bsm/sarama-cluster"
 

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/knative/eventing/contrib/kafka/pkg/utils"
-	"github.com/knative/eventing/pkg/reconciler/names"
 	"reflect"
 	"time"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/utils"
+	"github.com/knative/eventing/pkg/reconciler/names"
 
 	"github.com/Shopify/sarama"
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"

--- a/contrib/kafka/pkg/reconciler/controller/resources/topic.go
+++ b/contrib/kafka/pkg/reconciler/controller/resources/topic.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 )
 

--- a/contrib/kafka/pkg/reconciler/dispatcher/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/dispatcher/kafkachannel.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 	clientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned"
 	messaginginformers "github.com/knative/eventing/contrib/kafka/pkg/client/informers/externalversions/messaging/v1alpha1"

--- a/contrib/kafka/pkg/utils/util.go
+++ b/contrib/kafka/pkg/utils/util.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/bsm/sarama-cluster"
+	cluster "github.com/bsm/sarama-cluster"
 
 	"github.com/knative/pkg/configmap"
 )


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
