### PR TITLE
Add scrape annotation to services exporting metrics

### DIFF
--- a/config/400-source-controller-service.yaml
+++ b/config/400-source-controller-service.yaml
@@ -15,6 +15,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
   labels:
     eventing.knative.dev/release: devel
     app: sources-controller

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -325,6 +325,7 @@ func TestReconcile(t *testing.T) {
 			WantCreates: []runtime.Object{
 				NewService(filterServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
+					WithServiceAnnotations(resources.FilterAnnotations()),
 					WithServiceLabels(resources.FilterLabels(brokerName)),
 					WithServicePorts(servicePorts(filterContainerName, 8080))),
 			},
@@ -524,6 +525,7 @@ func TestReconcile(t *testing.T) {
 			WantCreates: []runtime.Object{
 				NewService(ingressServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
+					WithServiceAnnotations(resources.IngressAnnotations()),
 					WithServiceLabels(resources.IngressLabels(brokerName)),
 					WithServicePorts(servicePorts(ingressContainerName, 8080))),
 			},
@@ -1127,6 +1129,7 @@ func TestReconcileCRD(t *testing.T) {
 			WantCreates: []runtime.Object{
 				NewService(filterServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
+					WithServiceAnnotations(resources.FilterAnnotations()),
 					WithServiceLabels(resources.FilterLabels(brokerName)),
 					WithServicePorts(servicePorts(filterContainerName, 8080))),
 			},
@@ -1302,6 +1305,7 @@ func TestReconcileCRD(t *testing.T) {
 			WantCreates: []runtime.Object{
 				NewService(ingressServiceName, testNS,
 					WithServiceOwnerReferences(ownerReferences()),
+					WithServiceAnnotations(resources.IngressAnnotations()),
 					WithServiceLabels(resources.IngressLabels(brokerName)),
 					WithServicePorts(servicePorts(ingressContainerName, 8080))),
 			},

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -102,9 +102,10 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 func MakeFilterService(b *eventingv1alpha1.Broker) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: b.Namespace,
-			Name:      fmt.Sprintf("%s-broker-filter", b.Name),
-			Labels:    FilterLabels(b.Name),
+			Namespace:   b.Namespace,
+			Name:        fmt.Sprintf("%s-broker-filter", b.Name),
+			Annotations: FilterAnnotations(),
+			Labels:      FilterLabels(b.Name),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},
@@ -132,5 +133,14 @@ func FilterLabels(brokerName string) map[string]string {
 	return map[string]string{
 		"eventing.knative.dev/broker":     brokerName,
 		"eventing.knative.dev/brokerRole": "filter",
+	}
+}
+
+// FilterAnnotations generates the annotation that allow Prometheus to scrape the metrics exposed
+// by this service.
+func FilterAnnotations() map[string]string {
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "9090",
 	}
 }

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -113,8 +113,9 @@ func MakeIngressService(b *eventingv1alpha1.Broker) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Namespace,
 			// TODO add -ingress to the name to be consistent with the filter service naming.
-			Name:   fmt.Sprintf("%s-broker", b.Name),
-			Labels: IngressLabels(b.Name),
+			Name:        fmt.Sprintf("%s-broker", b.Name),
+			Annotations: IngressAnnotations(),
+			Labels:      IngressLabels(b.Name),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},
@@ -142,5 +143,14 @@ func IngressLabels(brokerName string) map[string]string {
 	return map[string]string{
 		"eventing.knative.dev/broker":     brokerName,
 		"eventing.knative.dev/brokerRole": "ingress",
+	}
+}
+
+// IngressAnnotations generates the annotation that allow Prometheus to scrape the metrics exposed
+// by this service.
+func IngressAnnotations() map[string]string {
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "9090",
 	}
 }

--- a/pkg/reconciler/testing/service.go
+++ b/pkg/reconciler/testing/service.go
@@ -57,3 +57,9 @@ func WithServicePorts(ports []corev1.ServicePort) ServiceOption {
 		s.Spec.Ports = ports
 	}
 }
+
+func WithServiceAnnotations(annotations map[string]string) ServiceOption {
+	return func(s *corev1.Service) {
+		s.ObjectMeta.Annotations = annotations
+	}
+}


### PR DESCRIPTION
Partially address #1225 

## Proposed Changes

- Add prometheus scrape annotation to services that export metrics. So those metrics can be scraped by prometheus

**Release Note**

```release-note
None
```