### PR TITLE
Remove role & rolebinding configuration for in-memory-channel-dispatcher

### DIFF
--- a/config/provisioners/in-memory-channel/in-memory-channel.yaml
+++ b/config/provisioners/in-memory-channel/in-memory-channel.yaml
@@ -184,43 +184,6 @@ roleRef:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: in-memory-channel-dispatcher
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "configmaps"
-    verbs:
-      - get
-      - list
-      - watch
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: in-memory-channel-dispatcher
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: devel
-subjects:
-  - kind: ServiceAccount
-    name: in-memory-channel-dispatcher
-    namespace: knative-eventing
-roleRef:
-  kind: Role
-  name: in-memory-channel-dispatcher
-  apiGroup: rbac.authorization.k8s.io
-
----
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Fixes #
Duplicated role & rolebinding configuration for **in-memory-channel-dispatcher**.

## Proposed Changes
During the deployment of knative-eventing with release yaml of **v0.8.0**, deployment file has ClusterRole & Role information duplicated for **in-memory-channel-dispatcher**.

https://github.com/knative/eventing/blob/a59dae6f326057211f43f7c2d1414a9fd821b8aa/config/provisioners/in-memory-channel/in-memory-channel.yaml#L187-L220

**Release Note**

<!-- -->

```
Upcoming release for knative-eventing should be included with **in-memory-channel-dispatcher** cluster role & cluster role binding. 
```
