### PR TITLE
Make gcloud a no-op if not available for test scripts

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,6 +18,9 @@
 
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
 
+# If gcloud is not available make it a no-op, not an error.
+which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
+
 # Eventing main config.
 readonly EVENTING_CONFIG="config/"
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -16,6 +16,9 @@
 
 set -o errexit
 
+# If gcloud is not available make it a no-op, not an error.
+which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
+
 function upload_test_images() {
   echo ">> Publishing test images"
   local image_dirs="$(find $(dirname $0)/test_images -mindepth 1 -maxdepth 1 -type d)"


### PR DESCRIPTION
Fixes #1507

## Proposed Changes
Create a no-op alias for gcloud if not available in test scripts.
