### PR TITLE
tweaks to get tests to work with private registry

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -99,7 +99,7 @@ you'll need to create a Secret in your `default` Namespace called
 will then be copied into any new Namespace that is created by the testing
 infrastructure, and linked to any ServiceAccount created as a imagePulLSecret.
 Note: some tests will use the `knative-eventing-injection` label to
-automatically create new ServiceAccounts in some Namespaces, This feature
+automatically create new ServiceAccounts in some Namespaces, this feature
 does not yet support private registries. See
 https://github.com/knative/eventing/issues/1862 for status of this issue.
 

--- a/test/README.md
+++ b/test/README.md
@@ -93,6 +93,16 @@ environment that meets
 [the e2e test environment requirements](#environment-requirements), and you need
 to specify the build tag `e2e`.
 
+If you are using a private registry that will require authentication then
+you'll need to create a Secret in your `default` Namespace called
+`kn-eventing-test-pull-secret` with the Docker login credentials. This Secret
+will then be copied into any new Namespace that is created by the testing
+infrastructure, and linked to any ServiceAccount created as a imagePulLSecret.
+Note: some tests will use the `knative-eventing-injection` label to
+automatically create new ServiceAccounts in some Namespaces, This feature
+does not yet support private registries. See
+https://github.com/knative/eventing/issues/1862 for status of this issue.
+
 ```bash
 go test -v -tags=e2e -count=1 ./test/e2e
 ```

--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -18,10 +18,10 @@ package common
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
@@ -273,10 +273,8 @@ func (client *Client) CreateServiceAccountOrFail(saName string) {
 // CreateClusterRoleOrFail creates the given ClusterRole or fail the test if there is an error.
 func (client *Client) CreateClusterRoleOrFail(cr *rbacv1.ClusterRole) {
 	crs := client.Kube.Kube.RbacV1().ClusterRoles()
-	if _, err := crs.Create(cr); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			client.T.Fatalf("Failed to create cluster role %q: %v", cr.Name, err)
-		}
+	if _, err := crs.Create(cr); err != nil && !errors.IsAlreadyExists(err) {
+		client.T.Fatalf("Failed to create cluster role %q: %v", cr.Name, err)
 	}
 	client.Tracker.Add(rbacAPIGroup, rbacAPIVersion, "clusterroles", "", cr.Name)
 }
@@ -287,10 +285,8 @@ func (client *Client) CreateRoleBindingOrFail(saName, crName, rbName, rbNamespac
 	rb := resources.RoleBinding(saName, saNamespace, crName, rbName, rbNamespace)
 	rbs := client.Kube.Kube.RbacV1().RoleBindings(rbNamespace)
 
-	if _, err := rbs.Create(rb); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			client.T.Fatalf("Failed to create role binding %q: %v", rbName, err)
-		}
+	if _, err := rbs.Create(rb); err != nil && !errors.IsAlreadyExists(err) {
+		client.T.Fatalf("Failed to create role binding %q: %v", rbName, err)
 	}
 	client.Tracker.Add(rbacAPIGroup, rbacAPIVersion, "rolebindings", rbNamespace, rb.GetName())
 }
@@ -300,10 +296,8 @@ func (client *Client) CreateClusterRoleBindingOrFail(saName, crName, crbName str
 	saNamespace := client.Namespace
 	crb := resources.ClusterRoleBinding(saName, saNamespace, crName, crbName)
 	crbs := client.Kube.Kube.RbacV1().ClusterRoleBindings()
-	if _, err := crbs.Create(crb); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			client.T.Fatalf("Failed to create cluster role binding %q: %v", crbName, err)
-		}
+	if _, err := crbs.Create(crb); err != nil && !errors.IsAlreadyExists(err) {
+		client.T.Fatalf("Failed to create cluster role binding %q: %v", crbName, err)
 	}
 	client.Tracker.Add(rbacAPIGroup, rbacAPIVersion, "clusterrolebindings", "", crb.GetName())
 }

--- a/test/common/test_runner.go
+++ b/test/common/test_runner.go
@@ -159,7 +159,7 @@ func CreateNamespaceIfNeeded(t *testing.T, client *Client, namespace string) {
 			newSecret, err := nsSecI.Create(
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: testSecret.ObjectMeta.Name,
+						Name: TestPullSecretName,
 					},
 					Data: testSecret.Data,
 					Type: testSecret.Type,
@@ -170,7 +170,7 @@ func CreateNamespaceIfNeeded(t *testing.T, client *Client, namespace string) {
 
 			// Now add it to the "default" ServiceAccount as a Pull Secret
 			newSecretRef := corev1.LocalObjectReference{
-				Name: newSecret.ObjectMeta.Name,
+				Name: TestPullSecretName,
 			}
 			sa, err := nsSAI.Get("default", metav1.GetOptions{})
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Doug Davis <dug@us.ibm.com>

## Proposed Changes

While trying to get the e2e tests to work with a private registry I had to make some "interesting"
choices. This PR isn't all of them, but they're most of the ones I can share at this time. They include:

- when creating the various "cluster roles", if the role already exists then we just ignore the error. TBH, I'm not sure why other people are not seeing this, perhaps my env already has them by default, or perhaps they're left around from a previous run and never got cleaned up, but either way, I don't think this should be a test-stopping error condition.
- I added code to look for a secret in the `default` namespace called
  `kn-eventing-test-pull-secret` when creating new namespaces and service accounts. And
  if it exists, we will now inject that secret as an ImagePullSecret into the namespace's 
  `default` service accounts, or the new service account.

I'm not 100% sure these are the best solutions, but they at least worked for me. I'm open to 
other ideas for how to get the PullSecret injected.  If the PullSecret approach sounds out
I can then update the test docs to mention it.

Note - this does not get around #1862 

**Release Note**

```release-note
NONE
```
