### PR TITLE
fix testcases, duplicated if conditions in subscribe_types_test.go

### DIFF
--- a/pkg/apis/duck/v1alpha1/subscribable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_test.go
@@ -172,7 +172,7 @@ func TestSubscribableTypeStatusHelperMethods(t *testing.T) {
 	})
 
 	// Check if the subscriber was added to both the fields of SubscribableTypeStatus
-	if len(subscribableTypeStatus.DeprecatedSubscribableStatus.Subscribers) != 3 &&
+	if len(subscribableTypeStatus.SubscribableStatus.Subscribers) != 3 &&
 		len(subscribableTypeStatus.DeprecatedSubscribableStatus.Subscribers) != 3 {
 		t.Error("AddSubscriberToSubscribableStatus didn't add subscriberstatus to both the fields of SubscribableTypeStatus")
 	}


### PR DESCRIPTION

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
