### PR TITLE
Add Grafana dashboard configuration

### DIFF
--- a/config/monitoring/metrics/grafana/100-grafana-dash-eventing.yaml
+++ b/config/monitoring/metrics/grafana/100-grafana-dash-eventing.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2019 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/monitoring/metrics/grafana/100-grafana-dash-eventing.yaml
+++ b/config/monitoring/metrics/grafana/100-grafana-dash-eventing.yaml
@@ -1,0 +1,264 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To enable eventing dashboard in Grafana, run:
+# kubectl patch configmap grafana-dashboard-definition-knative \
+# --patch "$(cat 100-grafana-dash-eventing.yaml)" -n knative-monitoring
+---
+data:
+  eventing-dashboard.json: |+
+    {
+      "__inputs": [
+        {
+          "description": "",
+          "label": "prometheus",
+          "name": "prometheus",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus",
+          "type": "datasource"
+        }
+      ],
+      "annotations": {
+        "list": []
+      },
+      "description": "Knative Eventing",
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "links": [],
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 4,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.98, rate(broker_dispatch_time_bucket[1m]))",
+              "format": "time_series",
+              "interval": "1m",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Broker Dispatch Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurationms",
+            "logBase": 1,
+            "max": "50",
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#508642",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "max": null,
+            "min": null,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 6,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.98, rate(trigger_dispatch_time_bucket[1m]))",
+              "format": "time_series",
+              "interval": "1m",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Trigger Dispatch Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurationms",
+            "logBase": 1,
+            "max": "50",
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateGreens",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 8,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.98, rate(trigger_filter_time_bucket[1m]))",
+              "format": "time_series",
+              "interval": "1m",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Trigger Filter Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurationms",
+            "logBase": 1,
+            "max": "50",
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 16,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-120m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "Knative Eventing",
+      "uid": "im_gFbWik",
+      "version": 2
+    }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-This is a list of metrics exported by Knative Eventing components.
+This is a list of metrics exported by Knative Eventing components. 
 
 ## Broker
 
@@ -20,3 +20,21 @@ These are exported by `broker-filter` pods.
 | `trigger_events_total`  | count     | Number of events received. | `result`, `broker`, `trigger`                  |
 | `trigger_dispatch_time` | histogram | Time to dispatch an event. | `result`, `broker`, `trigger`                  |
 | `trigger_filter_time`   | histogram | Time to filter an event.   | `result`, `broker`, `trigger`, `filter_result` |
+
+## Access metrics
+
+Accessing metrics requires Prometheus and Grafana installed. Follow the [instructions to install Prometheus and Grafana](https://github.com/knative/docs/blob/master/docs/serving/installing-logging-metrics-traces.md) in namespace `knative-monitoring`.
+
+### Prometheus
+
+Follow the [instructions to open Prometheus UI](https://github.com/knative/docs/blob/master/docs/serving/accessing-metrics.md#prometheus), then you will access the metrics at [http://localhost:9090](http://localhost:9090).
+
+### Grafana
+
+You can add the eventing dashboard to Grafana by running below command line under the root folder of `eventing` source code:
+
+```
+kubectl patch configmap grafana-dashboard-definition-knative --patch "$(cat config/monitoring/metrics/grafana/100-grafana-dash-eventing.yaml)" -n knative-monitoring
+```
+
+Follow the [instructions to open Grafana dashboard](https://github.com/knative/docs/blob/master/docs/serving/accessing-metrics.md#grafana), then you will access the metrics at [http://localhost:3000](http://localhost:3000).


### PR DESCRIPTION
Fixes #1225 

## Proposed Changes

- Add an eventing dashboard to Grafana
- Add instructions to metrics.md to access metrics with Grafana and Prometheus

**Release Note**

```release-note
Accessing metrics with Grafana and Prometheus is enabled. Follow the guidance in [metrics.md](https://github.com/knative/eventing/blob/master/docs/metrics.md) to understand details.
```