### PR TITLE
Fixing outdated broker crd file

### DIFF
--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -54,26 +54,15 @@ spec:
       properties:
         spec:
           properties:
-            channelTemplate:
+            channelTemplateSpec:
               type: object
               required:
-                - provisioner
+                - apiVersion
+                - kind
               properties:
-                provisioner:
-                  type: object
-                  required:
-                    - apiVersion
-                    - kind
-                    - name
-                  properties:
-                    apiVersion:
-                      type: string
-                      minLength: 1
-                    kind:
-                      type: string
-                      minLength: 1
-                    name:
-                      type: string
-                      minLength: 1
-                arguments:
-                  type: object
+                apiVersion:
+                  type: string
+                  minLength: 1
+                kind:
+                  type: string
+                  minLength: 1

--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -66,3 +66,5 @@ spec:
                 kind:
                   type: string
                   minLength: 1
+                spec:
+                  type: object


### PR DESCRIPTION
CRD still used old channelTemplate/provisioner code

## Proposed Changes

- update to channelTemplateSpec and apiVetrsion/kind

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
