### PR TITLE
Broker preserves TraceIDs from incoming requests

### DIFF
--- a/pkg/broker/ingress/ingress_handler.go
+++ b/pkg/broker/ingress/ingress_handler.go
@@ -3,14 +3,9 @@ package ingress
 import (
 	"context"
 	"errors"
-	"fmt"
-	"go.opencensus.io/plugin/ochttp/propagation/b3"
-	"go.opencensus.io/trace"
 	"net/http"
 	"net/url"
 	"reflect"
-	"strconv"
-	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -74,18 +69,6 @@ func (h *Handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *
 		resp.Status = http.StatusNotFound
 		return nil
 	}
-
-	// Inject trace into HTTP header.
-	spanContext := trace.FromContext(ctx).SpanContext()
-	tctx.Header.Set(b3.TraceIDHeader, spanContext.TraceID.String())
-	tctx.Header.Set(b3.SpanIDHeader, spanContext.SpanID.String())
-	tctx.Header.Set(b3.SampledHeader, strconv.Itoa(int(spanContext.TraceOptions&1)))
-
-	// Set CloudEvent standard extension attribute for distributed tracing, traceparent,
-	// which contains a version ("00" is the current version), trace ID, span ID, and
-	// trace options(only support flag sampled in current version).
-	traceParent := strings.Join([]string{"00",  spanContext.TraceID.String(), spanContext.SpanID.String(), fmt.Sprintf("%02x", spanContext.TraceOptions)},"-")
-	event.SetExtension(broker.TraceParent, traceParent)
 
 	reporterArgs := &ReportArgs{
 		ns:        h.Namespace,

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -22,6 +22,8 @@ const (
 	validHTTPMethod = nethttp.MethodPost
 )
 
+var validHTTPHeader = nethttp.Header{}
+
 type mockReporter struct{}
 
 func (r *mockReporter) ReportEventCount(args *ReportArgs, err error) error {
@@ -78,7 +80,7 @@ func TestIngressHandler_ServeHTTP_FAIL(t *testing.T) {
 			}
 			event := cloudevents.NewEvent()
 			resp := new(cloudevents.EventResponse)
-			tctx := http.TransportContext{Method: tc.httpmethod, URI: tc.URI}
+			tctx := http.TransportContext{Header: validHTTPHeader, Method: tc.httpmethod, URI: tc.URI}
 			ctx := http.WithTransportContext(context.Background(), tctx)
 			_ = handler.serveHTTP(ctx, event, resp)
 			if resp.Status != tc.expectedStatus {
@@ -104,7 +106,7 @@ func TestIngressHandler_ServeHTTP_Succeed(t *testing.T) {
 	}
 	event := cloudevents.NewEvent()
 	resp := new(cloudevents.EventResponse)
-	tctx := http.TransportContext{Method: validHTTPMethod, URI: validURI}
+	tctx := http.TransportContext{Header: validHTTPHeader, Method: validHTTPMethod, URI: validURI}
 	ctx := http.WithTransportContext(context.Background(), tctx)
 	_ = handler.serveHTTP(ctx, event, resp)
 	if !client.sent {

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -22,8 +22,6 @@ const (
 	validHTTPMethod = nethttp.MethodPost
 )
 
-var validHTTPHeader = nethttp.Header{}
-
 type mockReporter struct{}
 
 func (r *mockReporter) ReportEventCount(args *ReportArgs, err error) error {
@@ -80,7 +78,7 @@ func TestIngressHandler_ServeHTTP_FAIL(t *testing.T) {
 			}
 			event := cloudevents.NewEvent()
 			resp := new(cloudevents.EventResponse)
-			tctx := http.TransportContext{Header: validHTTPHeader, Method: tc.httpmethod, URI: tc.URI}
+			tctx := http.TransportContext{Method: tc.httpmethod, URI: tc.URI}
 			ctx := http.WithTransportContext(context.Background(), tctx)
 			_ = handler.serveHTTP(ctx, event, resp)
 			if resp.Status != tc.expectedStatus {
@@ -106,7 +104,7 @@ func TestIngressHandler_ServeHTTP_Succeed(t *testing.T) {
 	}
 	event := cloudevents.NewEvent()
 	resp := new(cloudevents.EventResponse)
-	tctx := http.TransportContext{Header: validHTTPHeader, Method: validHTTPMethod, URI: validURI}
+	tctx := http.TransportContext{Method: validHTTPMethod, URI: validURI}
 	ctx := http.WithTransportContext(context.Background(), tctx)
 	_ = handler.serveHTTP(ctx, event, resp)
 	if !client.sent {

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -22,8 +22,6 @@ const (
 	validHTTPMethod = nethttp.MethodPost
 )
 
-var validHTTPHeader = nethttp.Header{}
-
 type mockReporter struct{}
 
 func (r *mockReporter) ReportEventCount(args *ReportArgs, err error) error {
@@ -80,7 +78,7 @@ func TestIngressHandler_ServeHTTP_FAIL(t *testing.T) {
 			}
 			event := cloudevents.NewEvent()
 			resp := new(cloudevents.EventResponse)
-			tctx := http.TransportContext{Header: validHTTPHeader, Method: tc.httpmethod, URI: tc.URI}
+			tctx := http.TransportContext{Header: nethttp.Header{}, Method: tc.httpmethod, URI: tc.URI}
 			ctx := http.WithTransportContext(context.Background(), tctx)
 			_ = handler.serveHTTP(ctx, event, resp)
 			if resp.Status != tc.expectedStatus {
@@ -106,7 +104,7 @@ func TestIngressHandler_ServeHTTP_Succeed(t *testing.T) {
 	}
 	event := cloudevents.NewEvent()
 	resp := new(cloudevents.EventResponse)
-	tctx := http.TransportContext{Header: validHTTPHeader, Method: validHTTPMethod, URI: validURI}
+	tctx := http.TransportContext{Header: nethttp.Header{}, Method: validHTTPMethod, URI: validURI}
 	ctx := http.WithTransportContext(context.Background(), tctx)
 	_ = handler.serveHTTP(ctx, event, resp)
 	if !client.sent {

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -23,6 +23,11 @@ const (
 	// Should be set using time.Now(), which returns the current local time.
 	// The format is: 2019-08-26T23:38:17.834384404Z.
 	EventArrivalTime = "knativearrivaltime"
+
+	// TraceParent is a documented extension for CloudEvent to include traces.
+	// https://github.com/cloudevents/spec/blob/v0.3/extensions/distributed-tracing.md#traceparent
+	// The format is: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,
+	// which stands for version(00" is the current version)-traceID-spanID-trace options
 	TraceParent = "traceparent"
 )
 

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -27,7 +27,7 @@ const (
 	// TraceParent is a documented extension for CloudEvent to include traces.
 	// https://github.com/cloudevents/spec/blob/v0.3/extensions/distributed-tracing.md#traceparent
 	// The format is: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,
-	// which stands for version(00" is the current version)-traceID-spanID-trace options
+	// which stands for version("00" is the current version)-traceID-spanID-trace options
 	TraceParent = "traceparent"
 )
 

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -23,7 +23,6 @@ const (
 	// Should be set using time.Now(), which returns the current local time.
 	// The format is: 2019-08-26T23:38:17.834384404Z.
 	EventArrivalTime = "knativearrivaltime"
-	TraceParent = "traceparent"
 )
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -23,6 +23,7 @@ const (
 	// Should be set using time.Now(), which returns the current local time.
 	// The format is: 2019-08-26T23:38:17.834384404Z.
 	EventArrivalTime = "knativearrivaltime"
+	TraceParent = "traceparent"
 )
 
 // Buckets125 generates an array of buckets with approximate powers-of-two

--- a/vendor/knative.dev/pkg/tracing/opencensus.go
+++ b/vendor/knative.dev/pkg/tracing/opencensus.go
@@ -124,9 +124,9 @@ func WithExporter(name string, logger *zap.SugaredLogger) ConfigOption {
 			}
 			exporter = exp
 		case config.Zipkin:
-			zipEP, err := zipkin.NewEndpoint(name, ":80")
+			zipEP, err := zipkin.NewEndpoint(name, "")
 			if err != nil {
-				logger.Errorw("error building zipkin endpoint", err)
+				logger.Error("error building zipkin endpoint", err)
 				return
 			}
 			reporter := httpreporter.NewReporter(cfg.ZipkinEndpoint)

--- a/vendor/knative.dev/pkg/tracing/opencensus.go
+++ b/vendor/knative.dev/pkg/tracing/opencensus.go
@@ -124,9 +124,9 @@ func WithExporter(name string, logger *zap.SugaredLogger) ConfigOption {
 			}
 			exporter = exp
 		case config.Zipkin:
-			zipEP, err := zipkin.NewEndpoint(name, "")
+			zipEP, err := zipkin.NewEndpoint(name, ":80")
 			if err != nil {
-				logger.Error("error building zipkin endpoint", err)
+				logger.Errorw("error building zipkin endpoint", err)
 				return
 			}
 			reporter := httpreporter.NewReporter(cfg.ZipkinEndpoint)


### PR DESCRIPTION
Fixes #

## Proposed Changes
- Inject trace into HTTP header
- Set extension attribute (traceparent) into CloudEvent
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```NONE
