### PR TITLE
add gcp-pubsub provisioner test back

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,6 +30,6 @@ source $(dirname $0)/e2e-common.sh
 
 initialize $@ --skip-istio-addon
 
-go_test_e2e -timeout=20m -parallel=12 ./test/e2e -clusterChannelProvisioners=in-memory,natss,kafka || fail_test
+go_test_e2e -timeout=20m -parallel=12 ./test/e2e -clusterChannelProvisioners=in-memory,natss,kafka,gcp-pubsub || fail_test
 
 success


### PR DESCRIPTION
## Proposed Changes
- E2E test is not flaky anymore, add test for `gcp-pubsub` back until we completely get rid of `ClusterChannelProvisioner`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
