### PR TITLE
Enable istio injection on knative-eventing namespace

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -16,4 +16,5 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
+    istio-injection: enabled
     eventing.knative.dev/release: devel


### PR DESCRIPTION
 - We should have istio-injection enabled in namespace
   such that the dispatcher is able to send events to
   the service.

Fixes #1336 

## Proposed Changes

- Adding `istio-injection` to the `knative-eventing` namespace.
- This should allow the dispatcher to be within the `istio-service mesh` and would be able to deliver events to the `knative services`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Istio side car injection is enabled by default for the knative eventing namespace. 
```
