### PR TITLE
Disable logging headers in nats dispatcher

### DIFF
--- a/contrib/natss/pkg/dispatcher/dispatcher.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher.go
@@ -270,7 +270,7 @@ func (s *SubscriptionsSupervisor) subscribe(channel provisioners.ChannelReferenc
 			s.logger.Error("Failed to unmarshal message: ", zap.Error(err))
 			return
 		}
-		s.logger.Sugar().Infof("NATSS message received from subject: %v; sequence: %v; timestamp: %v, headers: '%s'", msg.Subject, msg.Sequence, msg.Timestamp, message.Headers)
+		s.logger.Sugar().Debugf("NATSS message received from subject: %v; sequence: %v; timestamp: %v, headers: '%s'", msg.Subject, msg.Sequence, msg.Timestamp, message.Headers)
 		if err := s.dispatcher.DispatchMessage(&message, subscription.SubscriberURI, subscription.ReplyURI, provisioners.DispatchDefaults{Namespace: channel.Namespace}); err != nil {
 			s.logger.Error("Failed to dispatch message: ", zap.Error(err))
 			return

--- a/contrib/natss/pkg/dispatcher/dispatcher.go
+++ b/contrib/natss/pkg/dispatcher/dispatcher.go
@@ -126,7 +126,7 @@ func createReceiverFunction(s *SubscriptionsSupervisor, logger *zap.SugaredLogge
 			}
 			return err
 		}
-		logger.Infof("Published [%s] : '%s'", channel.String(), m.Headers)
+		logger.Debugf("Published [%s] : '%s'", channel.String(), m.Headers)
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1551

## Proposed Changes

- Changing log level for headers in natss dispatcher to debug

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
