### PR TITLE
1 minute timeout is too short.

### DIFF
--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	writeTimeout = 1 * time.Minute
+	writeTimeout = 15 * time.Minute
 
 	passFilter FilterResult = "pass"
 	failFilter FilterResult = "fail"

--- a/pkg/channel/fanout/fanout_handler.go
+++ b/pkg/channel/fanout/fanout_handler.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	defaultTimeout = 1 * time.Minute
+	defaultTimeout = 15 * time.Minute
 
 	messageBufferSize = 500
 )

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -40,8 +40,8 @@ const (
 	// itself when creating events.
 	controllerAgentName = "in-memory-channel-dispatcher"
 
-	readTimeout  = 1 * time.Minute
-	writeTimeout = 1 * time.Minute
+	readTimeout  = 15 * time.Minute
+	writeTimeout = 15 * time.Minute
 	port         = 8080
 )
 


### PR DESCRIPTION
Fixes all of @mattmoor 's problems.

## Proposed Changes

- Don't use a 1 minute timeout when the runtime contracts for serving say at least 15 minutes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
channel/broker timeouts are now longer: 15 minutes (use to be 1 minute).
```
