### PR TITLE
Add eventTypes to CronJobSource and ApiServerSource CRDs

### DIFF
--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -38,12 +38,69 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+        registry:
           type: object
+          description: "Internal information, users should not set this property"
+          properties:
+            eventTypes:
+              # TODO: set the schemas.
+              type: object
+              description: "Event types that ApiServerSource can produce"
+              properties:
+                addResource:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.resource.add"
+                    schema:
+                      type: string
+                      pattern: ""
+                deleteResource:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.resource.delete"
+                    schema:
+                      type: string
+                      pattern: ""
+                updateResource:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.resource.update"
+                    schema:
+                      type: string
+                      pattern: ""
+                addRef:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.ref.add"
+                    schema:
+                      type: string
+                      pattern: ""
+                deleteRef:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.ref.delete"
+                    schema:
+                      type: string
+                      pattern: ""
+                updateRef:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.apiserver.ref.update"
+                    schema:
+                      type: string
+                      pattern: ""
         spec:
           properties:
             serviceAccountName:

--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -43,7 +43,7 @@ spec:
           description: "Internal information, users should not set this property"
           properties:
             eventTypes:
-              # TODO: set the schemas.
+              # TODO: set the schemas' patterns.
               type: object
               description: "Event types that ApiServerSource can produce"
               properties:
@@ -55,7 +55,6 @@ spec:
                       pattern: "dev.knative.apiserver.resource.add"
                     schema:
                       type: string
-                      pattern: ""
                 deleteResource:
                   type: object
                   properties:
@@ -64,7 +63,6 @@ spec:
                       pattern: "dev.knative.apiserver.resource.delete"
                     schema:
                       type: string
-                      pattern: ""
                 updateResource:
                   type: object
                   properties:
@@ -73,7 +71,6 @@ spec:
                       pattern: "dev.knative.apiserver.resource.update"
                     schema:
                       type: string
-                      pattern: ""
                 addRef:
                   type: object
                   properties:
@@ -82,7 +79,6 @@ spec:
                       pattern: "dev.knative.apiserver.ref.add"
                     schema:
                       type: string
-                      pattern: ""
                 deleteRef:
                   type: object
                   properties:
@@ -91,7 +87,6 @@ spec:
                       pattern: "dev.knative.apiserver.ref.delete"
                     schema:
                       type: string
-                      pattern: ""
                 updateRef:
                   type: object
                   properties:
@@ -100,7 +95,6 @@ spec:
                       pattern: "dev.knative.apiserver.ref.update"
                     schema:
                       type: string
-                      pattern: ""
         spec:
           properties:
             serviceAccountName:

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -53,7 +53,6 @@ spec:
                       pattern: "dev.knative.cronjob.event"
                     schema:
                       type: string
-                      pattern: ""
         spec:
           properties:
             data:

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -37,12 +37,23 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
+        registry:
           type: object
+          description: "Internal information, users should not set this property"
+          properties:
+            eventTypes:
+              type: object
+              description: "Event types that CronJobSource can produce"
+              properties:
+                cron:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      pattern: "dev.knative.cronjob.event"
+                    schema:
+                      type: string
+                      pattern: ""
         spec:
           properties:
             data:


### PR DESCRIPTION
Helps with #1550

## Proposed Changes

- Adding a `registry` property in CronJobSource and ApiServerSource CRDs, with the `eventTypes` they can produce.
- Removing unnecessary apiVersion, kind and metadata.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
CronJobSource and ApiServerSource are discoverable. By describing their CRDs, you can identify what are the event types they can produce.
```
