### PR TITLE
Format markdown

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,17 +6,17 @@ This is a list of metrics exported by Knative Eventing components.
 
 These are exported by `broker-ingress` pods.
 
-| Name                    | Type      | Description                  | Tags               |
-| ----------------------- | --------- | ---------------------------- | ------------------ |
-| `broker_events_total`   | count     | Number of events received.   | `result`, `broker` |
-| `broker_dispatch_time`  | histogram | Time to dispatch an event.   | `result`, `broker` |
+| Name                   | Type      | Description                | Tags               |
+| ---------------------- | --------- | -------------------------- | ------------------ |
+| `broker_events_total`  | count     | Number of events received. | `result`, `broker` |
+| `broker_dispatch_time` | histogram | Time to dispatch an event. | `result`, `broker` |
 
 ## Trigger
 
 These are exported by `broker-filter` pods.
 
-| Name                   | Type      | Description                  | Tags                                           |
-| ---------------------- | --------- | ---------------------------- | -----------------------------------------------|
-| `trigger_events_total` | count     | Number of events received.   | `result`, `broker`, `trigger`                  |
-| `trigger_dispatch_time`| histogram | Time to dispatch an event.   | `result`, `broker`, `trigger`                  |
-| `trigger_filter_time`  | histogram | Time to filter an event.     | `result`, `broker`, `trigger`, `filter_result` |
+| Name                    | Type      | Description                | Tags                                           |
+| ----------------------- | --------- | -------------------------- | ---------------------------------------------- |
+| `trigger_events_total`  | count     | Number of events received. | `result`, `broker`, `trigger`                  |
+| `trigger_dispatch_time` | histogram | Time to dispatch an event. | `result`, `broker`, `trigger`                  |
+| `trigger_filter_time`   | histogram | Time to filter an event.   | `result`, `broker`, `trigger`, `filter_result` |


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`