### PR TITLE
Adding the cfg for the (deprecated) NATSS CCP

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,6 +26,7 @@ COMPONENTS=(
   ["kafka-ccp.yaml"]="contrib/kafka/config/provisioner"
   ["gcp-pubsub.yaml"]="contrib/gcppubsub/config"
   ["natss.yaml"]="contrib/natss/config"
+  ["natss-ccp.yaml"]="contrib/natss/config/provisioner"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
Similar to #1486, but for NATSS CCP.

## Proposed Changes

- Add a `natss-ccp.yaml` artifact to the 0.7 release branch since the `natss.yaml` file now contains only the NatssChannel CRD.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adding back NATSS CCP yaml.
```
