### PR TITLE
Adding missing attributes field in Trigger CRD yaml

### DIFF
--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -74,6 +74,8 @@ spec:
                 attributes:
                   type: object
                   description: "Map of CloudEvents attributes used for filtering events."
+                  additionalProperties:
+                    type: string
             subscriber:
               type: object
               properties:

--- a/config/300-trigger.yaml
+++ b/config/300-trigger.yaml
@@ -71,6 +71,9 @@ spec:
                       type: string
                     source:
                       type: string
+                attributes:
+                  type: object
+                  description: "Map of CloudEvents attributes used for filtering events."
             subscriber:
               type: object
               properties:


### PR DESCRIPTION
## Proposed Changes
 
- Adding attributes field inside filter in Trigger CRD yaml file.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
