### PR TITLE
Fix issue with broker dropping messages with "No TTL Seen"

### DIFF
--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -134,8 +134,8 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 
 	// Remove the TTL attribute that is used by the Broker.
 	originalV2 := event.Context.AsV02()
-	ttl, present := originalV2.Extensions[V02TTLAttribute]
-	if !present {
+	ttl, ttlKey := GetTTL(event.Context)
+	if ttl == nil {
 		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
 		// event wasn't sent by the Broker, so we can drop it.
 		r.logger.Warn("No TTL seen, dropping", zap.Any("triggerRef", triggerRef), zap.Any("event", event))
@@ -144,7 +144,7 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 		// framework returns a 500 to the caller, so the Channel would send this repeatedly.
 		return nil
 	}
-	delete(originalV2.Extensions, V02TTLAttribute)
+	delete(originalV2.Extensions, ttlKey)
 	event.Context = originalV2
 
 	r.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -209,8 +209,6 @@ func TestReceiver(t *testing.T) {
 					"Knative-Foo": []string{"baz", "qux"},
 					// X-Ot-Foo will pass as a prefix match.
 					"X-Ot-Foo": []string{"haden"},
-					// knative-importer will be canonicalized.
-					"knative-importer": []string{"exporter"},
 				},
 			},
 			expectedHeaders: http.Header{
@@ -224,8 +222,6 @@ func TestReceiver(t *testing.T) {
 				"Knative-Foo": []string{"baz", "qux"},
 				// X-Ot-Foo will pass as a prefix match.
 				"X-Ot-Foo": []string{"haden"},
-				// Passes prefix match, but gets case changed.
-				"Knative-Importer": []string{"exporter"},
 			},
 			expectedDispatch: true,
 			returnedEvent:    makeDifferentEvent(),

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -209,6 +209,8 @@ func TestReceiver(t *testing.T) {
 					"Knative-Foo": []string{"baz", "qux"},
 					// X-Ot-Foo will pass as a prefix match.
 					"X-Ot-Foo": []string{"haden"},
+					// knative-importer will be canonicalized.
+					"knative-importer": []string{"exporter"},
 				},
 			},
 			expectedHeaders: http.Header{
@@ -222,6 +224,8 @@ func TestReceiver(t *testing.T) {
 				"Knative-Foo": []string{"baz", "qux"},
 				// X-Ot-Foo will pass as a prefix match.
 				"X-Ot-Foo": []string{"haden"},
+				// Passes prefix match, but gets case changed.
+				"Knative-Importer": []string{"exporter"},
 			},
 			expectedDispatch: true,
 			returnedEvent:    makeDifferentEvent(),

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -23,7 +23,9 @@ import (
 const (
 	// V02TTLAttribute is the name of the CloudEvents 0.2 extension attribute used to store the
 	// Broker's TTL (number of times a single event can reply through a Broker continuously).
-	V02TTLAttribute = "knativebrokerttl"
+	// Extensions should be formatted as described in net/textproto.CanonicalMIMEHeaderKey, as
+	// they may have their case changed in transit.
+	V02TTLAttribute = "Knativebrokerttl"
 )
 
 // SetTTL sets the TTL into the EventContext. ttl should be a positive integer.

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -17,16 +17,28 @@
 package broker
 
 import (
+	"strings"
+
 	cloudevents "github.com/cloudevents/sdk-go"
 )
 
 const (
 	// V02TTLAttribute is the name of the CloudEvents 0.2 extension attribute used to store the
 	// Broker's TTL (number of times a single event can reply through a Broker continuously).
-	// Extensions should be formatted as described in net/textproto.CanonicalMIMEHeaderKey, as
-	// they may have their case changed in transit.
-	V02TTLAttribute = "Knativebrokerttl"
+	V02TTLAttribute = "knativebrokerttl"
 )
+
+// GetTTL finds the TTL in the EventContext using a case insensitive comparison
+// for the key. The second return param, is the case preserved key that matched.
+// Depending on the encoding/transport, the extension case could be changed.
+func GetTTL(ctx cloudevents.EventContext) (interface{}, string) {
+	for k, v := range ctx.AsV02().Extensions {
+		if lower := strings.ToLower(k); lower == V02TTLAttribute {
+			return v, k
+		}
+	}
+	return nil, V02TTLAttribute
+}
 
 // SetTTL sets the TTL into the EventContext. ttl should be a positive integer.
 func SetTTL(ctx cloudevents.EventContext, ttl interface{}) (cloudevents.EventContext, error) {


### PR DESCRIPTION
Fixes #1392
Fixes #1444

## Proposed Changes

Change casing on constant due to the way go http libraries use canonical mime encoding for http headers, this causes issues with using binary encoding for CloudEvents.

**Release Note**

```release-note
Fixes issue where the broker may drop messages with a "no TTL" error.
```
