### PR TITLE
Add K8s Services to the addressable resolver role.

### DIFF
--- a/config/200-addressable-resolvers-clusterrole.yaml
+++ b/config/200-addressable-resolvers-clusterrole.yaml
@@ -24,7 +24,26 @@ aggregationRule:
 rules: [] # Rules are automatically filled in by the controller manager.
 
 ---
- 
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-addressable-resolver
+  labels:
+      duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
## Proposed Changes

- Add K8s Services to the addressable resolver role.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The addressable-resolver role now includes Kubernetes Services.
```
