### PR TITLE
Fixing knative eventing namespace teardown step

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -81,6 +81,7 @@ function knative_teardown() {
   echo ">> Stopping Knative Eventing"
   echo "Uninstalling Knative Eventing"
   ko delete --ignore-not-found=true --now --timeout 60s -f ${EVENTING_CONFIG}
+  wait_until_object_does_not_exist namespaces knative-eventing
 }
 
 # Setup resources common to all eventing tests.
@@ -103,7 +104,6 @@ function test_teardown() {
   kafka_teardown
 
   uninstall_test_resources
-  wait_until_object_does_not_exist namespaces knative-eventing
 }
 
 function install_test_resources() {


### PR DESCRIPTION
Fixes #1536

## Bug Description
https://github.com/knative/eventing/blob/1bfb3465ae0946e15b151ab9226203ff7ab66251/test/e2e-common.sh#L106
The above statement is called when all the test resources are uninstalled. But knative-eventing namespace is still present and will be present untill https://github.com/knative/eventing/blob/1bfb3465ae0946e15b151ab9226203ff7ab66251/test/e2e-common.sh#L80 is invoked, as a result e2e-test script waits until ```wait_until_object_does_not_exist ``` function times out and then deletes the knative-eventing namespace based on the ```--skip-knative-setup``` parameter

## Proposed Changes

- Semantically rearranging statement  ``` wait_until_object_does_not_exist namespaces knative-eventing ``` and making it part of knative-teardown function as :

```shell
# Teardown the Knative environment after tests finish.
function knative_teardown() {
  echo ">> Stopping Knative Eventing"
  echo "Uninstalling Knative Eventing"
  ko delete --ignore-not-found=true --now --timeout 60s -f ${EVENTING_CONFIG}
  wait_until_object_does_not_exist namespaces knative-eventing
}
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
