### PR TITLE
Remove unnecessary mako constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -119,7 +119,3 @@ required = [
 [[constraint]]
   name = "github.com/tsenart/vegeta"
   version = "12.7.0"
-
-[[constraint]]
-  name = "github.com/google/mako"
-  version = "0.1.0"


### PR DESCRIPTION
All Mako-dependent code moved to pkg, so we don't need this constraint anymore.

Fixes this message on running `hack/update-deps.sh`:

```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/google/mako

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.
```