### PR TITLE
Removing code that's not used at all

### DIFF
--- a/pkg/logconfig/config.go
+++ b/pkg/logconfig/config.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// ConfigMapNameEnv is the environment value to get the name of the config map used for knative-eventing logging config.
-	ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-
 	// Named Loggers are used to override the default log level. config-logging.yaml will use the follow:
 	//
 	// loglevel.controller: "info"
@@ -33,28 +30,9 @@ const (
 	// Controller is the name of the override key used inside of the logging config for Controller.
 	Controller = "controller"
 
-	// SourcesController is the name of the override key used inside of the logging config for Sources Controller.
-	SourcesController = "sources-controller"
-
 	// Webhook is the name of the override key used inside of the logging config for Webhook Controller.
 	WebhookNameEnv = "WEBHOOK_NAME"
 )
-
-func ConfigMapName() string {
-	if cm := os.Getenv(ConfigMapNameEnv); cm != "" {
-		return cm
-	}
-
-	panic(fmt.Sprintf(`The environment variable %q is not set
-
-If this is a process running on Kubernetes, then it should be using the downward
-API to initialize this variable via:
-
-  env:
-  - name: CONFIG_LOGGING_NAME
-    value: config-logging
-`, ConfigMapNameEnv))
-}
 
 func WebhookName() string {
 	if webhook := os.Getenv(WebhookNameEnv); webhook != "" {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -24,8 +24,6 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-const ConfigMapNameEnv = "CONFIG_LOGGING_NAME"
-
 func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
 	return logging.WithLogger(ctx, logger.Sugar())
 }

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -21,28 +21,13 @@ import (
 	"strings"
 	"text/template"
 
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/metrics"
 )
 
 const (
 	ObservabilityConfigName = "config-observability"
-	metricsDomain           = "knative.dev/eventing"
 	defaultLogURLTemplate   = "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
 )
-
-// UpdateExporterFromConfigMap returns a helper func that can be used to update the exporter
-// when a config map is updated
-func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) func(configMap *corev1.ConfigMap) {
-	return func(configMap *corev1.ConfigMap) {
-		metrics.UpdateExporter(metrics.ExporterOptions{
-			Domain:    metricsDomain,
-			Component: component,
-			ConfigMap: configMap.Data,
-		}, logger)
-	}
-}
 
 // ObservabilityConfig contains the configuration defined in the observability ConfigMap.
 type ObservabilityConfig struct {

--- a/pkg/provisioners/message_receiver.go
+++ b/pkg/provisioners/message_receiver.go
@@ -49,15 +49,6 @@ type ReceiverOptions func(*MessageReceiver) error
 // before calling receiverFunc.
 type ResolveChannelFromHostFunc func(string) (ChannelReference, error)
 
-// ResolveChannelFromHostHeader is a ReceiverOption for NewMessageReceiver which enables the caller to overwrite the
-// default behaviour defined by ParseChannel function.
-func ResolveChannelFromHostHeader(hostToChannelFunc ResolveChannelFromHostFunc) ReceiverOptions {
-	return func(r *MessageReceiver) error {
-		r.hostToChannelFunc = hostToChannelFunc
-		return nil
-	}
-}
-
 // NewMessageReceiver creates a message receiver passing new messages to the
 // receiverFunc.
 func NewMessageReceiver(receiverFunc func(ChannelReference, *Message) error, logger *zap.SugaredLogger, opts ...ReceiverOptions) (*MessageReceiver, error) {


### PR DESCRIPTION
While looking for more dead code, especially regarding our old CCP library (here and in `eventing-contrib`), I found more (generally) unused code bits

## Proposed Changes

- removing code, not used (some of these are not used b/c counter parts in `knative/pkg` repo)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
