### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,12 +1,13 @@
 ---
 name: Bug
 about: Create a bug report to help us improve
-title: '[BUG]'
+title: ''
 labels: kind/bug
+assignees: ''
 
 ---
 
- **Describe the bug**
+**Describe the bug**
 A clear and concise description of what the bug is.
 
  **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,8 +1,9 @@
 ---
 name: Feature Request
-about: Suggest an idea for this project	about
+about: "Suggest an idea for this project\tabout"
 title: ''
 labels: kind/feature-request
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Label kind/bug already set, so having bug prefix in title is redundant. Removed bug prefix from title.