### PR TITLE
golang format tools

### DIFF
--- a/pkg/duck/sinks.go
+++ b/pkg/duck/sinks.go
@@ -19,6 +19,7 @@ package duck
 import (
 	"context"
 	"fmt"
+
 	"github.com/knative/pkg/injection/clients/dynamicclient"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -19,9 +19,10 @@ package apiserversource
 import (
 	"context"
 	"fmt"
-	"github.com/knative/pkg/configmap"
 	"os"
 	"testing"
+
+	"github.com/knative/pkg/configmap"
 
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/reconciler/apiserversource/cfg_host.go
+++ b/pkg/reconciler/apiserversource/cfg_host.go
@@ -18,6 +18,7 @@ package apiserversource
 
 import (
 	"context"
+
 	"github.com/knative/pkg/injection"
 	"github.com/knative/pkg/logging"
 	"k8s.io/client-go/rest"

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -18,6 +18,7 @@ package apiserversource
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing/pkg/duck"
 	"github.com/knative/eventing/pkg/reconciler"

--- a/pkg/reconciler/apiserversource/controller_test.go
+++ b/pkg/reconciler/apiserversource/controller_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package apiserversource
 
 import (
+	"testing"
+
 	"github.com/knative/pkg/configmap"
 	"k8s.io/client-go/rest"
-	"testing"
 
 	logtesting "github.com/knative/pkg/logging/testing"
 	. "github.com/knative/pkg/reconciler/testing"

--- a/pkg/reconciler/containersource/controller_test.go
+++ b/pkg/reconciler/containersource/controller_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package containersource
 
 import (
-	"github.com/knative/pkg/configmap"
 	"testing"
+
+	"github.com/knative/pkg/configmap"
 
 	logtesting "github.com/knative/pkg/logging/testing"
 	. "github.com/knative/pkg/reconciler/testing"

--- a/pkg/reconciler/cronjobsource/controller.go
+++ b/pkg/reconciler/cronjobsource/controller.go
@@ -18,6 +18,7 @@ package cronjobsource
 
 import (
 	"context"
+
 	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing/pkg/duck"
 	"github.com/knative/eventing/pkg/reconciler"

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -19,9 +19,10 @@ package cronjobsource
 import (
 	"context"
 	"fmt"
-	"github.com/knative/pkg/configmap"
 	"os"
 	"testing"
+
+	"github.com/knative/pkg/configmap"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -18,11 +18,12 @@ package reconciler
 
 import (
 	"context"
+	"time"
+
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection/clients/dynamicclient"
 	"github.com/knative/pkg/injection/clients/kubeclient"
 	"github.com/knative/pkg/logging"
-	"time"
 
 	eventingclient "github.com/knative/eventing/pkg/client/injection/client"
 

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -19,9 +19,10 @@ package testing
 import (
 	"context"
 	"encoding/json"
+	"testing"
+
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/test/base/resources/sources.go
+++ b/test/base/resources/sources.go
@@ -105,11 +105,11 @@ func ContainerSourceBasicTemplate(
 	args []string,
 ) *corev1.PodTemplateSpec {
 	envVars := []corev1.EnvVar{
-		corev1.EnvVar{
+		{
 			Name:  "POD_NAME",
 			Value: name,
 		},
-		corev1.EnvVar{
+		{
 			Name:  "POD_NAMESPACE",
 			Value: namespace,
 		},
@@ -121,7 +121,7 @@ func ContainerSourceBasicTemplate(
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				corev1.Container{
+				{
 					Name:            imageName,
 					Image:           pkgTest.ImagePath(imageName),
 					ImagePullPolicy: corev1.PullAlways,

--- a/test/common/config.go
+++ b/test/common/config.go
@@ -27,18 +27,18 @@ const DefaultClusterChannelProvisioner = resources.InMemoryProvisioner
 // ValidProvisionersMap saves the provisioner-features mapping.
 // Each pair means the provisioner support the list of features.
 var ValidProvisionersMap = map[string]ChannelConfig{
-	resources.InMemoryProvisioner: ChannelConfig{
+	resources.InMemoryProvisioner: {
 		Features:     []Feature{FeatureBasic},
 		CRDSupported: true,
 	},
-	resources.GCPPubSubProvisioner: ChannelConfig{
+	resources.GCPPubSubProvisioner: {
 		Features: []Feature{FeatureBasic, FeatureRedelivery, FeaturePersistence},
 	},
-	resources.KafkaProvisioner: ChannelConfig{
+	resources.KafkaProvisioner: {
 		Features:     []Feature{FeatureBasic, FeatureRedelivery, FeaturePersistence},
 		CRDSupported: true,
 	},
-	resources.NatssProvisioner: ChannelConfig{
+	resources.NatssProvisioner: {
 		Features: []Feature{FeatureBasic, FeatureRedelivery, FeaturePersistence},
 	},
 }


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
