### PR TITLE
Add arbitrary sleep after updating configmap in e2e test for defaultchannel

### DIFF
--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -19,6 +19,7 @@ package helpers
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ghodss/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,6 +159,9 @@ func updateDefaultChannelCM(client *common.Client, updateConfig func(config *def
 	// update the defaultchannel configmap
 	configMap.Data[channelDefaulterKey] = string(configBytes)
 	_, err = cmInterface.Update(configMap)
+	// In cmd/webhook.go, configMapWatcher watches the configmap changes and set the config for channeldefaulter,
+	// the resync time is set to 0, so 5 seconds should be enough to get the OnChange callback triggered.
+	time.Sleep(5 * time.Second)
 	return nil
 }
 


### PR DESCRIPTION
## Proposed Changes
The e2e test for `NatssChannel` is flaky, see https://testgrid.knative.dev/eventing-contrib#continuous.
The reason is in the test for `DefaultChannel`, after we update the configmap, the change is not immediately synced to the `channeldefaulter` singleton. Since the resync time is set to 0 in `configMapWatcher`, adding 5 seconds sleep should be enough to fix this issue.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @grantr 
