### PR TITLE
Make a small adjustment to hack/update-deps.sh

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -435,7 +435,8 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:d6d25cf50e69e0e69e7a1719143135bced01f2dc695646ae1ec0a95da22cfc68"
+  branch = "master"
+  digest = "1:a3cabcef7cdb39039c0e37353e1d1ac257f4fa926176494ca4bae3f616c3e820"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -510,7 +511,7 @@
     "webhook",
   ]
   pruneopts = "T"
-  revision = "f48815f4545fe120cb9d9fb9a05a40367cbe8072"
+  revision = "139b81e637e39b1d7c1763e793e13b364f2dd26a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,12 +82,10 @@ required = [
   name = "github.com/json-iterator/go"
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
-# Constrain the version of knative/pkg we would like to import.
-# This controls when we upgrade apis independently of Serving.
+# Our master branch tracks kantive/pkg master.
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2919-06-10
-  revision = "f48815f4545fe120cb9d9fb9a05a40367cbe8072"
+  branch = "master"
 
 # TODO why is this overridden?
 [[override]]

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/breaking-change.md
@@ -1,0 +1,22 @@
+---
+name: Breaking Change
+about: Makes a breaking change to knative/pkg
+title: ''
+labels: 
+assignees: 'mattmoor'
+
+---
+
+BREAKING CHANGES MUST STAGE CHANGES ONTO DOWNSTREAM
+KNATIVE REPOSITORIES
+
+
+| Repo              | Pull Request                   |
+|-------------------|--------------------------------|
+| Build             | knative/build#1234             |
+| Eventing          | knative/eventing#1234          |
+| Serving           | knative/serving#1234           |
+| Sample Controller | knative/sample-controller#1234 |
+
+
+cc @n3wscott @jasonhall

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
@@ -1,0 +1,10 @@
+---
+name: Bug Fix
+about: Fixes a bug in knative/pkg
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+Fixes:

--- a/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
+++ b/vendor/github.com/knative/pkg/.github/PULL_REQUEST_TEMPLATE/normal-change.md
@@ -1,0 +1,8 @@
+---
+name: Normal Change
+about: Makes a boring change to the repo.
+title: ''
+labels: 
+assignees: ''
+
+---

--- a/vendor/github.com/knative/pkg/.github/pull-request-template.md
+++ b/vendor/github.com/knative/pkg/.github/pull-request-template.md
@@ -1,6 +1,0 @@
-<!--
-Pro-tip: To automatically close issues when a PR is merged,
-include the following in your PR description:
-
-Fixes: <LINK TO ISSUE>
--->

--- a/vendor/github.com/knative/pkg/Gopkg.lock
+++ b/vendor/github.com/knative/pkg/Gopkg.lock
@@ -857,7 +857,7 @@
   version = "kubernetes-1.12.6"
 
 [[projects]]
-  digest = "1:07be043078c2dc2ee33e81278b264a84f364c6d711811d2932aa42212fc4f2ae"
+  digest = "1:b7dd0420e85cb2968ffb945f2810ea6c796dc2a08660618e2200c08c596f0624"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1005,11 +1005,9 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
-    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
     "testing",
-    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -1027,7 +1025,6 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/jsonpath",
     "util/retry",
     "util/workqueue",
   ]
@@ -1174,13 +1171,13 @@
     "k8s.io/client-go/informers/apps/v1",
     "k8s.io/client-go/informers/autoscaling/v1",
     "k8s.io/client-go/informers/autoscaling/v2beta1",
+    "k8s.io/client-go/informers/batch/v1",
     "k8s.io/client-go/informers/core/v1",
     "k8s.io/client-go/informers/rbac/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",

--- a/vendor/github.com/knative/pkg/hack/update-deps.sh
+++ b/vendor/github.com/knative/pkg/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
-
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/fake/fake.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory/fake"
+)
+
+var Get = job.Get
+
+func init() {
+	injection.Fake.RegisterInformer(withInformer)
+}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := fake.Get(ctx)
+	inf := f.Batch().V1().Jobs()
+	return context.WithValue(ctx, job.Key{}, inf), inf.Informer()
+}

--- a/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/job.go
+++ b/vendor/github.com/knative/pkg/injection/informers/kubeinformers/batchv1/job/job.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"context"
+
+	batchv1 "k8s.io/client-go/informers/batch/v1"
+
+	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection"
+	"github.com/knative/pkg/injection/informers/kubeinformers/factory"
+	"github.com/knative/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterInformer(withInformer)
+}
+
+// Key is used as the key for associating information
+// with a context.Context.
+type Key struct{}
+
+func withInformer(ctx context.Context) (context.Context, controller.Informer) {
+	f := factory.Get(ctx)
+	inf := f.Batch().V1().Jobs()
+	return context.WithValue(ctx, Key{}, inf), inf.Informer()
+}
+
+// Get extracts the Kubernetes Job informer from the context.
+func Get(ctx context.Context) batchv1.JobInformer {
+	untyped := ctx.Value(Key{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panicf(
+			"Unable to fetch %T from context.", (batchv1.JobInformer)(nil))
+	}
+	return untyped.(batchv1.JobInformer)
+}

--- a/vendor/github.com/knative/pkg/injection/sharedmain/main.go
+++ b/vendor/github.com/knative/pkg/injection/sharedmain/main.go
@@ -24,9 +24,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/controller"
 	"github.com/knative/pkg/injection"


### PR DESCRIPTION
This form should be more hospitable to running things to auto-update `knative/pkg` and `knative/test-infra`.

I canaried this change in `knative/sample-controller`, and was able to produce: https://github.com/knative/sample-controller/pull/11

