### PR TITLE
Format markdown

### DIFF
--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,18 +1,24 @@
-
 # Knative Eventing Roadmap
 
-## 0.8 | __in progress__
+## 0.8 | **in progress**
 
-Six features were [voted on](https://docs.google.com/spreadsheets/d/1WlbpQ0EcD3IIRsdr_ydpKiNpq5fP0CEcOHW2bUb-Bp8/edit#gid=0)
+Six features were
+[voted on](https://docs.google.com/spreadsheets/d/1WlbpQ0EcD3IIRsdr_ydpKiNpq5fP0CEcOHW2bUb-Bp8/edit#gid=0)
 for inclusion in the 0.8 release.
 
-* #1250 [Fixed names rather than Generate Name](https://github.com/knative/eventing/issues/1250)
-* #1381 [Make it easier to consume events directly from specific sources](https://github.com/knative/eventing/issues/1381)
-* #1214 [Modify GCP pubsub channel to use CRD](https://github.com/knative/eventing/issues/1214)
-* #1387 [Move artifacts from eventing/contrib folder into eventing-contrib repo](https://github.com/knative/eventing/issues/1387)
-* #1343 [Support for default channel](https://github.com/knative/eventing/issues/1343)
-* #1225 [Integrate Knative Eventing into metrics Scrapers/Dashboards](https://github.com/knative/eventing/issues/1225)
+- #1250
+  [Fixed names rather than Generate Name](https://github.com/knative/eventing/issues/1250)
+- #1381
+  [Make it easier to consume events directly from specific sources](https://github.com/knative/eventing/issues/1381)
+- #1214
+  [Modify GCP pubsub channel to use CRD](https://github.com/knative/eventing/issues/1214)
+- #1387
+  [Move artifacts from eventing/contrib folder into eventing-contrib repo](https://github.com/knative/eventing/issues/1387)
+- #1343
+  [Support for default channel](https://github.com/knative/eventing/issues/1343)
+- #1225
+  [Integrate Knative Eventing into metrics Scrapers/Dashboards](https://github.com/knative/eventing/issues/1225)
 
-## 0.7 | __25 July 2019__
+## 0.7 | **25 July 2019**
 
 [0.7 feature voting spreadsheet](https://docs.google.com/spreadsheets/d/1bwN2CE1uYct6jOCQqwIn-ymg7BTx18Y3rv44ilTRiqY/edit?pli=1#gid=0)

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -46,10 +46,9 @@ created, backing all messages from the channel.
 #### Aggregated Channelable Manipulator ClusterRole
 
 Every CRD must create a corresponding ClusterRole, that will be aggregated into
-the `channelable-manipulator` ClusterRole. This ClusterRole must
-include permissions to create, list, watch, patch, and update the
-CRD's custom objects and their status. Below is an example for the
-`KafkaChannel`:
+the `channelable-manipulator` ClusterRole. This ClusterRole must include
+permissions to create, list, watch, patch, and update the CRD's custom objects
+and their status. Below is an example for the `KafkaChannel`:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1
@@ -193,10 +192,14 @@ not the individual Subscription.
 #### Metrics
 
 Channels SHOULD expose a variety of metrics, including, but not limited to:
-- Number of malformed incoming event queueing events (`400 Bad Requests` responses)
-- Number of unauthorized or malformed bearer token requests (`403 Forbidden` responses)
+
+- Number of malformed incoming event queueing events (`400 Bad Requests`
+  responses)
+- Number of unauthorized or malformed bearer token requests (`403 Forbidden`
+  responses)
 - Number of accepted incoming event queuing events (`202 Accpeted` responses)
-- Number of egress cloudevent produced (with the former metric, used to derive channel queue size)
+- Number of egress cloudevent produced (with the former metric, used to derive
+  channel queue size)
 
 Metrics SHOULD be enabled by default, but a configuration parameter included to
 disable if desired.


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @n3wscott
