### PR TITLE
fixing RBAC for finalizers sub-resource

### DIFF
--- a/contrib/kafka/config/provisioner/kafka.yaml
+++ b/contrib/kafka/config/provisioner/kafka.yaml
@@ -44,6 +44,13 @@ rules:
       - watch
       - update
   - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - channels/finalizers
+      - clusterchannelprovisioners/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "" # Core API group.
     resources:
       - services


### PR DESCRIPTION
Running on Openshift 4.1, getting:

```
{"level":"info","ts":"2019-06-07T13:01:47.237Z","logger":"provisioner","caller":"controller/reconcile.go:43","msg":"reconciling ClusterChannelProvisioner","request":"/kafka"}
{"level":"info","ts":"2019-06-07T13:01:47.255Z","logger":"provisioner","caller":"controller/reconcile.go:100","msg":"error creating the ClusterProvisioner's K8s Service","error":"services \"kafka-dispatcher\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
{"level":"info","ts":"2019-06-07T13:01:47.255Z","logger":"provisioner","caller":"controller/reconcile.go:76","msg":"error reconciling ClusterProvisioner","error":"services \"kafka-dispatcher\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
{"level":"error","ts":1559912507.2552495,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"kafka-provisioner-controller","request":"/kafka","error":"services \"kafka-dispatcher\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/knative/eventing/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/knative/eventing/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/knative/eventing/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/knative/eventing/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\ngithub.com/knative/eventing/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/go/src/github.com/knative/eventing/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/knative/eventing/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

adding the suggested patch, fixes it.


**NOTE:** very similar to the CR for the `in-memory-channel` CCP, and also on the Kafka CRD, we have `finalizers` sub-resource.
