### PR TITLE
Add new broker-to-trigger delivery time metric to docs

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,7 @@ These are exported by `broker-filter` pods.
 | `trigger_events_total`  | count     | Number of events received. | `result`, `broker`, `trigger`                  |
 | `trigger_dispatch_time` | histogram | Time to dispatch an event. | `result`, `broker`, `trigger`                  |
 | `trigger_filter_time`   | histogram | Time to filter an event.   | `result`, `broker`, `trigger`, `filter_result` |
+| `broker_to_function_delivery_time` | histogram | Time from ingress of an event until it is dispatched | `result`, `broker`, `trigger` |
 
 ## Access metrics
 


### PR DESCRIPTION
Fixes #1635 

## Proposed Changes

- Documents the new metric that measures time between ingress at broker to delivery to trigger function

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
