### PR TITLE
Update status.ObservedGeneration for sources resources when sources r…

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -175,6 +175,7 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ApiServerSo
 		return err
 	}
 	source.Status.MarkEventTypes()
+	source.Status.ObservedGeneration = source.Generation
 
 	return nil
 }

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -141,6 +141,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ApiServerSource) error {
+	source.Status.ObservedGeneration = source.Generation
+
 	source.Status.InitializeConditions()
 
 	track := r.resourceTracker.TrackInNamespace(source)
@@ -175,7 +177,6 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ApiServerSo
 		return err
 	}
 	source.Status.MarkEventTypes()
-	source.Status.ObservedGeneration = source.Generation
 
 	return nil
 }

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -105,6 +105,7 @@ func TestReconcile(t *testing.T) {
 					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
+					WithApiServerSourceStatusObservedGeneration(generation),
 					WithApiServerSourceSinkNotFound,
 				),
 			}},

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -68,6 +68,8 @@ const (
 
 	sinkName = "testsink"
 	source   = "apiserveraddr"
+
+	generation = 1
 )
 
 func init() {
@@ -89,6 +91,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 			},
 			Key:     testNS + "/" + sourceName,
@@ -99,6 +102,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceSinkNotFound,
@@ -119,6 +123,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -143,11 +148,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 		},
@@ -165,6 +172,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -189,11 +197,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceDeploymentUnavailable,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -215,6 +225,7 @@ func TestReconcile(t *testing.T) {
 						ServiceAccountName: "malin",
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -240,11 +251,13 @@ func TestReconcile(t *testing.T) {
 						ServiceAccountName: "malin",
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeploymentUnavailable,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -265,6 +278,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -289,11 +303,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeploymentUnavailable,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -314,6 +330,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -339,11 +356,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{
@@ -364,6 +383,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewBroker(sinkName, testNS,
 					WithInitBrokerConditions,
@@ -388,11 +408,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -418,6 +440,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewBroker(sinkName, testNS,
 					WithInitBrokerConditions,
@@ -445,11 +468,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -472,6 +497,7 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 				),
 				NewBroker(sinkName, testNS,
 					WithInitBrokerConditions,
@@ -502,11 +528,13 @@ func TestReconcile(t *testing.T) {
 						Sink: &brokerRef,
 					}),
 					WithApiServerSourceUID(sourceUID),
+					WithApiServerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
 					WithApiServerSourceEventTypes,
+					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -113,6 +113,7 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ContainerSo
 		return nil
 	}
 
+	source.Status.ObservedGeneration = source.Generation
 	source.Status.InitializeConditions()
 
 	annotations := make(map[string]string)
@@ -157,7 +158,6 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ContainerSo
 		source.Status.MarkDeployed()
 		r.Recorder.Eventf(source, corev1.EventTypeNormal, "DeploymentReady", "Deployment %q has %d ready replicas", ra.Name, ra.Status.ReadyReplicas)
 	}
-	source.Status.ObservedGeneration = source.Generation
 	return nil
 }
 

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -157,7 +157,7 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ContainerSo
 		source.Status.MarkDeployed()
 		r.Recorder.Eventf(source, corev1.EventTypeNormal, "DeploymentReady", "Deployment %q has %d ready replicas", ra.Name, ra.Status.ReadyReplicas)
 	}
-
+	source.Status.ObservedGeneration = source.Generation
 	return nil
 }
 

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -47,6 +47,7 @@ const (
 	sourceUID  = "1234-5678-90"
 	testNS     = "testnamespace"
 	sinkName   = "testsink"
+	generation = 1
 )
 
 var (
@@ -104,6 +105,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 			},
 			Key:     testNS + "/" + sourceName,
@@ -117,6 +119,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": Error fetching sink &ObjectReference{Kind:Channel,Namespace:testnamespace,Name:testsink,UID:,APIVersion:messaging.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} for source "testnamespace/test-container-source, /, Kind=": channels.messaging.knative.dev "testsink" not found"`),
@@ -130,6 +133,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &nonsinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 				NewTrigger(sinkName, testNS, ""),
 			},
@@ -144,6 +148,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &nonsinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": sink &ObjectReference{Kind:Trigger,Namespace:testnamespace,Name:testsink,UID:,APIVersion:eventing.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} does not contain address"`),
@@ -157,6 +162,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS),
 			},
@@ -171,6 +177,7 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": sink &ObjectReference{Kind:Channel,Namespace:testnamespace,Name:testsink,UID:,APIVersion:messaging.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} does not contain address"`),
@@ -183,6 +190,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 						DeprecatedImage: image,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 			},
 			Key:     testNS + "/" + sourceName,
@@ -195,6 +203,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceSpec(sourcesv1alpha1.ContainerSourceSpec{
 						DeprecatedImage: image,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSinkMissing("Sink missing from spec"),
@@ -218,6 +227,7 @@ func TestAllCases(t *testing.T) {
 						},
 						Sink: &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceUID(sourceUID),
 				),
 				NewChannel(sinkName, testNS,
@@ -246,10 +256,12 @@ func TestAllCases(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -269,6 +281,7 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithChannelAddress(sinkDNS),
@@ -285,11 +298,13 @@ func TestAllCases(t *testing.T) {
 						DeprecatedImage: image,
 						Sink:            &sinkRef,
 					}),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceUID(sourceUID),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -319,6 +334,7 @@ func TestAllCases(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(`Created deployment ""`),
@@ -356,10 +372,12 @@ func TestAllCases(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					// Status Update:
 					WithContainerSourceDeployed,
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 		}, {
@@ -371,6 +389,7 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(`Created deployment ""`),
@@ -398,10 +417,12 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					// Status Update:
 					WithContainerSourceDeployed,
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 		}, {
@@ -423,6 +444,7 @@ func TestAllCases(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceLabels(map[string]string{"label": "labeled"}),
 					WithContainerSourceAnnotations(map[string]string{"annotation": "annotated"}),
 				),
@@ -452,12 +474,14 @@ func TestAllCases(t *testing.T) {
 						Sink: &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceLabels(map[string]string{"label": "labeled"}),
 					WithContainerSourceAnnotations(map[string]string{"annotation": "annotated"}),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -477,6 +501,7 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceLabels(map[string]string{"label": "labeled"}),
 					WithContainerSourceAnnotations(map[string]string{"annotation": "annotated"}),
 				),
@@ -496,12 +521,14 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					WithContainerSourceLabels(map[string]string{"label": "labeled"}),
 					WithContainerSourceAnnotations(map[string]string{"annotation": "annotated"}),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeploying(fmt.Sprintf(`Created deployment "%s"`, deploymentName)),
+					WithContainerSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -521,6 +548,7 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithChannelAddress(sinkDNS),
@@ -541,6 +569,7 @@ func TestAllCases(t *testing.T) {
 						Sink:            &sinkRef,
 					}),
 					WithContainerSourceUID(sourceUID),
+					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
 					WithContainerSourceSink(sinkURI),

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -122,6 +122,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
+					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": Error fetching sink &ObjectReference{Kind:Channel,Namespace:testnamespace,Name:testsink,UID:,APIVersion:messaging.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} for source "testnamespace/test-container-source, /, Kind=": channels.messaging.knative.dev "testsink" not found"`),
 				),
 			}},
@@ -151,6 +152,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
+					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": sink &ObjectReference{Kind:Trigger,Namespace:testnamespace,Name:testsink,UID:,APIVersion:eventing.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} does not contain address"`),
 				),
 			}},
@@ -180,6 +182,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
+					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourceSinkNotFound(`Couldn't get Sink URI from "testnamespace/testsink": sink &ObjectReference{Kind:Channel,Namespace:testnamespace,Name:testsink,UID:,APIVersion:messaging.knative.dev/v1alpha1,ResourceVersion:,FieldPath:,} does not contain address"`),
 				),
 			}},
@@ -206,6 +209,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
+					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourceSinkMissing("Sink missing from spec"),
 				),
 			}},
@@ -572,6 +576,7 @@ func TestAllCases(t *testing.T) {
 					WithContainerSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitContainerSourceConditions,
+					WithContainerSourceStatusObservedGeneration(generation),
 					WithContainerSourceSink(sinkURI),
 					WithContainerSourceDeployFailed(`Could not create deployment: inducing failure for create deployments`),
 				),

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -128,6 +128,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cronjob *v1alpha1.CronJobSou
 	//     - Will be garbage collected by K8s when this CronJobSource is deleted.
 	// 3. Create the EventType that it can emit.
 	//     - Will be garbage collected by K8s when this CronJobSource is deleted.
+	cronjob.Status.ObservedGeneration = cronjob.Generation
 
 	cronjob.Status.InitializeConditions()
 
@@ -169,7 +170,6 @@ func (r *Reconciler) reconcile(ctx context.Context, cronjob *v1alpha1.CronJobSou
 		return fmt.Errorf("reconciling event types: %v", err)
 	}
 	cronjob.Status.MarkEventType()
-	cronjob.Status.ObservedGeneration = cronjob.Generation
 
 	return nil
 }

--- a/pkg/reconciler/cronjobsource/cronjobsource.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource.go
@@ -169,6 +169,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cronjob *v1alpha1.CronJobSou
 		return fmt.Errorf("reconciling event types: %v", err)
 	}
 	cronjob.Status.MarkEventType()
+	cronjob.Status.ObservedGeneration = cronjob.Generation
 
 	return nil
 }

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -77,7 +77,8 @@ const (
 	testSchedule = "*/2 * * * *"
 	testData     = "data"
 
-	sinkName = "testsink"
+	sinkName   = "testsink"
+	generation = 1
 )
 
 func init() {
@@ -107,6 +108,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 			},
 			Key:     testNS + "/" + sourceName,
@@ -122,6 +124,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithInvalidCronJobSourceSchedule,
@@ -137,6 +140,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 			},
 			Key:     testNS + "/" + sourceName,
@@ -149,6 +153,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
@@ -165,6 +170,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -185,6 +191,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
@@ -192,6 +199,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceDeployed,
 					WithCronJobSourceSink(sinkURI),
 					WithCronJobSourceEventType,
+					WithCronJobSourceStatusObservedGeneration(generation),
 				),
 			}},
 		}, {
@@ -204,6 +212,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &brokerRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 				NewBroker(sinkName, testNS,
 					WithInitBrokerConditions,
@@ -224,6 +233,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &brokerRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
@@ -231,6 +241,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceDeployed,
 					WithCronJobSourceEventType,
 					WithCronJobSourceSink(sinkURI),
+					WithCronJobSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -251,6 +262,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &brokerRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 				NewBroker(sinkName, testNS,
 					WithInitBrokerConditions,
@@ -277,6 +289,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &brokerRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
@@ -284,6 +297,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceDeployed,
 					WithCronJobSourceEventType,
 					WithCronJobSourceSink(sinkURI),
+					WithCronJobSourceStatusObservedGeneration(generation),
 				),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
@@ -307,6 +321,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 				),
 				NewChannel(sinkName, testNS,
 					WithInitChannelConditions,
@@ -327,6 +342,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
@@ -334,6 +350,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceDeployed,
 					WithCronJobSourceSink(sinkURI),
 					WithCronJobSourceEventType,
+					WithCronJobSourceStatusObservedGeneration(generation),
 				),
 			}},
 		}, {
@@ -346,6 +363,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
 					WithValidCronJobSourceResources,
@@ -360,6 +378,25 @@ func TestAllCases(t *testing.T) {
 				makeAvailableReceiveAdapter(sinkRef),
 			},
 			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewCronJobSource(sourceName, testNS,
+					WithCronJobSourceSpec(sourcesv1alpha1.CronJobSourceSpec{
+						Schedule: testSchedule,
+						Data:     testData,
+						Sink:     &sinkRef,
+					}),
+					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
+					// Status Update:
+					WithInitCronJobSourceConditions,
+					WithValidCronJobSourceSchedule,
+					WithValidCronJobSourceResources,
+					WithCronJobSourceDeployed,
+					WithCronJobSourceSink(sinkURI),
+					WithCronJobSourceEventType,
+					WithCronJobSourceStatusObservedGeneration(generation),
+				),
+			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "CronJobSourceReconciled", `CronJobSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
@@ -373,6 +410,7 @@ func TestAllCases(t *testing.T) {
 						Sink:     &sinkRef,
 					}),
 					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
 					WithInitCronJobSourceConditions,
 					WithValidCronJobSourceSchedule,
 					WithValidCronJobSourceResources,
@@ -394,6 +432,25 @@ func TestAllCases(t *testing.T) {
 					WithEventTypeOwnerReference(ownerRef)),
 			},
 			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewCronJobSource(sourceName, testNS,
+					WithCronJobSourceSpec(sourcesv1alpha1.CronJobSourceSpec{
+						Schedule: testSchedule,
+						Data:     testData,
+						Sink:     &sinkRef,
+					}),
+					WithCronJobSourceUID(sourceUID),
+					WithCronJobSourceObjectMetaGeneration(generation),
+					// Status Update:
+					WithInitCronJobSourceConditions,
+					WithValidCronJobSourceSchedule,
+					WithValidCronJobSourceResources,
+					WithCronJobSourceDeployed,
+					WithCronJobSourceSink(sinkURI),
+					WithCronJobSourceEventType,
+					WithCronJobSourceStatusObservedGeneration(generation),
+				),
+			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "CronJobSourceReconciled", `CronJobSource reconciled: "%s/%s"`, testNS, sourceName),
 			},

--- a/pkg/reconciler/cronjobsource/cronjobsource_test.go
+++ b/pkg/reconciler/cronjobsource/cronjobsource_test.go
@@ -127,6 +127,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
+					WithCronJobSourceStatusObservedGeneration(generation),
 					WithInvalidCronJobSourceSchedule,
 				),
 			}},
@@ -156,6 +157,7 @@ func TestAllCases(t *testing.T) {
 					WithCronJobSourceObjectMetaGeneration(generation),
 					// Status Update:
 					WithInitCronJobSourceConditions,
+					WithCronJobSourceStatusObservedGeneration(generation),
 					WithValidCronJobSourceSchedule,
 					WithCronJobSourceSinkNotFound,
 				),

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -89,3 +89,15 @@ func WithApiServerSourceSpec(spec v1alpha1.ApiServerSourceSpec) ApiServerSourceO
 		c.Spec = spec
 	}
 }
+
+func WithApiServerSourceStatusObservedGeneration(generation int64) ApiServerSourceOption {
+	return func(c *v1alpha1.ApiServerSource) {
+		c.Status.ObservedGeneration = generation
+	}
+}
+
+func WithApiServerSourceObjectMetaGeneration(generation int64) ApiServerSourceOption {
+	return func(c *v1alpha1.ApiServerSource) {
+		c.ObjectMeta.Generation = generation
+	}
+}

--- a/pkg/reconciler/testing/containersource.go
+++ b/pkg/reconciler/testing/containersource.go
@@ -111,3 +111,15 @@ func WithContainerSourceAnnotations(annotations map[string]string) ContainerSour
 		c.Annotations = annotations
 	}
 }
+
+func WithContainerSourceStatusObservedGeneration(generation int64) ContainerSourceOption {
+	return func(c *v1alpha1.ContainerSource) {
+		c.Status.ObservedGeneration = generation
+	}
+}
+
+func WithContainerSourceObjectMetaGeneration(generation int64) ContainerSourceOption {
+	return func(c *v1alpha1.ContainerSource) {
+		c.ObjectMeta.Generation = generation
+	}
+}

--- a/pkg/reconciler/testing/cronjobsource.go
+++ b/pkg/reconciler/testing/cronjobsource.go
@@ -99,3 +99,15 @@ func WithCronJobApiVersion(apiVersion string) CronJobSourceOption {
 		c.APIVersion = apiVersion
 	}
 }
+
+func WithCronJobSourceStatusObservedGeneration(generation int64) CronJobSourceOption {
+	return func(c *v1alpha1.CronJobSource) {
+		c.Status.ObservedGeneration = generation
+	}
+}
+
+func WithCronJobSourceObjectMetaGeneration(generation int64) CronJobSourceOption {
+	return func(c *v1alpha1.CronJobSource) {
+		c.ObjectMeta.Generation = generation
+	}
+}


### PR DESCRIPTION
Fixes #1893 

## Proposed Changes

- Update status.ObservedGeneration for sources resources when sources resources get reconciled successfully
- Added unit tests
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
