### PR TITLE
Remove incorrect host names from tracing setup.

### DIFF
--- a/cmd/apiserver_receive_adapter/main.go
+++ b/cmd/apiserver_receive_adapter/main.go
@@ -146,7 +146,7 @@ func main() {
 		logger.Fatal("error building dynamic client", zap.Error(err))
 	}
 
-	if err = tracing.SetupStaticPublishing(loggerSugared, "apiserversource", tracing.OnePercentSampling); err != nil {
+	if err = tracing.SetupStaticPublishing(loggerSugared, "", tracing.OnePercentSampling); err != nil {
 		// If tracing doesn't work, we will log an error, but allow the source
 		// to continue to start.
 		logger.Error("Error setting up trace publishing", zap.Error(err))

--- a/cmd/cronjob_receive_adapter/main.go
+++ b/cmd/cronjob_receive_adapter/main.go
@@ -114,7 +114,7 @@ func main() {
 	if err != nil {
 		logger.Error("error building statsreporter", zap.Error(err))
 	}
-	if err = tracing.SetupStaticPublishing(loggerSugared, "cronjobsource", tracing.OnePercentSampling); err != nil {
+	if err = tracing.SetupStaticPublishing(loggerSugared, "", tracing.OnePercentSampling); err != nil {
 		// If tracing doesn't work, we will log an error, but allow the importer to continue to
 		// start.
 		logger.Error("Error setting up trace publishing", zap.Error(err))


### PR DESCRIPTION
Helps with #1889

knative/pkg#741 tracks a more desirable fix.

## Proposed Changes

- ApiServerSource and CronJobSource use their host name for traces.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
