### PR TITLE
Adding release label to GCPPubSub

### DIFF
--- a/contrib/gcppubsub/config/gcppubsub.yaml
+++ b/contrib/gcppubsub/config/gcppubsub.yaml
@@ -16,6 +16,8 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
   name: gcp-pubsub
+  labels:
+    eventing.knative.dev/release: devel
 spec: {}
 
 ---
@@ -25,6 +27,8 @@ kind: ServiceAccount
 metadata:
   name: gcp-pubsub-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -32,6 +36,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gcp-pubsub-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -76,6 +82,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gcp-pubsub-channel-controller
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: gcp-pubsub-channel-controller
@@ -92,6 +100,8 @@ kind: Deployment
 metadata:
   name: gcp-pubsub-channel-controller
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -127,6 +137,8 @@ kind: ServiceAccount
 metadata:
   name: gcp-pubsub-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 
 ---
 
@@ -134,6 +146,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: gcp-pubsub-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -168,6 +182,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: gcp-pubsub-channel-dispatcher
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: gcp-pubsub-channel-dispatcher
@@ -184,6 +200,8 @@ kind: Role
 metadata:
   name: gcp-pubsub-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "" # Core API group.
@@ -201,6 +219,8 @@ kind: RoleBinding
 metadata:
   name: gcp-pubsub-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: gcp-pubsub-channel-dispatcher
@@ -217,6 +237,8 @@ kind: Deployment
 metadata:
   name: gcp-pubsub-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -252,6 +274,8 @@ kind: Service
 metadata:
   name: gcp-pubsub-dispatcher
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
## Proposed Changes

- Adding release label to gcppubsub channel provisioner

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
