### PR TITLE
fixing RBAC for finalizers sub-resource of Channel

### DIFF
--- a/config/200-controller-clusterrole.yaml
+++ b/config/200-controller-clusterrole.yaml
@@ -92,6 +92,7 @@ rules:
     resources:
       - "sequences/finalizers"
       - "parallels/finalizers"
+      - "channels/finalizers"
     verbs:
       - "update"
 


### PR DESCRIPTION
Running on Openshift 4.2 and setting the `KafkaChannel` as the default `Channel`, creating a channel does not work, and the status of the generic `Channel` says:

```
Channel reconcile error: problem reconciling the backing channel: kafkachannels.messaging.knative.dev "greetings-channel" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

related to:
* #1450
* #1495 
