### PR TITLE
Fix channel imc benchmark

### DIFF
--- a/test/performance/benchmarks/channel-imc/continuous/200-channel-imc.yaml
+++ b/test/performance/benchmarks/channel-imc/continuous/200-channel-imc.yaml
@@ -46,7 +46,6 @@ spec:
                 - "--sink=http://channel-imc-kn-channel.default.svc.cluster.local"
                 - "--aggregator=channel-imc-aggregator:10000"
                 - "--pace=100:10,400:20,800:30,1000:60,2000:60,3000:60"
-                - "--verbose"
               env:
                 - name: GOGC
                   value: "off"
@@ -98,11 +97,10 @@ spec:
             - name: aggregator
               image: knative.dev/eventing/test/test_images/performance
               args:
-                - "--role=aggregator"
-                # set to the number of sender-receiver
+                - "--roles=aggregator"
+                # set to the number of sender + receiver (same image that does both counts 2)
                 - "--expect-records=2"
                 - "--mako-tags=channel=imc"
-                - "--verbose"
                 - "--benchmark-key=5683818216292352"
                 - "--benchmark-name=Development - Channel Latency & Throughput"
               ports:


### PR DESCRIPTION
## Proposed Changes
- Fix the channel-imc benchmark configuration file due to the change in https://github.com/knative/eventing/pull/1979

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @grantr 
