### PR TITLE
golang format tools

### DIFF
--- a/pkg/duck/addressable.go
+++ b/pkg/duck/addressable.go
@@ -20,17 +20,18 @@ import (
 	"context"
 	"sync"
 
+	"time"
+
 	"github.com/knative/pkg/apis/duck"
 	"github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/controller"
+	"github.com/knative/pkg/injection/clients/dynamicclient"
+	"github.com/knative/pkg/tracker"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"github.com/knative/pkg/injection/clients/dynamicclient"
 	"k8s.io/client-go/tools/cache"
-	"time"
-	"github.com/knative/pkg/tracker"
 )
 
 // AddressableInformer is an informer that allows tracking arbitrary Addressables.
@@ -77,9 +78,9 @@ func NewAddressableInformer(ctx context.Context) AddressableInformer {
 }
 
 func (i *addressableInformer) NewTracker(callback func(string), lease time.Duration) AddressableTracker {
-	return &addressableTracker {
+	return &addressableTracker{
 		informer: i,
-		tracker: tracker.New(callback, lease),
+		tracker:  tracker.New(callback, lease),
 		concrete: map[schema.GroupVersionResource]struct{}{},
 	}
 }
@@ -112,9 +113,9 @@ func (i *addressableInformer) ensureInformer(ref corev1.ObjectReference) (cache.
 	return informer, nil
 }
 
-type addressableTracker struct{
+type addressableTracker struct {
 	informer *addressableInformer
-	tracker tracker.Interface
+	tracker  tracker.Interface
 
 	concrete     map[schema.GroupVersionResource]struct{}
 	concreteLock sync.RWMutex

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -50,9 +50,9 @@ func NewController(
 	addressableInformer := duck.NewAddressableInformer(ctx)
 
 	r := &Reconciler{
-		Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
-		sequenceLister:      sequenceInformer.Lister(),
-		subscriptionLister:  subscriptionInformer.Lister(),
+		Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
+		sequenceLister:     sequenceInformer.Lister(),
+		subscriptionLister: subscriptionInformer.Lister(),
 	}
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -55,10 +55,10 @@ type Reconciler struct {
 	*reconciler.Base
 
 	// listers index properties about resources
-	sequenceLister      listers.SequenceLister
-	tracker             tracker.Interface
-	addressableTracker  duck.AddressableTracker
-	subscriptionLister  eventinglisters.SubscriptionLister
+	sequenceLister     listers.SequenceLister
+	tracker            tracker.Interface
+	addressableTracker duck.AddressableTracker
+	subscriptionLister eventinglisters.SubscriptionLister
 }
 
 // Check that our Reconciler implements controller.Reconciler

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -34,14 +34,15 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
+	"time"
+
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
+	"github.com/knative/eventing/pkg/duck"
 	"github.com/knative/eventing/pkg/reconciler"
 	"github.com/knative/eventing/pkg/reconciler/sequence/resources"
 	. "github.com/knative/eventing/pkg/reconciler/testing"
 	reconciletesting "github.com/knative/eventing/pkg/reconciler/testing"
-	"time"
-	"github.com/knative/eventing/pkg/duck"
 )
 
 const (
@@ -492,10 +493,10 @@ func TestAllCases(t *testing.T) {
 	defer logtesting.ClearAll()
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
-			Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
-			sequenceLister:      listers.GetSequenceLister(),
-			addressableTracker:  fakeAddressableTracker{},
-			subscriptionLister:  listers.GetSubscriptionLister(),
+			Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
+			sequenceLister:     listers.GetSequenceLister(),
+			addressableTracker: fakeAddressableTracker{},
+			subscriptionLister: listers.GetSubscriptionLister(),
 		}
 	}, false))
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -68,9 +68,9 @@ type Reconciler struct {
 	*reconciler.Base
 
 	// listers index properties about resources
-	subscriptionLister  listers.SubscriptionLister
+	subscriptionLister             listers.SubscriptionLister
 	customResourceDefinitionLister apiextensionslisters.CustomResourceDefinitionLister
-	addressableTracker eventingduck.AddressableTracker
+	addressableTracker             eventingduck.AddressableTracker
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -129,7 +129,6 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 	if err := subscription.Validate(ctx); err != nil {
 		return err
 	}
-
 
 	// Track the channel using the addressableTracker.
 	// We don't need the explicitly set a channelInformer, as this will dynamically generate one for us.

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -38,10 +38,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
+	"time"
+
+	"github.com/knative/eventing/pkg/duck"
 	. "github.com/knative/eventing/pkg/reconciler/testing"
 	. "github.com/knative/pkg/reconciler/testing"
-	"github.com/knative/eventing/pkg/duck"
-	"time"
 )
 
 const (

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -59,12 +59,12 @@ func NewController(
 	addressableInformer := duck.NewAddressableInformer(ctx)
 
 	r := &Reconciler{
-		Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
-		triggerLister:       triggerInformer.Lister(),
-		channelLister:       channelInformer.Lister(),
-		subscriptionLister:  subscriptionInformer.Lister(),
-		brokerLister:        brokerInformer.Lister(),
-		serviceLister:       serviceInformer.Lister(),
+		Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
+		triggerLister:      triggerInformer.Lister(),
+		channelLister:      channelInformer.Lister(),
+		subscriptionLister: subscriptionInformer.Lister(),
+		brokerLister:       brokerInformer.Lister(),
+		serviceLister:      serviceInformer.Lister(),
 	}
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -64,12 +64,12 @@ const (
 type Reconciler struct {
 	*reconciler.Base
 
-	triggerLister       listers.TriggerLister
-	channelLister       listers.ChannelLister
-	subscriptionLister  listers.SubscriptionLister
-	brokerLister        listers.BrokerLister
-	serviceLister       corev1listers.ServiceLister
-	addressableTracker  duck.AddressableTracker
+	triggerLister      listers.TriggerLister
+	channelLister      listers.ChannelLister
+	subscriptionLister listers.SubscriptionLister
+	brokerLister       listers.BrokerLister
+	serviceLister      corev1listers.ServiceLister
+	addressableTracker duck.AddressableTracker
 }
 
 var brokerGVK = v1alpha1.SchemeGroupVersion.WithKind("Broker")

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -44,9 +44,10 @@ import (
 
 	. "github.com/knative/pkg/reconciler/testing"
 
-	. "github.com/knative/eventing/pkg/reconciler/testing"
 	"time"
+
 	"github.com/knative/eventing/pkg/duck"
+	. "github.com/knative/eventing/pkg/reconciler/testing"
 )
 
 const (
@@ -500,13 +501,13 @@ func TestAllCases(t *testing.T) {
 	defer logtesting.ClearAll()
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
-			Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
-			triggerLister:       listers.GetTriggerLister(),
-			channelLister:       listers.GetChannelLister(),
-			subscriptionLister:  listers.GetSubscriptionLister(),
-			brokerLister:        listers.GetBrokerLister(),
-			serviceLister:       listers.GetK8sServiceLister(),
-			addressableTracker:  fakeAddressableTracker{},
+			Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
+			triggerLister:      listers.GetTriggerLister(),
+			channelLister:      listers.GetChannelLister(),
+			subscriptionLister: listers.GetSubscriptionLister(),
+			brokerLister:       listers.GetBrokerLister(),
+			serviceLister:      listers.GetK8sServiceLister(),
+			addressableTracker: fakeAddressableTracker{},
 		}
 	},
 		false,

--- a/test/base/resources/kube.go
+++ b/test/base/resources/kube.go
@@ -185,7 +185,7 @@ func EventWatcherClusterRole(crName string) *rbacv1.ClusterRole {
 			Name: crName,
 		},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1.PolicyRule{
+			{
 				APIGroups: []string{rbacv1.APIGroupAll},
 				Resources: []string{"events"},
 				Verbs:     []string{"get", "list", "watch"},

--- a/test/e2e/source_api_server_test.go
+++ b/test/e2e/source_api_server_test.go
@@ -50,7 +50,7 @@ func TestApiServerSource(t *testing.T) {
 	// create the ApiServerSource
 	// apiServerSourceResources is the list of resources to watch for this ApiServerSource
 	apiServerSourceResources := []sourcesv1alpha1.ApiServerResource{
-		sourcesv1alpha1.ApiServerResource{
+		{
 			APIVersion: "v1",
 			Kind:       "Event",
 		},


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
