### PR TITLE
Backport #1452

### DIFF
--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -126,8 +126,8 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 
 	// Remove the TTL attribute that is used by the Broker.
 	originalV2 := event.Context.AsV02()
-	ttl, present := originalV2.Extensions[V02TTLAttribute]
-	if !present {
+	ttl, ttlKey := GetTTL(event.Context)
+	if ttl == nil {
 		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
 		// event wasn't sent by the Broker, so we can drop it.
 		r.logger.Warn("No TTL seen, dropping", zap.Any("triggerRef", triggerRef), zap.Any("event", event))
@@ -136,7 +136,7 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 		// framework returns a 500 to the caller, so the Channel would send this repeatedly.
 		return nil
 	}
-	delete(originalV2.Extensions, V02TTLAttribute)
+	delete(originalV2.Extensions, ttlKey)
 	event.Context = originalV2
 
 	r.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -17,6 +17,8 @@
 package broker
 
 import (
+	"strings"
+
 	cloudevents "github.com/cloudevents/sdk-go"
 )
 
@@ -25,6 +27,18 @@ const (
 	// Broker's TTL (number of times a single event can reply through a Broker continuously).
 	V02TTLAttribute = "knativebrokerttl"
 )
+
+// GetTTL finds the TTL in the EventContext using a case insensitive comparison
+// for the key. The second return param, is the case preserved key that matched.
+// Depending on the encoding/transport, the extension case could be changed.
+func GetTTL(ctx cloudevents.EventContext) (interface{}, string) {
+	for k, v := range ctx.AsV02().Extensions {
+		if lower := strings.ToLower(k); lower == V02TTLAttribute {
+			return v, k
+		}
+	}
+	return nil, V02TTLAttribute
+}
 
 // SetTTL sets the TTL into the EventContext. ttl should be a positive integer.
 func SetTTL(ctx cloudevents.EventContext, ttl interface{}) (cloudevents.EventContext, error) {


### PR DESCRIPTION
Backport #1452 by @mikehelmick into 0.6.

* Fix issue with broker dropping messages with "No TTL Seen"
* Treat the broker TTL attribute as case insensitive, in line with how cloudevents attributes should be handled. See https://github.com/cloudevents/spec/pull/321 for context.
* Remove unnecessary test change.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed an issue with the Broker TTL attribute that could cause events to be incorrectly dropped.
```
