### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
+++ b/contrib/kafka/pkg/apis/messaging/v1alpha1/kafka_channel_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis"
 	"testing"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/knative/pkg/apis"
 	"reflect"
 	"time"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"github.com/knative/eventing/pkg/reconciler/names"

--- a/contrib/natss/cmd/channel_controller/main.go
+++ b/contrib/natss/cmd/channel_controller/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/knative/eventing/contrib/natss/pkg/stanutil"
 	"github.com/knative/eventing/contrib/natss/pkg/util"
-	"log"
 
 	clientset "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned"
 	eventingScheme "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned/scheme"

--- a/contrib/natss/cmd/channel_dispatcher/main.go
+++ b/contrib/natss/cmd/channel_dispatcher/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/contrib/natss/pkg/util"
 	"log"
+
+	"github.com/knative/eventing/contrib/natss/pkg/util"
 
 	clientset "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned"
 	eventingScheme "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned/scheme"

--- a/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_lifecycle_test.go
+++ b/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_lifecycle_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/knative/pkg/apis"
 	"testing"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_validation.go
+++ b/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/pkg/apis"
 )
 

--- a/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_validation_test.go
+++ b/contrib/natss/pkg/apis/messaging/v1alpha1/natss_channel_validation_test.go
@@ -18,9 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/webhook"
-	"testing"
 
 	eventingduck "github.com/knative/eventing/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/apis"

--- a/contrib/natss/pkg/reconciler/controller/natsschannel.go
+++ b/contrib/natss/pkg/reconciler/controller/natsschannel.go
@@ -19,10 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/knative/eventing/pkg/reconciler/names"
-	"github.com/knative/pkg/apis"
 	"reflect"
 	"time"
+
+	"github.com/knative/eventing/pkg/reconciler/names"
+	"github.com/knative/pkg/apis"
 
 	"github.com/knative/eventing/contrib/natss/pkg/apis/messaging/v1alpha1"
 	clientset "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned"

--- a/contrib/natss/pkg/reconciler/dispatcher/natsschannel.go
+++ b/contrib/natss/pkg/reconciler/dispatcher/natsschannel.go
@@ -19,9 +19,10 @@ package controller
 import (
 	"context"
 	"encoding/json"
+
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/eventing/contrib/natss/pkg/apis/messaging/v1alpha1"

--- a/pkg/apis/eventing/v1alpha1/user_info.go
+++ b/pkg/apis/eventing/v1alpha1/user_info.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/eventing"
 	"github.com/knative/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/inmemorychannel/dispatcher_test.go
+++ b/pkg/inmemorychannel/dispatcher_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package inmemorychannel
 
 import (
-	"github.com/knative/eventing/pkg/provisioners/swappable"
 	"testing"
 	"time"
+
+	"github.com/knative/eventing/pkg/provisioners/swappable"
 
 	logtesting "github.com/knative/pkg/logging/testing"
 )

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"fmt"
-	"github.com/knative/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 	"testing"
+
+	"github.com/knative/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 
 	"github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
 	"github.com/knative/eventing/pkg/reconciler"

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/inmemorychannel"
 
 	"github.com/knative/eventing/pkg/apis/messaging/v1alpha1"

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package controller
 
 import (
+	"testing"
+
 	"github.com/knative/eventing/pkg/inmemorychannel"
 	"github.com/knative/eventing/pkg/provisioners/multichannelfanout"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
 	fakeclientset "github.com/knative/eventing/pkg/client/clientset/versioned/fake"

--- a/pkg/tracing/setup.go
+++ b/pkg/tracing/setup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/tracing"
 	tracingconfig "github.com/knative/pkg/tracing/config"
-	"github.com/openzipkin/zipkin-go"
+	zipkin "github.com/openzipkin/zipkin-go"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/base/resources.go
+++ b/test/base/resources.go
@@ -242,11 +242,11 @@ func ContainerSourceBasicTemplate(
 	args []string,
 ) *corev1.PodTemplateSpec {
 	envVars := []corev1.EnvVar{
-		corev1.EnvVar{
+		{
 			Name:  "POD_NAME",
 			Value: name,
 		},
-		corev1.EnvVar{
+		{
 			Name:  "POD_NAMESPACE",
 			Value: namespace,
 		},
@@ -258,7 +258,7 @@ func ContainerSourceBasicTemplate(
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:            imageName,
 					Image:           pkgTest.ImagePath(imageName),
 					ImagePullPolicy: corev1.PullAlways,


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
