### PR TITLE
GenerateName ensures there is a dash between the prefix and the UID.

### DIFF
--- a/pkg/provisioners/channel_util.go
+++ b/pkg/provisioners/channel_util.go
@@ -276,7 +276,7 @@ func k8sServiceLabels(c *eventingv1alpha1.Channel) map[string]string {
 }
 
 func channelServiceName(channelName string) string {
-	return fmt.Sprintf("%s-channel-", channelName)
+	return fmt.Sprintf("%s-channel", channelName)
 }
 
 func channelHostName(channelName, namespace string) string {

--- a/pkg/provisioners/channel_util_test.go
+++ b/pkg/provisioners/channel_util_test.go
@@ -296,7 +296,7 @@ func TestChannelNames(t *testing.T) {
 		F: func() string {
 			return channelServiceName("foo")
 		},
-		Want: "foo-channel-",
+		Want: "foo-channel",
 	}, {
 		Name: "channelHostName",
 		F: func() string {

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -63,6 +63,7 @@ var (
 const (
 	image      = "github.com/knative/test/image"
 	sourceName = "test-apiserver-source"
+	sourceUID  = "1234"
 	testNS     = "testnamespace"
 
 	sinkName = "testsink"
@@ -83,7 +84,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "missing sink",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Sink: &sinkRef,
 					}),
@@ -92,7 +93,7 @@ func TestReconcile(t *testing.T) {
 			Key:     testNS + "/" + sourceName,
 			WantErr: true,
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Sink: &sinkRef,
 					}),
@@ -105,7 +106,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "valid",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -128,7 +129,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -149,7 +150,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "deployment update due to env",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -172,7 +173,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReconciled", `ApiServerSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -196,7 +197,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "deployment update due to service account",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -220,7 +221,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReconciled", `ApiServerSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -245,7 +246,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "deployment update due to container count",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -268,7 +269,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReconciled", `ApiServerSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -292,7 +293,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "valid with event types to delete",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -316,7 +317,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -340,7 +341,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "valid with broker sink",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -363,7 +364,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -392,7 +393,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "valid with broker sink and missing event types",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -418,7 +419,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -444,7 +445,7 @@ func TestReconcile(t *testing.T) {
 		{
 			Name: "valid with broker sink and event types to delete",
 			Objects: []runtime.Object{
-				NewApiServerSource(sourceName, testNS,
+				NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -473,7 +474,7 @@ func TestReconcile(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "ApiServerSourceReadinessChanged", `ApiServerSource %q became ready`, sourceName),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewApiServerSource(sourceName, testNS,
+				Object: NewApiServerSource(sourceName, testNS, sourceUID,
 					WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 						Resources: []sourcesv1alpha1.ApiServerResource{
 							{
@@ -507,7 +508,7 @@ func TestReconcile(t *testing.T) {
 	defer logtesting.ClearAll()
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
-			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
+			Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
 			apiserversourceLister: listers.GetApiServerSourceLister(),
 			deploymentLister:      listers.GetDeploymentLister(),
 			source:                source,
@@ -521,7 +522,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func makeReceiveAdapter() *appsv1.Deployment {
-	src := NewApiServerSource(sourceName, testNS,
+	src := NewApiServerSource(sourceName, testNS, sourceUID,
 		WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 			Resources: []sourcesv1alpha1.ApiServerResource{
 				{
@@ -583,7 +584,7 @@ func makeEventTypeWithName(eventType, name string) *v1alpha1.EventType {
 func makeEventType(eventType string) *v1alpha1.EventType {
 	return &v1alpha1.EventType{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s", eventType),
+			Name:      fmt.Sprintf("%s-%s", eventType, sourceUID),
 			Labels:    resources.Labels(sourceName),
 			Namespace: testNS,
 			OwnerReferences: []metav1.OwnerReference{
@@ -603,7 +604,7 @@ func makeEventType(eventType string) *v1alpha1.EventType {
 }
 
 func makeApiServerSource() *sourcesv1alpha1.ApiServerSource {
-	return NewApiServerSource(sourceName, testNS,
+	return NewApiServerSource(sourceName, testNS, sourceUID,
 		WithApiServerSourceSpec(sourcesv1alpha1.ApiServerSourceSpec{
 			Resources: []sourcesv1alpha1.ApiServerResource{
 				{

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -64,7 +64,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 	want := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "source-namespace",
-			Name:      "apiserversource-source-name1234",
+			Name:      "apiserversource-source-name-1234",
 			Labels: map[string]string{
 				"test-key1": "test-value1",
 				"test-key2": "test-value2",

--- a/pkg/reconciler/broker/resources/subscription.go
+++ b/pkg/reconciler/broker/resources/subscription.go
@@ -32,7 +32,7 @@ func MakeSubscriptionCRD(b *v1alpha1.Broker, c *duckv1alpha1.Channelable, svc *c
 	return &v1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Namespace,
-			Name:      utils.GenerateFixedName(b, fmt.Sprintf("internal-ingress-%s-", b.Name)),
+			Name:      utils.GenerateFixedName(b, fmt.Sprintf("internal-ingress-%s", b.Name)),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -23,17 +23,19 @@ import (
 	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	"github.com/knative/eventing/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ApiServerSourceOption enables further configuration of a ApiServer.
 type ApiServerSourceOption func(*v1alpha1.ApiServerSource)
 
 // NewApiServerSource creates a ApiServer with ApiServerOptions
-func NewApiServerSource(name, namespace string, o ...ApiServerSourceOption) *v1alpha1.ApiServerSource {
+func NewApiServerSource(name, namespace, uid string, o ...ApiServerSourceOption) *v1alpha1.ApiServerSource {
 	c := &v1alpha1.ApiServerSource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(uid),
 		},
 	}
 	for _, opt := range o {

--- a/pkg/reconciler/trigger/resources/subscription.go
+++ b/pkg/reconciler/trigger/resources/subscription.go
@@ -34,7 +34,7 @@ func NewSubscription(t *eventingv1alpha1.Trigger, brokerTrigger, brokerIngress *
 	return &eventingv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
-			Name:      utils.GenerateFixedName(t, fmt.Sprintf("%s-%s-", t.Spec.Broker, t.Name)),
+			Name:      utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(t),
 			},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -116,6 +116,12 @@ func ToDNS1123Subdomain(name string) string {
 // The name's length will be short enough to be valid for K8s Services.
 func GenerateFixedName(owner metav1.Object, prefix string) string {
 	uid := string(owner.GetUID())
+	// Make sure the UID is separated from the prefix by a leading dash.
+	if !strings.HasPrefix(uid, "-") {
+		uid = "-" + uid
+	}
+	// Trim any trailing dash from the prefix as the UID is now prepended with the dash.
+	prefix = strings.TrimSuffix(prefix, "-")
 	pl := validation.DNS1123LabelMaxLength - len(uid)
 	if pl > len(prefix) {
 		pl = len(prefix)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -75,13 +75,23 @@ func TestGenerateFixedName(t *testing.T) {
 	}{
 		"standard": {
 			uid:      "2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
-			prefix:   "default-text-extractor-",
+			prefix:   "default-text-extractor",
 			expected: "default-text-extractor-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
 		},
 		"too long": {
 			uid:      "2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
 			prefix:   "this-is-an-extremely-long-prefix-which-will-make-the-generated-name-too-long-",
-			expected: "this-is-an-extremely-long-p2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+			expected: "this-is-an-extremely-long--2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+		},
+		"uid starts with dash": {
+			uid:      "-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+			prefix:   "this-is-an-extremely-long-prefix-which-will-make-the-generated-name-too-long-",
+			expected: "this-is-an-extremely-long--2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+		},
+		"prefix ends with dash": {
+			uid:      "2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+			prefix:   "default-text-extractor-",
+			expected: "default-text-extractor-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
 		},
 	}
 	for n, tc := range testCases {


### PR DESCRIPTION
## Proposed Changes

- GenerateName ensures there is a dash between the prefix and the UID.
    - As noticed by @lionelvillard in https://github.com/knative/eventing/pull/1602#issuecomment-517491978

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
