### PR TITLE
E2E tracing tests does not set sampling to 100%.

### DIFF
--- a/test/conformance/helpers/tracing/zipkin.go
+++ b/test/conformance/helpers/tracing/zipkin.go
@@ -30,19 +30,22 @@ func Setup(t *testing.T, client *common.Client) {
 	// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
 	// TestMain.
 	zipkin.SetupZipkinTracing(client.Kube.Kube, t.Logf)
-	setTracingConfigToDebugMode(t, client)
+	setTracingConfigToZipkin(t, client)
 }
 
 var setTracingConfigOnce = sync.Once{}
 
-// TODO Do we need a tear down method as well?
-func setTracingConfigToDebugMode(t *testing.T, client *common.Client) {
+// setTracingConfigToZipkin sets the tracing configuration to point at the standard Zipkin endpoint
+// installed by the e2e test setup scripts.
+// Note that this used to set the sampling rate to 100%. We _think_ that overwhelmed the Zipkin
+// instance and caused https://github.com/knative/eventing/issues/2040. So now we just ensure that
+// the tests that test tracing ensure that the requests are made with the sampled flag set to true.
+// TODO Do we need a tear down method to revert the config map to its original state?
+func setTracingConfigToZipkin(t *testing.T, client *common.Client) {
 	setTracingConfigOnce.Do(func() {
 		err := client.Kube.UpdateConfigMap("knative-eventing", "config-tracing", map[string]string{
 			"backend":         "zipkin",
 			"zipkin-endpoint": "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans",
-			"debug":           "true",
-			"sample-rate":     "1.0",
 		})
 		if err != nil {
 			t.Fatalf("Unable to set the ConfigMap: %v", err)


### PR DESCRIPTION
Might help with #2040.

## Proposed Changes

- E2E tracing tests does not set sampling to 100%.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
