### PR TITLE
Refactor tracing tests to make it easier to use in other repos.

### DIFF
--- a/test/conformance/broker_tracing_test.go
+++ b/test/conformance/broker_tracing_test.go
@@ -25,5 +25,5 @@ import (
 )
 
 func TestBrokerTracing(t *testing.T) {
-	helpers.BrokerTracingTestHelper(t, channelTestRunner)
+	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, channelTestRunner, helpers.SetupClientFuncNoop)
 }

--- a/test/conformance/channel_tracing_test.go
+++ b/test/conformance/channel_tracing_test.go
@@ -25,5 +25,5 @@ import (
 )
 
 func TestChannelTracingWithReply(t *testing.T) {
-	helpers.ChannelTracingTestHelperWithReply(t, channelTestRunner)
+	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, helpers.SetupClientFuncNoop)
 }

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -32,7 +32,11 @@ import (
 
 // BrokerTracingTestHelperWithChannelTestRunner runs the Broker tracing tests for all Channels in
 // the ChannelTestRunner.
-func BrokerTracingTestHelperWithChannelTestRunner(t *testing.T, channelTestRunner common.ChannelTestRunner, setupClient SetupClientFunc) {
+func BrokerTracingTestHelperWithChannelTestRunner(
+	t *testing.T,
+	channelTestRunner common.ChannelTestRunner,
+	setupClient SetupClientFunc,
+) {
 	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
 		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
 		t := struct{}{}
@@ -65,12 +69,18 @@ func BrokerTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient 
 // 4. Sender Pod which sends a 'foo' event.
 // It returns a string that is expected to be sent by the SendEvents Pod and should be present in
 // the LogEvents Pod logs.
-func setupBrokerTracing(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string) {
-	// Create the Broker.
+func setupBrokerTracing(
+	t *testing.T,
+	channel *metav1.TypeMeta,
+	client *common.Client,
+	loggerPodName string,
+	tc TracingTestCase,
+) (tracinghelper.TestSpanTree, string) {
 	const (
 		etTransformer = "transformer"
 		etLogger      = "logger"
 	)
+	// Create the Broker.
 	client.CreateRBACResourcesForBrokers()
 	broker := client.CreateBrokerOrFail("br", channel)
 

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/openzipkin/zipkin-go/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/test/base/resources"
@@ -29,8 +30,32 @@ import (
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 )
 
-func BrokerTracingTestHelper(t *testing.T, channelTestRunner common.ChannelTestRunner) {
-	tracingTestHelper(t, channelTestRunner, setupBrokerTracing)
+// BrokerTracingTestHelperWithChannelTestRunner runs the Broker tracing tests for all Channels in
+// the ChannelTestRunner.
+func BrokerTracingTestHelperWithChannelTestRunner(t *testing.T, channelTestRunner common.ChannelTestRunner, setupClient SetupClientFunc) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
+		t := struct{}{}
+		_ = fmt.Sprintf("%s", t)
+
+		channelTypeMeta := common.GetChannelTypeMeta(channel)
+		BrokerTracingTestHelper(st, *channelTypeMeta, setupClient)
+	})
+}
+
+// BrokerTracingTestHelper runs the Broker tracing test using the given TypeMeta.
+func BrokerTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient SetupClientFunc) {
+	testCases := map[string]TracingTestCase{
+		"includes incoming trace id": {
+			IncomingTraceId: true,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tracingTest(t, setupClient, setupBrokerTracing, channel, tc)
+		})
+	}
 }
 
 // setupBrokerTracing is the general setup for TestBrokerTracing. It creates the following:
@@ -40,15 +65,14 @@ func BrokerTracingTestHelper(t *testing.T, channelTestRunner common.ChannelTestR
 // 4. Sender Pod which sends a 'foo' event.
 // It returns a string that is expected to be sent by the SendEvents Pod and should be present in
 // the LogEvents Pod logs.
-func setupBrokerTracing(t *testing.T, channel string, client *common.Client, loggerPodName string, incomingTraceId bool) (tracinghelper.TestSpanTree, string) {
+func setupBrokerTracing(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string) {
 	// Create the Broker.
 	const (
 		etTransformer = "transformer"
 		etLogger      = "logger"
 	)
 	client.CreateRBACResourcesForBrokers()
-	channelTypeMeta := common.GetChannelTypeMeta(channel)
-	broker := client.CreateBrokerOrFail("br", channelTypeMeta)
+	broker := client.CreateBrokerOrFail("br", channel)
 
 	// TODO Remove this wait once https://github.com/knative/eventing/issues/1998 is fixed.
 	if err := client.WaitForResourceReady(broker.Name, common.BrokerTypeMeta); err != nil {
@@ -101,7 +125,7 @@ func setupBrokerTracing(t *testing.T, channel string, client *common.Client, log
 
 	// Send the CloudEvent (either with or without tracing inside the SendEvents Pod).
 	sendEvent := client.SendFakeEventToAddressable
-	if incomingTraceId {
+	if tc.IncomingTraceId {
 		sendEvent = client.SendFakeEventWithTracingToAddressable
 	}
 	if err := sendEvent(senderName, broker.Name, common.BrokerTypeMeta, event); err != nil {
@@ -422,7 +446,7 @@ func setupBrokerTracing(t *testing.T, channel string, client *common.Client, log
 		},
 	}
 
-	if incomingTraceId {
+	if tc.IncomingTraceId {
 		expected.Children = []tracinghelper.TestSpanTree{
 			{
 				Note:                     "1. Send pod sends event to the Broker Ingress (only if the sending pod generates a span).",

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/openzipkin/zipkin-go/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/eventing/test/base/resources"
 	"knative.dev/eventing/test/common"
@@ -30,48 +31,84 @@ import (
 	"knative.dev/pkg/test/zipkin"
 )
 
-type setupFunc func(t *testing.T, channel string, client *common.Client, loggerPodName string, incomingTraceId bool) (tracinghelper.TestSpanTree, string)
+// SetupClientFunc sets up the client for running tracing tests. It does the equivalent of
+// client.Setup().
+type SetupClientFunc func(*common.Client) error
 
-func tracingTestHelper(t *testing.T, channelTestRunner common.ChannelTestRunner, setup setupFunc) {
-	testCases := map[string]struct {
-		incomingTraceId bool
-		istio           bool
-	}{
+// SetupClientFuncNoop is a SetupClientFunc that does nothing.
+var SetupClientFuncNoop SetupClientFunc = func(*common.Client) error {
+	return nil
+}
+
+// SetupInfrastructureFunc sets up the infrastructure for running tracing tests. It returns the
+// expected trace as well as a string that is expected to be in the logger Pod's logs.
+type SetupInfrastructureFunc func(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string)
+
+// TracingTestCase is the test case information for tracing tests.
+type TracingTestCase struct {
+	// IncomingTraceId controls whether the original request is sent to the Broker/Channel already
+	// has a trace ID associated with it by the sender.
+	IncomingTraceId bool
+	// Istio controls whether the Pods being created for the test (sender, transformer, logger,
+	// etc.) have Istio sidecars. It does not affect the Channel Pods.
+	Istio bool
+}
+
+// ChannelTracingTestHelperWithChannelTestRunner runs the Channel tracing tests for all Channels in
+// the ChannelTestRunner.
+func ChannelTracingTestHelperWithChannelTestRunner(t *testing.T, channelTestRunner common.ChannelTestRunner, setupClient SetupClientFunc) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
+		t := struct{}{}
+		_ = fmt.Sprintf("%s", t)
+
+		channelTypeMeta := common.GetChannelTypeMeta(channel)
+		ChannelTracingTestHelper(st, *channelTypeMeta, setupClient)
+	})
+}
+
+// ChannelTracingTestHelper runs the Channel tracing test using the given TypeMeta.
+func ChannelTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient SetupClientFunc) {
+	testCases := map[string]TracingTestCase{
 		"includes incoming trace id": {
-			incomingTraceId: true,
+			IncomingTraceId: true,
 		},
 	}
 
 	for n, tc := range testCases {
-		loggerPodName := "logger"
 		t.Run(n, func(t *testing.T) {
-			channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
-				// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless
-				// type.
-				t := struct{}{}
-				_ = fmt.Sprintf("%s", t)
-
-				client := common.Setup(st, true)
-				defer common.TearDown(client)
-
-				// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
-				// TestMain.
-				tracinghelper.Setup(st, client)
-
-				expected, mustContain := setup(st, channel, client, loggerPodName, tc.incomingTraceId)
-				assertLogContents(st, client, loggerPodName, mustContain)
-				traceID := getTraceID(st, client, loggerPodName)
-				trace, err := zipkin.JSONTrace(traceID, expected.SpanCount(), 2*time.Minute)
-				if err != nil {
-					st.Fatalf("Unable to get trace %q: %v. Trace so far %+v", traceID, err, tracinghelper.PrettyPrintTrace(trace))
-				}
-
-				tree := tracinghelper.GetTraceTree(st, trace)
-				if err := expected.Matches(tree); err != nil {
-					st.Fatalf("Trace Tree did not match expected: %v", err)
-				}
-			})
+			tracingTest(t, setupClient, setupChannelTracingWithReply, channel, tc)
 		})
+	}
+}
+
+func tracingTest(t *testing.T, setupClient SetupClientFunc, setupInfrastructure SetupInfrastructureFunc, channel metav1.TypeMeta, tc TracingTestCase) {
+	const (
+		loggerPodName = "logger"
+	)
+
+	client := common.Setup(t, true)
+	defer common.TearDown(client)
+	if err := setupClient(client); err != nil {
+		t.Fatalf("SetupClient function failed: %v", err)
+	}
+
+	// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
+	// TestMain.
+	tracinghelper.Setup(t, client)
+
+	expected, mustContain := setupInfrastructure(t, &channel, client, loggerPodName, tc)
+	assertLogContents(t, client, loggerPodName, mustContain)
+
+	traceID := getTraceID(t, client, loggerPodName)
+	trace, err := zipkin.JSONTrace(traceID, expected.SpanCount(), 2*time.Minute)
+	if err != nil {
+		t.Fatalf("Unable to get trace %q: %v. Trace so far %+v", traceID, err, tracinghelper.PrettyPrintTrace(trace))
+	}
+
+	tree := tracinghelper.GetTraceTree(t, trace)
+	if err := expected.Matches(tree); err != nil {
+		t.Fatalf("Trace Tree did not match expected: %v", err)
 	}
 }
 
@@ -99,24 +136,19 @@ func getTraceID(t *testing.T, client *common.Client, loggerPodName string) strin
 	return traceID
 }
 
-func ChannelTracingTestHelperWithReply(t *testing.T, channelTestRunner common.ChannelTestRunner) {
-	tracingTestHelper(t, channelTestRunner, setupChannelTracingWithReply)
-}
-
 // setupChannelTracing is the general setup for TestChannelTracing. It creates the following:
 // SendEvents (Pod) -> Channel -> Subscription -> K8s Service -> Mutate (Pod)
 //                                                                   v
 // LogEvents (Pod) <- K8s Service <- Subscription  <- Channel <- (Reply) Subscription
 // It returns the expected trace tree and a string that is expected to be sent by the SendEvents Pod
 // and should be present in the LogEvents Pod logs.
-func setupChannelTracingWithReply(t *testing.T, channel string, client *common.Client, loggerPodName string, incomingTraceId bool) (tracinghelper.TestSpanTree, string) {
+func setupChannelTracingWithReply(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string) {
 	// Create the Channels.
 	channelName := "ch"
-	channelTypeMeta := common.GetChannelTypeMeta(channel)
-	client.CreateChannelOrFail(channelName, channelTypeMeta)
+	client.CreateChannelOrFail(channelName, channel)
 
 	replyChannelName := "reply-ch"
-	client.CreateChannelOrFail(replyChannelName, channelTypeMeta)
+	client.CreateChannelOrFail(replyChannelName, channel)
 
 	// Create the 'sink', a LogEvents Pod and a K8s Service that points to it.
 	loggerPod := resources.EventDetailsPod(loggerPodName)
@@ -132,15 +164,15 @@ func setupChannelTracingWithReply(t *testing.T, channel string, client *common.C
 	client.CreateSubscriptionOrFail(
 		"sub",
 		channelName,
-		channelTypeMeta,
+		channel,
 		resources.WithSubscriberForSubscription(transformerPod.Name),
-		resources.WithReplyForSubscription(replyChannelName, channelTypeMeta))
+		resources.WithReplyForSubscription(replyChannelName, channel))
 
 	// Create the Subscription linking the reply Channel to the LogEvents K8s Service.
 	client.CreateSubscriptionOrFail(
 		"reply-sub",
 		replyChannelName,
-		channelTypeMeta,
+		channel,
 		resources.WithSubscriberForSubscription(loggerPodName),
 	)
 
@@ -163,10 +195,10 @@ func setupChannelTracingWithReply(t *testing.T, channel string, client *common.C
 
 	// Send the CloudEvent (either with or without tracing inside the SendEvents Pod).
 	sendEvent := client.SendFakeEventToAddressable
-	if incomingTraceId {
+	if tc.IncomingTraceId {
 		sendEvent = client.SendFakeEventWithTracingToAddressable
 	}
-	if err := sendEvent(senderName, channelName, channelTypeMeta, event); err != nil {
+	if err := sendEvent(senderName, channelName, channel, event); err != nil {
 		t.Fatalf("Failed to send fake CloudEvent to the channel %q", channelName)
 	}
 
@@ -267,7 +299,7 @@ func setupChannelTracingWithReply(t *testing.T, channel string, client *common.C
 		},
 	}
 
-	if incomingTraceId {
+	if tc.IncomingTraceId {
 		expected.Children = []tracinghelper.TestSpanTree{
 			{
 				// 1. Sending pod sends event to Channel (only if the sending pod generates a span).

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -42,7 +42,13 @@ var SetupClientFuncNoop SetupClientFunc = func(*common.Client) error {
 
 // SetupInfrastructureFunc sets up the infrastructure for running tracing tests. It returns the
 // expected trace as well as a string that is expected to be in the logger Pod's logs.
-type SetupInfrastructureFunc func(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string)
+type SetupInfrastructureFunc func(
+	t *testing.T,
+	channel *metav1.TypeMeta,
+	client *common.Client,
+	loggerPodName string,
+	tc TracingTestCase,
+) (tracinghelper.TestSpanTree, string)
 
 // TracingTestCase is the test case information for tracing tests.
 type TracingTestCase struct {
@@ -56,7 +62,11 @@ type TracingTestCase struct {
 
 // ChannelTracingTestHelperWithChannelTestRunner runs the Channel tracing tests for all Channels in
 // the ChannelTestRunner.
-func ChannelTracingTestHelperWithChannelTestRunner(t *testing.T, channelTestRunner common.ChannelTestRunner, setupClient SetupClientFunc) {
+func ChannelTracingTestHelperWithChannelTestRunner(
+	t *testing.T,
+	channelTestRunner common.ChannelTestRunner,
+	setupClient SetupClientFunc,
+) {
 	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
 		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
 		t := struct{}{}
@@ -82,7 +92,13 @@ func ChannelTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient
 	}
 }
 
-func tracingTest(t *testing.T, setupClient SetupClientFunc, setupInfrastructure SetupInfrastructureFunc, channel metav1.TypeMeta, tc TracingTestCase) {
+func tracingTest(
+	t *testing.T,
+	setupClient SetupClientFunc,
+	setupInfrastructure SetupInfrastructureFunc,
+	channel metav1.TypeMeta,
+	tc TracingTestCase,
+) {
 	const (
 		loggerPodName = "logger"
 	)
@@ -142,7 +158,13 @@ func getTraceID(t *testing.T, client *common.Client, loggerPodName string) strin
 // LogEvents (Pod) <- K8s Service <- Subscription  <- Channel <- (Reply) Subscription
 // It returns the expected trace tree and a string that is expected to be sent by the SendEvents Pod
 // and should be present in the LogEvents Pod logs.
-func setupChannelTracingWithReply(t *testing.T, channel *metav1.TypeMeta, client *common.Client, loggerPodName string, tc TracingTestCase) (tracinghelper.TestSpanTree, string) {
+func setupChannelTracingWithReply(
+	t *testing.T,
+	channel *metav1.TypeMeta,
+	client *common.Client,
+	loggerPodName string,
+	tc TracingTestCase,
+) (tracinghelper.TestSpanTree, string) {
 	// Create the Channels.
 	channelName := "ch"
 	client.CreateChannelOrFail(channelName, channel)


### PR DESCRIPTION
## Proposed Changes

- Refactor tracing tests to make it easier to use in other repos.
  - `ChannelTracingTestHelper` will be used by most repos, as most will only have a single Channel to test.
  - `ChannelTracingTestHelperWithChannelTestRunner` will be used by repos that have multiple Channels to test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
