### PR TITLE
Using CamelCase syntax for the Kafka Channels

### DIFF
--- a/contrib/kafka/config/400-kafka-config.yaml
+++ b/contrib/kafka/config/400-kafka-config.yaml
@@ -20,9 +20,9 @@ metadata:
 data:
   # Broker URL. Replace this with the URLs for your kafka cluster,
   # which is in the format of my-cluster-kafka-bootstrap.my-kafka-namespace:9092.
-  bootstrap_servers: REPLACE_WITH_CLUSTER_URL
+  bootstrapServers: REPLACE_WITH_CLUSTER_URL
 
   # Consumer mode to dispatch events from different partitions in parallel.
   # By default(multiplex), partitions are multiplexed with a single go channel.
   # `multiplex` and `partitions` are valid values.
-  ## consumer_mode: partitions
+  ## consumerMode: partitions

--- a/contrib/kafka/config/README.md
+++ b/contrib/kafka/config/README.md
@@ -18,7 +18,7 @@ topics.
    > installation.
 
 1. Now that Apache Kafka is installed, you need to configure the
-   `bootstrap_servers` value in the `config-kafka` ConfigMap, located inside the
+   `bootstrapServers` value in the `config-kafka` ConfigMap, located inside the
    `contrib/kafka/config/400-kafka-config.yaml` file:
 
    ```yaml
@@ -30,7 +30,7 @@ topics.
    data:
      # Broker URL. Replace this with the URLs for your kafka cluster,
      # which is in the format of my-cluster-kafka-bootstrap.my-kafka-namespace:9092.
-     bootstrap_servers: REPLACE_WITH_CLUSTER_URL
+     bootstrapServers: REPLACE_WITH_CLUSTER_URL
    ```
 
 1. Apply the Kafka config:
@@ -84,7 +84,7 @@ objects:
 kubectl get deployment -n knative-eventing kafka-webhook
 ```
 
-The Kafka Config Map is used to configure the `bootstrap_servers` of your Apache
+The Kafka Config Map is used to configure the `bootstrapServers` of your Apache
 Kafka installation:
 
 ```shell

--- a/contrib/kafka/config/provisioner/README.md
+++ b/contrib/kafka/config/provisioner/README.md
@@ -15,7 +15,7 @@ Deployment steps:
    > installation.
 
 1. Now that Apache Kafka is installed, you need to configure the
-   `bootstrap_servers` value in the `kafka-channel-controller-config` ConfigMap,
+   `bootstrapServers` value in the `kafka-channel-controller-config` ConfigMap,
    located inside the `contrib/kafka/config/provisioner/kafka.yaml` file:
 
    ```yaml
@@ -27,12 +27,12 @@ Deployment steps:
      namespace: knative-eventing
    data:
      # Broker URL's for the provisioner
-     bootstrap_servers: my-cluster-kafka-bootstrap.my-kafka-namespace:9092
+     bootstrapServers: my-cluster-kafka-bootstrap.my-kafka-namespace:9092
 
      # Consumer mode to dispatch events from different partitions in parallel.
      # By default(multiplex), partitions are multiplexed with a single go channel.
      # `multiplex` and `partitions` are valid values.
-     ## consumer_mode: partitions
+     ## consumerMode: partitions
      ...
    ```
 
@@ -73,7 +73,7 @@ colocated in one Pod:
 kubectl get deployment -n knative-eventing kafka-channel-controller
 ```
 
-The Channel Controller Config Map is used to configure the `bootstrap_servers`
+The Channel Controller Config Map is used to configure the `bootstrapServers`
 of your Apache Kafka installation:
 
 ```shell

--- a/contrib/kafka/config/provisioner/kafka.yaml
+++ b/contrib/kafka/config/provisioner/kafka.yaml
@@ -106,12 +106,12 @@ metadata:
 data:
   # Broker URL's for the provisioner. Replace this with the URL's for your kafka cluster,
   # which is in the format of my-cluster-kafka-bootstrap.my-kafka-namespace:9092.
-  bootstrap_servers: REPLACE_WITH_CLUSTER_URL
+  bootstrapServers: REPLACE_WITH_CLUSTER_URL
 
   # Consumer mode to dispatch events from different partitions in parallel.
   # By default(multiplex), partitions are multiplexed with a single go channel.
   # `multiplex` and `partitions` are valid values.
-  ## consumer_mode: partitions
+  ## consumerMode: partitions
 ---
 
 apiVersion: apps/v1

--- a/contrib/kafka/pkg/utils/util.go
+++ b/contrib/kafka/pkg/utils/util.go
@@ -22,13 +22,12 @@ import (
 	"strings"
 
 	cluster "github.com/bsm/sarama-cluster"
-
 	"github.com/knative/pkg/configmap"
 )
 
 const (
-	BrokerConfigMapKey                 = "bootstrap_servers"
-	ConsumerModeConfigMapKey           = "consumer_mode"
+	BrokerConfigMapKey                 = "bootstrapServers"
+	ConsumerModeConfigMapKey           = "consumerMode"
 	ConsumerModePartitionConsumerValue = "partitions"
 	ConsumerModeMultiplexConsumerValue = "multiplex"
 	KafkaChannelSeparator              = "."
@@ -80,7 +79,7 @@ func GetKafkaConfig(path string) (*KafkaConfig, error) {
 		case ConsumerModePartitionConsumerValue:
 			config.ConsumerMode = cluster.ConsumerModePartitions
 		default:
-			log.Printf("consumer_mode: %q is invalid. Using default mode %q", mode, ConsumerModeMultiplexConsumerValue)
+			log.Printf("consumerMode: %q is invalid. Using default mode %q", mode, ConsumerModeMultiplexConsumerValue)
 			config.ConsumerMode = cluster.ConsumerModeMultiplex
 		}
 	}

--- a/contrib/kafka/pkg/utils/util_test.go
+++ b/contrib/kafka/pkg/utils/util_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	cluster "github.com/bsm/sarama-cluster"
-
 	"github.com/google/go-cmp/cmp"
 	_ "github.com/knative/pkg/system/testing"
 )
@@ -48,32 +47,32 @@ func TestGetKafkaConfig(t *testing.T) {
 			getError: "missing configuration",
 		},
 		{
-			name:     "configmap with no bootstrap_servers key",
+			name:     "configmap with no bootstrapServers key",
 			data:     map[string]string{"key": "value"},
-			getError: "missing key bootstrap_servers in configuration",
+			getError: "missing key bootstrapServers in configuration",
 		},
 		{
-			name:     "configmap with empty bootstrap_servers value",
-			data:     map[string]string{"bootstrap_servers": ""},
-			getError: "empty bootstrap_servers value in configuration",
+			name:     "configmap with empty bootstrapServers value",
+			data:     map[string]string{"bootstrapServers": ""},
+			getError: "empty bootstrapServers value in configuration",
 		},
 		{
-			name: "single bootstrap_servers",
-			data: map[string]string{"bootstrap_servers": "kafkabroker.kafka:9092"},
+			name: "single bootstrapServers",
+			data: map[string]string{"bootstrapServers": "kafkabroker.kafka:9092"},
 			expected: &KafkaConfig{
 				Brokers: []string{"kafkabroker.kafka:9092"},
 			},
 		},
 		{
-			name: "multiple bootstrap_servers",
-			data: map[string]string{"bootstrap_servers": "kafkabroker1.kafka:9092,kafkabroker2.kafka:9092"},
+			name: "multiple bootstrapServers",
+			data: map[string]string{"bootstrapServers": "kafkabroker1.kafka:9092,kafkabroker2.kafka:9092"},
 			expected: &KafkaConfig{
 				Brokers: []string{"kafkabroker1.kafka:9092", "kafkabroker2.kafka:9092"},
 			},
 		},
 		{
 			name: "partition consumer",
-			data: map[string]string{"bootstrap_servers": "kafkabroker.kafka:9092", "consumer_mode": "partitions"},
+			data: map[string]string{"bootstrapServers": "kafkabroker.kafka:9092", "consumerMode": "partitions"},
 			expected: &KafkaConfig{
 				Brokers:      []string{"kafkabroker.kafka:9092"},
 				ConsumerMode: cluster.ConsumerModePartitions,
@@ -81,15 +80,15 @@ func TestGetKafkaConfig(t *testing.T) {
 		},
 		{
 			name: "default multiplex",
-			data: map[string]string{"bootstrap_servers": "kafkabroker.kafka:9092", "consumer_mode": "multiplex"},
+			data: map[string]string{"bootstrapServers": "kafkabroker.kafka:9092", "consumerMode": "multiplex"},
 			expected: &KafkaConfig{
 				Brokers:      []string{"kafkabroker.kafka:9092"},
 				ConsumerMode: cluster.ConsumerModeMultiplex,
 			},
 		},
 		{
-			name: "default multiplex from invalid consumer_mode",
-			data: map[string]string{"bootstrap_servers": "kafkabroker.kafka:9092", "consumer_mode": "foo"},
+			name: "default multiplex from invalid consumerMode",
+			data: map[string]string{"bootstrapServers": "kafkabroker.kafka:9092", "consumerMode": "foo"},
 			expected: &KafkaConfig{
 				Brokers:      []string{"kafkabroker.kafka:9092"},
 				ConsumerMode: cluster.ConsumerModeMultiplex,


### PR DESCRIPTION
Similar to the source (in contrib repo) we going with camelCase for kafka channel cfg.

the changes apply to the new CRD (new in 0.7.0), as well to the old/deprecated CCP for Kafka.

Since users anyways have to change the config on the "channel", to point to the accessible Kafka cluster, it's not that of a harm if the argument is now called `bootstrapServers`, instead of `bootstrap_servers`, I think...

/cc @nachocano 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
the configuration for the kafka CCP is now camel case
```
