### PR TITLE
Measure time from arrival at ingress to delivery

### DIFF
--- a/pkg/broker/ingress/ingress_handler.go
+++ b/pkg/broker/ingress/ingress_handler.go
@@ -56,6 +56,7 @@ func (h *Handler) Start(stopCh <-chan struct{}) error {
 }
 
 func (h *Handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *cloudevents.EventResponse) error {
+	event.SetExtension(broker.TimeInFlightMetadataName, time.Now())
 	tctx := cloudevents.HTTPTransportContextFrom(ctx)
 	if tctx.Method != http.MethodPost {
 		resp.Status = http.StatusMethodNotAllowed

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -47,6 +47,14 @@ var (
 		stats.UnitMilliseconds,
 	)
 
+	// MeasureDeliveryTime records the time spent between arrival at ingress
+	// and delivery to the trigger subscriber.
+	MeasureDeliveryTime = stats.Int64(
+		"knative.dev/eventing/trigger/measures/delivery_time",
+		"Time between an event arriving at ingress and delivery to the trigger subscriber",
+		stats.UnitMilliseconds,
+	)
+
 	// Tag keys must conform to the restrictions described in
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
@@ -89,6 +97,12 @@ func init() {
 			Measure:     MeasureTriggerFilterTime,
 			Aggregation: view.Distribution(Buckets125(0.1, 10)...), // 0.1, 0.2, 0.5, 1, 2, 5, 10
 			TagKeys:     []tag.Key{TagResult, TagFilterResult, TagBroker, TagTrigger},
+		},
+		&view.View{
+			Name:        "broker_to_function_delivery_time",
+			Measure:     MeasureDeliveryTime,
+			Aggregation: view.Distribution(Buckets125(1, 100)...), // 1, 2, 5, 10, 20, 50, 100
+			TagKeys:     []tag.Key{TagResult, TagBroker, TagTrigger},
 		},
 	)
 	if err != nil {

--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -37,6 +37,10 @@ import (
 
 const (
 	writeTimeout = 1 * time.Minute
+	// TimeInFlightMetadataName is used to access the metadata stored on a
+	// CloudEvent to measure the time difference between when an event is
+	// received and when it is dispatched to the trigger function.
+	TimeInFlightMetadataName = "kn00timeinflight"
 )
 
 // Receiver parses Cloud Events, determines if they pass a filter, and sends them to a subscriber.
@@ -189,9 +193,16 @@ func (r *Receiver) sendEvent(ctx context.Context, tctx cloudevents.HTTPTransport
 	// Record event count and filtering time
 	startTS := time.Now()
 	defer func() {
-		dispatchTimeMS := int64(time.Now().Sub(startTS) / time.Millisecond)
+		var deliveryTime time.Time
+		now := time.Now()
+		dispatchTimeMS := int64(now.Sub(startTS) / time.Millisecond)
 		stats.Record(ctx, MeasureTriggerDispatchTime.M(dispatchTimeMS))
 		stats.Record(ctx, MeasureTriggerEventsTotal.M(1))
+		if err := event.ExtensionAs(TimeInFlightMetadataName, &deliveryTime); err != nil {
+			return
+		}
+		timeInFlightMS := int64(now.Sub(deliveryTime) / time.Millisecond)
+		stats.Record(ctx, MeasureDeliveryTime.M(timeInFlightMS))
 	}()
 
 	subscriberURIString := t.Status.SubscriberURI


### PR DESCRIPTION
This measures the time from when an event is received by the broker
ingress until it is delivered to the trigger function.

Closes #1371

## Proposed Changes

- Measure time from when an event is received by broker ingress until it is delivered to the trigger function

**Release Note**

```release-note
Adds `broker_to_function_delivery_time` metric to measure the time from when an event is received by broker ingress until it is delivered to the trigger function.
```
