### PR TITLE
Make e2e-tests.sh work on MAC

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -24,8 +24,6 @@ which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
 # Let sed work on mac.
 if [ "$(uname)" == "Darwin" ]; then
   sed=gsed
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  sed=sed
 fi
 
 # Eventing main config.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -21,6 +21,13 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 # If gcloud is not available make it a no-op, not an error.
 which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
 
+# Let sed work on mac.
+if [ "$(uname)" == "Darwin" ]; then
+  sed=gsed
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  sed=sed
+fi
+
 # Eventing main config.
 readonly EVENTING_CONFIG="config/"
 


### PR DESCRIPTION
## Proposed Changes
- The current `e2e-tests.sh` will fail on MAC because of the implementation difference for `sed` command on MAC and Linux. This PR will make it use `gsed` if the current operating system is MAC OS.

Reference:
https://github.com/GoogleCloudPlatform/cloud-run-events/blob/f7e9e75106d256f9a3c6f94f5b6e77a7a7a23c80/hack/update-codegen.sh#L21

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @Harwayne 
