### PR TITLE
Adding the cfg for the (deprecated) Kafka CCP

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,6 +23,7 @@ COMPONENTS=(
   ["in-memory-channel-crd.yaml"]="config/channels/in-memory-channel"
   ["in-memory-channel-provisioner.yaml"]="config/provisioners/in-memory-channel"
   ["kafka.yaml"]="contrib/kafka/config"
+  ["kafka-ccp.yaml"]="contrib/kafka/config/provisioner"
   ["gcp-pubsub.yaml"]="contrib/gcppubsub/config"
   ["natss.yaml"]="contrib/natss/config"
 )


### PR DESCRIPTION
Fixes #1485

## Proposed Changes

- patch to release branch, to have the `kafka-ccp.yaml` file ... since the `kafka.yaml` now contains the CRD, only

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
adding back Kafka CCP yaml
```
