### PR TITLE
Automatic release version labels

### DIFF
--- a/config/200-clusterrole-namespaced.yaml
+++ b/config/200-clusterrole-namespaced.yaml
@@ -17,6 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-namespaced-admin
   labels:
+    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -28,6 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-messaging-namespaced-admin
   labels:
+    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -40,6 +42,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-sources-namespaced-admin
   labels:
+    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups: ["sources.eventing.knative.dev"]

--- a/contrib/kafka/config/200-channelable-manipulator-clusterrole.yaml
+++ b/contrib/kafka/config/200-channelable-manipulator-clusterrole.yaml
@@ -17,6 +17,7 @@ kind: ClusterRole
 metadata:
   name: kafka-channelable-manipulator
   labels:
+    eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/contrib/kafka/config/200-controller-clusterrole.yaml
+++ b/contrib/kafka/config/200-controller-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-ch-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/contrib/kafka/config/200-dispatcher-clusterrole.yaml
+++ b/contrib/kafka/config/200-dispatcher-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-ch-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/contrib/kafka/config/200-dispatcher-service.yaml
+++ b/contrib/kafka/config/200-dispatcher-service.yaml
@@ -18,13 +18,14 @@ metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
   labels:
-      messaging.knative.dev/channel: kafka-channel
-      messaging.knative.dev/role: dispatcher
+    eventing.knative.dev/release: devel
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher
 spec:
   selector:
-      messaging.knative.dev/channel: kafka-channel
-      messaging.knative.dev/role: dispatcher
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher
   ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
+  - port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/contrib/kafka/config/200-serviceaccount.yaml
+++ b/contrib/kafka/config/200-serviceaccount.yaml
@@ -17,13 +17,16 @@ kind: ServiceAccount
 metadata:
   name: kafka-ch-controller
   namespace: knative-eventing
-
+  labels:
+    eventing.knative.dev/release: devel
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 apiVersion: v1
@@ -31,3 +34,5 @@ kind: ServiceAccount
 metadata:
   name: kafka-webhook
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel

--- a/contrib/kafka/config/200-webhook-clusterrole.yaml
+++ b/contrib/kafka/config/200-webhook-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-webhook
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/contrib/kafka/config/201-clusterrolebinding.yaml
+++ b/contrib/kafka/config/201-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-ch-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-ch-controller
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-ch-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-ch-dispatcher
@@ -46,6 +50,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook

--- a/contrib/kafka/config/300-kafka-channel.yaml
+++ b/contrib/kafka/config/300-kafka-channel.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
  name: kafkachannels.messaging.knative.dev
  labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
 spec:

--- a/contrib/kafka/config/400-webhook-service.yaml
+++ b/contrib/kafka/config/400-webhook-service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    eventing.knative.dev/release: devel
     role: kafka-webhook
   name: kafka-webhook
   namespace: knative-eventing

--- a/contrib/kafka/config/500-controller.yaml
+++ b/contrib/kafka/config/500-controller.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: kafka-ch-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/kafka/config/500-dispatcher.yaml
+++ b/contrib/kafka/config/500-dispatcher.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/kafka/config/500-webhook.yaml
+++ b/contrib/kafka/config/500-webhook.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: kafka-webhook
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/kafka/config/provisioner/kafka.yaml
+++ b/contrib/kafka/config/provisioner/kafka.yaml
@@ -16,6 +16,8 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
   name: kafka
+  labels:
+    eventing.knative.dev/release: devel
 spec: {}
 ---
 
@@ -24,12 +26,16 @@ kind: ServiceAccount
 metadata:
   name: kafka-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 ---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kafka-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -88,6 +94,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-channel-controller-manage
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-channel-controller
@@ -119,6 +127,8 @@ kind: Deployment
 metadata:
   name: kafka-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -151,6 +161,8 @@ kind: ServiceAccount
 metadata:
   name: kafka-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -158,6 +170,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "" # Core API group.
@@ -181,6 +195,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-channel-dispatcher
@@ -197,6 +213,8 @@ kind: Deployment
 metadata:
   name: kafka-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/natss/config/200-channelable-manipulator-clusterrole.yaml
+++ b/contrib/natss/config/200-channelable-manipulator-clusterrole.yaml
@@ -17,6 +17,7 @@ kind: ClusterRole
 metadata:
   name: natss-channelable-manipulator
   labels:
+    eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/contrib/natss/config/200-controller-clusterrole.yaml
+++ b/contrib/natss/config/200-controller-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: natss-ch-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/contrib/natss/config/200-dispatcher-clusterrole.yaml
+++ b/contrib/natss/config/200-dispatcher-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: natss-ch-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/contrib/natss/config/200-dispatcher-service.yaml
+++ b/contrib/natss/config/200-dispatcher-service.yaml
@@ -18,13 +18,14 @@ metadata:
   name: natss-ch-dispatcher
   namespace: knative-eventing
   labels:
-      messaging.knative.dev/channel: natss-channel
-      messaging.knative.dev/role: dispatcher
+    eventing.knative.dev/release: devel
+    messaging.knative.dev/channel: natss-channel
+    messaging.knative.dev/role: dispatcher
 spec:
   selector:
-      messaging.knative.dev/channel: natss-channel
-      messaging.knative.dev/role: dispatcher
+    messaging.knative.dev/channel: natss-channel
+    messaging.knative.dev/role: dispatcher
   ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
+  - port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/contrib/natss/config/200-serviceaccount.yaml
+++ b/contrib/natss/config/200-serviceaccount.yaml
@@ -17,6 +17,8 @@ kind: ServiceAccount
 metadata:
   name: natss-ch-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 apiVersion: v1
@@ -24,3 +26,5 @@ kind: ServiceAccount
 metadata:
   name: natss-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel

--- a/contrib/natss/config/201-clusterrolebinding.yaml
+++ b/contrib/natss/config/201-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: natss-ch-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-ch-controller
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: natss-ch-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-ch-dispatcher

--- a/contrib/natss/config/300-natss-channel.yaml
+++ b/contrib/natss/config/300-natss-channel.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
  name: natsschannels.messaging.knative.dev
  labels:
+    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
 spec:

--- a/contrib/natss/config/500-controller.yaml
+++ b/contrib/natss/config/500-controller.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: natss-ch-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/natss/config/500-dispatcher.yaml
+++ b/contrib/natss/config/500-dispatcher.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: natss-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/contrib/natss/config/provisioner/provisioner.yaml
+++ b/contrib/natss/config/provisioner/provisioner.yaml
@@ -16,6 +16,8 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
   name: natss
+  labels:
+    eventing.knative.dev/release: devel
 spec: {}
 
 ---
@@ -25,6 +27,8 @@ kind: ServiceAccount
 metadata:
   name: natss-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -32,6 +36,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: natss-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -62,6 +68,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: natss-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-controller
@@ -78,6 +86,8 @@ kind: Deployment
 metadata:
   name: natss-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -105,6 +115,8 @@ kind: ServiceAccount
 metadata:
   name: natss-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -112,6 +124,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: natss-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -135,6 +149,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: natss-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-dispatcher
@@ -151,6 +167,8 @@ kind: Role
 metadata:
   name: natss-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "" # Core API group.
@@ -168,6 +186,8 @@ kind: RoleBinding
 metadata:
   name: natss-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: natss-dispatcher
@@ -184,6 +204,8 @@ kind: Deployment
 metadata:
   name: natss-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -38,12 +38,21 @@ RELEASES=(
 readonly RELEASES
 
 function build_release() {
+  # Update release labels if this is a tagged release
+  if [[ -n "${TAG}" ]]; then
+    echo "Tagged release, updating release labels to eventing.knative.dev/release: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|eventing.knative.dev/release: devel|eventing.knative.dev/release: \"${TAG}\"|")
+  else
+    echo "Untagged release, will NOT update release labels"
+    LABEL_YAML_CMD=(cat)
+  fi
+
   # Build the components
   local all_yamls=()
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative Eventing - ${config}"
-    ko resolve ${KO_FLAGS} -f ${config}/ > ${yaml}
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release


### PR DESCRIPTION
## Proposed Changes

- Automatically update version labels in release artifacts when a tagged release is generated
- Add release labels to non-ConfigMap objects that don't have them, mainly Kafka and NATSS channels.

/cc @n3wscott 