### PR TITLE
Remove test logger cache cleanup, and create one logger per test

### DIFF
--- a/pkg/inmemorychannel/dispatcher_test.go
+++ b/pkg/inmemorychannel/dispatcher_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestNewDispatcher(t *testing.T) {
-	defer logtesting.ClearAll()
-
 	logger := logtesting.TestLogger(t).Desugar()
 	sh, err := swappable.NewEmptyHandler(logger)
 

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -40,8 +40,8 @@ import (
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
 
+	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/eventing/pkg/reconciler/testing"
 	. "knative.dev/pkg/reconciler/testing"
 )
@@ -553,7 +553,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
 			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -566,6 +566,7 @@ func TestReconcile(t *testing.T) {
 		return r
 	},
 		true,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/apiserversource/controller_test.go
+++ b/pkg/reconciler/apiserversource/controller_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -34,7 +33,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 	ctx = withCfgHost(ctx, &rest.Config{Host: "unit_test"})
 	os.Setenv("METRICS_DOMAIN", "knative.dev/eventing")

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -797,7 +797,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                      reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -813,6 +813,7 @@ func TestReconcile(t *testing.T) {
 		}
 	},
 		false,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -32,7 +31,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	_ = os.Setenv("BROKER_INGRESS_IMAGE", "INGRESS_IMAGE")

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -35,8 +35,8 @@ import (
 	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 const (
@@ -244,7 +244,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -253,6 +253,7 @@ func TestReconcile(t *testing.T) {
 		}
 	},
 		false,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/channel/controller_test.go
+++ b/pkg/reconciler/channel/controller_test.go
@@ -21,7 +21,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -31,7 +30,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -36,9 +36,9 @@ import (
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
 
 	. "knative.dev/eventing/pkg/reconciler/testing"
+	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 )
 
@@ -632,7 +632,7 @@ func TestAllCases(t *testing.T) {
 		//},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
 			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -643,6 +643,7 @@ func TestAllCases(t *testing.T) {
 		return r
 	},
 		true,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/containersource/controller_test.go
+++ b/pkg/reconciler/containersource/controller_test.go
@@ -21,7 +21,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -30,7 +29,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/cronjobsource/controller_test.go
+++ b/pkg/reconciler/cronjobsource/controller_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -41,7 +40,6 @@ func TestNew(t *testing.T) {
 			setEnv: true,
 		},
 	}
-	defer logtesting.ClearAll()
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			if tc.setEnv {

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -38,9 +38,9 @@ import (
 	"knative.dev/eventing/pkg/utils"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
 
 	. "knative.dev/eventing/pkg/reconciler/testing"
+	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 )
 
@@ -464,7 +464,7 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
 			Base:             reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -479,6 +479,7 @@ func TestAllCases(t *testing.T) {
 		return r
 	},
 		true,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/eventtype/controller_test.go
+++ b/pkg/reconciler/eventtype/controller_test.go
@@ -21,7 +21,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -30,7 +29,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -166,5 +166,6 @@ func TestReconcile(t *testing.T) {
 		}
 	},
 		false,
+		logger,
 	))
 }

--- a/pkg/reconciler/inmemorychannel/controller/controller_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -31,7 +30,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -277,7 +277,7 @@ func TestAllCases(t *testing.T) {
 		}, {},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                     reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -293,6 +293,7 @@ func TestAllCases(t *testing.T) {
 		}
 	},
 		false,
+		logger,
 	))
 }
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -28,7 +27,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, &configmap.InformedWatcher{})

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -121,7 +121,7 @@ func TestAllCases(t *testing.T) {
 		}, {},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -130,7 +130,7 @@ func TestAllCases(t *testing.T) {
 			inmemorychannelInformer: nil,
 			dispatcher:              &fakeDispatcher{},
 		}
-	}, false))
+	}, false, logger))
 }
 
 type fakeDispatcher struct{}

--- a/pkg/reconciler/namespace/controller_test.go
+++ b/pkg/reconciler/namespace/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -31,7 +30,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -310,7 +310,7 @@ func TestAllCases(t *testing.T) {
 	// TODO: we need a existing default un-owned test.
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -320,5 +320,5 @@ func TestAllCases(t *testing.T) {
 			roleBindingLister:    listers.GetRoleBindingLister(),
 			tracker:              tracker.New(func(types.NamespacedName) {}, 0),
 		}
-	}, false))
+	}, false, logger))
 }

--- a/pkg/reconciler/parallel/controller_test.go
+++ b/pkg/reconciler/parallel/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -29,7 +28,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/parallel/parallel_test.go
+++ b/pkg/reconciler/parallel/parallel_test.go
@@ -405,7 +405,7 @@ func TestAllBranches(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -413,7 +413,7 @@ func TestAllBranches(t *testing.T) {
 			resourceTracker:    fakeResourceTracker{},
 			subscriptionLister: listers.GetSubscriptionLister(),
 		}
-	}, false))
+	}, false, logger))
 }
 
 func createBranchReplyChannel(caseNumber int) *corev1.ObjectReference {

--- a/pkg/reconciler/sequence/controller_test.go
+++ b/pkg/reconciler/sequence/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -29,7 +28,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -468,7 +468,7 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:               reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -476,5 +476,5 @@ func TestAllCases(t *testing.T) {
 			resourceTracker:    &MockResourceTracker{},
 			subscriptionLister: listers.GetSubscriptionLister(),
 		}
-	}, false))
+	}, false, logger))
 }

--- a/pkg/reconciler/subscription/controller_test.go
+++ b/pkg/reconciler/subscription/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition/fake"
@@ -30,7 +29,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -784,7 +784,7 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                           reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -792,7 +792,7 @@ func TestAllCases(t *testing.T) {
 			resourceTracker:                &MockResourceTracker{},
 			customResourceDefinitionLister: listers.GetCustomResourceDefinitionLister(),
 		}
-	}, false))
+	}, false, logger))
 }
 
 func TestFinalizers(t *testing.T) {

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	ktesting "k8s.io/client-go/testing"
+	"go.uber.org/zap"
 	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
 
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -51,12 +51,11 @@ const (
 type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
 
 // MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
-func MakeFactory(ctor Ctor, unstructured bool) Factory {
+func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factory {
 	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList, *FakeStatsReporter) {
 		ls := NewListers(r.Objects)
 
 		ctx := context.Background()
-		logger := logtesting.TestLogger(t)
 		ctx = logging.WithLogger(ctx, logger)
 
 		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)

--- a/pkg/reconciler/trigger/controller_test.go
+++ b/pkg/reconciler/trigger/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"knative.dev/pkg/configmap"
-	logtesting "knative.dev/pkg/logging/testing"
 	. "knative.dev/pkg/reconciler/testing"
 
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
@@ -32,7 +31,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	defer logtesting.ClearAll()
 	ctx, _ := SetupFakeContext(t)
 
 	c := NewController(ctx, configmap.NewStaticWatcher())

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -636,7 +636,7 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
-	defer logtesting.ClearAll()
+	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		return &Reconciler{
 			Base:                     reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -649,6 +649,7 @@ func TestAllCases(t *testing.T) {
 		}
 	},
 		false,
+		logger,
 	))
 }
 

--- a/vendor/knative.dev/pkg/logging/testing/util.go
+++ b/vendor/knative.dev/pkg/logging/testing/util.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -26,14 +27,39 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+var (
+	loggers = make(map[string]*zap.SugaredLogger)
+	m       sync.Mutex
+)
+
 // TestLogger gets a logger to use in unit and end to end tests
 func TestLogger(t *testing.T) *zap.SugaredLogger {
+	m.Lock()
+	defer m.Unlock()
+
+	logger, ok := loggers[t.Name()]
+
+	if ok {
+		return logger
+	}
+
 	opts := zaptest.WrapOptions(
 		zap.AddCaller(),
 		zap.Development(),
 	)
 
-	return zaptest.NewLogger(t, opts).Sugar()
+	logger = zaptest.NewLogger(t, opts).Sugar().Named(t.Name())
+	loggers[t.Name()] = logger
+
+	return logger
+}
+
+// ClearAll removes all the testing loggers.
+// `go test -count=X` executes runs in the same process, thus the map
+// persists between the runs, but the `t` will no longer be valid and will
+// cause a panic deep inside testing code.
+func ClearAll() {
+	loggers = make(map[string]*zap.SugaredLogger)
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/vendor/knative.dev/pkg/logging/testing/util.go
+++ b/vendor/knative.dev/pkg/logging/testing/util.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -27,39 +26,14 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-var (
-	loggers = make(map[string]*zap.SugaredLogger)
-	m       sync.Mutex
-)
-
 // TestLogger gets a logger to use in unit and end to end tests
 func TestLogger(t *testing.T) *zap.SugaredLogger {
-	m.Lock()
-	defer m.Unlock()
-
-	logger, ok := loggers[t.Name()]
-
-	if ok {
-		return logger
-	}
-
 	opts := zaptest.WrapOptions(
 		zap.AddCaller(),
 		zap.Development(),
 	)
 
-	logger = zaptest.NewLogger(t, opts).Sugar().Named(t.Name())
-	loggers[t.Name()] = logger
-
-	return logger
-}
-
-// ClearAll removes all the testing loggers.
-// `go test -count=X` executes runs in the same process, thus the map
-// persists between the runs, but the `t` will no longer be valid and will
-// cause a panic deep inside testing code.
-func ClearAll() {
-	loggers = make(map[string]*zap.SugaredLogger)
+	return zaptest.NewLogger(t, opts).Sugar()
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/vendor/knative.dev/pkg/reconciler/testing/context.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/context.go
@@ -25,7 +25,6 @@ import (
 
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
-	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // SetupFakeContext sets up the the Context and the fake informers for the tests.
@@ -37,7 +36,7 @@ func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
 // SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
 // The provided context can be canceled using provided callback.
 func SetupFakeContextWithCancel(t *testing.T) (context.Context, context.CancelFunc, []controller.Informer) {
-	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
+	ctx, c := context.WithCancel(context.TODO())
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
 	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
 	return ctx, c, is

--- a/vendor/knative.dev/pkg/reconciler/testing/context.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/context.go
@@ -25,6 +25,7 @@ import (
 
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 // SetupFakeContext sets up the the Context and the fake informers for the tests.
@@ -36,7 +37,7 @@ func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
 // SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
 // The provided context can be canceled using provided callback.
 func SetupFakeContextWithCancel(t *testing.T) (context.Context, context.CancelFunc, []controller.Informer) {
-	ctx, c := context.WithCancel(context.TODO())
+	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
 	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
 	return ctx, c, is


### PR DESCRIPTION
/lint

Part of https://github.com/knative/pkg/issues/643

## Proposed Changes
- Remove logger cache cleanup

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @vagababov 
