### PR TITLE
Rename kn2 to kne

### DIFF
--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -58,7 +58,7 @@ const (
 	triggerChannel channelType = "TriggerChannel"
 	ingressChannel channelType = "IngressChannel"
 
-	ingressChannelName = "test-broker-kn2-ingress"
+	ingressChannelName = "test-broker-kne-ingress"
 )
 
 var (
@@ -952,7 +952,7 @@ func createChannel(namespace string, t channelType, ready bool) *unstructured.Un
 	var hostname string
 	var url string
 	if t == triggerChannel {
-		name = fmt.Sprintf("%s-kn2-trigger", brokerName)
+		name = fmt.Sprintf("%s-kne-trigger", brokerName)
 		labels = map[string]interface{}{
 			"eventing.knative.dev/broker":           brokerName,
 			"eventing.knative.dev/brokerEverything": "true",
@@ -960,7 +960,7 @@ func createChannel(namespace string, t channelType, ready bool) *unstructured.Un
 		hostname = triggerChannelHostname
 		url = fmt.Sprintf("http://%s", triggerChannelHostname)
 	} else {
-		name = fmt.Sprintf("%s-kn2-ingress", brokerName)
+		name = fmt.Sprintf("%s-kne-ingress", brokerName)
 		labels = map[string]interface{}{
 			"eventing.knative.dev/broker":        brokerName,
 			"eventing.knative.dev/brokerIngress": "true",
@@ -1028,7 +1028,7 @@ func createTriggerChannelRef() *corev1.ObjectReference {
 		APIVersion: "messaging.knative.dev/v1alpha1",
 		Kind:       "InMemoryChannel",
 		Namespace:  testNS,
-		Name:       fmt.Sprintf("%s-kn2-trigger", brokerName),
+		Name:       fmt.Sprintf("%s-kne-trigger", brokerName),
 	}
 }
 
@@ -1037,6 +1037,6 @@ func createIngressChannelRef() *corev1.ObjectReference {
 		APIVersion: "messaging.knative.dev/v1alpha1",
 		Kind:       "InMemoryChannel",
 		Namespace:  testNS,
-		Name:       fmt.Sprintf("%s-kn2-ingress", brokerName),
+		Name:       fmt.Sprintf("%s-kne-ingress", brokerName),
 	}
 }

--- a/pkg/reconciler/broker/resources/channel.go
+++ b/pkg/reconciler/broker/resources/channel.go
@@ -30,9 +30,10 @@ import (
 // BrokerChannelName creates a name for the Channel for a Broker for a given
 // Channel type.
 func BrokerChannelName(brokerName, channelType string) string {
-	return fmt.Sprintf("%s-kn2-%s", brokerName, channelType)
+	return fmt.Sprintf("%s-kne-%s", brokerName, channelType)
 }
 
+// test
 // NewChannel returns an unstructured.Unstructured based on the ChannelTemplateSpec
 // for a given Broker.
 func NewChannel(channelType string, b *v1alpha1.Broker, l map[string]string) (*unstructured.Unstructured, error) {

--- a/pkg/reconciler/broker/resources/channel_test.go
+++ b/pkg/reconciler/broker/resources/channel_test.go
@@ -29,7 +29,7 @@ import (
 func TestBrokerChannelName(t *testing.T) {
 	// Any changes to this name are breaking changes, this test is here so that changes can't be
 	// made by accident.
-	expected := "default-kn2-ingress"
+	expected := "default-kne-ingress"
 	if actual := BrokerChannelName("default", "ingress"); actual != expected {
 		t.Errorf("expected %q, actual %q", expected, actual)
 	}
@@ -104,7 +104,7 @@ func TestNewChannel(t *testing.T) {
 			if md["namespace"] != b.Namespace {
 				t.Errorf("expected namespace %q, actually %q", b.Namespace, md["namespace"])
 			}
-			if name := md["name"]; name != "my-broker-kn2-ingress" {
+			if name := md["name"]; name != "my-broker-kne-ingress" {
 				t.Errorf("Expected name %q, actually %q", "my-broker-kn-ingress", name)
 			}
 			if l := md["labels"].(map[string]interface{}); len(l) != len(labels) {


### PR DESCRIPTION
## Proposed Changes

- renaming the `kn2` to `kne`, since we really just have one channel option (CRD, as CCP is dead)


## Tests

created a broker from 0.9.0 release, and and did `ko apply` this change.

Two new channels were created:
```
...
inmemorychannel.messaging.knative.dev/default-kne-ingress   True             default-kne-ingress-kn-chan
nel.default.svc.cluster.local   2m45s
inmemorychannel.messaging.knative.dev/default-kne-trigger   True             default-kne-trigger-kn-chan
nel.default.svc.cluster.local   2m45s
...
```

The subscription went to READY:

```
internal-ingress-default-eb08e7c9-dddd-11e9-a185-ec2a10221838   True             3m10s
```

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
This change has the potential to lose a few events right around the transition to the new (renamed) subscription
```
