### PR TITLE
Stop using PrependGenerateNameReactor.

### DIFF
--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -82,9 +82,6 @@ func MakeFactory(ctor Ctor, unstructured bool) Factory {
 		statsReporter := &FakeStatsReporter{}
 		//ctx = reconciler.WithStatsReporter(ctx, statsReporter) // TODO: upstream stats interface from eventing to PKG
 
-		PrependGenerateNameReactor(&client.Fake)
-		PrependGenerateNameReactor(&dynamicClient.Fake)
-
 		// Set up our Controller from the fakes.
 		c := ctor(ctx, &ls, configmap.NewFixedWatcher())
 


### PR DESCRIPTION
This is broken by the K8s test libs starting in 1.14, and to work properly we would need to patch vendor to partially revert the library change.

The intent of this is to remove the logic to avoid having someone unknowingly start to depend on this functionality, which keeps eventing from having to carry this patch.
