### PR TITLE
Kafka CRD Controller UT + Dispatcher tracing

### DIFF
--- a/contrib/kafka/cmd/channel_controller/main.go
+++ b/contrib/kafka/cmd/channel_controller/main.go
@@ -23,7 +23,6 @@ import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	eventingScheme "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/scheme"
 	informers "github.com/knative/eventing/contrib/kafka/pkg/client/informers/externalversions"
 	"github.com/knative/eventing/contrib/kafka/pkg/reconciler"
 	kafkachannel "github.com/knative/eventing/contrib/kafka/pkg/reconciler/controller"
@@ -36,7 +35,6 @@ import (
 	"github.com/knative/pkg/system"
 	"go.uber.org/zap"
 	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -90,9 +88,6 @@ func main() {
 	serviceInformer := kubeInformerFactory.Core().V1().Services()
 	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
-
-	// Adding the scheme.
-	eventingScheme.AddToScheme(scheme.Scheme)
 
 	// Build all of our controllers, with the clients constructed above.
 	// Add new controllers to this array.

--- a/contrib/kafka/cmd/channel_dispatcher/main.go
+++ b/contrib/kafka/cmd/channel_dispatcher/main.go
@@ -110,8 +110,8 @@ func main() {
 	//opt.ConfigMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
 
 	// Setup zipkin tracing.
-	if err = tracing.SetupDynamicZipkinPublishing(logger, opt.ConfigMapWatcher, "imc-dispatcher"); err != nil {
-		logger.Fatal("Error setting up Zipkin publishing", zap.Error(err))
+	if err = tracing.SetupDynamicZipkinPublishing(logger, opt.ConfigMapWatcher, "kafka-ch-dispatcher"); err != nil {
+		logger.Fatalw("Error setting up Zipkin publishing", zap.Error(err))
 	}
 
 	if err := opt.ConfigMapWatcher.Start(stopCh); err != nil {

--- a/contrib/kafka/cmd/channel_dispatcher/main.go
+++ b/contrib/kafka/cmd/channel_dispatcher/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/knative/eventing/pkg/tracing"
 	"log"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -107,6 +108,12 @@ func main() {
 	opt.ConfigMapWatcher.Watch(logconfig.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Controller))
 	// TODO: Watch the observability config map and dynamically update metrics exporter.
 	//opt.ConfigMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
+
+	// Setup zipkin tracing.
+	if err = tracing.SetupDynamicZipkinPublishing(logger, opt.ConfigMapWatcher, "imc-dispatcher"); err != nil {
+		logger.Fatal("Error setting up Zipkin publishing", zap.Error(err))
+	}
+
 	if err := opt.ConfigMapWatcher.Start(stopCh); err != nil {
 		logger.Fatalw("failed to start configuration manager", zap.Error(err))
 	}

--- a/contrib/kafka/cmd/channel_dispatcher/main.go
+++ b/contrib/kafka/cmd/channel_dispatcher/main.go
@@ -23,7 +23,6 @@ import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	eventingScheme "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/scheme"
 	informers "github.com/knative/eventing/contrib/kafka/pkg/client/informers/externalversions"
 	"github.com/knative/eventing/contrib/kafka/pkg/dispatcher"
 	"github.com/knative/eventing/contrib/kafka/pkg/reconciler"
@@ -35,7 +34,6 @@ import (
 	"github.com/knative/pkg/logging"
 	"github.com/knative/pkg/signals"
 	"go.uber.org/zap"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -87,9 +85,6 @@ func main() {
 
 	// Messaging
 	kafkaChannelInformer := messagingInformerFactory.Messaging().V1alpha1().KafkaChannels()
-
-	// Adding the scheme.
-	eventingScheme.AddToScheme(scheme.Scheme)
 
 	// Build all of our controllers, with the clients constructed above.
 	// Add new controllers to this array.

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
@@ -453,7 +453,7 @@ func (r *Reconciler) ensureFinalizer(channel *v1alpha1.KafkaChannel) error {
 		return err
 	}
 
-	_, err = r.eventingClientSet.MessagingV1alpha1().KafkaChannels(channel.Namespace).Patch(channel.Name, types.MergePatchType, patch)
+	_, err = r.KafkaClientSet.MessagingV1alpha1().KafkaChannels(channel.Namespace).Patch(channel.Name, types.MergePatchType, patch)
 	return err
 }
 

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel.go
@@ -30,12 +30,11 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
-	clientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned"
 	messaginginformers "github.com/knative/eventing/contrib/kafka/pkg/client/informers/externalversions/messaging/v1alpha1"
 	listers "github.com/knative/eventing/contrib/kafka/pkg/client/listers/messaging/v1alpha1"
+	"github.com/knative/eventing/contrib/kafka/pkg/reconciler"
 	"github.com/knative/eventing/contrib/kafka/pkg/reconciler/controller/resources"
 	"github.com/knative/eventing/pkg/logging"
-	"github.com/knative/eventing/pkg/reconciler"
 	"github.com/knative/pkg/controller"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -81,7 +80,6 @@ type Reconciler struct {
 	// Shopify/sarama, see https://github.com/Shopify/sarama/issues/1162.
 	kafkaClusterAdmin sarama.ClusterAdmin
 
-	eventingClientSet    clientset.Interface
 	kafkachannelLister   listers.KafkaChannelLister
 	kafkachannelInformer cache.SharedIndexInformer
 	deploymentLister     appsv1listers.DeploymentLister
@@ -105,7 +103,6 @@ var _ cache.ResourceEventHandler = (*Reconciler)(nil)
 // Registers event handlers to enqueue events.
 func NewController(
 	opt reconciler.Options,
-	eventingClientSet clientset.Interface,
 	kafkaConfig *utils.KafkaConfig,
 	dispatcherNamespace string,
 	dispatcherDeploymentName string,
@@ -122,7 +119,6 @@ func NewController(
 		dispatcherDeploymentName: dispatcherDeploymentName,
 		dispatcherServiceName:    dispatcherServiceName,
 		kafkaConfig:              kafkaConfig,
-		eventingClientSet:        eventingClientSet,
 		kafkachannelLister:       kafkachannelInformer.Lister(),
 		kafkachannelInformer:     kafkachannelInformer.Informer(),
 		deploymentLister:         deploymentInformer.Lister(),
@@ -234,7 +230,7 @@ func (r *Reconciler) reconcile(ctx context.Context, kc *v1alpha1.KafkaChannel) e
 			return err
 		}
 		removeFinalizer(kc)
-		_, err := r.eventingClientSet.MessagingV1alpha1().KafkaChannels(kc.Namespace).Update(kc)
+		_, err := r.KafkaClientSet.MessagingV1alpha1().KafkaChannels(kc.Namespace).Update(kc)
 		return err
 	}
 
@@ -377,11 +373,11 @@ func (r *Reconciler) updateStatus(ctx context.Context, desired *v1alpha1.KafkaCh
 	existing := kc.DeepCopy()
 	existing.Status = desired.Status
 
-	new, err := r.eventingClientSet.MessagingV1alpha1().KafkaChannels(desired.Namespace).UpdateStatus(existing)
+	new, err := r.KafkaClientSet.MessagingV1alpha1().KafkaChannels(desired.Namespace).UpdateStatus(existing)
 	if err == nil && becomesReady {
 		duration := time.Since(new.ObjectMeta.CreationTimestamp.Time)
 		r.Logger.Infof("KafkaChannel %q became ready after %v", kc.Name, duration)
-		if err := r.StatsReporter.ReportReady("Channel", kc.Namespace, kc.Name, duration); err != nil {
+		if err := r.StatsReporter.ReportReady("KafkaChannel", kc.Namespace, kc.Name, duration); err != nil {
 			r.Logger.Infof("Failed to record ready for KafkaChannel %q: %v", kc.Name, err)
 		}
 	}

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel_test.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	. "github.com/knative/eventing/contrib/kafka/pkg/utils"
+	"github.com/knative/eventing/pkg/utils"
+	"github.com/knative/pkg/kmeta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
+	fakeclientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/fake"
+	informers "github.com/knative/eventing/contrib/kafka/pkg/client/informers/externalversions"
+	"github.com/knative/eventing/contrib/kafka/pkg/reconciler"
+	"github.com/knative/eventing/contrib/kafka/pkg/reconciler/controller/resources"
+	reconciletesting "github.com/knative/eventing/contrib/kafka/pkg/reconciler/testing"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/knative/pkg/controller"
+	logtesting "github.com/knative/pkg/logging/testing"
+	. "github.com/knative/pkg/reconciler/testing"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+const (
+	systemNS                 = "knative-eventing"
+	testNS                   = "test-namespace"
+	kcName                   = "test-kc"
+	dispatcherDeploymentName = "test-deployment"
+	dispatcherServiceName    = "test-service"
+	channelServiceAddress    = "test-kc-kn-channel.test-namespace.svc.cluster.local"
+)
+
+var (
+	trueVal = true
+	// deletionTime is used when objects are marked as deleted. Rfc3339Copy()
+	// truncates to seconds to match the loss of precision during serialization.
+	deletionTime = metav1.Now().Rfc3339Copy()
+)
+
+func init() {
+	// Add types to scheme
+	_ = v1alpha1.AddToScheme(scheme.Scheme)
+	_ = duckv1alpha1.AddToScheme(scheme.Scheme)
+}
+
+func TestNewController(t *testing.T) {
+	kubeClient := fakekubeclientset.NewSimpleClientset()
+	messagingClient := fakeclientset.NewSimpleClientset()
+
+	// Create informer factories with fake clients. The second parameter sets the
+	// resync period to zero, disabling it.
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, 0)
+	messagingInformerFactory := informers.NewSharedInformerFactory(messagingClient, 0)
+
+	// Eventing
+	ncInformer := messagingInformerFactory.Messaging().V1alpha1().KafkaChannels()
+
+	// Kube
+	serviceInformer := kubeInformerFactory.Core().V1().Services()
+	endpointsInformer := kubeInformerFactory.Core().V1().Endpoints()
+	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
+
+	kafkaConfig := &KafkaConfig{}
+
+	c := NewController(
+		reconciler.Options{
+			KubeClientSet:  kubeClient,
+			KafkaClientSet: messagingClient,
+			Logger:         logtesting.TestLogger(t),
+		},
+		kafkaConfig,
+		systemNS,
+		dispatcherDeploymentName,
+		dispatcherServiceName,
+		ncInformer,
+		deploymentInformer,
+		serviceInformer,
+		endpointsInformer)
+
+	if c == nil {
+		t.Fatalf("Failed to create with NewController")
+	}
+}
+
+func TestAllCases(t *testing.T) {
+	kcKey := testNS + "/" + kcName
+	table := TableTest{
+		{
+			Name: "bad workqueue key",
+			// Make sure Reconcile handles bad keys.
+			Key: "too/many/parts",
+		}, {
+			Name: "key not found",
+			// Make sure Reconcile handles good keys that don't exist.
+			Key: "foo/not-found",
+		}, {
+			Name: "deleting",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeleted)},
+			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, channelReconciled, "KafkaChannel reconciled"),
+			},
+		}, {
+			Name: "deployment does not exist",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentNotReady("DispatcherDeploymentDoesNotExist", "Dispatcher Deployment does not exist")),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: deployment.apps \"test-deployment\" not found"),
+			},
+		}, {
+			Name: "Service does not exist",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServicetNotReady("DispatcherServiceDoesNotExist", "Dispatcher Service does not exist")),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: service \"test-service\" not found"),
+			},
+		}, {
+			Name: "Endpoints does not exist",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsNotReady("DispatcherEndpointsDoesNotExist", "Dispatcher Endpoints does not exist"),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: endpoints \"test-service\" not found"),
+			},
+		}, {
+			Name: "Endpoints not ready",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				makeEmptyEndpoints(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsNotReady("DispatcherEndpointsNotReady", "There are no endpoints ready for Dispatcher service"),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: there are no endpoints ready for Dispatcher service test-service"),
+			},
+		}, {
+			Name: "Works, creates new channel",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				makeReadyEndpoints(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: false,
+			WantCreates: []runtime.Object{
+				makeChannelService(reconciletesting.NewKafkaChannel(kcName, testNS)),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsReady(),
+					reconciletesting.WithKafkaChannelChannelServiceReady(),
+					reconciletesting.WithKafkaChannelAddress(channelServiceAddress),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, channelReconciled, "KafkaChannel reconciled"),
+			},
+		}, {
+			Name: "Works, channel exists",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				makeReadyEndpoints(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+				makeChannelService(reconciletesting.NewKafkaChannel(kcName, testNS)),
+			},
+			WantErr: false,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsReady(),
+					reconciletesting.WithKafkaChannelChannelServiceReady(),
+					reconciletesting.WithKafkaChannelAddress(channelServiceAddress),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, channelReconciled, "KafkaChannel reconciled"),
+			},
+		}, {
+			Name: "channel exists, not owned by us",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				makeReadyEndpoints(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+				makeChannelServiceNotOwnedByUs(reconciletesting.NewKafkaChannel(kcName, testNS)),
+			},
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsReady(),
+					reconciletesting.WithKafkaChannelChannelServicetNotReady("ChannelServiceFailed", "Channel Service failed: natsschannel: test-namespace/test-nc does not own Service: \"test-nc-kn-channel\""),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: natsschannel: test-namespace/test-nc does not own Service: \"test-nc-kn-channel\""),
+			},
+		}, {
+			Name: "channel does not exist, fails to create",
+			Key:  kcKey,
+			Objects: []runtime.Object{
+				makeReadyDeployment(),
+				makeService(),
+				makeReadyEndpoints(),
+				reconciletesting.NewKafkaChannel(kcName, testNS),
+			},
+			WantErr: true,
+			WithReactors: []clientgotesting.ReactionFunc{
+				InduceFailure("create", "Services"),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewKafkaChannel(kcName, testNS,
+					reconciletesting.WithInitKafkaChannelConditions,
+					reconciletesting.WithKafkaChannelDeploymentReady(),
+					reconciletesting.WithKafkaChannelServiceReady(),
+					reconciletesting.WithKafkaChannelEndpointsReady(),
+					reconciletesting.WithKafkaChannelChannelServicetNotReady("ChannelServiceFailed", "Channel Service failed: inducing failure for create services"),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeChannelService(reconciletesting.NewKafkaChannel(kcName, testNS)),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, channelReconcileFailed, "KafkaChannel reconciliation failed: inducing failure for create services"),
+			},
+		},
+	}
+	defer logtesting.ClearAll()
+
+	table.Test(t, reconciletesting.MakeFactory(func(listers *reconciletesting.Listers, opt reconciler.Options) controller.Reconciler {
+		return &Reconciler{
+			Base:                     reconciler.NewBase(opt, controllerAgentName),
+			dispatcherNamespace:      testNS,
+			dispatcherDeploymentName: dispatcherDeploymentName,
+			dispatcherServiceName:    dispatcherServiceName,
+			kafkachannelLister:       listers.GetKafkaChannelLister(),
+			// TODO fix
+			kafkachannelInformer: nil,
+			deploymentLister:     listers.GetDeploymentLister(),
+			serviceLister:        listers.GetServiceLister(),
+			endpointsLister:      listers.GetEndpointsLister(),
+		}
+	},
+	))
+}
+
+func makeDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      dispatcherDeploymentName,
+		},
+		Status: appsv1.DeploymentStatus{},
+	}
+}
+
+func makeReadyDeployment() *appsv1.Deployment {
+	d := makeDeployment()
+	d.Status.Conditions = []appsv1.DeploymentCondition{{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue}}
+	return d
+}
+
+func makeService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      dispatcherServiceName,
+		},
+	}
+}
+
+func makeChannelService(nc *v1alpha1.KafkaChannel) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      fmt.Sprintf("%s-kn-channel", kcName),
+			Labels: map[string]string{
+				resources.MessagingRoleLabel: resources.MessagingRole,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*kmeta.NewControllerRef(nc),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: fmt.Sprintf("%s.%s.svc.%s", dispatcherServiceName, testNS, utils.GetClusterDomainName()),
+		},
+	}
+}
+
+func makeChannelServiceNotOwnedByUs(nc *v1alpha1.KafkaChannel) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      fmt.Sprintf("%s-kn-channel", kcName),
+			Labels: map[string]string{
+				resources.MessagingRoleLabel: resources.MessagingRole,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: fmt.Sprintf("%s.%s.svc.%s", dispatcherServiceName, testNS, utils.GetClusterDomainName()),
+		},
+	}
+}
+
+func makeEmptyEndpoints() *corev1.Endpoints {
+	return &corev1.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Endpoints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      dispatcherServiceName,
+		},
+	}
+}
+
+func makeReadyEndpoints() *corev1.Endpoints {
+	e := makeEmptyEndpoints()
+	e.Subsets = []corev1.EndpointSubset{{Addresses: []corev1.EndpointAddress{{IP: "1.1.1.1"}}}}
+	return e
+}

--- a/contrib/kafka/pkg/reconciler/reconciler.go
+++ b/contrib/kafka/pkg/reconciler/reconciler.go
@@ -47,7 +47,7 @@ type Options struct {
 	Recorder      record.EventRecorder
 	StatsReporter StatsReporter
 
-	ConfigMapWatcher configmap.Watcher
+	ConfigMapWatcher *configmap.InformedWatcher
 	Logger           *zap.SugaredLogger
 
 	ResyncPeriod time.Duration

--- a/contrib/kafka/pkg/reconciler/reconciler.go
+++ b/contrib/kafka/pkg/reconciler/reconciler.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"time"
+
+	clientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned"
+	kafkaScheme "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/scheme"
+	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/logging/logkey"
+	"github.com/knative/pkg/system"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+)
+
+// Options defines the common reconciler options.
+// We define this to reduce the boilerplate argument list when
+// creating our controllers.
+type Options struct {
+	KubeClientSet    kubernetes.Interface
+	DynamicClientSet dynamic.Interface
+
+	KafkaClientSet clientset.Interface
+
+	Recorder      record.EventRecorder
+	StatsReporter StatsReporter
+
+	ConfigMapWatcher configmap.Watcher
+	Logger           *zap.SugaredLogger
+
+	ResyncPeriod time.Duration
+	StopChannel  <-chan struct{}
+}
+
+// This is mutable for testing.
+var resetPeriod = 30 * time.Second
+
+func NewOptionsOrDie(cfg *rest.Config, logger *zap.SugaredLogger, stopCh <-chan struct{}) Options {
+	kubeClient := kubernetes.NewForConfigOrDie(cfg)
+	dynamicClient := dynamic.NewForConfigOrDie(cfg)
+
+	kafkaClient := clientset.NewForConfigOrDie(cfg)
+
+	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
+
+	return Options{
+		KubeClientSet:    kubeClient,
+		DynamicClientSet: dynamicClient,
+		ConfigMapWatcher: configMapWatcher,
+		KafkaClientSet:   kafkaClient,
+		Logger:           logger,
+		ResyncPeriod:     10 * time.Hour, // Based on controller-runtime default.
+		StopChannel:      stopCh,
+	}
+}
+
+// GetTrackerLease returns a multiple of the resync period to use as the
+// duration for tracker leases. This attempts to ensure that resyncs happen to
+// refresh leases frequently enough that we don't miss updates to tracked
+// objects.
+func (o Options) GetTrackerLease() time.Duration {
+	return o.ResyncPeriod * 3
+}
+
+// Base implements the core controller logic, given a Reconciler.
+type Base struct {
+	// KubeClientSet allows us to talk to the k8s for core APIs
+	KubeClientSet kubernetes.Interface
+
+	// DynamicClientSet allows us to configure pluggable Build objects
+	DynamicClientSet dynamic.Interface
+
+	KafkaClientSet clientset.Interface
+
+	// ConfigMapWatcher allows us to watch for ConfigMap changes.
+	ConfigMapWatcher configmap.Watcher
+
+	// Recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	Recorder record.EventRecorder
+
+	// StatsReporter reports reconciler's metrics.
+	StatsReporter StatsReporter
+
+	// Sugared logger is easier to use but is not as performant as the
+	// raw logger. In performance critical paths, call logger.Desugar()
+	// and use the returned raw logger instead. In addition to the
+	// performance benefits, raw logger also preserves type-safety at
+	// the expense of slightly greater verbosity.
+	Logger *zap.SugaredLogger
+}
+
+// NewBase instantiates a new instance of Base implementing
+// the common & boilerplate code between our reconcilers.
+func NewBase(opt Options, controllerAgentName string) *Base {
+	// Enrich the logs with controller name
+	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
+
+	recorder := opt.Recorder
+	if recorder == nil {
+		// Create event broadcaster
+		logger.Debug("Creating event broadcaster")
+		eventBroadcaster := record.NewBroadcaster()
+		watches := []watch.Interface{
+			eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof),
+			eventBroadcaster.StartRecordingToSink(
+				&typedcorev1.EventSinkImpl{Interface: opt.KubeClientSet.CoreV1().Events("")}),
+		}
+		recorder = eventBroadcaster.NewRecorder(
+			scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+		go func() {
+			<-opt.StopChannel
+			for _, w := range watches {
+				w.Stop()
+			}
+		}()
+	}
+
+	statsReporter := opt.StatsReporter
+	if statsReporter == nil {
+		logger.Debug("Creating stats reporter")
+		var err error
+		statsReporter, err = NewStatsReporter(controllerAgentName)
+		if err != nil {
+			logger.Fatal(err)
+		}
+	}
+
+	base := &Base{
+		KubeClientSet:    opt.KubeClientSet,
+		DynamicClientSet: opt.DynamicClientSet,
+		KafkaClientSet:   opt.KafkaClientSet,
+		ConfigMapWatcher: opt.ConfigMapWatcher,
+		Recorder:         recorder,
+		StatsReporter:    statsReporter,
+		Logger:           logger,
+	}
+
+	return base
+}
+
+func init() {
+	// Add run types to the default Kubernetes Scheme so Events can be
+	// logged for run types.
+	_ = kafkaScheme.AddToScheme(scheme.Scheme)
+}

--- a/contrib/kafka/pkg/reconciler/reconciler.go
+++ b/contrib/kafka/pkg/reconciler/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Google LLC
+Copyright 2019 The Knative Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/contrib/kafka/pkg/reconciler/stats_reporter.go
+++ b/contrib/kafka/pkg/reconciler/stats_reporter.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/knative/pkg/metrics"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+type Measurement int
+
+const (
+	// KafkaChannelReadyCountN is the number of kafka channels that have become ready.
+	KafkaChannelReadyCountN = "kafkachannel_ready_count"
+	// KafkaChannelReadyCountN is the time it takes for a kafka channel to become ready since the resource is created.
+	KafkaChannelReadyLatencyN = "kafkachannel_ready_latency"
+)
+
+var (
+	KindToStatKeys = map[string]StatKey{
+		"KafkaChannel": {
+			ReadyCountKey:   KafkaChannelReadyCountN,
+			ReadyLatencyKey: KafkaChannelReadyLatencyN,
+		},
+	}
+
+	KindToMeasurements map[string]Measurements
+
+	reconcilerTagKey tag.Key
+	keyTagKey        tag.Key
+)
+
+type Measurements struct {
+	ReadyLatencyStat *stats.Int64Measure
+	ReadyCountStat   *stats.Int64Measure
+}
+
+type StatKey struct {
+	ReadyLatencyKey string
+	ReadyCountKey   string
+}
+
+func init() {
+	var err error
+	// Create the tag keys that will be used to add tags to our measurements.
+	// Tag keys must conform to the restrictions described in
+	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
+	// - length between 1 and 255 inclusive
+	// - characters are printable US-ASCII
+	reconcilerTagKey = mustNewTagKey("reconciler")
+	keyTagKey = mustNewTagKey("key")
+
+	KindToMeasurements = make(map[string]Measurements, len(KindToStatKeys))
+
+	for kind, keys := range KindToStatKeys {
+
+		readyLatencyStat := stats.Int64(
+			keys.ReadyLatencyKey,
+			fmt.Sprintf("Time it takes for a %s to become ready since created", kind),
+			stats.UnitMilliseconds)
+
+		readyCountStat := stats.Int64(
+			keys.ReadyCountKey,
+			fmt.Sprintf("Number of %s that became ready", kind),
+			stats.UnitDimensionless)
+
+		// Save the measurements for later marks.
+		KindToMeasurements[kind] = Measurements{
+			ReadyCountStat:   readyCountStat,
+			ReadyLatencyStat: readyLatencyStat,
+		}
+
+		// Create views to see our measurements. This can return an error if
+		// a previously-registered view has the same name with a different value.
+		// View name defaults to the measure name if unspecified.
+		err = view.Register(
+			&view.View{
+				Description: readyLatencyStat.Description(),
+				Measure:     readyLatencyStat,
+				Aggregation: view.LastValue(),
+				TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey},
+			},
+			&view.View{
+				Description: readyCountStat.Description(),
+				Measure:     readyCountStat,
+				Aggregation: view.Count(),
+				TagKeys:     []tag.Key{reconcilerTagKey, keyTagKey},
+			},
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// StatsReporter reports reconcilers' metrics.
+type StatsReporter interface {
+	// ReportReady reports the time it took a resource to become Ready.
+	ReportReady(kind, namespace, service string, d time.Duration) error
+}
+
+type reporter struct {
+	ctx context.Context
+}
+
+// NewStatsReporter creates a reporter for reconcilers' metrics
+func NewStatsReporter(reconciler string) (StatsReporter, error) {
+	ctx, err := tag.New(
+		context.Background(),
+		tag.Insert(reconcilerTagKey, reconciler))
+	if err != nil {
+		return nil, err
+	}
+	return &reporter{ctx: ctx}, nil
+}
+
+// ReportServiceReady reports the time it took a service to become Ready
+func (r *reporter) ReportReady(kind, namespace, service string, d time.Duration) error {
+	key := fmt.Sprintf("%s/%s", namespace, service)
+	v := int64(d / time.Millisecond)
+	ctx, err := tag.New(
+		r.ctx,
+		tag.Insert(keyTagKey, key))
+	if err != nil {
+		return err
+	}
+
+	m, ok := KindToMeasurements[kind]
+	if !ok {
+		return fmt.Errorf("unknown kind attempted to report ready, %q", kind)
+	}
+
+	metrics.Record(ctx, m.ReadyCountStat.M(1))
+	metrics.Record(ctx, m.ReadyLatencyStat.M(v))
+	return nil
+}
+
+func mustNewTagKey(s string) tag.Key {
+	tagKey, err := tag.NewKey(s)
+	if err != nil {
+		panic(err)
+	}
+	return tagKey
+}

--- a/contrib/kafka/pkg/reconciler/stats_reporter.go
+++ b/contrib/kafka/pkg/reconciler/stats_reporter.go
@@ -32,7 +32,7 @@ type Measurement int
 const (
 	// KafkaChannelReadyCountN is the number of kafka channels that have become ready.
 	KafkaChannelReadyCountN = "kafkachannel_ready_count"
-	// KafkaChannelReadyCountN is the time it takes for a kafka channel to become ready since the resource is created.
+	// KafkaChannelReadyLatencyN is the time it takes for a kafka channel to become ready since the resource is created.
 	KafkaChannelReadyLatencyN = "kafkachannel_ready_latency"
 )
 

--- a/contrib/kafka/pkg/reconciler/stats_reporter.go
+++ b/contrib/kafka/pkg/reconciler/stats_reporter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Google LLC
+Copyright 2019 The Knative Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/contrib/kafka/pkg/reconciler/testing/factory.go
+++ b/contrib/kafka/pkg/reconciler/testing/factory.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	fakedynamicclientset "k8s.io/client-go/dynamic/fake"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+
+	fakeclientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/fake"
+	"github.com/knative/eventing/contrib/kafka/pkg/reconciler"
+	"github.com/knative/pkg/controller"
+	logtesting "github.com/knative/pkg/logging/testing"
+
+	. "github.com/knative/pkg/reconciler/testing"
+)
+
+const (
+	// maxEventBufferSize is the estimated max number of event notifications that
+	// can be buffered during reconciliation.
+	maxEventBufferSize = 10
+)
+
+// Ctor functions create a k8s controller with given params.
+type Ctor func(*Listers, reconciler.Options) controller.Reconciler
+
+// MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
+func MakeFactory(ctor Ctor) Factory {
+	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList, *FakeStatsReporter) {
+		ls := NewListers(r.Objects)
+
+		kubeClient := fakekubeclientset.NewSimpleClientset(ls.GetKubeObjects()...)
+		client := fakeclientset.NewSimpleClientset(ls.GetMessagingObjects()...)
+
+		dynamicScheme := runtime.NewScheme()
+		for _, addTo := range clientSetSchemes {
+			addTo(dynamicScheme)
+		}
+
+		dynamicClient := fakedynamicclientset.NewSimpleDynamicClient(dynamicScheme, ls.GetAllObjects()...)
+		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
+		statsReporter := &FakeStatsReporter{}
+
+		PrependGenerateNameReactor(&client.Fake)
+		PrependGenerateNameReactor(&dynamicClient.Fake)
+
+		// Set up our Controller from the fakes.
+		c := ctor(&ls, reconciler.Options{
+			KubeClientSet:    kubeClient,
+			DynamicClientSet: dynamicClient,
+			KafkaClientSet:   client,
+			Recorder:         eventRecorder,
+			//StatsReporter:    statsReporter,
+			Logger: logtesting.TestLogger(t),
+		})
+
+		for _, reactor := range r.WithReactors {
+			kubeClient.PrependReactor("*", "*", reactor)
+			client.PrependReactor("*", "*", reactor)
+			dynamicClient.PrependReactor("*", "*", reactor)
+		}
+
+		// Validate all Create operations through the eventing client.
+		client.PrependReactor("create", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateCreates(context.Background(), action)
+		})
+		client.PrependReactor("update", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateUpdates(context.Background(), action)
+		})
+
+		actionRecorderList := ActionRecorderList{dynamicClient, client, kubeClient}
+		eventList := EventList{Recorder: eventRecorder}
+
+		return c, actionRecorderList, eventList, statsReporter
+	}
+}

--- a/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+
+	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
+	"github.com/knative/pkg/apis"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//	"k8s.io/apimachinery/pkg/types"
+)
+
+// KafkaChannelOption enables further configuration of a KafkaChannel.
+type KafkaChannelOption func(*v1alpha1.KafkaChannel)
+
+// NewKafkaChannel creates an KafkaChannel with KafkaChannelOptions.
+func NewKafkaChannel(name, namespace string, ncopt ...KafkaChannelOption) *v1alpha1.KafkaChannel {
+	nc := &v1alpha1.KafkaChannel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.KafkaChannelSpec{},
+	}
+	for _, opt := range ncopt {
+		opt(nc)
+	}
+	nc.SetDefaults(context.Background())
+	return nc
+}
+
+func WithInitKafkaChannelConditions(nc *v1alpha1.KafkaChannel) {
+	nc.Status.InitializeConditions()
+}
+
+func WithKafkaChannelDeleted(nc *v1alpha1.KafkaChannel) {
+	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
+	nc.ObjectMeta.SetDeletionTimestamp(&deleteTime)
+}
+
+func WithKafkaChannelDeploymentNotReady(reason, message string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkDispatcherFailed(reason, message)
+	}
+}
+
+func WithKafkaChannelDeploymentReady() KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.PropagateDispatcherStatus(&appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue}}})
+	}
+}
+
+func WithKafkaChannelServicetNotReady(reason, message string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkServiceFailed(reason, message)
+	}
+}
+
+func WithKafkaChannelServiceReady() KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkServiceTrue()
+	}
+}
+
+func WithKafkaChannelChannelServicetNotReady(reason, message string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkChannelServiceFailed(reason, message)
+	}
+}
+
+func WithKafkaChannelChannelServiceReady() KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkChannelServiceTrue()
+	}
+}
+
+func WithKafkaChannelEndpointsNotReady(reason, message string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkEndpointsFailed(reason, message)
+	}
+}
+
+func WithKafkaChannelEndpointsReady() KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkEndpointsTrue()
+	}
+}
+
+func WithKafkaChannelAddress(a string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.SetAddress(&apis.URL{
+			Scheme: "http",
+			Host:   a,
+		})
+	}
+}

--- a/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"time"
 
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
@@ -54,6 +55,12 @@ func WithInitKafkaChannelConditions(nc *v1alpha1.KafkaChannel) {
 func WithKafkaChannelDeleted(nc *v1alpha1.KafkaChannel) {
 	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
 	nc.ObjectMeta.SetDeletionTimestamp(&deleteTime)
+}
+
+func WithKafkaChannelTopicReady() KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		nc.Status.MarkTopicTrue()
+	}
 }
 
 func WithKafkaChannelDeploymentNotReady(reason, message string) KafkaChannelOption {
@@ -110,5 +117,13 @@ func WithKafkaChannelAddress(a string) KafkaChannelOption {
 			Scheme: "http",
 			Host:   a,
 		})
+	}
+}
+
+func WithKafkaFinalizer(finalizerName string) KafkaChannelOption {
+	return func(nc *v1alpha1.KafkaChannel) {
+		finalizers := sets.NewString(nc.Finalizers...)
+		finalizers.Insert(finalizerName)
+		nc.SetFinalizers(finalizers.List())
 	}
 }

--- a/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
@@ -26,7 +26,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//	"k8s.io/apimachinery/pkg/types"
 )
 
 // KafkaChannelOption enables further configuration of a KafkaChannel.

--- a/contrib/kafka/pkg/reconciler/testing/listers.go
+++ b/contrib/kafka/pkg/reconciler/testing/listers.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	messagingv1alpha1 "github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
+	fakemessagingclientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/fake"
+	messaginglisters "github.com/knative/eventing/contrib/kafka/pkg/client/listers/messaging/v1alpha1"
+	fakeeventsclientset "github.com/knative/eventing/pkg/client/clientset/versioned/fake"
+	fakesharedclientset "github.com/knative/pkg/client/clientset/versioned/fake"
+	"github.com/knative/pkg/reconciler/testing"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var clientSetSchemes = []func(*runtime.Scheme) error{
+	fakekubeclientset.AddToScheme,
+	fakesharedclientset.AddToScheme,
+	fakeeventsclientset.AddToScheme,
+	fakemessagingclientset.AddToScheme,
+}
+
+type Listers struct {
+	sorter testing.ObjectSorter
+}
+
+func NewListers(objs []runtime.Object) Listers {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+
+	ls := Listers{
+		sorter: testing.NewObjectSorter(scheme),
+	}
+
+	ls.sorter.AddObjects(objs...)
+
+	return ls
+}
+
+func (l *Listers) indexerFor(obj runtime.Object) cache.Indexer {
+	return l.sorter.IndexerForObjectType(obj)
+}
+
+func (l *Listers) GetKubeObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
+}
+
+func (l *Listers) GetEventsObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeeventsclientset.AddToScheme)
+}
+
+func (l *Listers) GetMessagingObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakemessagingclientset.AddToScheme)
+}
+
+func (l *Listers) GetAllObjects() []runtime.Object {
+	all := l.GetMessagingObjects()
+	all = append(all, l.GetEventsObjects()...)
+	all = append(all, l.GetKubeObjects()...)
+	return all
+}
+
+func (l *Listers) GetSharedObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakesharedclientset.AddToScheme)
+}
+
+func (l *Listers) GetServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
+	return corev1listers.NewEndpointsLister(l.indexerFor(&corev1.Endpoints{}))
+}
+
+func (l *Listers) GetKafkaChannelLister() messaginglisters.KafkaChannelLister {
+	return messaginglisters.NewKafkaChannelLister(l.indexerFor(&messagingv1alpha1.KafkaChannel{}))
+}
+
+func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
+	return appsv1listers.NewDeploymentLister(l.indexerFor(&appsv1.Deployment{}))
+}


### PR DESCRIPTION
## Proposed Changes

- Adding UTs to the new Kafka CRD controller.
- Needed a refactor to have our own reconciler, options, statsreporter, test factory, etc.
- Adding Zipkin tracing


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
