### PR TITLE
Add RBAC objects for latency test

### DIFF
--- a/test/performance/broker-latency/broker-latency-rbac.yaml
+++ b/test/performance/broker-latency/broker-latency-rbac.yaml
@@ -1,0 +1,45 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perf-eventing
+  namespace: perf-eventing
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-eventing
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: perf-eventing
+subjects:
+- kind: ServiceAccount
+  name: perf-eventing
+  namespace: perf-eventing
+roleRef:
+  kind: ClusterRole
+  name: perf-eventing
+  apiGroup: rbac.authorization.k8s.io

--- a/test/performance/broker-latency/broker-latency.yaml
+++ b/test/performance/broker-latency/broker-latency.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     role: broker-latency-consumer
 spec:
-  serviceAccountName: default
+  serviceAccountName: perf-eventing
   restartPolicy: Never
   containers:
   - name: "broker-latency"


### PR DESCRIPTION
## Proposed Changes

- Give Mako permissions to list Nodes

    Due to recent changes, Mako wants to determine the number of Kubernetes nodes in the cluster it runs in. This new ClusterRole does exactly that.

ref. knative/pkg#611
ref. knative/serving#5314

**Release Note**

```release-note
NONE
```