### PR TITLE
Passing benchmark ids to mako setup 

### DIFF
--- a/test/performance/broker-imc/continuous/200-broker-imc.yaml
+++ b/test/performance/broker-imc/continuous/200-broker-imc.yaml
@@ -101,6 +101,7 @@ spec:
             - "--expect-records=1"
             - "--mako-tags=channel=imc"
             - "--verbose"
+              # benchmark key and benchmark name come from dev.config
             - "--benchmark-key=5903682180743168"
             - "--benchmark-name=Development - Broker Latency & Throughput"
             ports:

--- a/test/performance/broker-imc/continuous/200-broker-imc.yaml
+++ b/test/performance/broker-imc/continuous/200-broker-imc.yaml
@@ -101,6 +101,8 @@ spec:
             - "--expect-records=1"
             - "--mako-tags=channel=imc"
             - "--verbose"
+            - "--benchmark-key=5903682180743168"
+            - "--benchmark-name=Development - Broker Latency & Throughput"
             ports:
             - name: grpc
               containerPort: 10000

--- a/test/performance/broker-imc/dev.config
+++ b/test/performance/broker-imc/dev.config
@@ -4,9 +4,9 @@
 # mako update_benchmark test/performance/broker-latency/dev.config
 
 project_name: "Knative"
-# benchmark_name: "Development - Broker Latency & Throughput"
-# description: "Measure latency and throughput of the broker using various channels."
-# benchmark_key: '5903682180743168'
+benchmark_name: "Development - Broker Latency & Throughput"
+description: "Measure latency and throughput of the broker using various channels."
+benchmark_key: '5903682180743168'
 
 # Human owners for manual benchmark adjustments.
 owner_list: "grantrodgers@google.com"

--- a/test/test_images/performance/aggregator.go
+++ b/test/test_images/performance/aggregator.go
@@ -101,7 +101,8 @@ func (ex *aggregatorExecutor) Run(ctx context.Context) {
 	printf("Configuring Mako")
 
 	// Use the benchmark key created
-	client, err := mako.Setup(ctx, ex.makoTags...)
+	// TODO support to check benchmark key for dev or prod
+	client, err := mako.SetupWithBenchmarkConfig(ctx, &benchmarkKey, &benchmarkName, ex.makoTags...)
 	if err != nil {
 		fatalf("Failed to setup mako: %v", err)
 	}

--- a/test/test_images/performance/dev.config
+++ b/test/test_images/performance/dev.config
@@ -4,9 +4,9 @@
 # mako update_benchmark test/performance/broker-latency/dev.config
 
 project_name: "Knative"
-benchmark_name: "Development - Broker Latency & Throughput"
-description: "Measure latency and throughput of the broker using various channels."
-benchmark_key: '5903682180743168'
+# benchmark_name: "Development - Broker Latency & Throughput"
+# description: "Measure latency and throughput of the broker using various channels."
+# benchmark_key: '5903682180743168'
 
 # Human owners for manual benchmark adjustments.
 owner_list: "grantrodgers@google.com"

--- a/test/test_images/performance/kodata/dev.config
+++ b/test/test_images/performance/kodata/dev.config
@@ -1,1 +1,0 @@
-../dev.config

--- a/test/test_images/performance/main.go
+++ b/test/test_images/performance/main.go
@@ -47,6 +47,8 @@ var (
 	expectRecords uint
 	listenAddr    string
 	makoTags      string
+	benchmarkKey  string
+	benchmarkName string
 )
 
 func init() {
@@ -66,6 +68,8 @@ func init() {
 	flag.UintVar(&expectRecords, "expect-records", 1, "Number of expected events records before aggregating data.")
 	flag.StringVar(&makoTags, "mako-tags", "", "Comma separated list of benchmark"+
 		" specific Mako tags.")
+	flag.StringVar(&benchmarkKey, "benchmark-key", "", "Benchmark key")
+	flag.StringVar(&benchmarkName, "benchmark-name", "", "Benchmark name")
 }
 
 type testExecutor interface {


### PR DESCRIPTION
# 
Proposed Changes
- Replace `mako.Setup()` with `mako.SetupWithBenchmarkConfig()`, which allow passing benchmark key and benchmark name to it
- Instead of including benchmark key and benchmark name in the *.config, these two values will be stored in aggregator container's spec.args
- Only support dev environment currently, need to support prod later 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
