### PR TITLE
Extend RunnableServer shutdown cutoff

### DIFF
--- a/pkg/utils/runnable_server_test.go
+++ b/pkg/utils/runnable_server_test.go
@@ -107,7 +107,7 @@ func TestRunnableServerShutdownContext(t *testing.T) {
 
 	// Give the request time to start
 	time.Sleep(time.Millisecond * 50)
-	shutdownCh := time.After(time.Millisecond * 20)
+	shutdownCh := time.After(time.Millisecond * 50)
 
 	close(stopCh)
 


### PR DESCRIPTION
This test has flaked a few times recently. Hopefully extending the timeout reduces timing flakes on heavily loaded CI nodes.

/cc @Fredy-Z 