### PR TITLE
Do not fail the performance cluster job if there's error in deletion

### DIFF
--- a/test/performance/tools/common.sh
+++ b/test/performance/tools/common.sh
@@ -121,7 +121,7 @@ function delete_benchmark_resources() {
 
   echo ">> Delete all existing jobs and test resources"
   kubectl delete job --all
-  ko delete -f "${TEST_ROOT_PATH}/${name}/${variant}/" || abort "Failed to delete ${name}/${variant} resources"
+  ko delete -f "${TEST_ROOT_PATH}/${name}/${variant}/"
 }
 
 # Apply all the benchmark resources


### PR DESCRIPTION
## Proposed Changes
We recycle the cluster for the benchmark every midnight, in a new cluster, there will not be any benchmark resources, so `ko delete` command will fail, see https://prow.knative.dev/?job=ci-knative-eventing-update-clusters. 

We should not abort the job if the deletion fails.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
