### PR TITLE
Address review comments for broker-latency perf test

### DIFF
--- a/test/test_images/latencymako/request_interceptor.go
+++ b/test/test_images/latencymako/request_interceptor.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "net/http"
+
+type requestInterceptor struct {
+	before func(*http.Request)
+	after  func(*http.Request, *http.Response, error)
+}
+
+func (r requestInterceptor) RoundTrip(request *http.Request) (*http.Response, error) {
+	if r.before != nil {
+		r.before(request)
+	}
+	res, err := http.DefaultTransport.RoundTrip(request)
+	if r.after != nil {
+		r.after(request, res, err)
+	}
+	return res, err
+}

--- a/test/test_images/latencymako/request_interceptor_test.go
+++ b/test/test_images/latencymako/request_interceptor_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestInterceptor(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer ts.Close()
+
+	var calledBefore, calledAfter bool
+
+	ti := requestInterceptor{
+		before: func(*http.Request) {
+			calledBefore = true
+		},
+		after: func(*http.Request, *http.Response, error) {
+			calledAfter = true
+		},
+	}
+
+	tc := http.Client{Transport: ti}
+
+	if _, err := tc.Get(ts.URL); err != nil {
+		t.Fatalf("Failed to send request to mock server: %v", err)
+	}
+
+	if !calledBefore || !calledAfter {
+		t.Errorf("Expected calls to before and after funcs (before: %t, after: %t)", calledBefore, calledAfter)
+	}
+}

--- a/test/test_images/latencymako/sender_receiver.go
+++ b/test/test_images/latencymako/sender_receiver.go
@@ -184,7 +184,7 @@ func (ex *senderReceiverExecutor) Run(ctx context.Context) {
 
 	printf("--- BEGIN WARMUP ---")
 	if warmupSeconds > 0 {
-		if err := ex.warmup(warmupSeconds); err != nil {
+		if err := ex.warmup(ctx, warmupSeconds); err != nil {
 			fatalf("Failed to run warmup: %v", err)
 		}
 	} else {
@@ -199,11 +199,11 @@ func (ex *senderReceiverExecutor) Run(ctx context.Context) {
 
 	waitForPortAvailable(defaultCEReceiverPort)
 
-	cancelCeReceiver, err := ex.startCloudEventsReceiver(ex.processReceiveEvent)
-	if err != nil {
-		fatalf("Failed to start CloudEvents receiver: %v", err)
-	}
-	defer cancelCeReceiver()
+	go func() {
+		if err := ex.startCloudEventsReceiver(ctx, ex.processReceiveEvent); err != nil {
+			fatalf("Failed to start CloudEvents receiver: %v", err)
+		}
+	}()
 
 	// Start the events processor
 	printf("Starting events processor")
@@ -260,20 +260,13 @@ func (ex *senderReceiverExecutor) Run(ctx context.Context) {
 
 type receiverFn func(cloudevents.Event)
 
-func (ex *senderReceiverExecutor) startCloudEventsReceiver(eventHandler receiverFn) (context.CancelFunc, error) {
+func (ex *senderReceiverExecutor) startCloudEventsReceiver(ctx context.Context, eventHandler receiverFn) error {
 	cli, err := newCloudEventsClient(sinkURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CloudEvents client: %v", err)
+		return fmt.Errorf("failed to create CloudEvents client: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		if err := cli.StartReceiver(ctx, eventHandler); err != nil {
-			fatalf("Failed to start CloudEvents receiver: %v", err)
-		}
-	}()
-
-	return cancel, nil
+	return cli.StartReceiver(ctx, eventHandler)
 }
 
 func parsePaceSpec(pace string) ([]paceSpec, error) {
@@ -302,12 +295,16 @@ func parsePaceSpec(pace string) ([]paceSpec, error) {
 	return pacerSpecs, nil
 }
 
-func (ex *senderReceiverExecutor) warmup(warmupSeconds uint) error {
-	cancelCeReceiver, err := ex.startCloudEventsReceiver(func(event cloudevents.Event) {})
-	if err != nil {
-		return fmt.Errorf("failed to start CloudEvents receiver: %v", err)
-	}
-	defer cancelCeReceiver()
+func (ex *senderReceiverExecutor) warmup(ctx context.Context, warmupSeconds uint) error {
+	ignoreEvents := func(event cloudevents.Event) {}
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		if err := ex.startCloudEventsReceiver(ctx, ignoreEvents); err != nil {
+			fatalf("Failed to start CloudEvents receiver: %v", err)
+		}
+	}()
+	defer cancel()
 
 	printf("Started CloudEvents receiver for warmup")
 

--- a/test/test_images/latencymako/sender_receiver.go
+++ b/test/test_images/latencymako/sender_receiver.go
@@ -179,22 +179,6 @@ func newSenderReceiverExecutor(ps []paceSpec, aggCli pb.EventsRecorderClient) te
 	return executor
 }
 
-type requestInterceptor struct {
-	before func(*http.Request)
-	after  func(*http.Request, *http.Response, error)
-}
-
-func (r requestInterceptor) RoundTrip(request *http.Request) (*http.Response, error) {
-	if r.before != nil {
-		r.before(request)
-	}
-	res, err := http.DefaultTransport.RoundTrip(request)
-	if r.after != nil {
-		r.after(request, res, err)
-	}
-	return res, err
-}
-
 func (ex *senderReceiverExecutor) Run(ctx context.Context) {
 	// --- Warmup phase
 


### PR DESCRIPTION
## Proposed Changes

Due to a dependency of #1831 on #1829, the latter was merged despite some minor [pending comments](https://github.com/knative/eventing/pull/1829#pullrequestreview-285738742). This PR addresses them.

- Move `requestInterceptor` type to its own file and add a unit test for it
- Pass parent context to subroutines (CloudEvents receiver, etc.) instead of using `Background()`

**Release Note**

```release-note
NONE
```

/assign grantr
/assign slinkydeveloper