### PR TITLE
Declare container ports used in latency test

### DIFF
--- a/test/performance/broker-latency/broker-latency-setup.yaml
+++ b/test/performance/broker-latency/broker-latency-setup.yaml
@@ -46,5 +46,5 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 8080
+    targetPort: cloudevents
     name: http

--- a/test/performance/broker-latency/broker-latency.yaml
+++ b/test/performance/broker-latency/broker-latency.yaml
@@ -31,6 +31,9 @@ spec:
         memory: 3Gi
     args:
     - "-event-count=1000"
+    ports:
+    - name: cloudevents
+      containerPort: 8080
     volumeMounts:
     - name: config-mako
       mountPath: /etc/config-mako
@@ -40,6 +43,9 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /var/secret/robot.json
+    ports:
+    - name: quickstore
+      containerPort: 9813
     volumeMounts:
     - name: mako-upload
       mountPath: /var/secret


### PR DESCRIPTION
## Proposed Changes

- Document ports of servers used in the latency test.
    
    I spent few minutes yesterday following dependencies to figure out what ports the Mako sidecar ([Quickstore microservice](https://github.com/google/mako/blob/df2650d/docs/GUIDE.md)) and [CloudEvents receiver](https://github.com/cloudevents/sdk-go/blob/ab65029/README.md) were listening on. I feel that documenting them inside Pod manifests would be a cheap but clear way to provide that information to people who are not familiar with Kn Eventing's performance tests.

**Release Note**

```release-note
NONE
```