### PR TITLE
Adding standard duck label on CRD to signal this resource adheres to Addressable

### DIFF
--- a/config/300-broker.yaml
+++ b/config/300-broker.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: eventing.knative.dev
   versions:

--- a/config/300-channel.yaml
+++ b/config/300-channel.yaml
@@ -20,6 +20,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   versions:

--- a/config/300-parallel.yaml
+++ b/config/300-parallel.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   version: v1alpha1

--- a/config/300-sequence.yaml
+++ b/config/300-sequence.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   versions:

--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -19,6 +19,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   versions:


### PR DESCRIPTION
## Proposed Changes

- Label Broker, Channel, Parallel, Sequence CRDs with `duck.knative.dev/addressable: "true"`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Broker, Channel, Parallel, Sequence CRDs are now labeled with duck.knative.dev/addressable: "true"
```
