### PR TITLE
Try to reduce test flakiness in continuous jobs

### DIFF
--- a/test/conformance/helpers/tracing/zipkin.go
+++ b/test/conformance/helpers/tracing/zipkin.go
@@ -19,6 +19,7 @@ package tracing
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"knative.dev/eventing/test/common"
 	"knative.dev/pkg/test/zipkin"
@@ -29,7 +30,9 @@ import (
 func Setup(t *testing.T, client *common.Client) {
 	// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
 	// TestMain.
-	zipkin.SetupZipkinTracing(client.Kube.Kube, t.Logf)
+	if !zipkin.SetupZipkinTracing(client.Kube.Kube, t.Logf) {
+		t.Fatalf("Unable to set up Zipkin for tracking")
+	}
 	setTracingConfigToZipkin(t, client)
 }
 
@@ -50,5 +53,7 @@ func setTracingConfigToZipkin(t *testing.T, client *common.Client) {
 		if err != nil {
 			t.Fatalf("Unable to set the ConfigMap: %v", err)
 		}
+		// Wait for 1 minute to let the ConfigMap be synced up.
+		time.Sleep(1 * time.Minute)
 	})
 }


### PR DESCRIPTION
## Proposed Changes
As we talked earlier, there are two possible reasons that caused the test flakiness in continuous test runs:
1. SetupZipkinTracing failed because the port was occupied
2. The ConfigMap change was not synced by the watcher
Let's make some change to see if we can reduce the test flakiness.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @Harwayne 
