### PR TITLE
Add e2e test for Broker using Channel CRDs

### DIFF
--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/test/base/resources"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -99,9 +100,14 @@ func (client *Client) CreateSubscriptionsOrFail(
 }
 
 // CreateBrokerOrFail will create a Broker or fail the test if there is an error.
-func (client *Client) CreateBrokerOrFail(name, provisionerName string) {
+func (client *Client) CreateBrokerOrFail(name string, channelTypeMeta *metav1.TypeMeta, provisionerName string) {
 	namespace := client.Namespace
-	broker := resources.Broker(name, provisionerName)
+	var broker *eventingv1alpha1.Broker
+	if channelTypeMeta.Kind == resources.ChannelKind {
+		broker = resources.Broker(name, resources.WithDeprecatedChannelTemplateForBroker(provisionerName))
+	} else {
+		broker = resources.Broker(name, resources.WithChannelTemplateForBroker(*channelTypeMeta))
+	}
 
 	brokers := client.Eventing.EventingV1alpha1().Brokers(namespace)
 	// update broker with the new reference
@@ -113,9 +119,9 @@ func (client *Client) CreateBrokerOrFail(name, provisionerName string) {
 }
 
 // CreateBrokersOrFail will create a list of Brokers.
-func (client *Client) CreateBrokersOrFail(names []string, provisionerName string) {
+func (client *Client) CreateBrokersOrFail(names []string, channelTypeMeta *metav1.TypeMeta, provisionerName string) {
 	for _, name := range names {
-		client.CreateBrokerOrFail(name, provisionerName)
+		client.CreateBrokerOrFail(name, channelTypeMeta, provisionerName)
 	}
 }
 

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -83,13 +83,14 @@ func testBrokerChannelFlow(t *testing.T, provisioner string, isCRD bool) {
 
 	client := Setup(t, true)
 	defer TearDown(client)
+	channelTypeMeta := getChannelTypeMeta(provisioner, isCRD)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role
 	client.CreateServiceAccountAndBindingOrFail(saIngressName, crIngressName)
 	client.CreateServiceAccountAndBindingOrFail(saFilterName, crFilterName)
 
 	// create a new broker
-	client.CreateBrokerOrFail(brokerName, provisioner)
+	client.CreateBrokerOrFail(brokerName, channelTypeMeta, provisioner)
 	client.WaitForResourceReady(brokerName, common.BrokerTypeMeta)
 
 	// create the event we want to transform to
@@ -126,7 +127,6 @@ func testBrokerChannelFlow(t *testing.T, provisioner string, isCRD bool) {
 	)
 
 	// create channel for trigger3
-	channelTypeMeta := getChannelTypeMeta(provisioner, isCRD)
 	client.CreateChannelOrFail(channelName, channelTypeMeta, provisioner)
 	client.WaitForResourceReady(channelName, channelTypeMeta)
 

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -72,13 +72,14 @@ func testEventTransformationForTrigger(t *testing.T, provisioner string, isCRD b
 
 	client := Setup(t, true)
 	defer TearDown(client)
+	channelTypeMeta := getChannelTypeMeta(provisioner, isCRD)
 
 	// creates ServiceAccount and ClusterRoleBinding with default cluster-admin role
 	client.CreateServiceAccountAndBindingOrFail(saIngressName, crIngressName)
 	client.CreateServiceAccountAndBindingOrFail(saFilterName, crFilterName)
 
 	// create a new broker
-	client.CreateBrokerOrFail(brokerName, provisioner)
+	client.CreateBrokerOrFail(brokerName, channelTypeMeta, provisioner)
 	client.WaitForResourceReady(brokerName, common.BrokerTypeMeta)
 
 	// create the event we want to transform to


### PR DESCRIPTION
Fixes #1380 

## Proposed Changes
- Add e2e test case to test `Broker` that uses the new `ChannelTemplate`.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @vaikas-google 