### PR TITLE
Add missing user info annotations on resources (#1980)

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -53,9 +53,13 @@ type Broker struct {
 
 var (
 	// Check that Broker can be validated, can be defaulted, and has immutable fields.
-	_ apis.Validatable   = (*Broker)(nil)
-	_ apis.Defaultable   = (*Broker)(nil)
-	_ apis.Immutable     = (*Broker)(nil)
+	_ apis.Validatable = (*Broker)(nil)
+	_ apis.Defaultable = (*Broker)(nil)
+	_ apis.Immutable   = (*Broker)(nil)
+
+	// Check that Broker can return its spec untyped.
+	_ apis.HasSpec = (*Broker)(nil)
+
 	_ runtime.Object     = (*Broker)(nil)
 	_ webhook.GenericCRD = (*Broker)(nil)
 

--- a/pkg/apis/eventing/v1alpha1/eventtype_types.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/webhook"
@@ -80,6 +81,11 @@ type EventTypeList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EventType `json:"items"`
+}
+
+// GetGroupVersionKind returns GroupVersionKind for EventType
+func (p *EventType) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind("EventType")
 }
 
 // GetUntypedSpec returns the spec of the EventType.

--- a/pkg/apis/eventing/v1alpha1/eventtype_types.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_types.go
@@ -81,3 +81,8 @@ type EventTypeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EventType `json:"items"`
 }
+
+// GetUntypedSpec returns the spec of the EventType.
+func (e *EventType) GetUntypedSpec() interface{} {
+	return e.Spec
+}

--- a/pkg/apis/eventing/v1alpha1/eventtype_types.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_types.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -42,12 +43,21 @@ type EventType struct {
 	Status EventTypeStatus `json:"status,omitempty"`
 }
 
-// Check that EventType can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*EventType)(nil)
-var _ apis.Defaultable = (*EventType)(nil)
-var _ apis.Immutable = (*EventType)(nil)
-var _ runtime.Object = (*EventType)(nil)
-var _ webhook.GenericCRD = (*EventType)(nil)
+var (
+	// Check that EventType can be validated, can be defaulted, and has immutable fields.
+	_ apis.Validatable = (*EventType)(nil)
+	_ apis.Defaultable = (*EventType)(nil)
+	_ apis.Immutable   = (*EventType)(nil)
+
+	// Check that EventType can return its spec untyped.
+	_ apis.HasSpec = (*EventType)(nil)
+
+	_ runtime.Object     = (*EventType)(nil)
+	_ webhook.GenericCRD = (*EventType)(nil)
+
+	// Check that we can create OwnerReferences to an EventType.
+	_ kmeta.OwnerRefable = (*EventType)(nil)
+)
 
 type EventTypeSpec struct {
 	// Type represents the CloudEvents type. It is authoritative.

--- a/pkg/apis/eventing/v1alpha1/eventtype_types_test.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_types_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestEventType_GetGroupVersionKind(t *testing.T) {
+	src := EventType{}
+	gvk := src.GetGroupVersionKind()
+
+	if gvk.Kind != "EventType" {
+		t.Errorf("Should be EventType.")
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -54,9 +54,13 @@ type Trigger struct {
 
 var (
 	// Check that Trigger can be validated, can be defaulted, and has immutable fields.
-	_ apis.Validatable   = (*Trigger)(nil)
-	_ apis.Defaultable   = (*Trigger)(nil)
-	_ apis.Immutable     = (*Trigger)(nil)
+	_ apis.Validatable = (*Trigger)(nil)
+	_ apis.Defaultable = (*Trigger)(nil)
+	_ apis.Immutable   = (*Trigger)(nil)
+
+	// Check that Trigger can return its spec untyped.
+	_ apis.HasSpec = (*Trigger)(nil)
+
 	_ runtime.Object     = (*Trigger)(nil)
 	_ webhook.GenericCRD = (*Trigger)(nil)
 

--- a/pkg/apis/messaging/v1alpha1/channel_types.go
+++ b/pkg/apis/messaging/v1alpha1/channel_types.go
@@ -99,3 +99,8 @@ type ChannelList struct {
 func (dc *Channel) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Channel")
 }
+
+// GetUntypedSpec returns the spec of the Channel.
+func (c *Channel) GetUntypedSpec() interface{} {
+	return c.Spec
+}

--- a/pkg/apis/messaging/v1alpha1/channel_types.go
+++ b/pkg/apis/messaging/v1alpha1/channel_types.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -46,11 +47,20 @@ type Channel struct {
 	Status ChannelStatus `json:"status,omitempty"`
 }
 
-// Check that Channel can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*Channel)(nil)
-var _ apis.Defaultable = (*Channel)(nil)
-var _ runtime.Object = (*Channel)(nil)
-var _ webhook.GenericCRD = (*Channel)(nil)
+var (
+	// Check that Channel can be validated and defaulted.
+	_ apis.Validatable = (*Channel)(nil)
+	_ apis.Defaultable = (*Channel)(nil)
+
+	// Check that Channel can return its spec untyped.
+	_ apis.HasSpec = (*Channel)(nil)
+
+	_ runtime.Object     = (*Channel)(nil)
+	_ webhook.GenericCRD = (*Channel)(nil)
+
+	// Check that we can create OwnerReferences to a Channel.
+	_ kmeta.OwnerRefable = (*Channel)(nil)
+)
 
 // ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
 // It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_types.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_types.go
@@ -91,3 +91,8 @@ type InMemoryChannelList struct {
 func (imc *InMemoryChannel) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("InMemoryChannel")
 }
+
+// GetUntypedSpec returns the spec of the InMemoryChannel.
+func (i *InMemoryChannel) GetUntypedSpec() interface{} {
+	return i.Spec
+}

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_types.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_types.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -45,11 +46,20 @@ type InMemoryChannel struct {
 	Status InMemoryChannelStatus `json:"status,omitempty"`
 }
 
-// Check that Channel can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*InMemoryChannel)(nil)
-var _ apis.Defaultable = (*InMemoryChannel)(nil)
-var _ runtime.Object = (*InMemoryChannel)(nil)
-var _ webhook.GenericCRD = (*InMemoryChannel)(nil)
+var (
+	// Check that InMemoryChannel can be validated and defaulted.
+	_ apis.Validatable = (*InMemoryChannel)(nil)
+	_ apis.Defaultable = (*InMemoryChannel)(nil)
+
+	// Check that InMemoryChannel can return its spec untyped.
+	_ apis.HasSpec = (*InMemoryChannel)(nil)
+
+	_ runtime.Object     = (*InMemoryChannel)(nil)
+	_ webhook.GenericCRD = (*InMemoryChannel)(nil)
+
+	// Check that we can create OwnerReferences to an InMemoryChannel.
+	_ kmeta.OwnerRefable = (*InMemoryChannel)(nil)
+)
 
 // InMemoryChannelSpec defines which subscribers have expressed interest in
 // receiving events from this InMemoryChannel.

--- a/pkg/apis/messaging/v1alpha1/parallel_types.go
+++ b/pkg/apis/messaging/v1alpha1/parallel_types.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -46,14 +47,23 @@ type Parallel struct {
 	Status ParallelStatus `json:"status,omitempty"`
 }
 
-// Check that Parallel can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*Parallel)(nil)
-var _ apis.Defaultable = (*Parallel)(nil)
+var (
+	// Check that Parallel can be validated and defaulted.
+	_ apis.Validatable = (*Parallel)(nil)
+	_ apis.Defaultable = (*Parallel)(nil)
 
-// TODO: make appropriate fields immutable.
-//var _ apis.Immutable = (*Parallel)(nil)
-var _ runtime.Object = (*Parallel)(nil)
-var _ webhook.GenericCRD = (*Parallel)(nil)
+	// Check that Parallel can return its spec untyped.
+	_ apis.HasSpec = (*Parallel)(nil)
+
+	// TODO: make appropriate fields immutable.
+	//_ apis.Immutable = (*Parallel)(nil)
+
+	_ runtime.Object     = (*Parallel)(nil)
+	_ webhook.GenericCRD = (*Parallel)(nil)
+
+	// Check that we can create OwnerReferences to a Parallel.
+	_ kmeta.OwnerRefable = (*Parallel)(nil)
+)
 
 type ParallelSpec struct {
 	// Branches is the list of Filter/Subscribers pairs.

--- a/pkg/apis/messaging/v1alpha1/parallel_types.go
+++ b/pkg/apis/messaging/v1alpha1/parallel_types.go
@@ -163,3 +163,8 @@ type ParallelList struct {
 func (p *Parallel) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Parallel")
 }
+
+// GetUntypedSpec returns the spec of the Parallel.
+func (p *Parallel) GetUntypedSpec() interface{} {
+	return p.Spec
+}

--- a/pkg/apis/messaging/v1alpha1/sequence_types.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_types.go
@@ -130,3 +130,8 @@ type SequenceList struct {
 func (p *Sequence) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Sequence")
 }
+
+// GetUntypedSpec returns the spec of the Sequence.
+func (s *Sequence) GetUntypedSpec() interface{} {
+	return s.Spec
+}

--- a/pkg/apis/messaging/v1alpha1/sequence_types.go
+++ b/pkg/apis/messaging/v1alpha1/sequence_types.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -46,14 +47,23 @@ type Sequence struct {
 	Status SequenceStatus `json:"status,omitempty"`
 }
 
-// Check that Sequence can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*Sequence)(nil)
-var _ apis.Defaultable = (*Sequence)(nil)
+var (
+	// Check that Sequence can be validated and defaulted.
+	_ apis.Validatable = (*Sequence)(nil)
+	_ apis.Defaultable = (*Sequence)(nil)
 
-// TODO: make appropriate fields immutable.
-//var _ apis.Immutable = (*Sequence)(nil)
-var _ runtime.Object = (*Sequence)(nil)
-var _ webhook.GenericCRD = (*Sequence)(nil)
+	// Check that Sequence can return its spec untyped.
+	_ apis.HasSpec = (*Sequence)(nil)
+
+	// TODO: make appropriate fields immutable.
+	//_ apis.Immutable = (*Sequence)(nil)
+
+	_ runtime.Object     = (*Sequence)(nil)
+	_ webhook.GenericCRD = (*Sequence)(nil)
+
+	// Check that we can create OwnerReferences to a Sequence.
+	_ kmeta.OwnerRefable = (*Sequence)(nil)
+)
 
 type SequenceSpec struct {
 	// Steps is the list of Subscribers (processors / functions) that will be called in the order

--- a/pkg/apis/messaging/v1alpha1/subscription_types.go
+++ b/pkg/apis/messaging/v1alpha1/subscription_types.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/webhook"
 )
 
@@ -39,12 +40,21 @@ type Subscription struct {
 	Status            SubscriptionStatus `json:"status,omitempty"`
 }
 
-// Check that Subscription can be validated, can be defaulted, and has immutable fields.
-var _ apis.Validatable = (*Subscription)(nil)
-var _ apis.Defaultable = (*Subscription)(nil)
-var _ apis.Immutable = (*Subscription)(nil)
-var _ runtime.Object = (*Subscription)(nil)
-var _ webhook.GenericCRD = (*Subscription)(nil)
+var (
+	// Check that Subscription can be validated, can be defaulted, and has immutable fields.
+	_ apis.Validatable = (*Subscription)(nil)
+	_ apis.Defaultable = (*Subscription)(nil)
+	_ apis.Immutable   = (*Subscription)(nil)
+
+	// Check that Subscription can return its spec untyped.
+	_ apis.HasSpec = (*Subscription)(nil)
+
+	_ runtime.Object     = (*Subscription)(nil)
+	_ webhook.GenericCRD = (*Subscription)(nil)
+
+	// Check that we can create OwnerReferences to a Subscription.
+	_ kmeta.OwnerRefable = (*Subscription)(nil)
+)
 
 // SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
 // for processing those events and where to put the result of the processing. Only

--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 )
@@ -37,8 +38,13 @@ type ApiServerSource struct {
 	Status ApiServerSourceStatus `json:"status,omitempty"`
 }
 
-// Check that we can create OwnerReferences to a Configuration.
-var _ kmeta.OwnerRefable = (*ApiServerSource)(nil)
+var (
+	// Check that we can create OwnerReferences to an ApiServerSource.
+	_ kmeta.OwnerRefable = (*ApiServerSource)(nil)
+
+	// Check that ApiServerSource can return its spec untyped.
+	_ apis.HasSpec = (*ApiServerSource)(nil)
+)
 
 const (
 	// ApiServerSourceAddEventType is the ApiServerSource CloudEvent type for adds.

--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -122,3 +122,8 @@ type ApiServerResource struct {
 	// If true, send an event referencing the object controlling the resource
 	Controller bool `json:"controller"`
 }
+
+// GetUntypedSpec returns the spec of the ApiServerSource.
+func (a *ApiServerSource) GetUntypedSpec() interface{} {
+	return a.Spec
+}

--- a/pkg/apis/sources/v1alpha1/containersource_types.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types.go
@@ -109,3 +109,8 @@ type ContainerSourceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ContainerSource `json:"items"`
 }
+
+// GetUntypedSpec returns the spec of the ContainerSource.
+func (c *ContainerSource) GetUntypedSpec() interface{} {
+	return c.Spec
+}

--- a/pkg/apis/sources/v1alpha1/containersource_types.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 )
@@ -39,11 +40,13 @@ type ContainerSource struct {
 }
 
 var (
-	// Check that ContainerSource can be validated and can be defaulted.
 	_ runtime.Object = (*ContainerSource)(nil)
 
 	// Check that we can create OwnerReferences to a ContainerSource.
 	_ kmeta.OwnerRefable = (*ContainerSource)(nil)
+
+	// Check that ContainerSource can return its spec untyped.
+	_ apis.HasSpec = (*ContainerSource)(nil)
 )
 
 // ContainerSourceSpec defines the desired state of ContainerSource

--- a/pkg/apis/sources/v1alpha1/cron_job_types.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"knative.dev/pkg/apis"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +47,11 @@ var (
 	// Check that it is a runtime object.
 	_ runtime.Object = (*CronJobSource)(nil)
 
-	// Check that we can create OwnerReferences to a Configuration.
+	// Check that we can create OwnerReferences to a CronJobSource.
 	_ kmeta.OwnerRefable = (*CronJobSource)(nil)
+
+	// Check that CronJobSource can return its spec untyped.
+	_ apis.HasSpec = (*CronJobSource)(nil)
 )
 
 const (

--- a/pkg/apis/sources/v1alpha1/cron_job_types.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_types.go
@@ -121,3 +121,8 @@ type CronJobSourceList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []CronJobSource `json:"items"`
 }
+
+// GetUntypedSpec returns the spec of the CronJobSource.
+func (c *CronJobSource) GetUntypedSpec() interface{} {
+	return c.Spec
+}

--- a/pkg/apis/sources/v1alpha1/cron_job_types_test.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_types_test.go
@@ -26,3 +26,11 @@ func TestCronJobSource_GetGroupVersionKind(t *testing.T) {
 		t.Errorf("Should be CronJobSource.")
 	}
 }
+
+func TestCronJobSource_CronJobEventSource(t *testing.T) {
+	ceCronJobSource := CronJobEventSource("ns1", "job1")
+
+	if ceCronJobSource != "/apis/v1/namespaces/ns1/cronjobsources/job1" {
+		t.Errorf("Should be '/apis/v1/namespaces/ns1/cronjobsources/job1'")
+	}
+}


### PR DESCRIPTION
Fixes #1980 

## Proposed Changes

- Make the resource types implement `HasUntypedSpec` so that the admission webhook extended from Knative/pkg will add the user info annotations (`xx.knative.dev/creator` and `xx.knative.dev/lastModifier`)
- Similar to https://github.com/knative/eventing/pull/1479, the business logic to add the annotations are tested in Knative/pkg. Thus, no tests here!

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
