### PR TITLE
change content-type of performance tests to application/json

### DIFF
--- a/test/common/cloudevents_vegeta_targeter.go
+++ b/test/common/cloudevents_vegeta_targeter.go
@@ -70,7 +70,7 @@ func (cet CloudEventsTargeter) VegetaTargeter() vegeta.Targeter {
 
 		t.Header.Set("Content-Type", "application/json")
 
-		t.Body = []byte(generateRandString(cet.msgSize))
+		t.Body = []byte("\"" + generateRandString(cet.msgSize) + "\"")
 
 		return nil
 	}

--- a/test/common/cloudevents_vegeta_targeter.go
+++ b/test/common/cloudevents_vegeta_targeter.go
@@ -68,7 +68,7 @@ func (cet CloudEventsTargeter) VegetaTargeter() vegeta.Targeter {
 		t.Header.Set("Ce-Source", cet.eventSource)
 		t.Header.Set("Ce-Specversion", "0.2")
 
-		t.Header.Set("Content-Type", "text/plain")
+		t.Header.Set("Content-Type", "application/json")
 
 		t.Body = []byte(generateRandString(cet.msgSize))
 


### PR DESCRIPTION
Fixes #2009 

## Proposed Changes

- change content-type of performance tests to application/json
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
