### PR TITLE
APIServerSource now supports filtering by controller apiVersion and kind

### DIFF
--- a/cmd/apiserver_receive_adapter/main.go
+++ b/cmd/apiserver_receive_adapter/main.go
@@ -59,14 +59,16 @@ func (s *StringList) Decode(value string) error {
 }
 
 type envConfig struct {
-	Namespace     string     `envconfig:"SYSTEM_NAMESPACE" default:"default"`
-	Mode          string     `envconfig:"MODE"`
-	SinkURI       string     `split_words:"true" required:"true"`
-	ApiVersion    StringList `split_words:"true" required:"true"`
-	Kind          StringList `required:"true"`
-	Controller    []bool     `required:"true"`
-	LabelSelector StringList `envconfig:"SELECTOR" required:"true"`
-	Name          string     `envconfig:"NAME" required:"true"`
+	Namespace       string     `envconfig:"SYSTEM_NAMESPACE" default:"default"`
+	Mode            string     `envconfig:"MODE"`
+	SinkURI         string     `split_words:"true" required:"true"`
+	ApiVersion      StringList `split_words:"true" required:"true"`
+	Kind            StringList `required:"true"`
+	Controller      []bool     `required:"true"`
+	LabelSelector   StringList `envconfig:"SELECTOR" required:"true"`
+	OwnerApiVersion StringList `envconfig:"OWNER_API_VERSION" required:"true"`
+	OwnerKind       StringList `envconfig:"OWNER_KIND" required:"true"`
+	Name            string     `envconfig:"NAME" required:"true"`
 	// MetricsConfigJson is a json string of metrics.ExporterOptions.
 	// This is used to configure the metrics exporter options,
 	// the config is stored in a config map inside the controllers
@@ -149,6 +151,8 @@ func main() {
 		kind := env.Kind[i]
 		controlled := env.Controller[i]
 		selector := env.LabelSelector[i]
+		ownerApiVersion := env.OwnerApiVersion[i]
+		ownerKind := env.OwnerKind[i]
 
 		gv, err := schema.ParseGroupVersion(apiVersion)
 		if err != nil {
@@ -157,9 +161,11 @@ func main() {
 		// TODO: pass down the resource and the kind so we do not have to guess.
 		gvr, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: kind, Group: gv.Group, Version: gv.Version})
 		gvrcs = append(gvrcs, apiserver.GVRC{
-			GVR:           gvr,
-			Controller:    controlled,
-			LabelSelector: selector,
+			GVR:             gvr,
+			Controller:      controlled,
+			LabelSelector:   selector,
+			OwnerApiVersion: ownerApiVersion,
+			OwnerKind:       ownerKind,
 		})
 	}
 

--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -120,6 +120,16 @@ spec:
                   labelSelector:
                     type: object
                     description: "Label selector restricting the list of objects to watch by their labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
+                  controllerSelector:
+                    type: object
+                    description: "Controller selector restricting the list of objects to watch by the kind of their controller."
+                    properties:
+                      apiVersion:
+                        type: string
+                        description: "API version of the controller"
+                      kind:
+                        type: string
+                        description: "Kind of the controller"
               type: array
           required:
           - resources

--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -119,17 +119,17 @@ spec:
                     description: "If true, emits the managing controller ref. Only supported for mode=Ref. More info: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/"
                   labelSelector:
                     type: object
-                    description: "Label selector restricting the list of objects to watch by their labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
+                    description: "Label selector restricting this  list of objects to watch by their labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
                   controllerSelector:
                     type: object
-                    description: "Controller selector restricting the list of objects to watch by the kind of their controller."
+                    description: "Controller selector restricting the list of objects to watch by a controlling owner reference of the specified kind."
                     properties:
                       apiVersion:
                         type: string
-                        description: "API version of the controller"
+                        description: "API version of the controlling owner reference."
                       kind:
                         type: string
-                        description: "Kind of the controller"
+                        description: "Kind of the controlling owner reference."
               type: array
           required:
           - resources

--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -139,6 +139,30 @@ func TestNewAdaptor(t *testing.T) {
 				LabelSelector: "environment=production,tier!=frontend",
 			}},
 		},
+		"with owner selector": {
+			source: "test-source",
+			opt: Options{
+				GVRCs: []GVRC{{
+					GVR: schema.GroupVersionResource{
+						Group:    "apps",
+						Version:  "v1",
+						Resource: "replicasets",
+					},
+					OwnerApiVersion: "v1",
+					OwnerKind:       "pod",
+				}},
+			},
+			wantMode: RefMode,
+			wantGVRCs: []GVRC{{
+				GVR: schema.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "replicasets",
+				},
+				OwnerApiVersion: "v1",
+				OwnerKind:       "pod",
+			}},
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/adapter/apiserver/controller.go
+++ b/pkg/adapter/apiserver/controller.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+// filter controller by apiVersion and/or kind
+type controller struct {
+	apiVersion string
+	kind       string
+	delegate   cache.Store
+}
+
+var _ cache.Store = (*controller)(nil)
+
+// Implements Store
+
+func (c *controller) Add(obj interface{}) error {
+	if c.filtered(obj) {
+		return nil
+	}
+
+	return c.delegate.Add(obj)
+}
+
+func (c *controller) Update(obj interface{}) error {
+	if c.filtered(obj) {
+		return nil
+	}
+
+	return c.delegate.Update(obj)
+}
+
+func (c *controller) Delete(obj interface{}) error {
+	if c.filtered(obj) {
+		return nil
+	}
+
+	return c.delegate.Delete(obj)
+}
+
+func (c *controller) filtered(obj interface{}) bool {
+	u := obj.(*unstructured.Unstructured)
+	controller := metav1.GetControllerOf(u)
+	return controller == nil || (c.apiVersion != "" && c.apiVersion != controller.APIVersion) ||
+		(c.kind != "" && c.kind != controller.Kind)
+}
+
+// Stub cache.Store impl
+
+// Implements cache.Store
+func (c *controller) List() []interface{} {
+	return nil
+}
+
+// Implements cache.Store
+func (c *controller) ListKeys() []string {
+	return nil
+}
+
+// Implements cache.Store
+func (c *controller) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// Implements cache.Store
+func (c *controller) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// Implements cache.Store
+func (c *controller) Replace([]interface{}, string) error {
+	return nil
+}
+
+// Implements cache.Store
+func (c *controller) Resync() error {
+	return nil
+}

--- a/pkg/adapter/apiserver/controller_test.go
+++ b/pkg/adapter/apiserver/controller_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"testing"
+
+	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
+	kncetesting "knative.dev/eventing/pkg/kncloudevents/testing"
+)
+
+func TestControllerAddEventWithNoController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Add(simplePod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceAddRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerAddEventWithWrongController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Add(simpleOwnedPod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceAddRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerAddEventWithGoodController(t *testing.T) {
+	c, tc := makeController("apps/v1", "ReplicaSet")
+	c.Add(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceAddRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func TestControllerAddEventWithGoodControllerNoAPIVersion(t *testing.T) {
+	c, tc := makeController("", "ReplicaSet")
+	c.Add(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceAddRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func TestControllerUpdateEventWithNoController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Update(simplePod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceUpdateRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerUpdateEventWithWrongController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Update(simpleOwnedPod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceUpdateRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerUpdateEventWithGoodController(t *testing.T) {
+	c, tc := makeController("apps/v1", "ReplicaSet")
+	c.Update(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceUpdateRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func TestControllerUpdateEventWithGoodControllerNoAPIVersion(t *testing.T) {
+	c, tc := makeController("", "ReplicaSet")
+	c.Update(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceUpdateRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func TestControllerDeleteEventWithNoController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Delete(simplePod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceDeleteRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerDeleteEventWithWrongController(t *testing.T) {
+	c, tc := makeController("v1", "Pod")
+	c.Delete(simpleOwnedPod("unit", "test"))
+	validateNotSent(t, tc, sourcesv1alpha1.ApiServerSourceDeleteRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 0)
+}
+
+func TestControllerDeleteEventWithGoodController(t *testing.T) {
+	c, tc := makeController("apps/v1", "ReplicaSet")
+	c.Delete(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceDeleteRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func TestControllerDeleteEventWithGoodControllerNoAPIVersion(t *testing.T) {
+	c, tc := makeController("", "ReplicaSet")
+	c.Delete(simpleOwnedPod("unit", "test"))
+	validateSent(t, tc, sourcesv1alpha1.ApiServerSourceDeleteRefEventType)
+	validateMetric(t, c.delegate.(*ref).reporter, 1)
+}
+
+func makeController(apiVersion, kind string) (*controller, *kncetesting.TestCloudEventsClient) {
+	delegate, tc := makeRefAndTestingClient()
+	return &controller{
+		apiVersion: apiVersion,
+		kind:       kind,
+		delegate:   delegate,
+	}, tc
+}

--- a/pkg/adapter/apiserver/resource.go
+++ b/pkg/adapter/apiserver/resource.go
@@ -57,8 +57,6 @@ func (a *resource) Update(obj interface{}) error {
 	}
 
 	return a.sendEvent(context.Background(), event)
-
-	return nil
 }
 
 func (a *resource) Delete(obj interface{}) error {

--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -117,7 +117,7 @@ type ApiServerResource struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
 
 	// ControllerSelector restricts this source to objects with the selected controller kind.
-	// Only apiVersion and kind are used. Both are optional
+	// Only apiVersion and kind are used. Both are optional.
 	// +optional
 	ControllerSelector *metav1.OwnerReference `json:"controllerSelector"`
 

--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -116,7 +116,7 @@ type ApiServerResource struct {
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
 
-	// ControllerSelector restricts this source to objects with the selected controller kind.
+	// ControllerSelector restricts this source to objects with a controlling owner reference of the specified kind.
 	// Only apiVersion and kind are used. Both are optional.
 	// +optional
 	ControllerSelector *metav1.OwnerReference `json:"controllerSelector"`

--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -116,6 +116,11 @@ type ApiServerResource struct {
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
 
+	// ControllerSelector restricts this source to objects with the selected controller kind.
+	// Only apiVersion and kind are used. Both are optional
+	// +optional
+	ControllerSelector *metav1.OwnerReference `json:"controllerSelector"`
+
 	// If true, send an event referencing the object controlling the resource
 	Controller bool `json:"controller"`
 }

--- a/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
@@ -34,6 +34,11 @@ func (in *ApiServerResource) DeepCopyInto(out *ApiServerResource) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ControllerSelector != nil {
+		in, out := &in.ControllerSelector, &out.ControllerSelector
+		*out = new(v1.OwnerReference)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -87,12 +87,21 @@ func makeEnv(sinkURI, loggingConfig, metricsConfig string, spec *v1alpha1.ApiSer
 	kinds := ""
 	controlled := ""
 	selectors := ""
+	ownerapiversions := ""
+	ownerkinds := ""
 	sep := ""
 	boolsep := ""
 
 	for _, res := range spec.Resources {
 		apiversions += sep + res.APIVersion
 		kinds += sep + res.Kind
+		if res.ControllerSelector != nil {
+			ownerapiversions += sep + res.ControllerSelector.APIVersion
+			ownerkinds += sep + res.ControllerSelector.Kind
+		} else {
+			ownerapiversions += sep
+			ownerkinds += sep
+		}
 		if res.Controller {
 			controlled += boolsep + "true"
 		} else {
@@ -124,6 +133,12 @@ func makeEnv(sinkURI, loggingConfig, metricsConfig string, spec *v1alpha1.ApiSer
 	}, {
 		Name:  "KIND",
 		Value: kinds,
+	}, {
+		Name:  "OWNER_API_VERSION",
+		Value: ownerapiversions,
+	}, {
+		Name:  "OWNER_KIND",
+		Value: ownerkinds,
 	}, {
 		Name:  "CONTROLLER",
 		Value: controlled,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -75,6 +75,10 @@ func TestMakeReceiveAdapter(t *testing.T) {
 							{Key: "anotherkey", Operator: "DoesNotExist"},
 						},
 					},
+					ControllerSelector: &metav1.OwnerReference{
+						APIVersion: "foo/v1alpha1",
+						Kind:       "Foo",
+					},
 				},
 			},
 		},
@@ -152,6 +156,12 @@ func TestMakeReceiveAdapter(t *testing.T) {
 								}, {
 									Name:  "KIND",
 									Value: "Namespace;Pod;Pod;Pod;Pod",
+								}, {
+									Name:  "OWNER_API_VERSION",
+									Value: ";;;;foo/v1alpha1",
+								}, {
+									Name:  "OWNER_KIND",
+									Value: ";;;;Foo",
 								}, {
 									Name:  "CONTROLLER",
 									Value: "false,true,false,false,false",

--- a/test/e2e/source_api_server_test.go
+++ b/test/e2e/source_api_server_test.go
@@ -54,9 +54,10 @@ func TestApiServerSource(t *testing.T) {
 			spec: sourcesv1alpha1.ApiServerSourceSpec{
 				Resources: []sourcesv1alpha1.ApiServerResource{
 					{
-						APIVersion:    "v1",
-						Kind:          "Event",
-						LabelSelector: &metav1.LabelSelector{},
+						APIVersion:         "v1",
+						Kind:               "Event",
+						LabelSelector:      &metav1.LabelSelector{},
+						ControllerSelector: &metav1.OwnerReference{},
 					},
 				},
 				Mode:               mode,
@@ -70,9 +71,10 @@ func TestApiServerSource(t *testing.T) {
 			spec: sourcesv1alpha1.ApiServerSourceSpec{
 				Resources: []sourcesv1alpha1.ApiServerResource{
 					{
-						APIVersion:    "v1",
-						Kind:          "Pod",
-						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"e2e": "testing"}},
+						APIVersion:         "v1",
+						Kind:               "Pod",
+						LabelSelector:      &metav1.LabelSelector{MatchLabels: map[string]string{"e2e": "testing"}},
+						ControllerSelector: &metav1.OwnerReference{},
 					},
 				},
 				Mode:               mode,
@@ -86,9 +88,10 @@ func TestApiServerSource(t *testing.T) {
 			spec: sourcesv1alpha1.ApiServerSourceSpec{
 				Resources: []sourcesv1alpha1.ApiServerResource{
 					{
-						APIVersion:    "v1",
-						Kind:          "Pod",
-						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"e2e": "testing"}},
+						APIVersion:         "v1",
+						Kind:               "Pod",
+						LabelSelector:      &metav1.LabelSelector{MatchLabels: map[string]string{"e2e": "testing"}},
+						ControllerSelector: &metav1.OwnerReference{},
 					},
 				},
 				Mode:               mode,
@@ -112,6 +115,7 @@ func TestApiServerSource(t *testing.T) {
 								{Key: "e2e", Operator: "Exists"},
 							},
 						},
+						ControllerSelector: &metav1.OwnerReference{},
 					},
 				},
 				Mode:               mode,


### PR DESCRIPTION
Fixes #1262 

## Proposed Changes

- APIServerSource supports filtering objects by their controller apiVersion and kind
