### PR TITLE
add application/json encoding

### DIFF
--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -110,6 +110,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 	event.SetType(eventType)
 	event.SetSource(source)
 	event.SetSubject(subject)
+	event.SetDataContentType("application/json")
 
 	if err := event.SetData(data); err != nil {
 		return nil, err

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -28,6 +28,8 @@ import (
 	"knative.dev/eventing/pkg/adapter/apiserver/events"
 )
 
+var contentType = "application/json"
+
 func simplePod(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -83,8 +85,9 @@ func TestMakeAddEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.resource.add",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.resource.add",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -120,8 +123,9 @@ func TestMakeUpdateEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.resource.update",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.resource.update",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -157,8 +161,9 @@ func TestMakeDeleteEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.resource.delete",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.resource.delete",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -195,8 +200,9 @@ func TestMakeAddRefEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.add",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.add",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -210,8 +216,9 @@ func TestMakeAddRefEvent(t *testing.T) {
 			asController: true,
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.add",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.add",
+					ContentType: &contentType,
+					Source:      *cloudevents.ParseURLRef("unit-test"),
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
@@ -248,8 +255,9 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.update",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.update",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -263,8 +271,9 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			asController: true,
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.update",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.update",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
@@ -301,8 +310,9 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.delete",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.delete",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
@@ -316,8 +326,9 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			asController: true,
 			want: &cloudevents.Event{
 				Context: cloudevents.EventContextV02{
-					Type:   "dev.knative.apiserver.ref.delete",
-					Source: *cloudevents.ParseURLRef("unit-test"),
+					Type:        "dev.knative.apiserver.ref.delete",
+					Source:      *cloudevents.ParseURLRef("unit-test"),
+					ContentType: &contentType,
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -105,6 +105,7 @@ func (a *cronJobAdapter) cronTick() {
 	event.SetType(sourcesv1alpha1.CronJobEventType)
 	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))
+	event.SetDataContentType("application/json")
 	reportArgs := &source.ReportArgs{
 		Namespace:     a.Namespace,
 		EventSource:   event.Source(),


### PR DESCRIPTION
Fixes #2124 

## Proposed Changes

- Set the application/json in cronjob / apiserver sources.
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 - cronjob / apiserver sources now set application/json when emitting events.
```
