### PR TITLE
Remove dushyanthsc and coryrc as productivity-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,8 +21,6 @@ aliases:
   productivity-reviewers:
   - adrcunha
   - chaodaiG
-  - coryrc
-  - dushyanthsc
   - Fredy-Z
   - srinivashegde86
   - steuhs


### PR DESCRIPTION
## Proposed Changes

Dushyanth is no longer on this team and I do not have any expertise to help at this time.