### PR TITLE
Revert Source to Importer decision.

### DIFF
--- a/cmd/apiserver_receive_adapter/main.go
+++ b/cmd/apiserver_receive_adapter/main.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	if err = tracing.SetupStaticPublishing(loggerSugared, "apiserversource", tracing.OnePercentSampling); err != nil {
-		// If tracing doesn't work, we will log an error, but allow the importer
+		// If tracing doesn't work, we will log an error, but allow the source
 		// to continue to start.
 		logger.Error("Error setting up trace publishing", zap.Error(err))
 	}

--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	if err = tracing.SetupStaticPublishing(logger, "cronjobsource", tracing.OnePercentSampling); err != nil {
-		// If tracing doesn't work, we will log an error, but allow the importer to continue to
+		// If tracing doesn't work, we will log an error, but allow the source to continue to
 		// start.
 		logger.Errorw("Error setting up trace publishing", err)
 	}

--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -29,7 +29,6 @@ spec:
     - knative
     - eventing
     - sources
-    - importers
     kind: ApiServerSource
     plural: apiserversources
   scope: Namespaced

--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -28,7 +28,6 @@ spec:
     - knative
     - eventing
     - sources
-    - importers
     kind: ContainerSource
     plural: containersources
   scope: Namespaced

--- a/config/300-cronjobsource.yaml
+++ b/config/300-cronjobsource.yaml
@@ -28,7 +28,6 @@ spec:
     - knative
     - eventing
     - sources
-    - importers
     kind: CronJobSource
     plural: cronjobsources
   scope: Namespaced

--- a/docs/decisions/discovery-and-faas-support.md
+++ b/docs/decisions/discovery-and-faas-support.md
@@ -45,6 +45,6 @@ implementation will be tracked in
 ## FaaS scenario
 
 When using Broker + Trigger: We will make implementation changes that allow for
-a trigger to be written so that it only receives events from a specific
-importer. The implementation and design is tracked in
+a trigger to be written so that it only receives events from a specific source.
+The implementation and design is tracked in
 [#1555](https://github.com/knative/eventing/issues/1555).

--- a/docs/decisions/reverted-sources-to-importers.md
+++ b/docs/decisions/reverted-sources-to-importers.md
@@ -1,3 +1,13 @@
+# Revert Renaming Sources to Importers
+
+As of 13 September 2019, we are reverting the decision to rename sources to
+importers as described in issue
+[#1857](https://github.com/knative/eventing/issues/1857).
+
+---
+
+_Archived_
+
 # Renaming Sources to Importers
 
 Decision date: 4 June 2019

--- a/docs/mission.md
+++ b/docs/mission.md
@@ -35,6 +35,6 @@ specification. Enable a pluggable architecture for the event delivery mechanism
 so that developers and operators can choose the correct event delivery substrate
 for their requirements.
 
-**Event Sourcing:** Provide a specification for how to create event importers as
+**Event Sourcing:** Provide a specification for how to create event sources as
 well as guidelines and tools for event providers to cleanly integrate in a
 CloudEvents environment.

--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -143,7 +143,7 @@ func TestNewAdaptor(t *testing.T) {
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
 			r := &mockReporter{}
-			a := NewAdaptor(tc.source, k8s, ce, logger, tc.opt, r, "test-importer")
+			a := NewAdaptor(tc.source, k8s, ce, logger, tc.opt, r, "test-source")
 
 			got, ok := a.(*adapter)
 			if !ok {
@@ -182,7 +182,7 @@ func TestAdapter_StartRef(t *testing.T) {
 		}},
 	}
 	r := &mockReporter{}
-	a := NewAdaptor(source, k8s, ce, logger, opt, r, "test-importer")
+	a := NewAdaptor(source, k8s, ce, logger, opt, r, "test-source")
 
 	err := errors.New("test never ran")
 	stopCh := make(chan struct{})
@@ -217,7 +217,7 @@ func TestAdapter_StartResource(t *testing.T) {
 		}},
 	}
 	r := &mockReporter{}
-	a := NewAdaptor(source, k8s, ce, logger, opt, r, "test-importer")
+	a := NewAdaptor(source, k8s, ce, logger, opt, r, "test-source")
 
 	err := errors.New("test never ran")
 	stopCh := make(chan struct{})

--- a/pkg/apis/duck/v1alpha1/resource_types.go
+++ b/pkg/apis/duck/v1alpha1/resource_types.go
@@ -26,7 +26,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
-// arbitrary other resources (such as any Importer or Addressable). This is not a real resource.
+// arbitrary other resources (such as any Source or Addressable). This is not a real resource.
 type Resource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1857

## Proposed Changes

- Revert Revert Source to Importer decision.
- Remove importer tags.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE.
```
