### PR TITLE
Adding channel category

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -29,6 +29,7 @@ spec:
     - all
     - knative
     - messaging
+    - channel
     shortNames:
     - imc
   scope: Namespaced

--- a/contrib/kafka/config/300-kafka-channel.yaml
+++ b/contrib/kafka/config/300-kafka-channel.yaml
@@ -30,6 +30,7 @@ spec:
     - all
     - knative
     - messaging
+    - channel
     shortNames:
     - kc
   scope: Namespaced

--- a/contrib/natss/config/300-natss-channel.yaml
+++ b/contrib/natss/config/300-natss-channel.yaml
@@ -30,6 +30,7 @@ spec:
     - all
     - knative
     - messaging
+    - channel
     shortNames:
     - natssc
   scope: Namespaced


### PR DESCRIPTION
Currently you have to `k get XyZChannel` to get the `channel`, like:

```
k get InMemoryChannel

matzew-pipeline-kn-pipeline-0   True             matzew-pipeline-kn-pipeline-0-kn-channel.default.svc.cluster.local   27m
matzew-pipeline-kn-pipeline-1   True             matzew-pipeline-kn-pipeline-1-kn-channel.default.svc.cluster.local   27m
```

@grantr did suggest adding `channel` to the `categories` section of the different CRDs