### PR TITLE
Overwrite the cluster node number to 1 for perf testing jobs

### DIFF
--- a/test/performance-tests.sh
+++ b/test/performance-tests.sh
@@ -17,6 +17,13 @@
 # This script runs the performance tests; It is run by prow daily.
 # For convenience, it can also be executed manually.
 
+# Overwrite the cluster node number to 1
+# TODO(Fredy-Z): since now we only have one single performance test case, and we want to minimize the
+#                impact delay, we perfer to run the test on one single node. When we have more complex 
+#                test scenarios, these two lines can be removed.
+export E2E_MIN_CLUSTER_NODES=1
+export E2E_MAX_CLUSTER_NODES=1
+
 source $(dirname $0)/e2e-common.sh
 
 # Override the default install_test_resources function by only installing Channel CRDs


### PR DESCRIPTION
## Proposed Changes
As suggested in another PR, overwrite the cluster node number to 1 for performance testing jobs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @adrcunha 