### PR TITLE
ContainerSource uses fixed names, rather than GenerateName

### DIFF
--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -29,10 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 
+	status "github.com/knative/eventing/pkg/apis/duck"
 	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	listers "github.com/knative/eventing/pkg/client/listers/sources/v1alpha1"
 	"github.com/knative/eventing/pkg/duck"
@@ -148,44 +148,20 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ContainerSo
 		return err
 	}
 
-	deploy, err := r.getDeployment(ctx, source)
+	ra, err := r.reconcileReceiveAdapter(ctx, source, args)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			deploy, err = r.createDeployment(ctx, source, args)
-			if err != nil {
-				r.markNotDeployedRecordEvent(source, corev1.EventTypeWarning, "DeploymentCreateFailed", "Could not create deployment: %v", err)
-				return err
-			}
-			r.markDeployingAndRecordEvent(source, corev1.EventTypeNormal, "DeploymentCreated", "Created deployment %q", deploy.Name)
-			// Since the Deployment has just been created, there's nothing more
-			// to do until it gets a status. This ContainerSource will be reconciled
-			// again when the Deployment is updated.
-			return nil
-		}
-		// Something unexpected happened getting the deployment.
-		r.markDeployingAndRecordEvent(source, corev1.EventTypeWarning, "DeploymentGetFailed", "Error getting deployment: %v", err)
-		return err
+		return fmt.Errorf("reconciling receive adapter: %v", err)
 	}
-
-	// Update Deployment spec if it's changed
-	expected := resources.MakeDeployment(args)
-	// Since the Deployment spec has fields defaulted by the webhook, it won't
-	// be equal to expected. Use DeepDerivative to compare only the fields that
-	// are set in expected.
-	if !equality.Semantic.DeepDerivative(expected.Spec, deploy.Spec) {
-		deploy.Spec = expected.Spec
-		if _, err = r.KubeClientSet.AppsV1().Deployments(deploy.Namespace).Update(deploy); err != nil {
-			r.markDeployingAndRecordEvent(source, corev1.EventTypeWarning, "DeploymentUpdateFailed", "Failed to update deployment %q: %v", deploy.Name, err)
-			return fmt.Errorf("updating deployment: %v", err)
+	// TODO Delete this after 0.8 is cut.
+	if status.DeploymentIsAvailable(&ra.Status, false) {
+		err = r.deleteOldReceiveAdapter(ctx, source, ra.Name)
+		if err != nil {
+			return fmt.Errorf("deleting old receive adapter: %v", err)
 		}
-		r.markDeployingAndRecordEvent(source, corev1.EventTypeNormal, "DeploymentUpdated", "Updated deployment %q", deploy.Name)
-		return nil
 	}
-
-	// Update source status
-	if deploy.Status.ReadyReplicas > 0 && !source.Status.IsDeployed() {
+	if status.DeploymentIsAvailable(&ra.Status, false) {
 		source.Status.MarkDeployed()
-		r.Recorder.Eventf(source, corev1.EventTypeNormal, "DeploymentReady", "Deployment %q has %d ready replicas", deploy.Name, deploy.Status.ReadyReplicas)
+		r.Recorder.Eventf(source, corev1.EventTypeNormal, "DeploymentReady", "Deployment %q has %d ready replicas", ra.Name, ra.Status.ReadyReplicas)
 	}
 
 	return nil
@@ -244,23 +220,75 @@ func sinkArg(source *v1alpha1.ContainerSource) (string, bool) {
 	return "", false
 }
 
-func (r *Reconciler) getDeployment(ctx context.Context, source *v1alpha1.ContainerSource) (*appsv1.Deployment, error) {
-	dl, err := r.KubeClientSet.AppsV1().Deployments(source.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		r.Logger.Errorf("Unable to list deployments: %v", zap.Error(err))
-		return nil, err
-	}
-	for _, c := range dl.Items {
-		if metav1.IsControlledBy(&c, source) {
-			return &c, nil
+func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, src *v1alpha1.ContainerSource, args resources.ContainerArguments) (*appsv1.Deployment, error) {
+	expected := resources.MakeDeployment(args)
+
+	ra, err := r.KubeClientSet.AppsV1().Deployments(src.Namespace).Get(expected.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		ra, err = r.KubeClientSet.AppsV1().Deployments(src.Namespace).Create(expected)
+		if err != nil {
+			r.markNotDeployedRecordEvent(src, corev1.EventTypeWarning, "DeploymentCreateFailed", "Could not create deployment: %v", err)
+			return nil, fmt.Errorf("creating new deployment: %v", err)
 		}
+		r.markDeployingAndRecordEvent(src, corev1.EventTypeNormal, "DeploymentCreated", "Created deployment %q", ra.Name)
+		return ra, nil
+	} else if err != nil {
+		r.markDeployingAndRecordEvent(src, corev1.EventTypeWarning, "DeploymentGetFailed", "Error getting deployment: %v", err)
+
+		return nil, fmt.Errorf("getting deployment: %v", err)
+	} else if !metav1.IsControlledBy(ra, src) {
+		r.markDeployingAndRecordEvent(src, corev1.EventTypeWarning, "DeploymentNotOwned", "Deployment %q is not owned by this ContainerSource", ra.Name)
+		return nil, fmt.Errorf("deploymtn %q is not owned by ContainerSource %q", ra.Name, src.Name)
+	} else if r.podSpecChanged(ra.Spec.Template.Spec, expected.Spec.Template.Spec) {
+		ra.Spec.Template.Spec = expected.Spec.Template.Spec
+		ra, err = r.KubeClientSet.AppsV1().Deployments(src.Namespace).Update(ra)
+		if err != nil {
+			return ra, fmt.Errorf("updating deployment: %v", err)
+		}
+		return ra, nil
+	} else {
+		logging.FromContext(ctx).Debug("Reusing existing receive adapter", zap.Any("receiveAdapter", ra))
 	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+	return ra, nil
 }
 
-func (r *Reconciler) createDeployment(ctx context.Context, source *v1alpha1.ContainerSource, args resources.ContainerArguments) (*appsv1.Deployment, error) {
-	deployment := resources.MakeDeployment(args)
-	return r.KubeClientSet.AppsV1().Deployments(source.Namespace).Create(deployment)
+func (r *Reconciler) podSpecChanged(oldPodSpec corev1.PodSpec, newPodSpec corev1.PodSpec) bool {
+	// Since the Deployment spec has fields defaulted by the webhook, it won't
+	// be equal to expected. Use DeepDerivative to compare only the fields that
+	// are set in expected.
+	if !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) {
+		return true
+	}
+	if len(oldPodSpec.Containers) != len(newPodSpec.Containers) {
+		return true
+	}
+	for i := range newPodSpec.Containers {
+		if !equality.Semantic.DeepEqual(newPodSpec.Containers[i].Env, oldPodSpec.Containers[i].Env) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) deleteOldReceiveAdapter(ctx context.Context, src *v1alpha1.ContainerSource, currentName string) error {
+	// Sadly there were no labels attached to the Deployment itself.
+	dl, err := r.KubeClientSet.AppsV1().Deployments(src.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing old receive adapter: %v", err)
+	}
+	for _, ora := range dl.Items {
+		// Note that this will match the new receive adapter as well.
+		if metav1.IsControlledBy(&ora, src) {
+			// Ignore the current receive adapter.
+			if ora.Name != currentName {
+				err = r.KubeClientSet.AppsV1().Deployments(src.Namespace).Delete(ora.Name, &metav1.DeleteOptions{})
+				if err != nil {
+					return fmt.Errorf("deleting old receive adapter %q: %v", ora.Name, err)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (r *Reconciler) markDeployingAndRecordEvent(source *v1alpha1.ContainerSource, evType string, reason string, messageFmt string, args ...interface{}) {

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -65,6 +65,11 @@ var (
 	sinkDNS = "sink.mynamespace.svc." + utils.GetClusterDomainName()
 	sinkURI = "http://" + sinkDNS
 
+	deploymentName = fmt.Sprintf("containersource-%s-%s", sourceName, sourceUID)
+
+	// We cannot take the address of constants, so copy it into a var.
+	conditionTrue = corev1.ConditionTrue
+
 	// TODO: k8s service does not work, fix.
 	//serviceRef = corev1.ObjectReference{
 	//	Name:       sinkName,
@@ -221,7 +226,7 @@ func TestAllCases(t *testing.T) {
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment ""`), // TODO on noes
+				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment "%s"`, deploymentName), // TODO on noes
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -244,7 +249,7 @@ func TestAllCases(t *testing.T) {
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
-					WithContainerSourceDeploying(`Created deployment ""`),
+					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -253,7 +258,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 0, nil, nil),
+				), nil, nil, nil),
 			},
 		}, {
 			Name: "valid first pass without template",
@@ -271,7 +276,7 @@ func TestAllCases(t *testing.T) {
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment ""`), // TODO on noes
+				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment "%s"`, deploymentName), // TODO on noes
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -284,7 +289,7 @@ func TestAllCases(t *testing.T) {
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
-					WithContainerSourceDeploying(`Created deployment ""`),
+					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -293,7 +298,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 0, nil, nil),
+				), nil, nil, nil),
 			},
 		}, {
 			Name: "valid, with ready deployment with template",
@@ -326,11 +331,11 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 1, nil, nil),
+				), &conditionTrue, nil, nil),
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentReady", `Deployment "" has 1 ready replicas`),
+				Eventf(corev1.EventTypeNormal, "DeploymentReady", `Deployment "%s" has 1 ready replicas`, deploymentName),
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReadinessChanged", `ContainerSource "test-container-source" became ready`),
 			},
@@ -378,11 +383,11 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 1, nil, nil),
+				), &conditionTrue, nil, nil),
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentReady", `Deployment "" has 1 ready replicas`),
+				Eventf(corev1.EventTypeNormal, "DeploymentReady", `Deployment "%s" has 1 ready replicas`, deploymentName),
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReadinessChanged", `ContainerSource "test-container-source" became ready`),
 			},
@@ -427,7 +432,7 @@ func TestAllCases(t *testing.T) {
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment ""`), // TODO on noes
+				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment "%s"`, deploymentName), // TODO on noes
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -452,7 +457,7 @@ func TestAllCases(t *testing.T) {
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
-					WithContainerSourceDeploying(`Created deployment ""`),
+					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -461,7 +466,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 0, map[string]string{"label": "labeled"}, map[string]string{"annotation": "annotated"}),
+				), nil, map[string]string{"label": "labeled"}, map[string]string{"annotation": "annotated"}),
 			},
 		}, {
 			Name: "valid first pass, with annotations and labels without template",
@@ -481,7 +486,7 @@ func TestAllCases(t *testing.T) {
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment ""`), // TODO on noes
+				Eventf(corev1.EventTypeNormal, "DeploymentCreated", `Created deployment "%s"`, deploymentName), // TODO on noes
 				Eventf(corev1.EventTypeNormal, "ContainerSourceReconciled", `ContainerSource reconciled: "testnamespace/test-container-source"`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -496,7 +501,7 @@ func TestAllCases(t *testing.T) {
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
-					WithContainerSourceDeploying(`Created deployment ""`),
+					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -505,7 +510,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 0, map[string]string{"label": "labeled"}, map[string]string{"annotation": "annotated"}),
+				), nil, map[string]string{"label": "labeled"}, map[string]string{"annotation": "annotated"}),
 			},
 		}, {
 			Name: "error for create deployment",
@@ -548,7 +553,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 					}),
 					WithContainerSourceUID(sourceUID),
-				), 0, nil, nil),
+				), nil, nil, nil),
 			},
 		},
 		//{ // TODO: k8s service does not work, fix.
@@ -605,15 +610,28 @@ func TestAllCases(t *testing.T) {
 	))
 }
 
-func makeDeployment(source *sourcesv1alpha1.ContainerSource, replicas int32, labels map[string]string, annotations map[string]string) *appsv1.Deployment {
+func makeDeployment(source *sourcesv1alpha1.ContainerSource, available *corev1.ConditionStatus, labels map[string]string, annotations map[string]string) *appsv1.Deployment {
 	args := append(source.Spec.DeprecatedArgs, fmt.Sprintf("--sink=%s", sinkURI))
 	env := append(source.Spec.DeprecatedEnv, corev1.EnvVar{Name: "SINK", Value: sinkURI})
 
 	labs := map[string]string{
-		"eventing.knative.dev/source": source.Name,
+		"sources.eventing.knative.dev/containerSource": source.Name,
 	}
 	for k, v := range labels {
 		labs[k] = v
+	}
+
+	status := appsv1.DeploymentStatus{}
+	if available != nil {
+		status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentAvailable,
+				Status: *available,
+			},
+		}
+		if *available == corev1.ConditionTrue {
+			status.ReadyReplicas = 1
+		}
 	}
 
 	return &appsv1.Deployment{
@@ -622,14 +640,17 @@ func makeDeployment(source *sourcesv1alpha1.ContainerSource, replicas int32, lab
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    fmt.Sprintf("%s-", source.Name),
+			Name:            deploymentName,
 			Namespace:       source.Namespace,
 			OwnerReferences: getOwnerReferences(),
+			Labels: map[string]string{
+				"sources.eventing.knative.dev/containerSource": source.Name,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"eventing.knative.dev/source": source.Name,
+					"sources.eventing.knative.dev/containerSource": source.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -649,9 +670,7 @@ func makeDeployment(source *sourcesv1alpha1.ContainerSource, replicas int32, lab
 				},
 			},
 		},
-		Status: appsv1.DeploymentStatus{
-			ReadyReplicas: replicas,
-		},
+		Status: status,
 	}
 }
 

--- a/pkg/reconciler/containersource/resources/deployment.go
+++ b/pkg/reconciler/containersource/resources/deployment.go
@@ -17,16 +17,19 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"strings"
 
-	"knative.dev/pkg/kmeta"
-
+	"github.com/knative/eventing/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
 )
 
-const sourceLabelKey = "eventing.knative.dev/source"
+const (
+	sourceLabelKey = "sources.eventing.knative.dev/containerSource"
+)
 
 func MakeDeployment(args ContainerArguments) *appsv1.Deployment {
 	template := args.Template
@@ -75,10 +78,13 @@ func MakeDeployment(args ContainerArguments) *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: args.Name + "-",
-			Namespace:    args.Namespace,
+			Name:      utils.GenerateFixedName(args.Source, fmt.Sprintf("containersource-%s", args.Source.Name)),
+			Namespace: args.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(args.Source),
+			},
+			Labels: map[string]string{
+				sourceLabelKey: args.Name,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/reconciler/containersource/resources/deployment_test.go
+++ b/pkg/reconciler/containersource/resources/deployment_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/knative/eventing/pkg/apis/sources/v1alpha1"
@@ -25,6 +26,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	name = "test-name"
+	uid  = "uid"
 )
 
 func TestMakeDeployment_template(t *testing.T) {
@@ -38,9 +44,9 @@ func TestMakeDeployment_template(t *testing.T) {
 			name: "sink override and annotation label not allowed",
 			args: ContainerArguments{
 				Source: &v1alpha1.ContainerSource{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 				},
-				Name:      "test-name",
+				Name:      name,
 				Namespace: "test-namespace",
 				Template: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -71,8 +77,8 @@ func TestMakeDeployment_template(t *testing.T) {
 				},
 				Sink: "test-sink",
 				Labels: map[string]string{
-					"eventing.knative.dev/source": "not-allowed",
-					"anotherlabel":                "extra-label",
+					"sources.eventing.knative.dev/containerSource": "not-allowed",
+					"anotherlabel":                                 "extra-label",
 				},
 				Annotations: map[string]string{
 					"sidecar.istio.io/inject": "false",
@@ -85,21 +91,24 @@ func TestMakeDeployment_template(t *testing.T) {
 					Kind:       "Deployment",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-name-",
-					Namespace:    "test-namespace",
+					Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+					Namespace: "test-namespace",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 						Kind:               "ContainerSource",
-						Name:               "test-name",
-						UID:                "TEST_UID",
+						Name:               name,
+						UID:                uid,
 						Controller:         &yes,
 						BlockOwnerDeletion: &yes,
 					}},
+					Labels: map[string]string{
+						"sources.eventing.knative.dev/containerSource": name,
+					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"eventing.knative.dev/source": "test-name",
+							"sources.eventing.knative.dev/containerSource": name,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
@@ -109,8 +118,8 @@ func TestMakeDeployment_template(t *testing.T) {
 								"anotherannotation":       "extra-annotation",
 							},
 							Labels: map[string]string{
-								"eventing.knative.dev/source": "test-name",
-								"anotherlabel":                "extra-label",
+								"sources.eventing.knative.dev/containerSource": name,
+								"anotherlabel":                                 "extra-label",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -152,9 +161,9 @@ func TestMakeDeployment_template(t *testing.T) {
 			name: "sink",
 			args: ContainerArguments{
 				Source: &v1alpha1.ContainerSource{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 				},
-				Name:      "test-name",
+				Name:      name,
 				Namespace: "test-namespace",
 				Template: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -207,27 +216,30 @@ func TestMakeDeployment_template(t *testing.T) {
 					Kind:       "Deployment",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-name-",
-					Namespace:    "test-namespace",
+					Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+					Namespace: "test-namespace",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 						Kind:               "ContainerSource",
-						Name:               "test-name",
-						UID:                "TEST_UID",
+						Name:               name,
+						UID:                uid,
 						Controller:         &yes,
 						BlockOwnerDeletion: &yes,
 					}},
+					Labels: map[string]string{
+						"sources.eventing.knative.dev/containerSource": name,
+					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"eventing.knative.dev/source": "test-name",
+							"sources.eventing.knative.dev/containerSource": name,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"eventing.knative.dev/source": "test-name",
+								"sources.eventing.knative.dev/containerSource": name,
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -296,9 +308,9 @@ func TestMakeDeployment_template(t *testing.T) {
 			name: "sink in args",
 			args: ContainerArguments{
 				Source: &v1alpha1.ContainerSource{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 				},
-				Name:      "test-name",
+				Name:      name,
 				Namespace: "test-namespace",
 				Template: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -343,7 +355,7 @@ func TestMakeDeployment_template(t *testing.T) {
 						},
 					},
 				},
-				Labels: map[string]string{"eventing.knative.dev/source": "test-name"},
+				Labels: map[string]string{"sources.eventing.knative.dev/containerSource": name},
 			},
 			want: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
@@ -351,27 +363,30 @@ func TestMakeDeployment_template(t *testing.T) {
 					Kind:       "Deployment",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-name-",
-					Namespace:    "test-namespace",
+					Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+					Namespace: "test-namespace",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 						Kind:               "ContainerSource",
-						Name:               "test-name",
-						UID:                "TEST_UID",
+						Name:               name,
+						UID:                uid,
 						Controller:         &yes,
 						BlockOwnerDeletion: &yes,
 					}},
+					Labels: map[string]string{
+						"sources.eventing.knative.dev/containerSource": name,
+					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"eventing.knative.dev/source": "test-name",
+							"sources.eventing.knative.dev/containerSource": name,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"eventing.knative.dev/source": "test-name",
+								"sources.eventing.knative.dev/containerSource": name,
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -440,9 +455,9 @@ func TestMakeDeployment_template(t *testing.T) {
 			name: "template takes precedence",
 			args: ContainerArguments{
 				Source: &v1alpha1.ContainerSource{
-					ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+					ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 				},
-				Name:      "test-name",
+				Name:      name,
 				Namespace: "test-namespace",
 				Template: &corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -494,27 +509,30 @@ func TestMakeDeployment_template(t *testing.T) {
 					Kind:       "Deployment",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-name-",
-					Namespace:    "test-namespace",
+					Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+					Namespace: "test-namespace",
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 						Kind:               "ContainerSource",
-						Name:               "test-name",
-						UID:                "TEST_UID",
+						Name:               name,
+						UID:                uid,
 						Controller:         &yes,
 						BlockOwnerDeletion: &yes,
 					}},
+					Labels: map[string]string{
+						"sources.eventing.knative.dev/containerSource": name,
+					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"eventing.knative.dev/source": "test-name",
+							"sources.eventing.knative.dev/containerSource": name,
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"eventing.knative.dev/source": "test-name",
+								"sources.eventing.knative.dev/containerSource": name,
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -571,9 +589,9 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 	yes := true
 	got := MakeDeployment(ContainerArguments{
 		Source: &v1alpha1.ContainerSource{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 		},
-		Name:      "test-name",
+		Name:      name,
 		Namespace: "test-namespace",
 		Image:     "test-image",
 		Args:      []string{"--test1=args1", "--test2=args2"},
@@ -591,8 +609,8 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 		ServiceAccountName: "test-service-account",
 		Sink:               "test-sink",
 		Labels: map[string]string{
-			"eventing.knative.dev/source": "not-allowed",
-			"anotherlabel":                "extra-label",
+			"sources.eventing.knative.dev/containerSource": "not-allowed",
+			"anotherlabel":                                 "extra-label",
 		},
 		Annotations: map[string]string{
 			"sidecar.istio.io/inject": "false",
@@ -606,21 +624,24 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-name-",
-			Namespace:    "test-namespace",
+			Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+			Namespace: "test-namespace",
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 				Kind:               "ContainerSource",
-				Name:               "test-name",
-				UID:                "TEST_UID",
+				Name:               name,
+				UID:                uid,
 				Controller:         &yes,
 				BlockOwnerDeletion: &yes,
 			}},
+			Labels: map[string]string{
+				"sources.eventing.knative.dev/containerSource": name,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"eventing.knative.dev/source": "test-name",
+					"sources.eventing.knative.dev/containerSource": name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -630,8 +651,8 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 						"anotherannotation":       "extra-annotation",
 					},
 					Labels: map[string]string{
-						"eventing.knative.dev/source": "test-name",
-						"anotherlabel":                "extra-label",
+						"sources.eventing.knative.dev/containerSource": name,
+						"anotherlabel":                                 "extra-label",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -677,9 +698,9 @@ func TestMakeDeployment_sink(t *testing.T) {
 	yes := true
 	got := MakeDeployment(ContainerArguments{
 		Source: &v1alpha1.ContainerSource{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 		},
-		Name:      "test-name",
+		Name:      name,
 		Namespace: "test-namespace",
 		Image:     "test-image",
 		Args:      []string{"--test1=args1", "--test2=args2"},
@@ -703,27 +724,30 @@ func TestMakeDeployment_sink(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-name-",
-			Namespace:    "test-namespace",
+			Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+			Namespace: "test-namespace",
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 				Kind:               "ContainerSource",
-				Name:               "test-name",
-				UID:                "TEST_UID",
+				Name:               name,
+				UID:                uid,
 				Controller:         &yes,
 				BlockOwnerDeletion: &yes,
 			}},
+			Labels: map[string]string{
+				"sources.eventing.knative.dev/containerSource": name,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"eventing.knative.dev/source": "test-name",
+					"sources.eventing.knative.dev/containerSource": name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"eventing.knative.dev/source": "test-name",
+						"sources.eventing.knative.dev/containerSource": name,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -769,9 +793,9 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 	yes := true
 	got := MakeDeployment(ContainerArguments{
 		Source: &v1alpha1.ContainerSource{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-name", UID: "TEST_UID"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, UID: uid},
 		},
-		Name:      "test-name",
+		Name:      name,
 		Namespace: "test-namespace",
 		Image:     "test-image",
 		Args:      []string{"--test1=args1", "--test2=args2", "--sink=test-sink"},
@@ -787,7 +811,7 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 			},
 		}},
 		ServiceAccountName: "test-service-account",
-		Labels:             map[string]string{"eventing.knative.dev/source": "test-name"},
+		Labels:             map[string]string{"sources.eventing.knative.dev/containerSource": name},
 	})
 
 	want := &appsv1.Deployment{
@@ -796,27 +820,30 @@ func TestMakeDeployment_sinkinargs(t *testing.T) {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-name-",
-			Namespace:    "test-namespace",
+			Name:      fmt.Sprintf("containersource-%s-%s", name, uid),
+			Namespace: "test-namespace",
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "sources.eventing.knative.dev/v1alpha1",
 				Kind:               "ContainerSource",
-				Name:               "test-name",
-				UID:                "TEST_UID",
+				Name:               name,
+				UID:                uid,
 				Controller:         &yes,
 				BlockOwnerDeletion: &yes,
 			}},
+			Labels: map[string]string{
+				"sources.eventing.knative.dev/containerSource": name,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"eventing.knative.dev/source": "test-name",
+					"sources.eventing.knative.dev/containerSource": name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"eventing.knative.dev/source": "test-name",
+						"sources.eventing.knative.dev/containerSource": name,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Helps with #1250

## Proposed Changes

- ContainerSource uses fixed names for its receive adapter Deployment.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ContainerSource will delete its old receive adapter Deployment only if the ContainerSource
is Ready=True. If the ContainerSource never reaches Ready=True, then a subsequent 
release will ignore any old GenerateName based receive adapter Deployments. They
will be garbage collected when the ContainerSource itself is deleted. 
```
