### PR TITLE
Update to cloudevents golang sdk v0.10.0, adding v1.0 spec support.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,8 +104,7 @@
   version = "v0.2.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:de0016e87636a076499c2c4840563d7e54c4acbc2fc5dca303390501a4d85b12"
+  digest = "1:902544577dcb868a5ae31529d73a1ce5031e224923290caedf6176241ee304e0"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     ".",
@@ -122,7 +121,8 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "8dc7a6994d99f07031904838c4e91101d5fd218a"
+  revision = "2fa4bb1fbb4aac4d906b0173a2a408f701439b82"
+  version = "v0.10.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -87,7 +87,7 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  branch = "master"
+  version = "0.10.0"
 
 # needed because pkg upgraded
 [[override]]

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/error.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/error.go
@@ -6,15 +6,17 @@ import "fmt"
 // message can not be converted.
 type ErrTransportMessageConversion struct {
 	fatal     bool
+	handled   bool
 	transport string
 	message   string
 }
 
 // NewErrMessageEncodingUnknown makes a new ErrMessageEncodingUnknown.
-func NewErrTransportMessageConversion(transport, message string, fatal bool) *ErrTransportMessageConversion {
+func NewErrTransportMessageConversion(transport, message string, handled, fatal bool) *ErrTransportMessageConversion {
 	return &ErrTransportMessageConversion{
 		transport: transport,
 		message:   message,
+		handled:   handled,
 		fatal:     fatal,
 	}
 }
@@ -22,6 +24,11 @@ func NewErrTransportMessageConversion(transport, message string, fatal bool) *Er
 // IsFatal reports if this error should be considered fatal.
 func (e *ErrTransportMessageConversion) IsFatal() bool {
 	return e.fatal
+}
+
+// Handled reports if this error should be considered accepted and no further action.
+func (e *ErrTransportMessageConversion) Handled() bool {
+	return e.handled
 }
 
 // Error implements error.Error

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
@@ -181,6 +181,7 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (conte
 		req.Method = t.Req.Method
 		req.URL = t.Req.URL
 		req.Close = t.Req.Close
+		req.Host = t.Req.Host
 		copyHeadersEnsure(t.Req.Header, &req.Header)
 	}
 
@@ -214,13 +215,20 @@ func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (conte
 			})
 			if err != nil {
 				isErr := true
+				handled := false
 				if txerr, ok := err.(*transport.ErrTransportMessageConversion); ok {
 					if !txerr.IsFatal() {
 						isErr = false
 					}
+					if txerr.Handled() {
+						handled = true
+					}
 				}
 				if isErr {
 					return rctx, nil, err
+				}
+				if handled {
+					return rctx, nil, nil
 				}
 			}
 			if accepted(resp) {
@@ -240,13 +248,13 @@ func (t *Transport) MessageToEvent(ctx context.Context, msg *Message) (*cloudeve
 	if msg.CloudEventsVersion() != "" {
 		// This is likely a cloudevents encoded message, try to decode it.
 		if ok := t.loadCodec(ctx); !ok {
-			err = transport.NewErrTransportMessageConversion("http", fmt.Sprintf("unknown encoding set on transport: %d", t.Encoding), true)
+			err = transport.NewErrTransportMessageConversion("http", fmt.Sprintf("unknown encoding set on transport: %d", t.Encoding), false, true)
 			logger.Error("failed to load codec", zap.Error(err))
 		} else {
 			event, err = t.codec.Decode(ctx, msg)
 		}
 	} else {
-		err = transport.NewErrTransportMessageConversion("http", "cloudevents version unknown", false)
+		err = transport.NewErrTransportMessageConversion("http", "cloudevents version unknown", false, false)
 	}
 
 	// If codec returns and error, or could not load the correct codec, try
@@ -254,10 +262,17 @@ func (t *Transport) MessageToEvent(ctx context.Context, msg *Message) (*cloudeve
 	if err != nil && t.HasConverter() {
 		event, err = t.Converter.Convert(ctx, msg, err)
 	}
+
 	// If err is still set, it means that there was no converter, or the
 	// converter failed to convert.
 	if err != nil {
 		logger.Debug("failed to decode message", zap.Error(err))
+	}
+
+	// If event and error are both nil, then there is nothing to do with this event, it was handled.
+	if err == nil && event == nil {
+		logger.Debug("convert function returned (nil, nil)")
+		err = transport.NewErrTransportMessageConversion("http", "convert function handled request", true, false)
 	}
 
 	return event, err
@@ -548,16 +563,30 @@ func (t *Transport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	})
 	if err != nil {
 		isFatal := true
+		handled := false
 		if txerr, ok := err.(*transport.ErrTransportMessageConversion); ok {
 			isFatal = txerr.IsFatal()
+			handled = txerr.Handled()
 		}
-		if isFatal || event == nil {
+		if isFatal {
 			logger.Errorw("failed to convert http message to event", zap.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"error":%q}`, err.Error())))
 			r.Error()
 			return
 		}
+		// if handled, do not pass to receiver.
+		if handled {
+			w.WriteHeader(http.StatusNoContent)
+			r.OK()
+			return
+		}
+	}
+	if event == nil {
+		logger.Error("failed to get non-nil event from MessageToEvent")
+		w.WriteHeader(http.StatusBadRequest)
+		r.Error()
+		return
 	}
 
 	resp, err := t.invokeReceiver(ctx, *event)


### PR DESCRIPTION
## Proposed Changes

- Add support for parsing v1.0 formatted cloudevents.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
BREAKING CHANGE: the new version of the cloudevents sdk no longer defaults content type to application/json if blank. Please set content type if required.
```

Cloudevents Golang SDK release: https://github.com/cloudevents/sdk-go/releases/tag/v0.10.0
