### PR TITLE
Remove openapi-gen annotations

### DIFF
--- a/pkg/apis/sources/v1alpha1/apiserver_types.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_types.go
@@ -29,7 +29,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ApiServerSource is the Schema for the apiserversources API
-// +k8s:openapi-gen=true
 type ApiServerSource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
ref. knative/pkg#775

## Proposed Changes

- Remove `openapi-gen` annotations from types definitions. `openapi-gen` is not used anymore in Knative.

**Release Note**

```release-note
NONE
```
