### PR TITLE
using constant from SDK instead of string

### DIFF
--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -110,7 +110,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 	event.SetType(eventType)
 	event.SetSource(source)
 	event.SetSubject(subject)
-	event.SetDataContentType("application/json")
+	event.SetDataContentType(cloudevents.ApplicationJSON)
 
 	if err := event.SetData(data); err != nil {
 		return nil, err

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -105,7 +105,7 @@ func (a *cronJobAdapter) cronTick() {
 	event.SetType(sourcesv1alpha1.CronJobEventType)
 	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))
-	event.SetDataContentType("application/json")
+	event.SetDataContentType(cloudevents.ApplicationJSON)
 	reportArgs := &source.ReportArgs{
 		Namespace:     a.Namespace,
 		EventSource:   event.Source(),

--- a/test/test_images/filterevents/main.go
+++ b/test/test_images/filterevents/main.go
@@ -47,7 +47,7 @@ func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
 		log.Println("Filter event")
 		resp.Status = 200
 	} else {
-		event.SetDataContentType("application/json")
+		event.SetDataContentType(cloudevents.ApplicationJSON)
 		log.Println("Reply with event")
 		resp.RespondWith(200, &event)
 	}

--- a/test/test_images/sequencestepper/main.go
+++ b/test/test_images/sequencestepper/main.go
@@ -52,7 +52,7 @@ func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
 		Data:    data,
 	}
 
-	r.SetDataContentType("application/json")
+	r.SetDataContentType(cloudevents.ApplicationJSON)
 
 	log.Println("Transform the event to: ")
 	log.Printf("[%s] %s %s: %+v", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), data)


### PR DESCRIPTION
minor, not using string - but the constant, noticed the string usage looking once #2126 got merged

Also, now we are aligned w/ the `eventing-contrib` usage

https://github.com/knative/eventing-contrib/search?q=SetDataContentType&unscoped_q=SetDataContentType

## Proposed Changes

- using constant

