### PR TITLE
Update test-infra to the latest version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1249,7 +1249,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:361c09209a9c7ab7723b981629bb73ab7c0eefbcdf4fc3fe96e91bfe0f51469f"
+  digest = "1:69d8653b65ad2c3e95903310135a5a1fc7dde820385f9822b6caee1c9a91ef87"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
@@ -1261,7 +1261,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "0dc2b0fa7ad5fd5a2753ec6171387da78c17155c"
+  revision = "5d61900bc90e7633c537a92d03b4b3f11e33f1eb"
 
 [[projects]]
   digest = "1:db96fceb1477924a5e724ebfd355842c73805eb8e44bf7f325898c3116a1d852"

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -288,10 +288,14 @@ function create_test_cluster_with_retries() {
       [[ "$(get_test_return_code)" == "0" ]] && return 0
       # Retry if cluster creation failed because of:
       # - stockout (https://github.com/knative/test-infra/issues/592)
-      # - latest GKE not available in this region/zone yet (https://github.com/knative/test-infra/issues/694)
+      # - latest GKE not available in this region/zone yet
+      #   (https://github.com/knative/test-infra/issues/694)
+      # - cluster created but some nodes are unhealthy
+      #   (https://github.com/knative/test-infra/issues/1291)
       [[ -z "$(grep -Fo 'does not have enough resources available to fulfill' ${cluster_creation_log})" \
           && -z "$(grep -Fo 'ResponseError: code=400, message=No valid versions with the prefix' ${cluster_creation_log})" \
           && -z "$(grep -Po 'ResponseError: code=400, message=Master version "[0-9a-z\-\.]+" is unsupported' ${cluster_creation_log})" ]] \
+          && -z "$(grep -Po '[0-9]+ nodes out of [0-9]+ are unhealthy' ${cluster_creation_log})" ]] \
           && return 1
     done
   done


### PR DESCRIPTION
      catch another cluster creation failure in e2e tests
