### PR TITLE
Fixing RBAC for finalizers sub-resource of Sequences

### DIFF
--- a/config/200-controller-clusterrole.yaml
+++ b/config/200-controller-clusterrole.yaml
@@ -86,6 +86,14 @@ rules:
       - "sequences/status"
     verbs: *everything
 
+  # Messaging resources and finalizers we care about.
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "sequences/finalizers"
+    verbs:
+      - "update"
+
   # Source resources and statuses we care about.
   - apiGroups:
       - "sources.eventing.knative.dev"


### PR DESCRIPTION

## Proposed Changes

Related to #1450, on Openshift 4.1, I getting:

```
{"level":"error","ts":"2019-07-02T08:48:43.619Z","logger":"controller.sequence-controller","caller":"sequence/sequence.go:96","msg":"Error reconciling Sequence","knative.dev/controller":"sequence-controller","knative.dev/traceid":"194327ce-a8a6-4740-a49b-f9fed810c62f","knative.dev/key":"default/sequence","error":"inmemorychannels.messaging.knative.dev \"sequence-kn-sequence-0\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/knative/eventing/pkg/reconciler/sequence.(*Reconciler).Reconcile\n\t/home/prow/go/src/github.com/knative/eventing/pkg/reconciler/sequence/sequence.go:96\ngithub.com/knative/eventing/vendor/github.com/knative/pkg/controller.(*Impl).processNextWorkItem\n\t/home/prow/go/src/github.com/knative/eventing/vendor/github.com/knative/pkg/controller/controller.go:330\ngithub.com/knative/eventing/vendor/github.com/knative/pkg/controller.(*Impl).Run.func1\n\t/home/prow/go/src/github.com/knative/eventing/vendor/github.com/knative/pkg/controller/controller.go:282"}
```

- therefore adding proper RBAC for `finalizers` subresource

