### PR TITLE
Format markdown

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -68,8 +68,8 @@ You can run it simply with:
 test/performance-tests.sh
 ```
 
-The steps and flags are exactly the same as e2e tests described above.
-After the tests are done, test results named as `artifacts` will be saved under
+The steps and flags are exactly the same as e2e tests described above. After the
+tests are done, test results named as `artifacts` will be saved under
 `./performance`. You can also check the historic test result through
 [testgrid](https://testgrid.knative.dev/eventing#performance).
 
@@ -100,8 +100,8 @@ go test -v -tags=e2e -count=1 ./test/e2e
 By default, it will run all applicable tests against the cluster's default
 `channel`.
 
-If you want to run tests against other `channels`, you can
-specify them through `-channels`.
+If you want to run tests against other `channels`, you can specify them through
+`-channels`.
 
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e -channels=InMemoryChannel,KafkaChannel

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -9,11 +9,12 @@ Knative Eventing e2e tests
 to verify the behavior of this specific implementation.
 
 If you want to add tests for a new `channel` and reuse existing tests for it,
-please look into [config.go](../common/config.go) and make corresponding changes.
+please look into [config.go](../common/config.go) and make corresponding
+changes.
 
 If you want to add a new test case, please add one new test file under [e2e](.)
-and use the `RunTests` function to run against multiple `channels` that have
-the feature you want to test.
+and use the `RunTests` function to run against multiple `channels` that have the
+feature you want to test.
 
 ### Requirements
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @n3wscott
