### PR TITLE
Migrate to use v0.3 of CloudEvents Spec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -447,7 +447,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:30a037a49636002408b75e05ee51c6995d45143cf073bfae173a7ec94ea260f8"
+  digest = "1:ff299a08b16aa96a95909732921d085cf25bcd1e0e5e982060b7db81204b2792"
   name = "github.com/knative/test-infra"
   packages = [
     "scripts",
@@ -459,7 +459,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "bf05b82bcaaf2e7516d0b2edfc96fc904813bcf2"
+  revision = "147de7845fecbb7f7af87782375b01bafa7eed4b"
 
 [[projects]]
   digest = "1:56dbf15e091bf7926cb33a57cb6bdfc658fc6d3498d2f76f10a97ce7856f1fde"

--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -106,7 +106,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 		Namespace:  obj.GetNamespace(),
 	})
 
-	event := cloudevents.NewEvent()
+	event := cloudevents.NewEvent(cloudevents.VersionV03)
 	event.SetType(eventType)
 	event.SetSource(source)
 	event.SetSubject(subject)

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -82,13 +82,13 @@ func TestMakeAddEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.resource.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -119,13 +119,13 @@ func TestMakeUpdateEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.resource.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -156,13 +156,13 @@ func TestMakeDeleteEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.resource.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -194,13 +194,13 @@ func TestMakeAddRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -209,13 +209,13 @@ func TestMakeAddRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},
@@ -247,13 +247,13 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -262,13 +262,13 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},
@@ -300,13 +300,13 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -315,13 +315,13 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV03{
 					Type:   "dev.knative.apiserver.ref.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV02(),
+				}.AsV03(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -82,7 +82,7 @@ func TestMakeAddEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.resource.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -119,7 +119,7 @@ func TestMakeUpdateEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.resource.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -156,7 +156,7 @@ func TestMakeDeleteEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.resource.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -194,7 +194,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -209,7 +209,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.add",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -247,7 +247,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -262,7 +262,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.update",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -300,7 +300,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
@@ -315,7 +315,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV03{
+				Context: cloudevents.EventContextV02{
 					Type:   "dev.knative.apiserver.ref.delete",
 					Source: *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -88,7 +88,7 @@ func (a *Adapter) Start(ctx context.Context, stopCh <-chan struct{}) error {
 func (a *Adapter) cronTick() {
 	logger := logging.FromContext(context.TODO())
 
-	event := cloudevents.NewEvent(cloudevents.VersionV02)
+	event := cloudevents.NewEvent(cloudevents.VersionV03)
 	event.SetType(sourcesv1alpha1.CronJobEventType)
 	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))

--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -133,7 +133,7 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 	}
 
 	// Remove the TTL attribute that is used by the Broker.
-	originalV2 := event.Context.AsV02()
+	originalV3 := event.Context.AsV03()
 	ttl, ttlKey := GetTTL(event.Context)
 	if ttl == nil {
 		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
@@ -144,8 +144,8 @@ func (r *Receiver) serveHTTP(ctx context.Context, event cloudevents.Event, resp 
 		// framework returns a 500 to the caller, so the Channel would send this repeatedly.
 		return nil
 	}
-	delete(originalV2.Extensions, ttlKey)
-	event.Context = originalV2
+	delete(originalV3.Extensions, ttlKey)
+	event.Context = originalV3
 
 	r.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))
 

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -410,7 +410,7 @@ func makeTriggerWithBadSubscriberURI() *eventingv1alpha1.Trigger {
 
 func makeEventWithoutTTL() *cloudevents.Event {
 	return &cloudevents.Event{
-		Context: cloudevents.EventContextV03{
+		Context: cloudevents.EventContextV02{
 			Type: eventType,
 			Source: cloudevents.URLRef{
 				URL: url.URL{
@@ -435,7 +435,7 @@ func addTTLToEvent(e cloudevents.Event) cloudevents.Event {
 
 func makeDifferentEvent() *cloudevents.Event {
 	return &cloudevents.Event{
-		Context: cloudevents.EventContextV03{
+		Context: cloudevents.EventContextV02{
 			Type: "some-other-type",
 			Source: cloudevents.URLRef{
 				URL: url.URL{

--- a/pkg/broker/receiver_test.go
+++ b/pkg/broker/receiver_test.go
@@ -301,7 +301,7 @@ func TestReceiver(t *testing.T) {
 
 			// The TTL will be added again.
 			expectedResponseEvent := addTTLToEvent(*tc.returnedEvent)
-			if diff := cmp.Diff(expectedResponseEvent.Context.AsV02(), resp.Event.Context.AsV02()); diff != "" {
+			if diff := cmp.Diff(expectedResponseEvent.Context.AsV03(), resp.Event.Context.AsV03()); diff != "" {
 				t.Errorf("Incorrect response event context (-want +got): %s", diff)
 			}
 			if diff := cmp.Diff(expectedResponseEvent.Data, resp.Event.Data); diff != "" {
@@ -323,7 +323,7 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	h.requestReceived = true
 
 	for n, v := range h.headers {
-		if strings.Contains(strings.ToLower(n), strings.ToLower(v02TTLAttribute)) {
+		if strings.Contains(strings.ToLower(n), strings.ToLower(v03TTLAttribute)) {
 			h.t.Errorf("Broker TTL should not be seen by the subscriber: %s", n)
 		}
 		if diff := cmp.Diff(v, req.Header[n]); diff != "" {
@@ -340,7 +340,7 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	c := &cehttp.CodecV02{}
+	c := &cehttp.CodecV03{}
 	m, err := c.Encode(*h.returnedEvent)
 	if err != nil {
 		h.t.Fatalf("Could not encode message: %v", err)
@@ -410,7 +410,7 @@ func makeTriggerWithBadSubscriberURI() *eventingv1alpha1.Trigger {
 
 func makeEventWithoutTTL() *cloudevents.Event {
 	return &cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: cloudevents.EventContextV03{
 			Type: eventType,
 			Source: cloudevents.URLRef{
 				URL: url.URL{
@@ -418,7 +418,7 @@ func makeEventWithoutTTL() *cloudevents.Event {
 				},
 			},
 			ContentType: cloudevents.StringOfApplicationJSON(),
-		}.AsV02(),
+		}.AsV03(),
 	}
 }
 
@@ -435,7 +435,7 @@ func addTTLToEvent(e cloudevents.Event) cloudevents.Event {
 
 func makeDifferentEvent() *cloudevents.Event {
 	return &cloudevents.Event{
-		Context: cloudevents.EventContextV02{
+		Context: cloudevents.EventContextV03{
 			Type: "some-other-type",
 			Source: cloudevents.URLRef{
 				URL: url.URL{
@@ -443,6 +443,6 @@ func makeDifferentEvent() *cloudevents.Event {
 				},
 			},
 			ContentType: cloudevents.StringOfApplicationJSON(),
-		}.AsV02(),
+		}.AsV03(),
 	}
 }

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -23,26 +23,26 @@ import (
 )
 
 const (
-	// v02TTLAttribute is the name of the CloudEvents 0.2 extension attribute used to store the
+	// v03TTLAttribute is the name of the CloudEvents 0.2 extension attribute used to store the
 	// Broker's TTL (number of times a single event can reply through a Broker continuously). All
 	// interactions with the attribute should be done through the GetTTL and SetTTL functions.
-	v02TTLAttribute = "knativebrokerttl"
+	v03TTLAttribute = "knativebrokerttl"
 )
 
 // GetTTL finds the TTL in the EventContext using a case insensitive comparison
 // for the key. The second return param, is the case preserved key that matched.
 // Depending on the encoding/transport, the extension case could be changed.
 func GetTTL(ctx cloudevents.EventContext) (interface{}, string) {
-	for k, v := range ctx.AsV02().Extensions {
-		if lower := strings.ToLower(k); lower == v02TTLAttribute {
+	for k, v := range ctx.AsV03().Extensions {
+		if lower := strings.ToLower(k); lower == v03TTLAttribute {
 			return v, k
 		}
 	}
-	return nil, v02TTLAttribute
+	return nil, v03TTLAttribute
 }
 
 // SetTTL sets the TTL into the EventContext. ttl should be a positive integer.
 func SetTTL(ctx cloudevents.EventContext, ttl interface{}) (cloudevents.EventContext, error) {
-	err := ctx.SetExtension(v02TTLAttribute, ttl)
+	err := ctx.SetExtension(v03TTLAttribute, ttl)
 	return ctx, err
 }

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -98,7 +98,7 @@ func main() {
 		hb.Sequence++
 
 		event := cloudevents.Event{
-			Context: cloudevents.EventContextV03{
+			Context: cloudevents.EventContextV02{
 				Type:   "dev.knative.eventing.samples.heartbeat",
 				Source: *source,
 				Extensions: map[string]interface{}{

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -98,7 +98,7 @@ func main() {
 		hb.Sequence++
 
 		event := cloudevents.Event{
-			Context: cloudevents.EventContextV02{
+			Context: cloudevents.EventContextV03{
 				Type:   "dev.knative.eventing.samples.heartbeat",
 				Source: *source,
 				Extensions: map[string]interface{}{
@@ -106,7 +106,7 @@ func main() {
 					"heart": "yes",
 					"beats": true,
 				},
-			}.AsV02(),
+			}.AsV03(),
 			Data: hb,
 		}
 

--- a/test/test_images/sequencestepper/main.go
+++ b/test/test_images/sequencestepper/main.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx := event.Context.AsV02()
+	ctx := event.Context.AsV03()
 
 	data := &resources.CloudEventBaseData{}
 	if err := event.DataAs(data); err != nil {

--- a/test/test_images/transformevents/main.go
+++ b/test/test_images/transformevents/main.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx := event.Context.AsV02()
+	ctx := event.Context.AsV03()
 
 	dataBytes, err := event.DataBytes()
 	if err != nil {

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -219,7 +219,7 @@ function create_test_cluster() {
 
   # Set a minimal kubernetes environment that satisfies kubetest
   # TODO(adrcunha): Remove once https://github.com/kubernetes/test-infra/issues/13029 is fixed.
-  local kubedir="$(mktemp -d --tmpdir kubernetes.XXXXXXXXXX)"
+  local kubedir="$(mktemp -d -t kubernetes.XXXXXXXXXX)"
   local test_wrapper="${kubedir}/e2e-test.sh"
   mkdir ${kubedir}/cluster
   ln -s "$(which kubectl)" ${kubedir}/cluster/kubectl.sh


### PR DESCRIPTION
Fixes #1471 

## Proposed Changes

-  Update references of EventContext to V03


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
