### PR TITLE
Format markdown

### DIFF
--- a/contrib/kafka/config/provisioner/README.md
+++ b/contrib/kafka/config/provisioner/README.md
@@ -73,8 +73,8 @@ colocated in one Pod:
 kubectl get deployment -n knative-eventing kafka-channel-controller
 ```
 
-The Channel Controller Config Map is used to configure the `bootstrapServers`
-of your Apache Kafka installation:
+The Channel Controller Config Map is used to configure the `bootstrapServers` of
+your Apache Kafka installation:
 
 ```shell
 kubectl get configmap -n knative-eventing kafka-channel-controller-config


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`