### PR TITLE
use webhook to validate messaging.v1alpha1 resources

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	messagingv1alpha1 "github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
 	"github.com/knative/eventing/pkg/logconfig"
 	"github.com/knative/pkg/configmap"
 	"github.com/knative/pkg/logging"
@@ -100,6 +101,9 @@ func main() {
 			eventingv1alpha1.SchemeGroupVersion.WithKind("Subscription"):              &eventingv1alpha1.Subscription{},
 			eventingv1alpha1.SchemeGroupVersion.WithKind("Trigger"):                   &eventingv1alpha1.Trigger{},
 			eventingv1alpha1.SchemeGroupVersion.WithKind("EventType"):                 &eventingv1alpha1.EventType{},
+			// For group messaging.knative.dev.
+			messagingv1alpha1.SchemeGroupVersion.WithKind("InMemoryChannel"): &messagingv1alpha1.InMemoryChannel{},
+			messagingv1alpha1.SchemeGroupVersion.WithKind("Sequence"):        &messagingv1alpha1.Sequence{},
 		},
 		Logger: logger,
 	}

--- a/pkg/apis/messaging/v1alpha1/sequence_types.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_types.go
@@ -63,7 +63,7 @@ type ChannelTemplateSpec struct {
 	// Spec defines the Spec to use for each channel created. Passed
 	// in verbatim to the Channel CRD as Spec section.
 	// +optional
-	Spec runtime.RawExtension `json:"spec"`
+	Spec *runtime.RawExtension `json:"spec,omitempty"`
 }
 
 // Internal version of ChannelTemplateSpec that includes ObjectMeta so that
@@ -78,7 +78,7 @@ type ChannelTemplateSpecInternal struct {
 	// Spec defines the Spec to use for each channel created. Passed
 	// in verbatim to the Channel CRD as Spec section.
 	// +optional
-	Spec runtime.RawExtension `json:"spec"`
+	Spec *runtime.RawExtension `json:"spec,omitempty"`
 }
 
 type SequenceSpec struct {

--- a/pkg/apis/messaging/v1alpha1/sequence_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_validation_test.go
@@ -69,7 +69,7 @@ func TestSequenceSpecValidation(t *testing.T) {
 			Kind:       "mykind",
 			APIVersion: "myapiversion",
 		},
-		runtime.RawExtension{},
+		&runtime.RawExtension{},
 	}
 	tests := []struct {
 		name string
@@ -103,7 +103,7 @@ func TestSequenceSpecValidation(t *testing.T) {
 	}, {
 		name: "invalid channeltemplatespec missing APIVersion",
 		ts: &SequenceSpec{
-			ChannelTemplate: ChannelTemplateSpec{metav1.TypeMeta{Kind: "mykind"}, runtime.RawExtension{}},
+			ChannelTemplate: ChannelTemplateSpec{metav1.TypeMeta{Kind: "mykind"}, &runtime.RawExtension{}},
 			Steps:           []eventingv1alpha1.SubscriberSpec{{URI: &subscriberURI}},
 		},
 		want: func() *apis.FieldError {
@@ -113,7 +113,7 @@ func TestSequenceSpecValidation(t *testing.T) {
 	}, {
 		name: "invalid channeltemplatespec missing Kind",
 		ts: &SequenceSpec{
-			ChannelTemplate: ChannelTemplateSpec{metav1.TypeMeta{APIVersion: "myapiversion"}, runtime.RawExtension{}},
+			ChannelTemplate: ChannelTemplateSpec{metav1.TypeMeta{APIVersion: "myapiversion"}, &runtime.RawExtension{}},
 			Steps:           []eventingv1alpha1.SubscriberSpec{{URI: &subscriberURI}},
 		},
 		want: func() *apis.FieldError {

--- a/pkg/apis/messaging/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1alpha1/zz_generated.deepcopy.go
@@ -31,7 +31,11 @@ import (
 func (in *ChannelTemplateSpec) DeepCopyInto(out *ChannelTemplateSpec) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	in.Spec.DeepCopyInto(&out.Spec)
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -58,7 +62,11 @@ func (in *ChannelTemplateSpecInternal) DeepCopyInto(out *ChannelTemplateSpecInte
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	in.Spec.DeepCopyInto(&out.Spec)
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -126,7 +126,7 @@ func TestAllCases(t *testing.T) {
 			APIVersion: "messaging.knative.dev/v1alpha1",
 			Kind:       "inmemorychannel",
 		},
-		runtime.RawExtension{Raw: []byte("{}")},
+		&runtime.RawExtension{Raw: []byte("{}")},
 	}
 
 	table := TableTest{


### PR DESCRIPTION
Fixes #1427 

## Proposed Changes

- Actually use webhook to validate messaging resources.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
