### PR TITLE
Mark Dependency status as Unknown when the dependency object's generation is not equal

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -264,10 +264,10 @@ func (r *Reconciler) propagateDependencyReadiness(dependencyObjRef corev1.Object
 	// The dependency hasn't yet reconciled our latest changes to
 	// its desired state, so its conditions are outdated.
 	if dependency.GetGeneration() != dependency.Status.ObservedGeneration {
-		logging.FromContext(ctx).Error("The ObjectMeta Generation of dependency is not equal to the observedGeneration of status",
-			zap.Any("ObjectMeta Generation of dependency", dependency.GetGeneration()),
-			zap.Any("ObservedGeneration of status", dependency.Status.ObservedGeneration))
-		t.Status.MarkDependencyUnknown("GenerationNotEqual", "The ObjectMeta Generation of dependency %q is not equal to the ObservedGeneration of status %q", dependency.GetGeneration(), dependency.Status.ObservedGeneration)
+		logging.FromContext(ctx).Info("The ObjectMeta Generation of dependency is not equal to the observedGeneration of status",
+			zap.Any("objectMetaGeneration", dependency.GetGeneration()),
+			zap.Any("statusObservedGeneration", dependency.Status.ObservedGeneration))
+		t.Status.MarkDependencyUnknown("GenerationNotEqual", "The dependency's metadata.generation, %q, is not equal to its status.observedGeneration, %q.", dependency.GetGeneration(), dependency.Status.ObservedGeneration)
 		return nil
 	}
 	t.Status.PropagateDependencyStatus(dependency)

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -260,15 +260,16 @@ func (r *Reconciler) propagateDependencyReadiness(dependencyObjRef corev1.Object
 		return fmt.Errorf("getting the dependency: %v", err)
 	}
 	dependency := dependencyObj.(*duckv1alpha1.KResource)
-	// Temporarily comment it until we figure out whether we update Status.ObservedGeneration when KResource changes
-	// From manual testing, it looks like we never update  Status.ObservedGeneration
-	//if dependency.GetGeneration() != dependency.Status.ObservedGeneration {
-	//	logging.FromContext(ctx).Error("The ObjectMeta Generation of dependency is not equal to the observedGeneration of status",
-	//		zap.Any("ObjectMeta Generation of dependency", dependency.GetGeneration()),
-	//		zap.Any("ObservedGeneration of status", dependency.Status.ObservedGeneration))
-	//	t.Status.MarkDependencyUnknown("GenerationNotEqual", "The ObjectMeta Generation of dependency %d is not equal to the ObservedGeneration of status %d", dependency.GetGeneration(), dependency.Status.ObservedGeneration)
-	//	return nil
-	//}
+
+	// The dependency hasn't yet reconciled our latest changes to
+	// its desired state, so its conditions are outdated.
+	if dependency.GetGeneration() != dependency.Status.ObservedGeneration {
+		logging.FromContext(ctx).Error("The ObjectMeta Generation of dependency is not equal to the observedGeneration of status",
+			zap.Any("ObjectMeta Generation of dependency", dependency.GetGeneration()),
+			zap.Any("ObservedGeneration of status", dependency.Status.ObservedGeneration))
+		t.Status.MarkDependencyUnknown("GenerationNotEqual", "The ObjectMeta Generation of dependency %q is not equal to the ObservedGeneration of status %q", dependency.GetGeneration(), dependency.Status.ObservedGeneration)
+		return nil
+	}
 	t.Status.PropagateDependencyStatus(dependency)
 	return nil
 }

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -598,7 +598,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithTriggerBrokerReady(),
 					reconciletesting.WithTriggerSubscribed(),
 					reconciletesting.WithTriggerStatusSubscriberURI(subscriberURI),
-					reconciletesting.WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The ObjectMeta Generation of dependency %q is not equal to the ObservedGeneration of status %q", currentGeneration, outdatedGeneration))),
+					reconciletesting.WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The dependency's metadata.generation, %q, is not equal to its status.observedGeneration, %q.", currentGeneration, outdatedGeneration))),
 			}},
 		},
 		{

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -79,6 +79,9 @@ const (
 	testSchedule            = "*/2 * * * *"
 	testData                = "data"
 	sinkName                = "testsink"
+
+	currentGeneration  = 1
+	outdatedGeneration = 0
 )
 
 var (
@@ -568,6 +571,37 @@ func TestAllCases(t *testing.T) {
 				),
 			}},
 		}, {
+			Name: "Dependency generation not equal",
+			Key:  triggerKey,
+			Objects: []runtime.Object{
+				makeReadyBroker(),
+				makeBrokerFilterService(),
+				makeReadySubscription(),
+				makeGenerationNotEqualCronJobSource(),
+				reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
+					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
+					reconciletesting.WithInitTriggerConditions,
+					reconciletesting.WithDependencyAnnotation(dependencyAnnotation),
+				),
+			},
+			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled")},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: reconciletesting.NewTrigger(triggerName, testNS, brokerName,
+					reconciletesting.WithTriggerUID(triggerUID),
+					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
+					// The first reconciliation will initialize the status conditions.
+					reconciletesting.WithInitTriggerConditions,
+					reconciletesting.WithDependencyAnnotation(dependencyAnnotation),
+					reconciletesting.WithTriggerBrokerReady(),
+					reconciletesting.WithTriggerSubscribed(),
+					reconciletesting.WithTriggerStatusSubscriberURI(subscriberURI),
+					reconciletesting.WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The ObjectMeta Generation of dependency %q is not equal to the ObservedGeneration of status %q", currentGeneration, outdatedGeneration))),
+			}},
+		},
+		{
 			Name: "Dependency ready",
 			Key:  triggerKey,
 			Objects: []runtime.Object{
@@ -759,6 +793,13 @@ func makeNotReadySubscription() *messagingv1alpha1.Subscription {
 
 func makeNotReadyCronJobSource() *sourcesv1alpha1.CronJobSource {
 	return NewCronJobSource(cronJobSourceName, testNS, WithCronJobApiVersion(cronJobSourceAPIVersion), WithCronJobSourceSinkNotFound)
+}
+
+func makeGenerationNotEqualCronJobSource() *sourcesv1alpha1.CronJobSource {
+	c := makeNotReadyCronJobSource()
+	c.Generation = currentGeneration
+	c.Status.ObservedGeneration = outdatedGeneration
+	return c
 }
 
 func makeReadyCronJobSource() *sourcesv1alpha1.CronJobSource {


### PR DESCRIPTION
Fixes #1911 

## Proposed Changes

- Mark Dependency status as Unknown when the dependency object’s ObjectMetadata.Generation and Status.ObservedGeneration are not equal during the trigger reconcile process 
- Added unit tests
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
