### PR TITLE
Ensure RoleBinding name is never too long

### DIFF
--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -73,10 +73,10 @@ func TestAllCases(t *testing.T) {
 	// Events
 	saIngressEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountCreated", "ServiceAccount 'eventing-broker-ingress' created for the Broker")
 	rbIngressEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'test-namespace/eventing-broker-ingress' created for the Broker")
-	rbIngressConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-config-reader-test-namespace-eventing-broker-ingress' created for the Broker")
+	rbIngressConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-broker-ingress-test-namespace' created for the Broker")
 	saFilterEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountCreated", "ServiceAccount 'eventing-broker-filter' created for the Broker")
 	rbFilterEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'test-namespace/eventing-broker-filter' created for the Broker")
-	rbFilterConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-config-reader-test-namespace-eventing-broker-filter' created for the Broker")
+	rbFilterConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-broker-filter-test-namespace' created for the Broker")
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 	nsEvent := Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\"")
 

--- a/pkg/reconciler/namespace/resources/names.go
+++ b/pkg/reconciler/namespace/resources/names.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package resources
 
-import "fmt"
+import (
+	"github.com/knative/pkg/kmeta"
+)
 
 const (
 	DefaultBrokerName = "default"
@@ -37,5 +39,5 @@ const (
 // are all created in the system namespace, they must be named for their
 // subject namespace.
 func ConfigRoleBindingName(saName, ns string) string {
-	return fmt.Sprintf("eventing-config-reader-%s-%s", ns, saName)
+	return kmeta.ChildName(saName, "-"+ns)
 }


### PR DESCRIPTION
If the RoleBinding name were too long, the APIServer would always reject it and the namespace injection would fail forever. `kmeta.ChildName` truncates the RoleBinding name to ensure it's never too long for Kubernetes to accept.

Thanks @n3wscott for pulling this in with #1433.

## Proposed Changes

- Use `kmeta.ChildName` to ensure RoleBinding name is always less than 64 characters.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
```
