### PR TITLE
Add code coverage for utils.go.

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -17,8 +17,14 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestGetDomainName(t *testing.T) {
@@ -59,5 +65,95 @@ options ndots:5
 		if got != tt.want {
 			t.Errorf("Test %s failed expected: %s but got: %s", tt.name, tt.want, got)
 		}
+	}
+}
+
+func TestObjectRef(t *testing.T) {
+	testCases := map[string]struct {
+		obj metav1.Object
+		gvk schema.GroupVersionKind
+	}{
+		"Service": {
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+					Name:      "my-name",
+				},
+			},
+			gvk: schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Service",
+			},
+		},
+		"Broker": {
+			obj: &v1alpha1.Broker{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "broker-ns",
+					Name:      "my-broker",
+				},
+			},
+			gvk: schema.GroupVersionKind{
+				Group:   "eventing.knative.dev",
+				Version: "v1alpha1",
+				Kind:    "Broker",
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			or := ObjectRef(tc.obj, tc.gvk)
+
+			expectedApiVersion := fmt.Sprintf("%s/%s", tc.gvk.Group, tc.gvk.Version)
+			// Special case for v1.
+			if tc.gvk.Group == "" {
+				expectedApiVersion = tc.gvk.Version
+			}
+
+			if api, _ := tc.gvk.ToAPIVersionAndKind(); api != expectedApiVersion {
+				t.Errorf("Expected APIVersion %q, actually %q", expectedApiVersion, api)
+			}
+			if kind := or.Kind; kind != tc.gvk.Kind {
+				t.Errorf("Expected kind %q, actually %q", tc.gvk.Kind, kind)
+			}
+			if ns := or.Namespace; ns != tc.obj.GetNamespace() {
+				t.Errorf("Expected namespace %q, actually %q", tc.obj.GetNamespace(), ns)
+			}
+			if n := or.Name; n != tc.obj.GetName() {
+				t.Errorf("Expected name %q, actually %q", tc.obj.GetName(), n)
+			}
+		})
+	}
+}
+
+func TestToDNS1123Subdomain(t *testing.T) {
+	testCases := map[string]struct {
+		name     string
+		expected string
+	}{
+		"short": {
+			name:     "abc",
+			expected: "abc",
+		},
+		"too long": {
+			name:     strings.Repeat("a", 300),
+			expected: strings.Repeat("a", 243),
+		},
+		"surrounded by dashes": {
+			name:     "-foo-",
+			expected: "foo",
+		},
+		"illegal characters": {
+			name:     "a$b",
+			expected: "ab",
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			a := ToDNS1123Subdomain(tc.name)
+			if a != tc.expected {
+				t.Errorf("Expected %q, actually %q", tc.expected, a)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- Increase code coverage of utils.go.

Found because #1563 started failing due to low coverage of this file.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
