### PR TITLE
Fix knative path to match the image paths

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,8 +36,8 @@ To check out this repository:
 1. Clone it to your machine:
 
 ```shell
-mkdir -p ${GOPATH}/src/github.com/knative
-cd ${GOPATH}/src/github.com/knative
+mkdir -p ${GOPATH}/src/knative.dev
+cd ${GOPATH}/src/knative.dev
 git clone git@github.com:${YOUR_GITHUB_USERNAME}/eventing.git
 cd eventing
 git remote add upstream git@github.com:knative/eventing.git


### PR DESCRIPTION
Fixes #

Currently the ko apply -f config/ will result in Pods failing to pull images due to image path missmatch.

## Proposed Changes

-
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
