### PR TITLE
Add AddressableTracker type.

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -37,7 +37,6 @@ import (
 	duckroot "github.com/knative/pkg/apis"
 	duckapis "github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/controller"
-	"github.com/knative/pkg/tracker"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,10 +72,7 @@ type Reconciler struct {
 	deploymentLister   appsv1listers.DeploymentLister
 	subscriptionLister eventinglisters.SubscriptionLister
 
-	addressableInformer duck.AddressableInformer
-
-	// Track my channels
-	tracker tracker.Interface
+	addressableTracker duck.AddressableTracker
 
 	ingressImage              string
 	ingressServiceAccountName string
@@ -280,7 +276,7 @@ func (r *Reconciler) reconcileCRD(ctx context.Context, b *v1alpha1.Broker) error
 	}
 
 	// Tell tracker to reconcile this Broker whenever my channels change.
-	track := r.addressableInformer.TrackInNamespace(r.tracker, b)
+	track := r.addressableTracker.TrackInNamespace(b)
 
 	// Start tracking trigger channel...
 	if err = track(utils.ObjectRef(triggerChan, triggerChan.GroupVersionKind())); err != nil {

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/knative/pkg/controller"
 	logtesting "github.com/knative/pkg/logging/testing"
 	. "github.com/knative/pkg/reconciler/testing"
-	"github.com/knative/pkg/tracker"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -108,10 +107,17 @@ func init() {
 	_ = v1alpha1.AddToScheme(scheme.Scheme)
 }
 
-type fakeAddressableInformer struct{}
+type fakeAddressableTracker struct{}
 
-func (*fakeAddressableInformer) TrackInNamespace(tracker.Interface, metav1.Object) func(corev1.ObjectReference) error {
+func (fakeAddressableTracker) TrackInNamespace(metav1.Object) func(corev1.ObjectReference) error {
 	return func(corev1.ObjectReference) error { return nil }
+}
+
+func (fakeAddressableTracker) Track(ref corev1.ObjectReference, obj interface{}) error {
+	return nil
+}
+
+func (fakeAddressableTracker) OnChanged(obj interface{}) {
 }
 
 func TestReconcile(t *testing.T) {
@@ -1660,7 +1666,7 @@ func TestReconcileCRD(t *testing.T) {
 			filterServiceAccountName:  filterSA,
 			ingressImage:              ingressImage,
 			ingressServiceAccountName: ingressSA,
-			addressableInformer:       &fakeAddressableInformer{},
+			addressableTracker:        fakeAddressableTracker{},
 		}
 	},
 		false,

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/knative/eventing/pkg/reconciler"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
-	"github.com/knative/pkg/tracker"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/knative/eventing/pkg/client/injection/informers/eventing/v1alpha1/subscription"
@@ -53,14 +52,13 @@ func NewController(
 	r := &Reconciler{
 		Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
 		sequenceLister:      sequenceInformer.Lister(),
-		addressableInformer: addressableInformer,
 		subscriptionLister:  subscriptionInformer.Lister(),
 	}
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 
 	r.Logger.Info("Setting up event handlers")
 
-	r.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.addressableTracker = addressableInformer.NewTracker(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 	sequenceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Sequence, so that

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -57,7 +57,7 @@ type Reconciler struct {
 	// listers index properties about resources
 	sequenceLister      listers.SequenceLister
 	tracker             tracker.Interface
-	addressableInformer duck.AddressableInformer
+	addressableTracker  duck.AddressableTracker
 	subscriptionLister  eventinglisters.SubscriptionLister
 }
 
@@ -135,7 +135,7 @@ func (r *Reconciler) reconcile(ctx context.Context, p *v1alpha1.Sequence) error 
 	}
 
 	// Tell tracker to reconcile this Sequence whenever my channels change.
-	track := r.addressableInformer.TrackInNamespace(r.tracker, p)
+	track := r.addressableTracker.TrackInNamespace(p)
 
 	channels := make([]*duckv1alpha1.Channelable, 0, len(p.Spec.Steps))
 	for i := 0; i < len(p.Spec.Steps); i++ {

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
-	"github.com/knative/pkg/tracker"
 
 	"github.com/knative/eventing/pkg/duck"
 	"github.com/knative/eventing/pkg/reconciler"
@@ -54,16 +53,15 @@ func NewController(
 		Base:                           reconciler.NewBase(ctx, controllerAgentName, cmw),
 		subscriptionLister:             subscriptionInformer.Lister(),
 		customResourceDefinitionLister: customResourceDefinitionInformer.Lister(),
-		addressableInformer:            addressableInformer,
 	}
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 
 	r.Logger.Info("Setting up event handlers")
 	subscriptionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-	// Tracker is used to notify us when the resources Subscription depends on change, so that the
+	// AddressableTracker is used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
-	r.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.addressableTracker = addressableInformer.NewTracker(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
 	return impl
 }


### PR DESCRIPTION
AddressableTracker is a tracker which supports registering callbacks
with an AddressableInformer and which can be created using an
AddressableInformer factory method. Previously TrackInNamespace could
be called directly on an AddressableInformer with an external
tracker but this method would only register callbacks for the first
tracker which attempted to track an addressables in each GVR.

Fixes #1383
