### PR TITLE
RBAC update

### DIFF
--- a/config/200-addressable-resolvers-clusterrole.yaml
+++ b/config/200-addressable-resolvers-clusterrole.yaml
@@ -88,6 +88,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels/finalizers
+  verbs:
+  - update
 
 ---
 


### PR DESCRIPTION
Got this error, running test on Openshift:

```
channel_defaulter_test_helper.go:103: Failed to get all test resources ready: failed waiting for {TypeMeta:{Kind:Channel APIVersion:messaging.knative.dev/v1alpha1} ObjectMeta:{Name:e2e-defaulter-channel GenerateName: Namespace:test-channel-cluster-defaulter-in-memory-channel SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Initializers:nil Finalizers:[] ClusterName: ManagedFields:[]}} to become ready: timed out waiting for the condition
```

## Proposed Changes

- adding update for `channels/finalizer` for proper RBAC

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

/assign @Harwayne 