### PR TITLE
Use shared observability config in broker data plane

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/knative/eventing/pkg/utils"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/signals"
+	"github.com/knative/pkg/system"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
@@ -82,7 +83,7 @@ func main() {
 	}
 
 	kc := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	configMapWatcher := configmap.NewInformedWatcher(kc, env.Namespace)
+	configMapWatcher := configmap.NewInformedWatcher(kc, system.Namespace())
 
 	zipkinServiceName := tracing.BrokerFilterName(tracing.BrokerFilterNameArgs{
 		Namespace:  env.Namespace,

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/knative/eventing/pkg/utils"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/signals"
+	"github.com/knative/pkg/system"
 	pkgtracing "github.com/knative/pkg/tracing"
 	"go.opencensus.io/exporter/prometheus"
 	"go.opencensus.io/stats"
@@ -100,7 +101,7 @@ func main() {
 	}
 
 	kc := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	configMapWatcher := configmap.NewInformedWatcher(kc, env.Namespace)
+	configMapWatcher := configmap.NewInformedWatcher(kc, system.Namespace())
 
 	zipkinServiceName := tracing.BrokerIngressName(tracing.BrokerIngressNameArgs{
 		Namespace:  env.Namespace,

--- a/config/200-broker-clusterrole.yaml
+++ b/config/200-broker-clusterrole.yaml
@@ -50,3 +50,19 @@ rules:
       - "get"
       - "list"
       - "watch"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-config-reader
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"

--- a/docs/broker/README.md
+++ b/docs/broker/README.md
@@ -22,11 +22,15 @@ Namespaces are reconciled by the
 1. Creates the Broker Ingress' `ServiceAccount`, `eventing-ingress-filter`.
 1. Ensures that `ServiceAccount` has the requisite RBAC permissions by giving it
    the [`eventing-broker-ingress`](../../config/200-broker-clusterrole.yaml)
-   `Role`.
+   `Role` and the
+   [`eventing-config-reader`](../../config/200-broker-clusterrole.yaml) `Role`
+   (in the system namespace).
 1. Creates the Broker Filter's `ServiceAccount`, `eventing-broker-filter`.
 1. Ensures that `ServiceAccount` has the requisite RBAC permissions by giving it
    the [`eventing-broker-filter`](../../config/200-broker-clusterrole.yaml)
-   `Role`.
+   `Role` and the
+   [`eventing-config-reader`](../../config/200-broker-clusterrole.yaml) `Role`
+   (in the system namespace).
 1. Creates a `Broker` named `default`.
 
 ### Broker

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/knative/pkg/configmap"
+	"github.com/knative/pkg/system"
 
 	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/reconciler"
@@ -1697,6 +1698,10 @@ func envVars(containerName string) []corev1.EnvVar {
 	case filterContainerName:
 		return []corev1.EnvVar{
 			{
+				Name:  system.NamespaceEnvKey,
+				Value: system.Namespace(),
+			},
+			{
 				Name: "NAMESPACE",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{
@@ -1711,6 +1716,10 @@ func envVars(containerName string) []corev1.EnvVar {
 		}
 	case ingressContainerName:
 		return []corev1.EnvVar{
+			{
+				Name:  system.NamespaceEnvKey,
+				Value: system.Namespace(),
+			},
 			{
 				Name: "NAMESPACE",
 				ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/pkg/system"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -62,6 +63,10 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 							Name:  "filter",
 							Image: args.Image,
 							Env: []corev1.EnvVar{
+								{
+									Name:  system.NamespaceEnvKey,
+									Value: system.Namespace(),
+								},
 								{
 									Name: "NAMESPACE",
 									ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/kmeta"
+	"github.com/knative/pkg/system"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -63,6 +64,10 @@ func MakeIngress(args *IngressArgs) *appsv1.Deployment {
 							Image: args.Image,
 							Name:  "ingress",
 							Env: []corev1.EnvVar{
+								{
+									Name:  system.NamespaceEnvKey,
+									Value: system.Namespace(),
+								},
 								{
 									Name: "NAMESPACE",
 									ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/namespace/resources/names.go
+++ b/pkg/reconciler/namespace/resources/names.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package resources
 
+import "fmt"
+
 const (
 	DefaultBrokerName = "default"
 
@@ -26,4 +28,14 @@ const (
 	IngressServiceAccountName = "eventing-broker-ingress"
 	IngressRoleBindingName    = "eventing-broker-ingress"
 	IngressClusterRoleName    = "eventing-broker-ingress"
+
+	ConfigClusterRoleName = "eventing-config-reader"
 )
+
+// ConfigRoleBindingName returns a name for a RoleBinding allowing access to the
+// shared ConfigMaps from a service account in another namespace. Because these
+// are all created in the system namespace, they must be named for their
+// subject namespace.
+func ConfigRoleBindingName(saName, ns string) string {
+	return fmt.Sprintf("eventing-config-reader-%s-%s", ns, saName)
+}

--- a/pkg/reconciler/namespace/resources/role_binding.go
+++ b/pkg/reconciler/namespace/resources/role_binding.go
@@ -24,11 +24,11 @@ import (
 
 // MakeRoleBinding creates a RoleBinding object for the Broker's filter
 // service account 'sa' in the Namespace 'ns'.
-func MakeRoleBinding(name string, sa *corev1.ServiceAccount, clusterRoleName string) *rbacv1.RoleBinding {
+func MakeRoleBinding(name string, ns string, sa *corev1.ServiceAccount, clusterRoleName string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: sa.Namespace,
 			Name:      name,
+			Namespace: ns,
 			Labels:    OwnedLabels(),
 		},
 		RoleRef: rbacv1.RoleRef{


### PR DESCRIPTION
Fixes #1416

## Proposed Changes

- Update ingress and filter pods to watch for observability ConfigMaps in the system namespace (normally `knative-eventing`) instead of the Broker's namespace. This removes the ability to create per-namespace configs, but we think that use case is much less likely than the cluster-wide config case.
- Add the `SYSTEM_NAMESPACE` env var to ingress and filter podspecs to inform knative/pkg where the system namespace is.
- When creating a default Broker via injection, add a RoleBinding in the system namespace allowing ConfigMap read from the ingress and filter service accounts in the Broker's namespace. Users creating non-injected Brokers will need to create this RoleBinding manually (and all other RBAC objects).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
All Broker ingress and filter pods now retrieve observability config from cluster-wide ConfigMaps (normally in the `knative-eventing` namespace) instead of per-namespace ConfigMaps.
```
