### PR TITLE
All performance test infra shares one single service account

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1346,14 +1346,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:15b833e870afd578a79069324b74c9cc2ac07b5547f34d54516d90f781c37461"
+  digest = "1:d98cbeb7a88cc866d8353ffec3116baf6397669bde5ceb4caccf540e8cacc496"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "75f9d5135b8f823b6a663fe49f00dbc498b6ad33"
+  revision = "5f177b80bed3c3aba1c78fb173c41099ef8b0f7c"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -20,7 +20,6 @@
 
 # Setup env vars to override the default settings
 export PROJECT_NAME="knative-eventing-performance"
-export SERVICE_ACCOUNT_NAME="mako-job"
 export BENCHMARK_ROOT_PATH="$GOPATH/src/knative.dev/eventing/test/performance/benchmarks"
 
 source vendor/knative.dev/test-infra/scripts/performance-tests.sh

--- a/vendor/knative.dev/test-infra/scripts/performance-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/performance-tests.sh
@@ -23,7 +23,7 @@ source $(dirname ${BASH_SOURCE})/library.sh
 # If not provided, they will fall back to the default values.
 readonly BENCHMARK_ROOT_PATH=${BENCHMARK_ROOT_PATH:-test/performance/benchmarks}
 readonly PROJECT_NAME=${PROJECT_NAME:-knative-performance}
-readonly SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-mako-job}
+readonly SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-mako-job@knative-performance.iam.gserviceaccount.com}
 
 # Setup env vars.
 export KO_DOCKER_REPO="gcr.io/${PROJECT_NAME}"
@@ -36,9 +36,8 @@ readonly SLACK_WRITE_TOKEN="/etc/performance-test/slack-write-token"
 # Set up the user for cluster operations.
 function setup_user() {
   echo ">> Setting up user"
-  local user_name="${SERVICE_ACCOUNT_NAME}@${PROJECT_NAME}.iam.gserviceaccount.com"
-  echo "Using gcloud user ${user_name}"
-  gcloud config set core/account ${user_name}
+  echo "Using gcloud user ${SERVICE_ACCOUNT_NAME}"
+  gcloud config set core/account ${SERVICE_ACCOUNT_NAME}
   echo "Using gcloud project ${PROJECT_NAME}"
   gcloud config set core/project ${PROJECT_NAME}
 }


### PR DESCRIPTION
## Proposed Changes
- All performance test infra shares one single service account, which is `mako-job@knative-performance.iam.gserviceaccount.com`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @nachocano 