### PR TITLE
fix PubSub Channel CRD name.

### DIFF
--- a/contrib/gcppubsub/pkg/controller/channel/reconcile.go
+++ b/contrib/gcppubsub/pkg/controller/channel/reconcile.go
@@ -62,7 +62,7 @@ const (
 	subscriptionSyncFailed    = "SubscriptionSyncFailed"
 	subscriptionDeleteFailed  = "SubscriptionDeleteFailed"
 
-	deprecatedMessage = "The `gcp-pubsub` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `PubSubChannel` CRD from https://github.com/GoogleCloudPlatform/cloud-run-events."
+	deprecatedMessage = "The `gcp-pubsub` ClusterChannelProvisioner is deprecated and will be removed in 0.8. Recommended replacement is using `Channel` CRD from https://github.com/GoogleCloudPlatform/cloud-run-events."
 )
 
 // reconciler reconciles GCP-PubSub Channels by creating the K8s Service (ExternalName)


### PR DESCRIPTION
## Proposed Changes

- Name is wrong in message, CRD is `Channel.events.cloud.run`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
