### PR TITLE
Add release label to channel and provisioner yamls

### DIFF
--- a/config/channels/in-memory-channel/200-channelable-manipulator-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-channelable-manipulator-clusterrole.yaml
@@ -17,6 +17,7 @@ kind: ClusterRole
 metadata:
   name: imc-channelable-manipulator
   labels:
+    eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/config/channels/in-memory-channel/200-controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-controller-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: imc-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/config/channels/in-memory-channel/200-dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-dispatcher-clusterrole.yaml
@@ -15,6 +15,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: imc-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/config/channels/in-memory-channel/200-dispatcher-service.yaml
+++ b/config/channels/in-memory-channel/200-dispatcher-service.yaml
@@ -17,8 +17,9 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-      messaging.knative.dev/channel: in-memory-channel
-      messaging.knative.dev/role: dispatcher
+    eventing.knative.dev/release: devel
+    messaging.knative.dev/channel: in-memory-channel
+    messaging.knative.dev/role: dispatcher
 spec:
   selector:
       messaging.knative.dev/channel: in-memory-channel

--- a/config/channels/in-memory-channel/200-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-serviceaccount.yaml
@@ -16,6 +16,8 @@ kind: ServiceAccount
 metadata:
   name: imc-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 apiVersion: v1
@@ -23,3 +25,5 @@ kind: ServiceAccount
 metadata:
   name: imc-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel

--- a/config/channels/in-memory-channel/201-clusterrolebinding.yaml
+++ b/config/channels/in-memory-channel/201-clusterrolebinding.yaml
@@ -15,6 +15,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: imc-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: imc-controller
@@ -30,6 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: imc-dispatcher

--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
  labels:
- labels:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"

--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -16,6 +16,8 @@ kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
  labels:
+ labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
 spec:

--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -16,6 +16,8 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
   name: in-memory
+  labels:
+    eventing.knative.dev/release: devel
 spec: {}
 
 ---
@@ -25,6 +27,8 @@ kind: ServiceAccount
 metadata:
   name: in-memory-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -32,6 +36,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: in-memory-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -82,6 +88,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: in-memory-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: in-memory-channel-controller
@@ -98,6 +106,8 @@ kind: Deployment
 metadata:
   name: in-memory-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -125,6 +135,8 @@ kind: ServiceAccount
 metadata:
   name: in-memory-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -132,6 +144,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: in-memory-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "eventing.knative.dev"
@@ -157,6 +171,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: in-memory-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: in-memory-channel-dispatcher
@@ -173,6 +189,8 @@ kind: Role
 metadata:
   name: in-memory-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - ""
@@ -190,6 +208,8 @@ kind: RoleBinding
 metadata:
   name: in-memory-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: in-memory-channel-dispatcher
@@ -206,6 +226,8 @@ kind: Deployment
 metadata:
   name: in-memory-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Everything is labeled with `eventing.knative.dev`, even though some of these objects are in the `messaging.knative.dev group`, because for now there's only one release.