### PR TITLE
Add yaml to explicitly create our webhook configs.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1243,7 +1243,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:70af147aaa464fa6248d55e038e1db0d7c70ff6a7a2226c33b5f0d6bf820193b"
+  digest = "1:d91a27f79bca7f71b57bdc3581542d646c90dca75862c38d21ad7b1aca6c22aa"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1306,6 +1306,7 @@
     "metrics/metricstest",
     "metrics/testing",
     "profiling",
+    "ptr",
     "reconciler/testing",
     "signals",
     "source",
@@ -1332,7 +1333,7 @@
     "webhook",
   ]
   pruneopts = "T"
-  revision = "f684a1078ac309f4b32e6240d9b622bea092296e"
+  revision = "cad41c40ccb5a40de7a3b65097649703c8d96e0b"
 
 [[projects]]
   branch = "master"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -137,14 +137,14 @@ func main() {
 	}
 
 	options := webhook.ControllerOptions{
-		ServiceName:                     logconfig.WebhookName(),
-		DeploymentName:                  logconfig.WebhookName(),
-		Namespace:                       system.Namespace(),
-		Port:                            8443,
-		SecretName:                      "eventing-webhook-certs",
+		ServiceName:       logconfig.WebhookName(),
+		Namespace:         system.Namespace(),
+		Port:              8443,
+		SecretName:        "eventing-webhook-certs",
+		StatsReporter:     stats,
+		RegistrationDelay: registrationDelay * time.Second,
+
 		ResourceMutatingWebhookName:     "webhook.eventing.knative.dev",
-		StatsReporter:                   stats,
-		RegistrationDelay:               registrationDelay * time.Second,
 		ResourceAdmissionControllerPath: "/",
 	}
 

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -1,0 +1,29 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: eventing-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: webhook.eventing.knative.dev

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -38,9 +38,6 @@ spec:
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: knative.dev/eventing/cmd/webhook
-        volumeMounts:
-        - name: config-logging
-          mountPath: /etc/config-logging
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/vendor/knative.dev/pkg/apis/duck/README.md
+++ b/vendor/knative.dev/pkg/apis/duck/README.md
@@ -1,0 +1,95 @@
+# Duck Types
+
+Knative leverages duck-typing to interact with resources inside of Kubernetes
+without explicit knowlage of the full resource shape. `knative/pkg` defines two
+duck types that are used throughout Knative: `Addressable` and `Source`.
+
+For APIs leveraging `ObjectReference`, the context of the resource in question
+identifies the duck-type. To enable the case where no `ObjectRefrence` is used,
+we have labeled the Custom Resource Definition with the duck-type. Those labels
+are as follows:
+
+| Label                               | Duck-Type                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| `duck.knative.dev/addressable=true` | [Addressable](https://godoc.org/knative.dev/pkg/apis/duck/v1#AddressableType) |
+| `duck.knative.dev/source=true`      | [Source](https://godoc.org/knative.dev/pkg/apis/duck/v1#Source)               |
+
+## Addressable Shape
+
+Addressable is expected to be the following shape:
+
+```yaml
+apiVersion: group/version
+kind: Kind
+status:
+  address:
+    url: http://host/path?query
+```
+
+## Source Shape
+
+Source is expected to be in the following shape:
+
+(with ref sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    ref:
+      apiVersion: group/version
+      kind: AnAddressableKind
+      name: a-name
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host
+```
+
+(with uri sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    uri: http://host/path?query
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host/path?query
+```
+
+(with ref and uri sink)
+
+```yaml
+apiVersion: group/version
+kind: Kind
+spec:
+  sink:
+    ref:
+      apiVersion: group/version
+      kind: AnAddressableKind
+      name: a-name
+    uri: /path?query
+  ceOverrides:
+    extensions:
+      key: value
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+  sinkUri: http://host/path?query
+```

--- a/vendor/knative.dev/pkg/webhook/config_validation_controller.go
+++ b/vendor/knative.dev/pkg/webhook/config_validation_controller.go
@@ -22,13 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 
-	"github.com/markbates/inflect"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +33,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // ConfigValidationController implements the AdmissionController for ConfigMaps
@@ -81,84 +79,53 @@ func (ac *ConfigValidationController) Admit(ctx context.Context, request *admiss
 func (ac *ConfigValidationController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
 	client := kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	logger := logging.FromContext(ctx)
-	failurePolicy := admissionregistrationv1beta1.Fail
-
-	resourceGVK := corev1.SchemeGroupVersion.WithKind("ConfigMap")
-	var rules []admissionregistrationv1beta1.RuleWithOperations
-	plural := strings.ToLower(inflect.Pluralize(resourceGVK.Kind))
 
 	ruleScope := admissionregistrationv1beta1.NamespacedScope
-	rules = append(rules, admissionregistrationv1beta1.RuleWithOperations{
+	rules := []admissionregistrationv1beta1.RuleWithOperations{{
 		Operations: []admissionregistrationv1beta1.OperationType{
 			admissionregistrationv1beta1.Create,
 			admissionregistrationv1beta1.Update,
 		},
 		Rule: admissionregistrationv1beta1.Rule{
-			APIGroups:   []string{resourceGVK.Group},
-			APIVersions: []string{resourceGVK.Version},
-			Resources:   []string{plural + "/*"},
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"configmaps/*"},
 			Scope:       &ruleScope,
 		},
-	})
+	}}
 
-	webhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ac.options.ConfigValidationWebhookName,
-		},
-		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
-			Name:  ac.options.ConfigValidationWebhookName,
-			Rules: rules,
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.Namespace,
-					Name:      ac.options.ServiceName,
-					Path:      &ac.options.ConfigValidationControllerPath,
-				},
-				CABundle: caCert,
-			},
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{{
-					Key:      ac.options.ConfigValidationNamespaceLabel,
-					Operator: metav1.LabelSelectorOpExists,
-				}},
-			},
-			FailurePolicy: &failurePolicy,
-		}},
+	configuredWebhook, err := client.Get(ac.options.ConfigValidationWebhookName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
 
-	// Set the owner to our deployment.
-	deployment, err := kubeClient.AppsV1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch our deployment: %v", err)
-	}
-	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
-	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+	webhook := configuredWebhook.DeepCopy()
 
-	// Try to create the webhook and if it already exists validate webhook rules.
-	_, err = client.Create(webhook)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create a webhook: %v", err)
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
 		}
-		logger.Info("Webhook already exists")
-		configuredWebhook, err := client.Get(ac.options.ConfigValidationWebhookName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error retrieving webhook: %v", err)
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
-			return fmt.Errorf("error diffing webhooks: %v", err)
-		} else if !ok {
-			logger.Info("Updating webhook")
-			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
-			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("failed to update webhook: %s", err)
-			}
-		} else {
-			logger.Info("Webhook is already valid")
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.options.ConfigValidationControllerPath)
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		if _, err := client.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
-		logger.Info("Created a webhook")
+		logger.Info("Webhook is valid")
 	}
 
 	return nil

--- a/vendor/knative.dev/pkg/webhook/resource_admission_controller.go
+++ b/vendor/knative.dev/pkg/webhook/resource_admission_controller.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
@@ -40,6 +39,7 @@ import (
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
 )
 
 // ResourceCallback defines a signature for resource specific (Route, Configuration, etc.)
@@ -108,7 +108,6 @@ func (ac *ResourceAdmissionController) Admit(ctx context.Context, request *admis
 func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient kubernetes.Interface, caCert []byte) error {
 	client := kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 	logger := logging.FromContext(ctx)
-	failurePolicy := admissionregistrationv1beta1.Fail
 
 	var rules []admissionregistrationv1beta1.RuleWithOperations
 	for gvk := range ac.handlers {
@@ -139,58 +138,39 @@ func (ac *ResourceAdmissionController) Register(ctx context.Context, kubeClient 
 		return lhs.Resources[0] < rhs.Resources[0]
 	})
 
-	webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ac.options.ResourceMutatingWebhookName,
-		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{{
-			Name:  ac.options.ResourceMutatingWebhookName,
-			Rules: rules,
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Namespace: ac.options.Namespace,
-					Name:      ac.options.ServiceName,
-					Path:      &ac.options.ResourceAdmissionControllerPath,
-				},
-				CABundle: caCert,
-			},
-			FailurePolicy: &failurePolicy,
-		}},
+	configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
 	}
 
-	// Set the owner to our deployment.
-	deployment, err := kubeClient.AppsV1().Deployments(ac.options.Namespace).Get(ac.options.DeploymentName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to fetch our deployment: %v", err)
-	}
-	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
-	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
+	webhook := configuredWebhook.DeepCopy()
 
-	// Try to create the webhook and if it already exists validate webhook rules.
-	_, err = client.Create(webhook)
-	if err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create a webhook: %v", err)
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
 		}
-		logger.Info("Webhook already exists")
-		configuredWebhook, err := client.Get(ac.options.ResourceMutatingWebhookName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error retrieving webhook: %v", err)
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
 		}
-		if ok, err := kmp.SafeEqual(configuredWebhook.Webhooks, webhook.Webhooks); err != nil {
-			return fmt.Errorf("error diffing webhooks: %v", err)
-		} else if !ok {
-			logger.Info("Updating webhook")
-			// Set the ResourceVersion as required by update.
-			webhook.ObjectMeta.ResourceVersion = configuredWebhook.ObjectMeta.ResourceVersion
-			if _, err := client.Update(webhook); err != nil {
-				return fmt.Errorf("failed to update webhook: %s", err)
-			}
-		} else {
-			logger.Info("Webhook is already valid")
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(
+			ac.options.ResourceAdmissionControllerPath)
+	}
+
+	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	} else if !ok {
+		logger.Info("Updating webhook")
+		if _, err := client.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
 		}
 	} else {
-		logger.Info("Created a webhook")
+		logger.Info("Webhook is valid")
 	}
 	return nil
 }


### PR DESCRIPTION
This imports knative/pkg#802 and explicitly creates the
webhook configurations that updates, and handles the breaking struct changes.

Related: knative/serving#5845

/hold

Until upstream PR lands