### PR TITLE
issue 1546: change version->versions for CRD definitions

### DIFF
--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -97,4 +97,7 @@ spec:
             sinkUri:
               type: string
           type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Broker
     plural: brokers

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -20,7 +20,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Channel
     plural: channels

--- a/config/300-clusterchannelprovisioner.yaml
+++ b/config/300-clusterchannelprovisioner.yaml
@@ -20,7 +20,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: ClusterChannelProvisioner
     plural: clusterchannelprovisioners

--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -90,4 +90,7 @@ spec:
             sinkUri:
               type: string
           type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -100,4 +100,7 @@ spec:
             sinkUri:
               type: string
           type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/config/300-eventtype.yaml
+++ b/config/300-eventtype.yaml
@@ -20,7 +20,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: EventType
     plural: eventtypes

--- a/config/300-sequence.yaml
+++ b/config/300-sequence.yaml
@@ -20,7 +20,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: messaging.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Sequence
     plural: sequences

--- a/config/300-subscription.yaml
+++ b/config/300-subscription.yaml
@@ -20,7 +20,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Subscription
     plural: subscriptions

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -21,7 +21,10 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: Trigger
     plural: triggers

--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -21,7 +21,10 @@ metadata:
     messaging.knative.dev/subscribable: "true"
 spec:
   group: messaging.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   names:
     kind: InMemoryChannel
     plural: inmemorychannels


### PR DESCRIPTION
Fixes #1546 

## Proposed Changes

- Change CustomResourceDefinition.spec.version to versions.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
CRD definitions use versions instead of version.
```
