### PR TITLE
Allow the service account to be a benchmark owner

### DIFF
--- a/test/performance/broker-latency/prod.config
+++ b/test/performance/broker-latency/prod.config
@@ -14,7 +14,7 @@ owner_list: "chizhg@google.com"
 owner_list: "srinivashegde@google.com" 
 
 # Only this robot should publish data to Mako for this key!
-#owner_list: "mako-job@knative-eventing-performance.iam.gserviceaccount.com"
+owner_list: "mako-job@knative-eventing-performance.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {


### PR DESCRIPTION
I have updated the benchmark in mako to allow the owner. This PR updates the config in the repo.