### PR TITLE
Format markdown

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -13,7 +13,9 @@ A typical channel consists of a _Controller_ and a _Dispatcher_ pod.
 
 ## Conformance
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119][rfc2119].
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC2119][rfc2119].
 
 ## Channel Spec Parts
 
@@ -195,9 +197,12 @@ not the individual Subscription.
 
 ##### Retries
 
-Channels SHOULD retry resending CloudEvents when they fail to either connect or send CloudEvents to subscribers.
+Channels SHOULD retry resending CloudEvents when they fail to either connect or
+send CloudEvents to subscribers.
 
-Channels SHOULD support various retry configuration parameters, including, but not limited to:
+Channels SHOULD support various retry configuration parameters, including, but
+not limited to:
+
 - the maximum number of retries
 - the time in-between retries
 - the backoff rate


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @n3wscott
