### PR TITLE
eventing test work with go1.13

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -65,12 +65,12 @@ type EventingEnvironmentFlags struct {
 	Channels
 }
 
+// initializeEventingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
+// go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func initializeEventingFlags() *EventingEnvironmentFlags {
 	f := EventingEnvironmentFlags{}
 
 	flag.Var(&f.Channels, "channels", "The names of the channels, which are separated by comma.")
-
-	flag.Parse()
 
 	// If no channel is passed through the flag, initialize it as the DefaultChannel.
 	if f.Channels == nil || len(f.Channels) == 0 {


### PR DESCRIPTION
Test would fail with go1.13 as it changed where testing flags are registered, fixing it by deleting explicit flag parsing like in https://github.com/knative/serving/pull/5398

/cc @mattmoor 
/cc @n3wscott 
/cc @adrcunha 