### PR TITLE
Setting Broker label to Triggers in the Webhook

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults.go
@@ -20,9 +20,14 @@ import (
 	"context"
 )
 
+const (
+	BrokerLabel = "eventing.knative.dev/broker"
+)
+
 func (t *Trigger) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 	setUserInfoAnnotations(ctx, t)
+	setLabels(t)
 }
 
 func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
@@ -33,4 +38,11 @@ func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
 	if ts.Filter == nil {
 		ts.Filter = &TriggerFilter{}
 	}
+}
+
+func setLabels(t *Trigger) {
+	if len(t.Labels) == 0 {
+		t.Labels = map[string]string{}
+	}
+	t.Labels[BrokerLabel] = t.Spec.Broker
 }

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	BrokerLabel = "eventing.knative.dev/broker"
+	brokerLabel = "eventing.knative.dev/broker"
 )
 
 func (t *Trigger) SetDefaults(ctx context.Context) {
@@ -44,5 +44,5 @@ func setLabels(t *Trigger) {
 	if len(t.Labels) == 0 {
 		t.Labels = map[string]string{}
 	}
-	t.Labels[BrokerLabel] = t.Spec.Broker
+	t.Labels[brokerLabel] = t.Spec.Broker
 }

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -34,6 +35,9 @@ var (
 	}
 
 	defaultTrigger = Trigger{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{BrokerLabel: defaultBroker},
+		},
 		Spec: TriggerSpec{
 			Broker: defaultBroker,
 			Filter: defaultTriggerFilter,
@@ -47,16 +51,38 @@ func TestTriggerDefaults(t *testing.T) {
 		expected Trigger
 	}{
 		"nil broker": {
-			initial:  Trigger{Spec: TriggerSpec{Filter: otherTriggerFilter}},
-			expected: Trigger{Spec: TriggerSpec{Broker: defaultBroker, Filter: otherTriggerFilter}},
+			initial: Trigger{Spec: TriggerSpec{Filter: otherTriggerFilter}},
+			expected: Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{BrokerLabel: defaultBroker},
+				},
+				Spec: TriggerSpec{Broker: defaultBroker, Filter: otherTriggerFilter}},
 		},
 		"nil filter": {
-			initial:  Trigger{Spec: TriggerSpec{Broker: otherBroker}},
-			expected: Trigger{Spec: TriggerSpec{Broker: otherBroker, Filter: defaultTriggerFilter}},
+			initial: Trigger{Spec: TriggerSpec{Broker: otherBroker}},
+			expected: Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{BrokerLabel: otherBroker},
+				},
+				Spec: TriggerSpec{Broker: otherBroker, Filter: defaultTriggerFilter}},
 		},
 		"nil broker and nil filter": {
 			initial:  Trigger{},
 			expected: defaultTrigger,
+		},
+		"with broker and label": {
+			initial: Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"otherLabel": "my-other-label"},
+				},
+				Spec: TriggerSpec{Broker: defaultBroker}},
+			expected: Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"otherLabel": "my-other-label",
+						BrokerLabel:  defaultBroker},
+				},
+				Spec: TriggerSpec{Broker: defaultBroker, Filter: defaultTriggerFilter}},
 		},
 	}
 	for n, tc := range testCases {

--- a/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_defaults_test.go
@@ -36,7 +36,7 @@ var (
 
 	defaultTrigger = Trigger{
 		ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{BrokerLabel: defaultBroker},
+			Labels: map[string]string{brokerLabel: defaultBroker},
 		},
 		Spec: TriggerSpec{
 			Broker: defaultBroker,
@@ -54,7 +54,7 @@ func TestTriggerDefaults(t *testing.T) {
 			initial: Trigger{Spec: TriggerSpec{Filter: otherTriggerFilter}},
 			expected: Trigger{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{BrokerLabel: defaultBroker},
+					Labels: map[string]string{brokerLabel: defaultBroker},
 				},
 				Spec: TriggerSpec{Broker: defaultBroker, Filter: otherTriggerFilter}},
 		},
@@ -62,7 +62,7 @@ func TestTriggerDefaults(t *testing.T) {
 			initial: Trigger{Spec: TriggerSpec{Broker: otherBroker}},
 			expected: Trigger{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{BrokerLabel: otherBroker},
+					Labels: map[string]string{brokerLabel: otherBroker},
 				},
 				Spec: TriggerSpec{Broker: otherBroker, Filter: defaultTriggerFilter}},
 		},
@@ -80,7 +80,7 @@ func TestTriggerDefaults(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{
 						"otherLabel": "my-other-label",
-						BrokerLabel:  defaultBroker},
+						brokerLabel:  defaultBroker},
 				},
 				Spec: TriggerSpec{Broker: defaultBroker, Filter: defaultTriggerFilter}},
 		},

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -241,7 +241,7 @@ func (r *Handler) sendEvent(ctx context.Context, tctx cloudevents.HTTPTransportC
 	var arrivalTimeStr string
 	if extErr := event.ExtensionAs(broker.EventArrivalTime, &arrivalTimeStr); extErr == nil {
 		arrivalTime, err := time.Parse(time.RFC3339, arrivalTimeStr)
-		if err != nil {
+		if err == nil {
 			r.reporter.ReportEventProcessingTime(reportArgs, time.Since(arrivalTime))
 		}
 	}


### PR DESCRIPTION
Helps with #1693

## Proposed Changes

- Setting a broker label to triggers in the webhook. This will allow stackdriver to call us and list triggers with a broker selector. The trigger.spec.broker is immutable, so it's safe to set it once here.
- This won't be added to existing Triggers. For doing so, we should do changes in the reconciler.

- Fixing bug in the report of event processing time (my bad!)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
