### PR TITLE
use AddressStatus instead of Addressable

### DIFF
--- a/config/300-sequence.yaml
+++ b/config/300-sequence.yaml
@@ -39,6 +39,9 @@ spec:
     - name: Reason
       type: string
       JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Hostname
+      type: string
+      JSONPath: .status.address.hostname
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp

--- a/pkg/apis/messaging/v1alpha1/sequence_lifecycle.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_lifecycle.go
@@ -124,7 +124,7 @@ func (ps *SequenceStatus) PropagateChannelStatuses(channels []*duckv1alpha1.Chan
 			allReady = false
 		}
 
-		// If the first channel is addressable, mark it as such
+		// Mark the Sequence address as the Address of the first channel.
 		if i == 0 {
 			ps.setAddress(address)
 		}
@@ -148,21 +148,14 @@ func (ps *SequenceStatus) MarkAddressableNotReady(reason, messageFormat string, 
 	pCondSet.Manage(ps).MarkFalse(SequenceConditionAddressable, reason, messageFormat, messageA...)
 }
 
-// TODO: Use the new beta duck types.
 func (ps *SequenceStatus) setAddress(address *pkgduckv1alpha1.Addressable) {
+	ps.Address = address
+
 	if address == nil {
-		ps.Address.Hostname = ""
-		ps.Address.URL = nil
 		pCondSet.Manage(ps).MarkFalse(SequenceConditionAddressable, "emptyHostname", "hostname is the empty string")
 		return
 	}
-
-	if address.URL != nil {
-		ps.Address.Hostname = address.URL.Host
-		ps.Address.URL = address.URL
-		pCondSet.Manage(ps).MarkTrue(SequenceConditionAddressable)
-	} else if address.Hostname != "" {
-		ps.Address.Hostname = address.Hostname
+	if address.URL != nil || address.Hostname != "" {
 		pCondSet.Manage(ps).MarkTrue(SequenceConditionAddressable)
 	} else {
 		ps.Address.Hostname = ""

--- a/pkg/apis/messaging/v1alpha1/sequence_lifecycle_test.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_lifecycle_test.go
@@ -369,7 +369,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 	}{{
 		name:       "nil",
 		address:    nil,
-		want:       &pkgduckv1alpha1.Addressable{},
+		want:       nil,
 		wantStatus: corev1.ConditionFalse,
 	}, {
 		name:       "empty",
@@ -379,7 +379,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 	}, {
 		name:       "URL",
 		address:    &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{URL}, ""},
-		want:       &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{URL}, "example.com"},
+		want:       &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{URL}, ""},
 		wantStatus: corev1.ConditionTrue,
 	}, {
 		name:       "hostname",
@@ -398,7 +398,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 			ps := SequenceStatus{}
 			ps.setAddress(test.address)
 			got := ps.Address
-			if diff := cmp.Diff(test.want, &got, ignoreAllButTypeAndStatus); diff != "" {
+			if diff := cmp.Diff(test.want, got, ignoreAllButTypeAndStatus); diff != "" {
 				t.Errorf("unexpected address (-want, +got) = %v", diff)
 			}
 			gotStatus := ps.GetCondition(SequenceConditionAddressable).Status

--- a/pkg/apis/messaging/v1alpha1/sequence_types.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_types.go
@@ -134,8 +134,10 @@ type SequenceStatus struct {
 	// Matches the Spec.Steps array in the order.
 	ChannelStatuses []SequenceChannelStatus
 
-	// Addressable is the starting point to this Sequence. Sending to this will target the first Subscriber.
-	Address duckv1alpha1.Addressable `json:"address,omitempty"`
+	// AddressStatus is the starting point to this Sequence. Sending to this
+	// will target the first subscriber.
+	// It generally has the form {channel}.{namespace}.svc.{cluster domain name}
+	duckv1alpha1.AddressStatus `json:",inline"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/messaging/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1alpha1/zz_generated.deepcopy.go
@@ -307,7 +307,7 @@ func (in *SequenceStatus) DeepCopyInto(out *SequenceStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Address.DeepCopyInto(&out.Address)
+	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	return
 }
 


### PR DESCRIPTION
After the pipeline (now Sequence) was checked in, the Status was changed from Addressable => AddressStatus, so just making changes to be compliant with that change.

Also, print out the Status.Address (just like for channels).
Now prints out IMC / Sequence consistently:

kubectl -n foobar get sequence
NAME              READY   REASON   HOSTNAME                                                            AGE
vaikas-sequence   True             vaikas-sequence-kn-sequence-0-kn-channel.foobar.svc.cluster.local   8m

kubectl -n foobar get imc
NAME                            READY   REASON   HOSTNAME                                                            AGE
vaikas-sequence-kn-sequence-0   True             vaikas-sequence-kn-sequence-0-kn-channel.foobar.svc.cluster.local   8m
vaikas-sequence-kn-sequence-1   True             vaikas-sequence-kn-sequence-1-kn-channel.foobar.svc.cluster.local   8m
vaikas-sequence-kn-sequence-2   True             vaikas-sequence-kn-sequence-2-kn-channel.foobar.svc.cluster.local   8m


## Proposed Changes

- Inline duckv1alpha1.AddressStatus instead of Addressable to be consistent with other channel like constructs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Inline duckv1alpha1.AddressStatus instead of Addressable to be consistent with other channel like constructs.
```
