### PR TITLE
Use oneOf instead of anyOf

### DIFF
--- a/config/300-apiserversource.yaml
+++ b/config/300-apiserversource.yaml
@@ -62,7 +62,7 @@ spec:
               type: string
               description: "name of the ServiceAccount to use to run the receive adapter. More info: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/."
             sink:
-              anyOf:
+              oneOf:
               - type: object
                 description: "the destination that should receive events."
                 properties:

--- a/config/300-containersource.yaml
+++ b/config/300-containersource.yaml
@@ -61,7 +61,7 @@ spec:
             template:
               type: object
             sink:
-              anyOf:
+              oneOf:
                 - type: object
                   description: "the destination that should receive events."
                   properties:


### PR DESCRIPTION
We only allow one of these variants at a time.

## Proposed Changes

- change OpenAPI `sink` to allow one of destination or deprecated ref, but not both
