### PR TITLE
Use the correct zap sugared logger syntax

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -103,7 +103,7 @@ func main() {
 	logger = logger.With(zap.String(logkey.ControllerType, logconfig.WebhookName()))
 
 	if err := version.CheckMinimumVersion(kubeClient.Discovery()); err != nil {
-		logger.Fatalw("Version check failed", err)
+		logger.Fatalw("Version check failed", zap.Error(err))
 	}
 
 	logger.Infow("Starting the Eventing Webhook")


### PR DESCRIPTION
Fatalw needs either a zap.Field or `key, value` pair in the variadic args.

Related to https://github.com/knative/serving/issues/5746

## Proposed Changes
- Update Fatalw to correct syntax in webhook