### PR TITLE
Update ApiServerSource to warn on setting deprecated ref.

### DIFF
--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
@@ -20,8 +20,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
-	"knative.dev/eventing/pkg/apis/duck"
 	"knative.dev/pkg/apis"
+
+	"knative.dev/eventing/pkg/apis/duck"
 )
 
 const (

--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
 	"knative.dev/eventing/pkg/apis/duck"
 	"knative.dev/pkg/apis"
 )
@@ -56,6 +58,22 @@ func (s *ApiServerSourceStatus) MarkSink(uri string) {
 	s.SinkURI = uri
 	if len(uri) > 0 {
 		apiserverCondSet.Manage(s).MarkTrue(ApiServerConditionSinkProvided)
+	} else {
+		apiserverCondSet.Manage(s).MarkUnknown(ApiServerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
+	}
+}
+
+// MarkSinkWarnDeprecated sets the condition that the source has a sink configured and warns ref is deprecated.
+func (s *ApiServerSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
+	s.SinkURI = uri
+	if len(uri) > 0 {
+		c := apis.Condition{
+			Type:     ApiServerConditionSinkProvided,
+			Status:   corev1.ConditionTrue,
+			Severity: apis.ConditionSeverityError,
+			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
+		}
+		apiserverCondSet.Manage(s).SetCondition(c)
 	} else {
 		apiserverCondSet.Manage(s).MarkUnknown(ApiServerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
 	}

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -171,7 +171,13 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ApiServerSo
 		source.Status.MarkNoSink("NotFound", "")
 		return fmt.Errorf("getting sink URI: %v", err)
 	}
-	source.Status.MarkSink(sinkURI)
+	if source.Spec.Sink.DeprecatedAPIVersion != "" &&
+		source.Spec.Sink.DeprecatedKind != "" &&
+		source.Spec.Sink.DeprecatedName != "" {
+		source.Status.MarkSinkWarnRefDeprecated(sinkURI)
+	} else {
+		source.Status.MarkSink(sinkURI)
+	}
 
 	ra, err := r.createReceiveAdapter(ctx, source, sinkURI)
 	if err != nil {

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -315,7 +315,7 @@ func (r *Reconciler) makeEventTypes(src *v1alpha1.ApiServerSource) ([]eventingv1
 	// Only create EventTypes for Broker sinks.
 	// We add this check here in case the APIServerSource was changed from Broker to non-Broker sink.
 	// If so, we need to delete the existing ones, thus we return empty expected.
-	if src.Spec.Sink.Ref == nil || src.Spec.Sink.Ref.Kind != "Broker" {
+	if src.Spec.Sink.Ref == nil || (src.Spec.Sink.DeprecatedKind != "Broker" && src.Spec.Sink.Ref.Kind != "Broker") {
 		return eventTypes, nil
 	}
 

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -216,7 +216,7 @@ func TestReconcile(t *testing.T) {
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
-					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSinkDepRef(sinkURI),
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -65,6 +65,12 @@ func WithApiServerSourceSink(uri string) ApiServerSourceOption {
 	}
 }
 
+func WithApiServerSourceSinkDepRef(uri string) ApiServerSourceOption {
+	return func(s *v1alpha1.ApiServerSource) {
+		s.Status.MarkSinkWarnRefDeprecated(uri)
+	}
+}
+
 func WithApiServerSourceDeploymentUnavailable(s *v1alpha1.ApiServerSource) {
 	// The Deployment uses GenerateName, so its name is empty.
 	name := utils.GenerateFixedName(s, fmt.Sprintf("apiserversource-%s", s.Name))


### PR DESCRIPTION
Related to #1918
Relates to #2089

## Proposed Changes

- Update ApiServerSource to warn on setting deprecated ref.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adding deprecated warning message when using old spec.sink.[ref] fields for ApiServerSource.
```
