### PR TITLE
Don't restrict namespace for perf test objects

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -121,7 +121,7 @@ function delete_benchmark_resources() {
 
   echo ">> Delete all existing jobs and test resources"
   kubectl delete job --all
-  ko delete -n ${TEST_NAMESPACE} -f "${TEST_ROOT_PATH}/${name}/${variant}/" || abort "Failed to delete ${name}/${variant} resources"
+  ko delete -f "${TEST_ROOT_PATH}/${name}/${variant}/" || abort "Failed to delete ${name}/${variant} resources"
 }
 
 # Apply all the benchmark resources
@@ -135,7 +135,7 @@ function apply_benchmark_resources() {
   # NOTE: this assumes we have a benchmark with the same name as the cluster
   # If service creation takes long time, we will have some initially unreachable errors in the test
   echo "Using ko version $(ko version)"
-  ko apply -n ${TEST_NAMESPACE} -f "$TEST_ROOT_PATH/$name/${variant}/" || abort "Failed to apply ${name}/${variant} benchmark yamls"
+  ko apply -f "$TEST_ROOT_PATH/$name/${variant}/" || abort "Failed to apply ${name}/${variant} benchmark yamls"
 }
 
 # Update resources installed on the cluster with the up-to-date code. This


### PR DESCRIPTION
The RBAC rules for configmap read need to be created in a different namespace, so we can't restrict the namespace here or kubectl will error out.

## Proposed Changes

- Don't set a namespace when ko applying perf test config

/cc @chizhg 
