### PR TITLE
create a new own addressinformer for broker

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -157,7 +157,6 @@ func main() {
 			channelInformer,
 			serviceInformer,
 			deploymentInformer,
-			addressableInformer,
 			broker.ReconcilerArgs{
 				IngressImage:              env.BrokerIngressImage,
 				IngressServiceAccountName: env.BrokerIngressServiceAccount,

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -45,7 +45,6 @@ func NewController(
 	channelInformer eventinginformers.ChannelInformer,
 	serviceInformer corev1informers.ServiceInformer,
 	deploymentInformer appsv1informers.DeploymentInformer,
-	addressableInformer duck.AddressableInformer,
 	args ReconcilerArgs,
 ) *controller.Impl {
 
@@ -56,7 +55,6 @@ func NewController(
 		serviceLister:             serviceInformer.Lister(),
 		deploymentLister:          deploymentInformer.Lister(),
 		subscriptionLister:        subscriptionInformer.Lister(),
-		addressableInformer:       addressableInformer,
 		ingressImage:              args.IngressImage,
 		ingressServiceAccountName: args.IngressServiceAccountName,
 		filterImage:               args.FilterImage,
@@ -68,6 +66,7 @@ func NewController(
 
 	r.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
 
+	r.addressableInformer = duck.NewAddressableInformer(opt)
 	brokerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	channelInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{


### PR DESCRIPTION
Fixes #1383

## Proposed Changes

- Instead of using the shared AddressInformer from the main controller, create one for us

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
