### PR TITLE
Add release label to all objects

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -15,3 +15,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel

--- a/config/200-addressable-resolvers-clusterrole.yaml
+++ b/config/200-addressable-resolvers-clusterrole.yaml
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-  eventing.knative.dev/release: devel
+    eventing.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:

--- a/config/200-addressable-resolvers-clusterrole.yaml
+++ b/config/200-addressable-resolvers-clusterrole.yaml
@@ -17,6 +17,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: addressable-resolver
+  labels:
+  eventing.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -30,7 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-      duck.knative.dev/addressable: "true"
+    eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -49,7 +52,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: serving-addressable-resolver
   labels:
-      duck.knative.dev/addressable: "true"
+    eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -71,7 +75,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: channel-addressable-resolver
   labels:
-      duck.knative.dev/addressable: "true"
+    eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -91,7 +96,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: broker-addressable-resolver
   labels:
-      duck.knative.dev/addressable: "true"
+    eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:

--- a/config/200-broker-clusterrole.yaml
+++ b/config/200-broker-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-broker-filter
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - ""
@@ -41,6 +43,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - ""
@@ -57,6 +61,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-config-reader
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - ""

--- a/config/200-channelable-manipulator-clusterrole.yaml
+++ b/config/200-channelable-manipulator-clusterrole.yaml
@@ -17,6 +17,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: channelable-manipulator
+  labels:
+    eventing.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:

--- a/config/200-controller-clusterrole.yaml
+++ b/config/200-controller-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - ""

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -17,9 +17,13 @@ kind: ServiceAccount
 metadata:
   name: eventing-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: eventing-webhook
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel

--- a/config/200-webhook-clusterrole.yaml
+++ b/config/200-webhook-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -46,6 +50,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -61,6 +67,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook

--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
+    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: apiserversources.sources.eventing.knative.dev

--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -16,6 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -16,6 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterchannelprovisioners.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -16,6 +16,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: containersources.sources.eventing.knative.dev

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -16,6 +16,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: cronjobsources.sources.eventing.knative.dev

--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -16,6 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/300-sequence.yaml
+++ b/config/300-sequence.yaml
@@ -16,6 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.messaging.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: messaging.knative.dev

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -16,6 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev

--- a/config/400-source-controller-service.yaml
+++ b/config/400-source-controller-service.yaml
@@ -16,8 +16,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    eventing.knative.dev/release: devel
     app: sources-controller
-    serving.knative.dev/release: devel
   name: sources-controller
   namespace: knative-eventing
 spec:

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    eventing.knative.dev/release: devel
     role: eventing-webhook
   name: eventing-webhook
   namespace: knative-eventing

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: eventing-webhook
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -17,9 +17,6 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-
 data:
   _example: |
     ################################


### PR DESCRIPTION
Follows the serving strategy of labeling all resources with release names except configmaps (since we expect users will modify those).

These need to be updated to the correct release number in the release branch before the release is cut. I'll do that for today's 0.7 release.