### PR TITLE
Move 0.7 and 0.8 roadmap into a md doc on the repo (instead of a goog…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ For complete Knative Eventing documentation, see
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
 [Knative WORKING-GROUPS.md](https://www.knative.dev/contributing/working-groups/#eventing).
+Please read the [roadmap](./docs/planning/roadmap.md) to see what we're working
+on right now and what is planed for upcoming releases.
 
-Please join
-[knative-users](https://groups.google.com/forum/#!forum/knative-users) to view
-planned project releases in
-[roadmap](https://docs.google.com/document/d/1z0z412rL9FsBsF8kwKxG6w7sflJLKe9hIECkc7jWfOY/edit#).
+Interested users should join
+[knative-users](https://groups.google.com/forum/#!forum/knative-users),

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,0 +1,18 @@
+
+# Knative Eventing Roadmap
+
+## 0.8 | __in progress__
+
+Six features were [voted on](https://docs.google.com/spreadsheets/d/1WlbpQ0EcD3IIRsdr_ydpKiNpq5fP0CEcOHW2bUb-Bp8/edit#gid=0)
+for inclusion in the 0.8 release.
+
+* #1250 [Fixed names rather than Generate Name](https://github.com/knative/eventing/issues/1250)
+* #1381 [Make it easier to consume events directly from specific sources](https://github.com/knative/eventing/issues/1381)
+* #1214 [Modify GCP pubsub channel to use CRD](https://github.com/knative/eventing/issues/1214)
+* #1387 [Move artifacts from eventing/contrib folder into eventing-contrib repo](https://github.com/knative/eventing/issues/1387)
+* #1343 [Support for default channel](https://github.com/knative/eventing/issues/1343)
+* #1225 [Integrate Knative Eventing into metrics Scrapers/Dashboards](https://github.com/knative/eventing/issues/1225)
+
+## 0.7 | __25 July 2019__
+
+[0.7 feature voting spreadsheet](https://docs.google.com/spreadsheets/d/1bwN2CE1uYct6jOCQqwIn-ymg7BTx18Y3rv44ilTRiqY/edit?pli=1#gid=0)


### PR DESCRIPTION
…le doc).

Update main readme with links to the new doc

Fixes #852

## Proposed Changes
docs update only

**Release Note**

```release-note
NONE
```
