### PR TITLE
Improve InMemoryChannel tracing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1321,6 +1321,7 @@
     "github.com/google/mako/go/quickstore",
     "github.com/google/uuid",
     "github.com/kelseyhightower/envconfig",
+    "github.com/openzipkin/zipkin-go/model",
     "github.com/pkg/errors",
     "github.com/robfig/cron",
     "github.com/tsenart/vegeta/lib",

--- a/pkg/channel/message.go
+++ b/pkg/channel/message.go
@@ -35,6 +35,7 @@ var historySplitter = regexp.MustCompile(`\s*` + regexp.QuoteMeta(MessageHistory
 
 var forwardHeaders = []string{
 	"content-type",
+	"x-request-id",
 }
 
 var forwardPrefixes = []string{

--- a/pkg/channel/message.go
+++ b/pkg/channel/message.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -33,8 +35,6 @@ var historySplitter = regexp.MustCompile(`\s*` + regexp.QuoteMeta(MessageHistory
 
 var forwardHeaders = []string{
 	"content-type",
-	// tracing
-	"x-request-id",
 }
 
 var forwardPrefixes = []string{
@@ -42,9 +42,6 @@ var forwardPrefixes = []string{
 	"knative-",
 	// cloud events
 	"ce-",
-	// tracing
-	"x-b3-",
-	"x-ot-",
 }
 
 // Message represents a chunk of data within a channel dispatcher. The message contains both
@@ -53,6 +50,9 @@ var forwardPrefixes = []string{
 //
 // A message may represent a CloudEvent.
 type Message struct {
+	// Span is the tracing Span that was associated with the incoming request.
+	Span *trace.Span
+
 	// Headers provide metadata about the message payload. All header keys
 	// should be lowercase.
 	Headers map[string]string `json:"headers,omitempty"`

--- a/pkg/channel/message_receiver_test.go
+++ b/pkg/channel/message_receiver_test.go
@@ -100,8 +100,6 @@ func TestMessageReceiver_HandleRequest(t *testing.T) {
 					// discarded.
 					"knatIve-will-pass-through": "true",
 					"cE-pass-through":           "true",
-					"x-B3-pass":                 "true",
-					"x-ot-pass":                 "true",
 					"ce-knativehistory":         "test-name.test-namespace.svc." + utils.GetClusterDomainName(),
 				}
 				if diff := cmp.Diff(expectedHeaders, m.Headers); diff != "" {

--- a/test/conformance/helpers/tracing/traces.go
+++ b/test/conformance/helpers/tracing/traces.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+// PrettyPrintTrace pretty prints a Trace.
+func PrettyPrintTrace(trace []model.SpanModel) string {
+	b, _ := json.Marshal(trace)
+	return string(b)
+}
+
+// SpanTree is the tree of Spans representation of a Trace.
+type SpanTree struct {
+	Span     model.SpanModel
+	Children []SpanTree
+}
+
+// TestSpanTree is the expected version of SpanTree used for assertions in testing.
+type TestSpanTree struct {
+	Root                     bool
+	Kind                     model.Kind
+	LocalEndpointServiceName string
+	Tags                     map[string]string
+
+	Children []TestSpanTree
+}
+
+// GetTraceTree converts a set slice of spans into a SpanTree.
+func GetTraceTree(t *testing.T, trace []model.SpanModel) SpanTree {
+	var roots []model.SpanModel
+	parents := map[model.ID][]model.SpanModel{}
+	for _, span := range trace {
+		if span.ParentID != nil {
+			parents[*span.ParentID] = append(parents[*span.ParentID], span)
+		} else {
+			roots = append(roots, span)
+		}
+	}
+
+	children, err := getChildren(parents, roots)
+	if err != nil {
+		t.Fatalf("Could not create span tree for %v: %v", PrettyPrintTrace(trace), err)
+	}
+
+	tree := SpanTree{
+		Children: children,
+	}
+	if len(parents) != 0 {
+		t.Fatalf("Left over spans after generating the SpanTree: %v. Original: %v", parents, PrettyPrintTrace(trace))
+	}
+	return tree
+}
+
+func getChildren(parents map[model.ID][]model.SpanModel, current []model.SpanModel) ([]SpanTree, error) {
+	var children []SpanTree
+	for _, span := range current {
+		grandchildren, err := getChildren(parents, parents[span.ID])
+		if err != nil {
+			return children, err
+		}
+		children = append(children, SpanTree{
+			Span:     span,
+			Children: grandchildren,
+		})
+		delete(parents, span.ID)
+	}
+	return children, nil
+}
+
+// SpanCount gets the count of spans in this tree.
+func (t TestSpanTree) SpanCount() int {
+	spans := 1
+	if t.Root {
+		// The root span is artificial. It exits solely so we can easily pass around the tree.
+		spans = 0
+	}
+	for _, child := range t.Children {
+		spans += child.SpanCount()
+	}
+	return spans
+}
+
+// Matches checks to see if this TestSpanTree matches an actual SpanTree. It is intended to be used
+// for assertions while testing.
+func (t TestSpanTree) Matches(actual SpanTree) error {
+	return traceTreeMatches(".", t, actual)
+}
+
+func traceTreeMatches(pos string, want TestSpanTree, got SpanTree) error {
+	if g, w := got.Span.Kind, want.Kind; g != w {
+		return fmt.Errorf("unexpected kind at %q: got %q, want %q", pos, g, w)
+	}
+	gotLocalEndpointServiceName := ""
+	if got.Span.LocalEndpoint != nil {
+		gotLocalEndpointServiceName = got.Span.LocalEndpoint.ServiceName
+	}
+	if w := want.LocalEndpointServiceName; w != "" && gotLocalEndpointServiceName != w {
+		return fmt.Errorf("unexpected localEndpoint.ServiceName at %q: got %q, want %q", pos, gotLocalEndpointServiceName, w)
+	}
+	for k, w := range want.Tags {
+		if g := got.Span.Tags[k]; g != w {
+			return fmt.Errorf("unexpected tag[%s] value at %q: got %q, want %q", k, pos, g, w)
+		}
+	}
+	if g, w := len(got.Children), len(want.Children); g != w {
+		return fmt.Errorf("unexpected number of children at %q: got %v, want %v", pos, g, w)
+	}
+	// TODO: Children are actually unordered, assert them in an unordered fashion.
+	for i := range want.Children {
+		if err := traceTreeMatches(fmt.Sprintf("%s%d.", pos, i), want.Children[i], got.Children[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Helps with #1765.

## Proposed Changes

- Improve InMemoryChannel tracing, likely the other Channel implementations too.
- Increase the scope of the TestChannelTracing E2E test to actually assert things about the trace being generated.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
