### PR TITLE
GetAddressableURI supports status.addressable.url

### DIFF
--- a/test/common/operation.go
+++ b/test/common/operation.go
@@ -73,10 +73,14 @@ func (client *Client) SendFakeEventWithTracingToAddressable(
 
 // GetAddressableURI returns the URI of the addressable resource.
 // To use this function, the given resource must have implemented the Addressable duck-type.
-func (client *Client) GetAddressableURI(addressableName string, typemeta *metav1.TypeMeta) (string, error) {
+func (client *Client) GetAddressableURI(addressableName string, typeMeta *metav1.TypeMeta) (string, error) {
 	namespace := client.Namespace
-	metaAddressable := resources.NewMetaResource(addressableName, namespace, typemeta)
-	return base.GetAddressableURI(client.Dynamic, metaAddressable)
+	metaAddressable := resources.NewMetaResource(addressableName, namespace, typeMeta)
+	u, err := base.GetAddressableURI(client.Dynamic, metaAddressable)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
 }
 
 // sendFakeEventToAddress will create a sender pod, which will send the given event to the given url.


### PR DESCRIPTION
## Proposed Changes

- `GetAddressableURI` supports status.addressable.url, in addition to status.addressable.hostname.
- `GetAddressableURI` will return an error if the host name is empty.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
