### PR TITLE
golang format tools

### DIFF
--- a/pkg/broker/receiver.go
+++ b/pkg/broker/receiver.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/knative/eventing/pkg/logging"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/cloudevents/sdk-go"
+	"github.com/knative/eventing/pkg/logging"
+
+	cloudevents "github.com/cloudevents/sdk-go"
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	"github.com/knative/eventing/pkg/reconciler/trigger/path"

--- a/pkg/reconciler/containersource/resources/deployment_test.go
+++ b/pkg/reconciler/containersource/resources/deployment_test.go
@@ -78,7 +78,7 @@ func TestMakeDeployment_template(t *testing.T) {
 				Sink: "test-sink",
 				Labels: map[string]string{
 					"sources.eventing.knative.dev/containerSource": "not-allowed",
-					"anotherlabel":                                 "extra-label",
+					"anotherlabel": "extra-label",
 				},
 				Annotations: map[string]string{
 					"sidecar.istio.io/inject": "false",
@@ -119,7 +119,7 @@ func TestMakeDeployment_template(t *testing.T) {
 							},
 							Labels: map[string]string{
 								"sources.eventing.knative.dev/containerSource": name,
-								"anotherlabel":                                 "extra-label",
+								"anotherlabel": "extra-label",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -610,7 +610,7 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 		Sink:               "test-sink",
 		Labels: map[string]string{
 			"sources.eventing.knative.dev/containerSource": "not-allowed",
-			"anotherlabel":                                 "extra-label",
+			"anotherlabel": "extra-label",
 		},
 		Annotations: map[string]string{
 			"sidecar.istio.io/inject": "false",
@@ -652,7 +652,7 @@ func TestMakeDeployment_sinkoverrideannotationlabelnotallowed(t *testing.T) {
 					},
 					Labels: map[string]string{
 						"sources.eventing.knative.dev/containerSource": name,
-						"anotherlabel":                                 "extra-label",
+						"anotherlabel": "extra-label",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
