### PR TITLE
Update ContainerSource to use Destination

### DIFF
--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -61,7 +61,46 @@ spec:
             template:
               type: object
             sink:
-              type: object
+              anyOf:
+                - type: object
+                  description: "the destination that should receive events."
+                  properties:
+                    ref:
+                      type: object
+                      description: "a reference to a Kubernetes object from which to retrieve the target URI."
+                      required:
+                        - apiVersion
+                        - kind
+                        - name
+                      properties:
+                        apiVersion:
+                          type: string
+                          minLength: 1
+                        kind:
+                          type: string
+                          minLength: 1
+                        name:
+                          type: string
+                          minLength: 1
+                    uri:
+                      type: string
+                      description: "the target URI. If ref is provided, this must be relative URI reference."
+                - type: object
+                  description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
+                  required:
+                    - apiVersion
+                    - kind
+                    - name
+                  properties:
+                    apiVersion:
+                      type: string
+                      minLength: 1
+                    kind:
+                      type: string
+                      minLength: 1
+                    name:
+                      type: string
+                      minLength: 1
           type: object
         status:
           properties:

--- a/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
@@ -67,14 +67,14 @@ func (s *ContainerSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
 	s.SinkURI = uri
 	if len(uri) > 0 {
 		c := apis.Condition{
-			Type:     ApiServerConditionSinkProvided,
+			Type:     ContainerConditionSinkProvided,
 			Status:   corev1.ConditionTrue,
 			Severity: apis.ConditionSeverityError,
 			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
 		}
 		apiserverCondSet.Manage(s).SetCondition(c)
 	} else {
-		apiserverCondSet.Manage(s).MarkUnknown(ApiServerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
+		apiserverCondSet.Manage(s).MarkUnknown(ContainerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
 	}
 }
 

--- a/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -58,6 +59,22 @@ func (s *ContainerSourceStatus) MarkSink(uri string) {
 		containerCondSet.Manage(s).MarkTrue(ContainerConditionSinkProvided)
 	} else {
 		containerCondSet.Manage(s).MarkUnknown(ContainerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
+	}
+}
+
+// MarkSinkWarnDeprecated sets the condition that the source has a sink configured and warns ref is deprecated.
+func (s *ContainerSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
+	s.SinkURI = uri
+	if len(uri) > 0 {
+		c := apis.Condition{
+			Type:     ApiServerConditionSinkProvided,
+			Status:   corev1.ConditionTrue,
+			Severity: apis.ConditionSeverityError,
+			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
+		}
+		apiserverCondSet.Manage(s).SetCondition(c)
+	} else {
+		apiserverCondSet.Manage(s).MarkUnknown(ApiServerConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
 	}
 }
 

--- a/pkg/apis/sources/v1alpha1/containersource_types.go
+++ b/pkg/apis/sources/v1alpha1/containersource_types.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -83,8 +84,7 @@ type ContainerSourceSpec struct {
 	DeprecatedServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Sink is a reference to an object that will resolve to a domain name to use as the sink.
-	// +optional
-	Sink *corev1.ObjectReference `json:"sink,omitempty"`
+	Sink *apisv1alpha1.Destination `json:"sink,omitempty"`
 }
 
 // GetGroupVersionKind returns the GroupVersionKind.

--- a/pkg/apis/sources/v1alpha1/containersource_validation.go
+++ b/pkg/apis/sources/v1alpha1/containersource_validation.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"context"
 
-	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/pkg/apis"
 )
 
@@ -32,7 +31,7 @@ func (cs *ContainerSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if cs.Sink == nil {
 		fe := apis.ErrMissingField("sink")
 		errs = errs.Also(fe)
-	} else if fe := messagingv1alpha1.IsValidObjectReference(*cs.Sink); fe != nil {
+	} else if fe := cs.Sink.Validate(ctx); fe != nil {
 		errs = errs.Also(fe.ViaField("sink"))
 	}
 	return errs

--- a/pkg/apis/sources/v1alpha1/containersource_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/containersource_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
+	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
 )
 
 func TestContainerSourceValidation(t *testing.T) {
@@ -34,10 +35,12 @@ func TestContainerSourceValidation(t *testing.T) {
 		name: "valid spec",
 		spec: ContainerSourceSpec{
 			Template: &corev1.PodTemplateSpec{},
-			Sink: &corev1.ObjectReference{
-				APIVersion: "v1alpha1",
-				Kind:       "broker",
-				Name:       "default",
+			Sink: &apisv1alpha1.Destination{
+				Ref: &corev1.ObjectReference{
+					APIVersion: "v1alpha1",
+					Kind:       "broker",
+					Name:       "default",
+				},
 			},
 		},
 		want: nil,

--- a/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
@@ -233,8 +233,8 @@ func (in *ContainerSourceSpec) DeepCopyInto(out *ContainerSourceSpec) {
 	}
 	if in.Sink != nil {
 		in, out := &in.Sink, &out.Sink
-		*out = new(v1.ObjectReference)
-		**out = **in
+		*out = new(apisv1alpha1.Destination)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"knative.dev/pkg/resolver"
 	"reflect"
 	"strings"
 	"time"
@@ -33,14 +34,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"go.uber.org/zap"
+	"knative.dev/pkg/controller"
+
 	status "knative.dev/eventing/pkg/apis/duck"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	listers "knative.dev/eventing/pkg/client/listers/sources/v1alpha1"
-	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/eventing/pkg/reconciler/containersource/resources"
-	"knative.dev/pkg/controller"
 )
 
 const (
@@ -57,7 +58,7 @@ type Reconciler struct {
 	containerSourceLister listers.ContainerSourceLister
 	deploymentLister      appsv1listers.DeploymentLister
 
-	sinkReconciler *duck.SinkReconciler
+	sinkResolver *resolver.URIResolver
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -167,6 +168,7 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ContainerSo
 // If an error is returned from this function, the caller should also record
 // an Event containing the error string.
 func (r *Reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.ContainerSource, args *resources.ContainerArguments) error {
+
 	if uri, ok := sinkArg(source); ok {
 		source.Status.MarkSink(uri)
 		return nil
@@ -177,19 +179,29 @@ func (r *Reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.Contain
 		return errors.New("sink missing from spec")
 	}
 
-	sinkObjRef := source.Spec.Sink
-	if sinkObjRef.Namespace == "" {
-		sinkObjRef.Namespace = source.Namespace
+	dest := source.Spec.Sink.DeepCopy()
+	if dest.Ref != nil {
+		// To call URIFromDestination(), dest.Ref must have a Namespace. If there is
+		// no Namespace defined in dest.Ref, we will use the Namespace of the source
+		// as the Namespace of dest.Ref.
+		if dest.Ref.Namespace == "" {
+			//TODO how does this work with deprecated fields
+			dest.Ref.Namespace = source.GetNamespace()
+		}
+	} else if dest.DeprecatedName != "" && dest.DeprecatedNamespace == "" {
+		// If Ref is nil and the deprecated ref is present, we need to check for
+		// DeprecatedNamespace. This can be removed when DeprecatedNamespace is
+		// removed.
+		dest.DeprecatedNamespace = source.GetNamespace()
 	}
 
-	sourceDesc := source.Namespace + "/" + source.Name + ", " + source.GroupVersionKind().String()
-	uri, err := r.sinkReconciler.GetSinkURI(source.Spec.Sink, source, sourceDesc)
+	sinkURI, err := r.sinkResolver.URIFromDestination(*dest, source)
 	if err != nil {
-		source.Status.MarkNoSink("NotFound", `Couldn't get Sink URI from "%s/%s": %v"`, source.Spec.Sink.Namespace, source.Spec.Sink.Name, err)
-		return err
+		source.Status.MarkNoSink("NotFound", "")
+		return fmt.Errorf("getting sink URI: %v", err)
 	}
-	source.Status.MarkSink(uri)
-	args.Sink = uri
+	source.Status.MarkSink(sinkURI)
+	args.Sink = sinkURI
 
 	return nil
 }

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -197,7 +197,7 @@ func (r *Reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.Contain
 
 	sinkURI, err := r.sinkResolver.URIFromDestination(*dest, source)
 	if err != nil {
-		source.Status.MarkNoSink("NotFound", "")
+		source.Status.MarkNoSink("NotFound", `Couldn't get Sink URI from "%s/%s"`, dest.Ref.Namespace, dest.Ref.Name)
 		return fmt.Errorf("getting sink URI: %v", err)
 	}
 	source.Status.MarkSink(sinkURI)

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -200,7 +200,14 @@ func (r *Reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.Contain
 		source.Status.MarkNoSink("NotFound", `Couldn't get Sink URI from "%s/%s"`, dest.Ref.Namespace, dest.Ref.Name)
 		return fmt.Errorf("getting sink URI: %v", err)
 	}
-	source.Status.MarkSink(sinkURI)
+	if source.Spec.Sink.DeprecatedAPIVersion != "" &&
+		source.Spec.Sink.DeprecatedKind != "" &&
+		source.Spec.Sink.DeprecatedName != "" {
+		source.Status.MarkSinkWarnRefDeprecated(sinkURI)
+	} else {
+		source.Status.MarkSink(sinkURI)
+	}
+
 	args.Sink = sinkURI
 
 	return nil

--- a/pkg/reconciler/containersource/controller.go
+++ b/pkg/reconciler/containersource/controller.go
@@ -18,16 +18,18 @@ package containersource
 
 import (
 	"context"
+	"knative.dev/pkg/resolver"
 
 	"k8s.io/client-go/tools/cache"
-	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
-	"knative.dev/eventing/pkg/duck"
-	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
-	containersourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha1/containersource"
+	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
+	"knative.dev/eventing/pkg/reconciler"
+
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+
+	containersourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha1/containersource"
 )
 
 const (
@@ -54,7 +56,7 @@ func NewController(
 		deploymentLister:      deploymentInformer.Lister(),
 	}
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
-	r.sinkReconciler = duck.NewSinkReconciler(ctx, impl.EnqueueKey)
+	r.sinkResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 
 	r.Logger.Info("Setting up event handlers")
 	containerSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/test/e2e/source_container_test.go
+++ b/test/e2e/source_container_test.go
@@ -28,6 +28,7 @@ import (
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing"
 	"knative.dev/eventing/test/base/resources"
 	"knative.dev/eventing/test/common"
+	apisv1alpha1 "knative.dev/pkg/apis/v1alpha1"
 	pkgTest "knative.dev/pkg/test"
 )
 
@@ -83,7 +84,7 @@ func TestContainerSource(t *testing.T) {
 					},
 				},
 			},
-			Sink: resources.ServiceRef(loggerPodName),
+			Sink: &apisv1alpha1.Destination{Ref: resources.ServiceRef(loggerPodName)},
 		}),
 	)
 	client.CreateContainerSourceOrFail(containerSource)


### PR DESCRIPTION
Related to #1918 

## Proposed Changes

- Update type of `spec.sink` field in ContainerSource to Destination. This adds `spec.uri` and `spec.ref` fields.
- Destination includes deprecated ObjectReference fields for backward compatibility.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ContainerSource now uses the Destination API for `spec.sink`, with properties `ref` (an
ObjectReference) and `uri` (an absolute URL or URI reference). The previous `sink`
properties `apiVersion`, `kind`, and `name` have been deprecated and will be removed
in a future release. To preserve existing behavior, move those fields under
`spec.sink.ref`.
```
