### PR TITLE
Add a dev Mako config for broker latency test

### DIFF
--- a/test/performance/broker-latency/dev.config
+++ b/test/performance/broker-latency/dev.config
@@ -1,0 +1,39 @@
+### Creating this benchmark:
+# mako create_benchmark test/performance/broker-latency/dev.config
+### Updating this benchmark:
+# mako update_benchmark test/performance/broker-latency/dev.config
+
+project_name: "Knative"
+benchmark_name: "Development - Eventing Broker Latency"
+description: "Measure broker latency and reliability."
+benchmark_key: '5903682180743168'
+
+# Human owners for manual benchmark adjustments.
+owner_list: "grantrodgers@google.com"
+owner_list: "chizhg@google.com"
+
+# Anyone can add their IAM robot here to publish to this benchmark.
+owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
+# This is grantrodgers' robot:
+owner_list: "mako-upload@grantrodgers-crd.iam.gserviceaccount.com"
+
+# Define the name and type for x-axis of run charts
+input_value_info: {
+  value_key: "t"
+  label: "time"
+  type: TIMESTAMP
+}
+
+# Note: value_key is stored repeatedly and should be very short (ideally one or two characters).
+metric_info_list: {
+  value_key: "pl"
+  label: "publish-latency"
+}
+metric_info_list: {
+  value_key: "pe"
+  label: "publish-errors"
+}
+metric_info_list: {
+  value_key: "dl"
+  label: "deliver-latency"
+}


### PR DESCRIPTION
This is a benchmark config for the Broker latency test. You can see more configs at https://github.com/knative/serving/tree/master/test/performance.

This benchmark has been created in Mako [here](https://mako.dev/benchmark?benchmark_key=5903682180743168). Unfortunately Mako benchmark create, update, and data point create are limited to Googlers currently (https://github.com/google/mako/issues/2). We're trying to find solutions and workarounds to this with the Mako team.

Fixes #1696.

## Proposed Changes

- Add a dev Mako config for the broker latency test.
