### PR TITLE
Do not emit metrics in e2e test

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -79,9 +79,6 @@ func InitializeEventingFlags() {
 	}
 
 	testLogging.InitializeLogger(pkgTest.Flags.LogVerbose)
-	if pkgTest.Flags.EmitMetrics {
-		testLogging.InitializeMetricExporter("eventing")
-	}
 
 	EventingFlags = &f
 }


### PR DESCRIPTION
Might help with #2040

## Proposed Change
I just realized the e2e tests are only flaky for the continuous runs, but not for the presubmit tests. And the only difference between them is the continuous runs set `--emit-metrics` to be true, it seems to be something legacy and have conflict with the trace setting in eventing e2e test. And we should be able to safely remove it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```