### PR TITLE
golang format tools

### DIFF
--- a/cmd/in_memory/channel_dispatcher/main.go
+++ b/cmd/in_memory/channel_dispatcher/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/pkg/tracing"
 	"log"
 	"time"
+
+	"github.com/knative/eventing/pkg/tracing"
 
 	informers "github.com/knative/eventing/pkg/client/informers/externalversions"
 	dispatcher "github.com/knative/eventing/pkg/inmemorychannel"

--- a/contrib/kafka/cmd/channel_dispatcher/main.go
+++ b/contrib/kafka/cmd/channel_dispatcher/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/pkg/tracing"
 	"log"
+
+	"github.com/knative/eventing/pkg/tracing"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/contrib/kafka/pkg/reconciler/controller/kafkachannel_test.go
+++ b/contrib/kafka/pkg/reconciler/controller/kafkachannel_test.go
@@ -18,12 +18,13 @@ package controller
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Shopify/sarama"
 	. "github.com/knative/eventing/contrib/kafka/pkg/utils"
 	"github.com/knative/eventing/pkg/utils"
 	"github.com/knative/pkg/kmeta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 	fakeclientset "github.com/knative/eventing/contrib/kafka/pkg/client/clientset/versioned/fake"

--- a/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
+++ b/contrib/kafka/pkg/reconciler/testing/kafkachannel.go
@@ -18,8 +18,9 @@ package testing
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 	"github.com/knative/pkg/apis"

--- a/contrib/natss/cmd/channel_dispatcher/main.go
+++ b/contrib/natss/cmd/channel_dispatcher/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"flag"
-	"github.com/knative/eventing/pkg/tracing"
 	"log"
+
+	"github.com/knative/eventing/pkg/tracing"
 
 	"github.com/knative/eventing/contrib/natss/pkg/util"
 

--- a/contrib/natss/pkg/reconciler/controller/natsschannel_test.go
+++ b/contrib/natss/pkg/reconciler/controller/natsschannel_test.go
@@ -18,10 +18,11 @@ package controller
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/knative/eventing/pkg/utils"
 	"github.com/knative/pkg/kmeta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/knative/eventing/contrib/natss/pkg/apis/messaging/v1alpha1"
 	fakeclientset "github.com/knative/eventing/contrib/natss/pkg/client/clientset/versioned/fake"

--- a/pkg/apis/messaging/v1alpha1/pipeline_lifecycle_test.go
+++ b/pkg/apis/messaging/v1alpha1/pipeline_lifecycle_test.go
@@ -218,7 +218,7 @@ func TestPipelinePropagateSubscriptionStatuses(t *testing.T) {
 		want: corev1.ConditionFalse,
 	}, {
 		name: "empty status",
-		subs: []*eventingv1alpha1.Subscription{&eventingv1alpha1.Subscription{
+		subs: []*eventingv1alpha1.Subscription{{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "eventing.knative.dev/v1alpha1",
 				Kind:       "Subscription",

--- a/pkg/reconciler/pipeline/pipeline_test.go
+++ b/pkg/reconciler/pipeline/pipeline_test.go
@@ -197,7 +197,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithPipelineAddressableNotReady("emptyHostname", "hostname is the empty string"),
 					reconciletesting.WithPipelineSubscriptionsNotReady("SubscriptionsNotReady", "Subscriptions are not ready yet, or there are none"),
 					reconciletesting.WithPipelineChannelStatuses([]v1alpha1.PipelineChannelStatus{
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -213,7 +213,7 @@ func TestAllCases(t *testing.T) {
 						},
 					}),
 					reconciletesting.WithPipelineSubscriptionStatuses([]v1alpha1.PipelineSubscriptionStatus{
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -253,7 +253,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithPipelineChannelsNotReady("ChannelsNotReady", "Channels are not ready yet, or there are none"),
 					reconciletesting.WithPipelineSubscriptionsNotReady("SubscriptionsNotReady", "Subscriptions are not ready yet, or there are none"),
 					reconciletesting.WithPipelineChannelStatuses([]v1alpha1.PipelineChannelStatus{
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -269,7 +269,7 @@ func TestAllCases(t *testing.T) {
 						},
 					}),
 					reconciletesting.WithPipelineSubscriptionStatuses([]v1alpha1.PipelineSubscriptionStatus{
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -314,7 +314,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithPipelineAddressableNotReady("emptyHostname", "hostname is the empty string"),
 					reconciletesting.WithPipelineSubscriptionsNotReady("SubscriptionsNotReady", "Subscriptions are not ready yet, or there are none"),
 					reconciletesting.WithPipelineChannelStatuses([]v1alpha1.PipelineChannelStatus{
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -328,7 +328,7 @@ func TestAllCases(t *testing.T) {
 								Message: "Channel is not addressable",
 							},
 						},
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -342,7 +342,7 @@ func TestAllCases(t *testing.T) {
 								Message: "Channel is not addressable",
 							},
 						},
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -358,7 +358,7 @@ func TestAllCases(t *testing.T) {
 						},
 					}),
 					reconciletesting.WithPipelineSubscriptionStatuses([]v1alpha1.PipelineSubscriptionStatus{
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -366,7 +366,7 @@ func TestAllCases(t *testing.T) {
 								Namespace:  testNS,
 							},
 						},
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -374,7 +374,7 @@ func TestAllCases(t *testing.T) {
 								Namespace:  testNS,
 							},
 						},
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -430,7 +430,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithPipelineAddressableNotReady("emptyHostname", "hostname is the empty string"),
 					reconciletesting.WithPipelineSubscriptionsNotReady("SubscriptionsNotReady", "Subscriptions are not ready yet, or there are none"),
 					reconciletesting.WithPipelineChannelStatuses([]v1alpha1.PipelineChannelStatus{
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -444,7 +444,7 @@ func TestAllCases(t *testing.T) {
 								Message: "Channel is not addressable",
 							},
 						},
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -458,7 +458,7 @@ func TestAllCases(t *testing.T) {
 								Message: "Channel is not addressable",
 							},
 						},
-						v1alpha1.PipelineChannelStatus{
+						{
 							Channel: corev1.ObjectReference{
 								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "inmemorychannel",
@@ -474,7 +474,7 @@ func TestAllCases(t *testing.T) {
 						},
 					}),
 					reconciletesting.WithPipelineSubscriptionStatuses([]v1alpha1.PipelineSubscriptionStatus{
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -482,7 +482,7 @@ func TestAllCases(t *testing.T) {
 								Namespace:  testNS,
 							},
 						},
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",
@@ -490,7 +490,7 @@ func TestAllCases(t *testing.T) {
 								Namespace:  testNS,
 							},
 						},
-						v1alpha1.PipelineSubscriptionStatus{
+						{
 							Subscription: corev1.ObjectReference{
 								APIVersion: "eventing.knative.dev/v1alpha1",
 								Kind:       "Subscription",


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
