### PR TITLE
Backport #1460 to 0.6

### DIFF
--- a/pkg/utils/runnable_server_test.go
+++ b/pkg/utils/runnable_server_test.go
@@ -107,7 +107,7 @@ func TestRunnableServerShutdownContext(t *testing.T) {
 
 	// Give the request time to start
 	time.Sleep(time.Millisecond * 50)
-	shutdownCh := time.After(time.Millisecond * 20)
+	shutdownCh := time.After(time.Millisecond * 50)
 
 	close(stopCh)
 


### PR DESCRIPTION
Should help 0.6 CI be less flaky.