### PR TITLE
Channel Deprecation Condition

### DIFF
--- a/cmd/in_memory/channel_dispatcher/main.go
+++ b/cmd/in_memory/channel_dispatcher/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	// Setup zipkin tracing.
 	if err = tracing.SetupDynamicZipkinPublishing(logger, opt.ConfigMapWatcher, "imc-dispatcher"); err != nil {
-		logger.Fatal("Error setting up Zipkin publishing", zap.Error(err))
+		logger.Fatalw("Error setting up Zipkin publishing", zap.Error(err))
 	}
 
 	if err := opt.ConfigMapWatcher.Start(stopCh); err != nil {

--- a/contrib/gcppubsub/pkg/controller/channel/reconcile.go
+++ b/contrib/gcppubsub/pkg/controller/channel/reconcile.go
@@ -61,6 +61,8 @@ const (
 	topicDeleteFailed         = "TopicDeleteFailed"
 	subscriptionSyncFailed    = "SubscriptionSyncFailed"
 	subscriptionDeleteFailed  = "SubscriptionDeleteFailed"
+
+	deprecatedMessage = "The `gcp-pubsub` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `PubSubChannel` CRD from https://github.com/GoogleCloudPlatform/cloud-run-events."
 )
 
 // reconciler reconciles GCP-PubSub Channels by creating the K8s Service (ExternalName)
@@ -161,6 +163,8 @@ func ShouldReconcile(c *eventingv1alpha1.Channel) bool {
 // returned error indicates an error during reconciliation.
 func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel) (bool, error) {
 	c.Status.InitializeConditions()
+
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 
 	// We are syncing the following:
 	// - The K8s Service to talk to this Channel.

--- a/contrib/gcppubsub/pkg/controller/channel/reconcile_test.go
+++ b/contrib/gcppubsub/pkg/controller/channel/reconcile_test.go
@@ -831,6 +831,7 @@ func makeChannelWithSubscribersAndFinalizerAndPCSAndAddress() *eventingv1alpha1.
 func makeChannelWithFinalizer() *eventingv1alpha1.Channel {
 	c := makeChannel()
 	c.Finalizers = []string{finalizerName}
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 
@@ -869,24 +870,28 @@ func makeDeletingChannelWithoutPCS() *eventingv1alpha1.Channel {
 func makeDeletingChannelWithoutFinalizer() *eventingv1alpha1.Channel {
 	c := makeDeletingChannel()
 	c.Finalizers = nil
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 
 func makeDeletingChannelWithoutFinalizerOrPCS() *eventingv1alpha1.Channel {
 	c := makeDeletingChannelWithoutFinalizer()
 	c.Status.Internal = nil
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 
 func makeDeletingChannelWithSubscribers() *eventingv1alpha1.Channel {
 	c := makeDeletingChannel()
 	addSubscribers(c, subscribers)
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 
 func makeDeletingChannelWithSubscribersWithoutFinalizer() *eventingv1alpha1.Channel {
 	c := makeDeletingChannelWithSubscribers()
 	c.Finalizers = nil
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 

--- a/contrib/kafka/pkg/controller/channel/reconcile.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile.go
@@ -44,6 +44,8 @@ const (
 	// Name of the corev1.Events emitted from the reconciliation process
 	dispatcherReconcileFailed    = "DispatcherReconcileFailed"
 	dispatcherUpdateStatusFailed = "DispatcherUpdateStatusFailed"
+
+	deprecatedMessage = "The `kafka` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `KafkaChannel` CRD."
 )
 
 type channelArgs struct {
@@ -89,6 +91,8 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	channel.Status.InitializeConditions()
+
+	channel.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 
 	var requeue = false
 	if clusterChannelProvisioner.Status.IsReady() {

--- a/contrib/kafka/pkg/controller/channel/reconcile_test.go
+++ b/contrib/kafka/pkg/controller/channel/reconcile_test.go
@@ -454,6 +454,7 @@ func getNewChannelWithFinalizer(name, provisioner string) *eventingv1alpha1.Chan
 func getNewChannelWithStatusAndFinalizer(name, provisioner string) *eventingv1alpha1.Channel {
 	c := getNewChannelWithFinalizer(name, provisioner)
 	c.Status.InitializeConditions()
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	return c
 }
 
@@ -469,6 +470,7 @@ func getNewChannelWithArgs(name string, args map[string]interface{}) *eventingv1
 func getNewChannelProvisionedStatus(name, provisioner string) *eventingv1alpha1.Channel {
 	c := getNewChannel(name, provisioner)
 	c.Status.InitializeConditions()
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	c.Status.SetAddress(&apis.URL{
 		Scheme: "http",
 		Host:   serviceAddress,
@@ -487,6 +489,7 @@ func getNewChannelDeleted(name, provisioner string) *eventingv1alpha1.Channel {
 func getNewChannelNotProvisionedStatus(name, provisioner, msg string) *eventingv1alpha1.Channel {
 	c := getNewChannel(name, provisioner)
 	c.Status.InitializeConditions()
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	c.Status.MarkNotProvisioned("NotProvisioned", msg)
 	return c
 }

--- a/contrib/natss/pkg/controller/channel/reconcile.go
+++ b/contrib/natss/pkg/controller/channel/reconcile.go
@@ -33,6 +33,10 @@ import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 )
 
+const (
+	deprecatedMessage = "The `natss` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `NatssChannel` CRD."
+)
+
 type reconciler struct {
 	client   client.Client
 	recorder record.EventRecorder
@@ -113,6 +117,8 @@ func (r *reconciler) shouldReconcile(c *eventingv1alpha1.Channel) bool {
 
 func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel) error {
 	c.Status.InitializeConditions()
+
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 
 	// We are syncing two things:
 	// 1. The K8s Service to talk to this Channel.

--- a/contrib/natss/pkg/controller/channel/reconcile_test.go
+++ b/contrib/natss/pkg/controller/channel/reconcile_test.go
@@ -162,6 +162,7 @@ func makeNewChannel(name, provisioner string) *eventingv1alpha1.Channel {
 func makeNewChannelProvisionedStatus(name, provisioner string) *eventingv1alpha1.Channel {
 	c := makeNewChannel(name, provisioner)
 	c.Status.InitializeConditions()
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 	c.Status.SetAddress(&apis.URL{
 		Scheme: "http",
 		Host:   serviceAddress,

--- a/pkg/provisioners/inmemory/channel/reconcile.go
+++ b/pkg/provisioners/inmemory/channel/reconcile.go
@@ -39,6 +39,8 @@ const (
 	channelReconciled         = "ChannelReconciled"
 	channelUpdateStatusFailed = "ChannelUpdateStatusFailed"
 	k8sServiceCreateFailed    = "K8sServiceCreateFailed"
+
+	deprecatedMessage = "The `in-memory` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `InMemoryChannel` CRD."
 )
 
 type reconciler struct {
@@ -128,6 +130,8 @@ func (r *reconciler) reconcile(ctx context.Context, c *eventingv1alpha1.Channel)
 	logger := r.logger.With(zap.Any("channel", c))
 
 	c.Status.InitializeConditions()
+
+	c.Status.MarkDeprecated("ClusterChannelProvisionerDeprecated", deprecatedMessage)
 
 	// We are syncing K8s Service to talk to this Channel.
 	svc, err := util.CreateK8sService(ctx, r.client, c, util.ExternalService(c))


### PR DESCRIPTION
Helps with Channel CRDs

## Proposed Changes

- Adding a condition to the Channel provisioners saying that we are deprecating them, and that they will be removed in 0.8.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Channel provisioners (kafka, natss, gcp-pubsub and in-memory) are deprecated in 0.7. Will be removed in 0.8
```
