### PR TITLE
use consistent deprecation warning message

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -227,7 +227,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 			// have passed validation.
 			reply.Channel.DeprecatedNamespace = subscription.Namespace
 			// Add a condition warning that the fields are deprecated.
-			subscription.Status.MarkReplyDeprecatedRef(replyFieldsDeprecated, "Using depreated fields when specifying subscription.spec.reply. These will be removed in 0.11")
+			subscription.Status.MarkReplyDeprecatedRef(replyFieldsDeprecated, "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in 0.11")
 		}
 		replyURIStr, err := r.destinationResolver.URIFromDestination(*reply.Channel, subscription)
 		if err != nil {

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -197,6 +197,6 @@ func WithSubscriptionReplyNotDeprecated(gvk metav1.GroupVersionKind, name string
 
 func WithSubscriptionReplyDeprecated() SubscriptionOption {
 	return func(s *v1alpha1.Subscription) {
-		s.Status.MarkReplyDeprecatedRef("ReplyFieldsDeprecated", "Using depreated fields when specifying subscription.spec.reply. These will be removed in 0.11")
+		s.Status.MarkReplyDeprecatedRef("ReplyFieldsDeprecated", "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in 0.11")
 	}
 }


### PR DESCRIPTION

## Proposed Changes

- Fix typo in conditions warning message. Use consistent message with other deprecation warnings.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
