### PR TITLE
Add e2e test for sequence

### DIFF
--- a/test/base/resources/cloud_event.go
+++ b/test/base/resources/cloud_event.go
@@ -25,6 +25,12 @@ type CloudEvent struct {
 	Encoding string // binary or structured
 }
 
+// CloudEventBaseData defines a simple struct that can be used as data of a CloudEvent.
+type CloudEventBaseData struct {
+	Sequence int    `json:"id"`
+	Message  string `json:"message"`
+}
+
 // CloudEvent related constants.
 const (
 	CloudEventEncodingBinary     = "binary"

--- a/test/base/resources/constants.go
+++ b/test/base/resources/constants.go
@@ -58,6 +58,8 @@ const (
 	InMemoryChannelKind string = "InMemoryChannel"
 	KafkaChannelKind    string = "KafkaChannel"
 	NatssChannelKind    string = "NatssChannel"
+
+	SequenceKind string = "Sequence"
 )
 
 // Kind for sources resources.

--- a/test/base/resources/eventing.go
+++ b/test/base/resources/eventing.go
@@ -20,9 +20,9 @@ package resources
 
 import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
-	pkgTest "knative.dev/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 // BrokerOption enables further configuration of a Broker.
@@ -42,7 +42,7 @@ func clusterChannelProvisioner(name string) *corev1.ObjectReference {
 	return pkgTest.CoreV1ObjectReference(ClusterChannelProvisionerKind, EventingAPIVersion, name)
 }
 
-// channelRef returns an ObjectReference for a given Channel Name.
+// channelRef returns an ObjectReference for a given Channel name.
 func channelRef(name string, typemeta *metav1.TypeMeta) *corev1.ObjectReference {
 	return pkgTest.CoreV1ObjectReference(typemeta.Kind, typemeta.APIVersion, name)
 }
@@ -64,14 +64,14 @@ func WithSubscriberForSubscription(name string) SubscriptionOption {
 	return func(s *eventingv1alpha1.Subscription) {
 		if name != "" {
 			s.Spec.Subscriber = &eventingv1alpha1.SubscriberSpec{
-				Ref: pkgTest.CoreV1ObjectReference(ServiceKind, CoreAPIVersion, name),
+				Ref: ServiceRef(name),
 			}
 		}
 	}
 }
 
-// WithReply returns an options that adds a ReplyStrategy for the given Subscription.
-func WithReply(name string, typemeta *metav1.TypeMeta) SubscriptionOption {
+// WithReplyForSubscription returns an options that adds a ReplyStrategy for the given Subscription.
+func WithReplyForSubscription(name string, typemeta *metav1.TypeMeta) SubscriptionOption {
 	return func(s *eventingv1alpha1.Subscription) {
 		if name != "" {
 			s.Spec.Reply = &eventingv1alpha1.ReplyStrategy{
@@ -159,7 +159,7 @@ func WithSubscriberRefForTrigger(name string) TriggerOption {
 	return func(t *eventingv1alpha1.Trigger) {
 		if name != "" {
 			t.Spec.Subscriber = &eventingv1alpha1.SubscriberSpec{
-				Ref: pkgTest.CoreV1ObjectReference(ServiceKind, CoreAPIVersion, name),
+				Ref: ServiceRef(name),
 			}
 		}
 	}

--- a/test/base/resources/kube.go
+++ b/test/base/resources/kube.go
@@ -136,7 +136,8 @@ func SequenceStepperPod(name, eventMsgAppender string) *corev1.Pod {
 	const imageName = "sequencestepper"
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: map[string]string{"e2etest": string(uuid.NewUUID())},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{

--- a/test/base/resources/messaging.go
+++ b/test/base/resources/messaging.go
@@ -21,9 +21,14 @@ package resources
 import (
 	kafkamessagingv1alpha1 "github.com/knative/eventing/contrib/kafka/pkg/apis/messaging/v1alpha1"
 	natssmessagingv1alpha1 "github.com/knative/eventing/contrib/natss/pkg/apis/messaging/v1alpha1"
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1alpha1 "github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 )
+
+// SequenceOption enables further configuration of a Sequence.
+type SequenceOption func(*messagingv1alpha1.Sequence)
 
 // KafkaChannel returns a KafkaChannel resource.
 func KafkaChannel(name string) *kafkamessagingv1alpha1.KafkaChannel {
@@ -43,11 +48,42 @@ func InMemoryChannel(name string) *messagingv1alpha1.InMemoryChannel {
 	}
 }
 
-// NatssChannel returns an NatssChannel resource.
+// NatssChannel returns a NatssChannel resource.
 func NatssChannel(name string) *natssmessagingv1alpha1.NatssChannel {
 	return &natssmessagingv1alpha1.NatssChannel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
+}
+
+// WithReplyForSequence returns an option that adds a Reply for the given Sequence.
+func WithReplyForSequence(name string, typemeta *metav1.TypeMeta) SequenceOption {
+	return func(seq *messagingv1alpha1.Sequence) {
+		if name != "" {
+			seq.Spec.Reply = pkgTest.CoreV1ObjectReference(typemeta.Kind, typemeta.APIVersion, name)
+		}
+	}
+}
+
+// Sequence returns a Sequence resource.
+func Sequence(
+	name string,
+	steps []eventingv1alpha1.SubscriberSpec,
+	channelTemplate messagingv1alpha1.ChannelTemplateSpec,
+	options ...SequenceOption,
+) *messagingv1alpha1.Sequence {
+	sequence := &messagingv1alpha1.Sequence{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: messagingv1alpha1.SequenceSpec{
+			Steps:           steps,
+			ChannelTemplate: channelTemplate,
+		},
+	}
+	for _, option := range options {
+		option(sequence)
+	}
+	return sequence
 }

--- a/test/base/resources/sources.go
+++ b/test/base/resources/sources.go
@@ -20,9 +20,9 @@ package resources
 
 import (
 	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
-	pkgTest "knative.dev/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 // CronJobSourceOption enables further configuration of a CronJobSource.
@@ -37,7 +37,7 @@ type ApiServerSourceOption func(*sourcesv1alpha1.ApiServerSource)
 // WithSinkServiceForCronJobSource returns an option that adds a Kubernetes Service sink for the given CronJobSource.
 func WithSinkServiceForCronJobSource(name string) CronJobSourceOption {
 	return func(cjs *sourcesv1alpha1.CronJobSource) {
-		cjs.Spec.Sink = pkgTest.CoreV1ObjectReference(ServiceKind, CoreAPIVersion, name)
+		cjs.Spec.Sink = ServiceRef(name)
 	}
 }
 
@@ -80,7 +80,7 @@ func WithTemplateForContainerSource(template *corev1.PodTemplateSpec) ContainerS
 // WithSinkServiceForContainerSource returns an option that adds a Kubernetes Service sink for the given ContainerSource.
 func WithSinkServiceForContainerSource(name string) ContainerSourceOption {
 	return func(cs *sourcesv1alpha1.ContainerSource) {
-		cs.Spec.Sink = pkgTest.CoreV1ObjectReference(ServiceKind, CoreAPIVersion, name)
+		cs.Spec.Sink = ServiceRef(name)
 	}
 }
 
@@ -147,7 +147,7 @@ func WithServiceAccountForApiServerSource(saName string) ApiServerSourceOption {
 // WithSinkServiceForApiServerSource returns an option that adds a Kubernetes Service sink for the given ApiServerSource.
 func WithSinkServiceForApiServerSource(name string) ApiServerSourceOption {
 	return func(apiServerSource *sourcesv1alpha1.ApiServerSource) {
-		apiServerSource.Spec.Sink = pkgTest.CoreV1ObjectReference(ServiceKind, CoreAPIVersion, name)
+		apiServerSource.Spec.Sink = ServiceRef(name)
 	}
 }
 

--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	messagingv1alpha1 "github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
 	sourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing/test/base/resources"
 	corev1 "k8s.io/api/core/v1"
@@ -146,6 +147,25 @@ func (client *Client) CreateTriggerOrFail(name string, options ...resources.Trig
 		client.T.Fatalf("Failed to create trigger %q: %v", name, err)
 	}
 	client.Tracker.AddObj(trigger)
+}
+
+// CreateSequenceOrFail will create a Sequence or fail the test if there is an error.
+func (client *Client) CreateSequenceOrFail(
+	name string,
+	steps []eventingv1alpha1.SubscriberSpec,
+	channelTemplate messagingv1alpha1.ChannelTemplateSpec,
+	options ...resources.SequenceOption,
+) {
+	namespace := client.Namespace
+	sequence := resources.Sequence(name, steps, channelTemplate, options...)
+
+	sequences := client.Eventing.MessagingV1alpha1().Sequences(namespace)
+	// update sequence with the new reference
+	sequence, err := sequences.Create(sequence)
+	if err != nil {
+		client.T.Fatalf("Failed to create sequence %q: %v", name, err)
+	}
+	client.Tracker.AddObj(sequence)
 }
 
 // CreateCronJobSourceOrFail will create a CronJobSource or fail the test if there is an error.

--- a/test/common/operation.go
+++ b/test/common/operation.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/knative/eventing/test/base"
 	"github.com/knative/eventing/test/base/resources"
-	pkgTest "knative.dev/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
 )
 
 // LabelNamespace labels the given namespace with the labels map.
@@ -111,6 +111,6 @@ func (client *Client) WaitForAllTestResourcesReady() error {
 	}
 	// FIXME(Fredy-Z): This hacky sleep is added to try mitigating the test flakiness.
 	// Will delete it after we find the root cause and fix.
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	return nil
 }

--- a/test/common/operation.go
+++ b/test/common/operation.go
@@ -111,6 +111,6 @@ func (client *Client) WaitForAllTestResourcesReady() error {
 	}
 	// FIXME(Fredy-Z): This hacky sleep is added to try mitigating the test flakiness.
 	// Will delete it after we find the root cause and fix.
-	time.Sleep(30 * time.Second)
+	time.Sleep(10 * time.Second)
 	return nil
 }

--- a/test/common/typemeta.go
+++ b/test/common/typemeta.go
@@ -67,6 +67,9 @@ var InMemoryChannelTypeMeta = MessagingTypeMeta(resources.InMemoryChannelKind)
 // NatssChannelTypeMeta is the TypeMeta ref for NatssChannel.
 var NatssChannelTypeMeta = MessagingTypeMeta(resources.NatssChannelKind)
 
+// SequenceTypeMeta is the TypeMeta ref for Sequence.
+var SequenceTypeMeta = MessagingTypeMeta(resources.SequenceKind)
+
 // MessagingTypeMeta returns the TypeMeta ref for an eventing messaing resource.
 func MessagingTypeMeta(kind string) *metav1.TypeMeta {
 	return &metav1.TypeMeta{

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -65,7 +65,7 @@ func testChannelChain(t *testing.T, provisioner string, isCRD bool) {
 		subscriptionNames1,
 		channelNames[0],
 		channelTypeMeta,
-		resources.WithReply(channelNames[1], channelTypeMeta),
+		resources.WithReplyForSubscription(channelNames[1], channelTypeMeta),
 	)
 	// create subscriptions that subscribe the second channel, and call the logging service
 	client.CreateSubscriptionsOrFail(

--- a/test/e2e/channel_event_transformation_test.go
+++ b/test/e2e/channel_event_transformation_test.go
@@ -78,7 +78,7 @@ func TestEventTransformationForSubscription(t *testing.T) {
 			channelNames[0],
 			channelTypeMeta,
 			resources.WithSubscriberForSubscription(transformationPodName),
-			resources.WithReply(channelNames[1], channelTypeMeta),
+			resources.WithReplyForSubscription(channelNames[1], channelTypeMeta),
 		)
 		// create subscriptions that subscribe the second channel, and forward the received events to the logger service
 		client.CreateSubscriptionsOrFail(

--- a/test/e2e/sequence_test.go
+++ b/test/e2e/sequence_test.go
@@ -1,0 +1,138 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	messagingv1alpha1 "github.com/knative/eventing/pkg/apis/messaging/v1alpha1"
+	"github.com/knative/eventing/test/base/resources"
+	"github.com/knative/eventing/test/common"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+func TestSequence(t *testing.T) {
+	const (
+		sequenceName  = "e2e-sequence"
+		senderPodName = "e2e-sequence-sender-pod"
+
+		channelName      = "e2e-sequence-channel"
+		subscriptionName = "e2e-sequence-subscription"
+		loggerPodName    = "e2e-sequence-logger-pod"
+	)
+	stepSubscriberConfigs := []struct {
+		podName     string
+		msgAppender string
+	}{{
+		podName:     "e2e-stepper1",
+		msgAppender: "-step1",
+		// }, {
+		// 	podName:     "e2e-stepper2",
+		// 	msgAppender: "- step2",
+		// }, {
+		// 	podName:     "e2e-stepper3",
+		// 	msgAppender: "- step3",
+	}}
+	channelTypeMeta := common.InMemoryChannelTypeMeta
+
+	client := setup(t, true)
+	defer tearDown(client)
+
+	client.WaitForAllTestResourcesReady()
+
+	// construct steps for the sequence
+	steps := make([]eventingv1alpha1.SubscriberSpec, 0)
+	for _, config := range stepSubscriberConfigs {
+		// create a stepper Pod with Service
+		podName := config.podName
+		msgAppender := config.msgAppender
+		stepperPod := resources.SequenceStepperPod(podName, msgAppender)
+		client.CreatePodOrFail(stepperPod, common.WithService(podName))
+		// create a new step
+		step := eventingv1alpha1.SubscriberSpec{
+			Ref: resources.ServiceRef(podName),
+		}
+		// add the step into steps
+		steps = append(steps, step)
+	}
+
+	// create channelTemplate for the Sequence
+	channelTemplate := messagingv1alpha1.ChannelTemplateSpec{
+		TypeMeta: *(channelTypeMeta),
+	}
+
+	// create channel as reply of the Sequence
+	// TODO(Fredy-Z): now we'll have to use a channel plus its subscription here, since reply of the Sequence must be Addressable.
+	//                In the future if we use Knative Serving, we can make the logger service as a Knative service,
+	//                and remove the channel and subscription.
+	client.CreateChannelOrFail(channelName, channelTypeMeta, "")
+	// create logger service as the subscriber
+	loggerPod := resources.EventLoggerPod(loggerPodName)
+	client.CreatePodOrFail(loggerPod, common.WithService(loggerPodName))
+	// create subscription to subscribe the channel, and forward the received events to the logger service
+	client.CreateSubscriptionOrFail(
+		subscriptionName,
+		channelName,
+		channelTypeMeta,
+		resources.WithSubscriberForSubscription(loggerPodName),
+	)
+	// create replyOption for the Sequence
+	replyOption := resources.WithReplyForSequence(channelName, channelTypeMeta)
+
+	// create Sequence or fail the test if there is an error
+	client.CreateSequenceOrFail(sequenceName, steps, channelTemplate, replyOption)
+
+	// wait for all test resources to be ready, so that we can start sending events
+	if err := client.WaitForAllTestResourcesReady(); err != nil {
+		t.Fatalf("Failed to get all test resources ready: %v", err)
+	}
+
+	// send fake CloudEvent to the Sequence
+	msg := fmt.Sprintf("TestSequence %s", uuid.NewUUID())
+	eventData := resources.CloudEventBaseData{Sequence: 0, Message: msg}
+	eventDataBytes, err := json.Marshal(eventData)
+	if err != nil {
+		t.Fatalf("Failed to convert %v to json: %v", eventData, err)
+	}
+	event := &resources.CloudEvent{
+		Source:   senderPodName,
+		Type:     resources.CloudEventDefaultType,
+		Data:     string(eventDataBytes),
+		Encoding: resources.CloudEventDefaultEncoding,
+	}
+	if err := client.SendFakeEventToAddressable(
+		senderPodName,
+		sequenceName,
+		common.SequenceTypeMeta,
+		event,
+	); err != nil {
+		t.Fatalf("Failed to send fake CloudEvent to the sequence %q", sequenceName)
+	}
+
+	// verify the logger service receives the correct transformed event
+	expectedMsg := msg
+	for _, config := range stepSubscriberConfigs {
+		expectedMsg += config.msgAppender
+	}
+	if err := client.CheckLog(loggerPodName, common.CheckerContains(expectedMsg)); err != nil {
+		t.Fatalf("String %q not found in logs of logger pod %q: %v", expectedMsg, loggerPodName, err)
+	}
+}

--- a/test/test_images/sequencestepper/main.go
+++ b/test/test_images/sequencestepper/main.go
@@ -22,47 +22,38 @@ import (
 	"log"
 
 	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/knative/eventing/test/base/resources"
 )
 
 var (
-	eventType   string
-	eventSource string
-	eventData   string
+	eventMsgAppender string
 )
 
 func init() {
-	flag.StringVar(&eventType, "event-type", "", "The Event Type to use.")
-	flag.StringVar(&eventSource, "event-source", "", "Source URI to use. Defaults to the current machine's hostname")
-	flag.StringVar(&eventData, "event-data", "", "Cloudevent data body.")
+	flag.StringVar(&eventMsgAppender, "msg-appender", "", "a string we want to append on the event message")
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	ctx := event.Context.AsV02()
 
-	dataBytes, err := event.DataBytes()
-	if err != nil {
+	data := &resources.CloudEventBaseData{}
+	if err := event.DataAs(data); err != nil {
 		log.Printf("Got Data Error: %s\n", err.Error())
 		return err
 	}
-	log.Println("Received a new event: ")
-	log.Printf("[%s] %s %s: %s", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), dataBytes)
 
-	if eventSource != "" {
-		ctx.SetSource(eventSource)
-	}
-	if eventType != "" {
-		ctx.SetType(eventType)
-	}
-	if eventData != "" {
-		dataBytes = []byte(eventData)
-	}
+	log.Println("Received a new event: ")
+	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), data)
+
+	// append eventMsgAppender to message of the data
+	data.Message = data.Message + eventMsgAppender
 	r := cloudevents.Event{
 		Context: ctx,
-		Data:    string(eventData),
+		Data:    data,
 	}
 
 	log.Println("Transform the event to: ")
-	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), eventData)
+	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), data)
 
 	resp.RespondWith(200, &r)
 	return nil

--- a/test/test_images/transformevents/main.go
+++ b/test/test_images/transformevents/main.go
@@ -58,11 +58,11 @@ func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
 	}
 	r := cloudevents.Event{
 		Context: ctx,
-		Data:    string(eventData),
+		Data:    string(dataBytes),
 	}
 
 	log.Println("Transform the event to: ")
-	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), eventData)
+	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), dataBytes)
 
 	resp.RespondWith(200, &r)
 	return nil


### PR DESCRIPTION
Fixes #1388 

## Proposed Changes
- This test only uses `InMemoryChannel` as the `ChannelTemplate`, I think since the underlying code is generic, and we have E2E test coverage for other `Channels`, there is no need to test with other `ChannelTemplates`. Please correct me if I'm wrong.
- This test case only tests against the first scenario documented in https://github.com/knative/docs/blob/master/docs/eventing/sequence.md, after it goes in, I'll add test cases for the other two scenarios.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vaikas-google 
/cc @grantr 