### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/cmd/webhook/main.go
+++ b/contrib/kafka/cmd/webhook/main.go
@@ -17,8 +17,9 @@ package main
 
 import (
 	"flag"
-	"go.uber.org/zap"
 	"log"
+
+	"go.uber.org/zap"
 
 	messagingv1alpha1 "github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 	"github.com/knative/eventing/pkg/logconfig"

--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis"
 	"testing"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/knative/pkg/apis"
 	"reflect"
 	"time"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"github.com/knative/eventing/pkg/reconciler/names"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
