### PR TITLE
Append random postfix for namespace used in e2e tests

### DIFF
--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -92,7 +92,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			},
 			deprecatedTriggerFilter: true,
 		}, {
-			name: "test default broker with many attribute triggers",
+			name: "test default broker with many attrs triggers",
 			eventsToReceive: []eventReceiver{
 				{eventContext{Type: any, Source: any}, newSelector()},
 				{eventContext{Type: eventType1, Source: any}, newSelector()},
@@ -108,7 +108,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			deprecatedTriggerFilter: false,
 		},
 		{
-			name: "test default broker with many attribute and extension triggers",
+			name: "test default broker with many attrs and exts triggers",
 			eventsToReceive: []eventReceiver{
 				{eventContext{Type: any, Source: any, Extensions: map[string]interface{}{extensionName1: extensionValue1}}, newSelector()},
 				{eventContext{Type: any, Source: any, Extensions: map[string]interface{}{extensionName1: extensionValue1, extensionName2: extensionValue2}}, newSelector()},
@@ -131,6 +131,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			deprecatedTriggerFilter: false,
 		},
 	}
+	t.Parallel()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := setup(t, true)

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 /*
-TestEventTransformationForTrigger tests the following scenario:
+TestEventTransForTrigger tests the following scenario:
 
                          5                 4
                    ------------- ----------------------
@@ -37,6 +37,6 @@ EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
 
 Note: the number denotes the sequence of the event that flows in this test case.
 */
-func TestEventTransformationForTrigger(t *testing.T) {
+func TestEventTransForTrigger(t *testing.T) {
 	helpers.EventTransformationForTriggerTestHelper(t, channelTestRunner)
 }

--- a/test/e2e/channel_event_transformation_test.go
+++ b/test/e2e/channel_event_transformation_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 /*
-TestEventTransformationForSubscriptiop tests the following scenario:
+TestEventTransForSubscriptiop tests the following scenario:
 
              1            2                 5            6                  7
 EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> Service(Logger)
@@ -35,6 +35,6 @@ EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> 
                                    |  ---------
                                    -----------> Service(Transformation)
 */
-func TestEventTransformationForSubscription(t *testing.T) {
+func TestEventTransForSubscription(t *testing.T) {
 	helpers.EventTransformationForSubscriptionTestHelper(t, channelTestRunner)
 }

--- a/test/e2e/channel_single_event_test.go
+++ b/test/e2e/channel_single_event_test.go
@@ -32,7 +32,7 @@ EventSource ---> Channel ---> Subscription ---> Service(Logger)
 
 */
 
-func TestSingleBinaryEventForChannel(t *testing.T) {
+func TestOneBinaryEventForChannel(t *testing.T) {
 	helpers.SingleEventForChannelTestHelper(
 		t,
 		resources.CloudEventEncodingBinary,
@@ -40,7 +40,7 @@ func TestSingleBinaryEventForChannel(t *testing.T) {
 	)
 }
 
-func TestSingleStructuredEventForChannel(t *testing.T) {
+func TestOneStructedEventForChannel(t *testing.T) {
 	helpers.SingleEventForChannelTestHelper(
 		t,
 		resources.CloudEventEncodingStructured,


### PR DESCRIPTION
## Proposed Changes
- Fixes #1824 
- Do clean up if the test is interrupted

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
