### PR TITLE
add SufficientPermission condition on APIServerSource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1397,6 +1397,7 @@
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/status",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/authorization/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/config/200-sourcecontroller-clusterrole.yaml
+++ b/config/200-sourcecontroller-clusterrole.yaml
@@ -76,3 +76,11 @@ rules:
     resources:
       - events
     verbs: *everything
+
+  # Authorization checker
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create

--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
@@ -35,6 +35,9 @@ const (
 	// ApiServerConditionDeployed has status True when the ApiServerSource has had it's deployment created.
 	ApiServerConditionDeployed apis.ConditionType = "Deployed"
 
+	// ApiServerConditionSufficientPermissions has status True when the ApiServerSource has sufficient permissions to access resources.
+	ApiServerConditionSufficientPermissions apis.ConditionType = "SufficientPermissions"
+
 	// ApiServerConditionEventTypeProvided has status True when the ApiServerSource has been configured with its event types.
 	ApiServerConditionEventTypeProvided apis.ConditionType = "EventTypesProvided"
 )
@@ -42,6 +45,7 @@ const (
 var apiserverCondSet = apis.NewLivingConditionSet(
 	ApiServerConditionSinkProvided,
 	ApiServerConditionDeployed,
+	ApiServerConditionSufficientPermissions,
 )
 
 // GetCondition returns the condition currently associated with the given type, or nil.
@@ -105,6 +109,16 @@ func (s *ApiServerSourceStatus) MarkEventTypes() {
 // MarkNoEventTypes sets the condition that the source does not its event type configured.
 func (s *ApiServerSourceStatus) MarkNoEventTypes(reason, messageFormat string, messageA ...interface{}) {
 	apiserverCondSet.Manage(s).MarkFalse(ApiServerConditionEventTypeProvided, reason, messageFormat, messageA...)
+}
+
+// MarkSufficientPermissions sets the condition that the source has enough permissions to access the resources.
+func (s *ApiServerSourceStatus) MarkSufficientPermissions() {
+	apiserverCondSet.Manage(s).MarkTrue(ApiServerConditionSufficientPermissions)
+}
+
+// MarkNoSufficientPermissions sets the condition that the source does not have enough permissions to access the resources
+func (s *ApiServerSourceStatus) MarkNoSufficientPermissions(reason, messageFormat string, messageA ...interface{}) {
+	apiserverCondSet.Manage(s).MarkFalse(ApiServerConditionSufficientPermissions, reason, messageFormat, messageA...)
 }
 
 // IsReady returns true if the resource is ready overall.

--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle_test.go
@@ -75,7 +75,7 @@ func TestApiServerSourceStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
-		name: "mark sufficient persimissions",
+		name: "mark sufficient permissions",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
 			s.InitializeConditions()

--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle_test.go
@@ -75,6 +75,15 @@ func TestApiServerSourceStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
+		name: "mark sufficient persimissions",
+		s: func() *ApiServerSourceStatus {
+			s := &ApiServerSourceStatus{}
+			s.InitializeConditions()
+			s.MarkSufficientPermissions()
+			return s
+		}(),
+		want: false,
+	}, {
 		name: "mark event types",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
@@ -84,26 +93,38 @@ func TestApiServerSourceStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
-		name: "mark sink and deployed",
+		name: "mark sink and sufficient permissions and deployed",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink("uri://example")
+			s.MarkSufficientPermissions()
 			s.PropagateDeploymentAvailability(availableDeployment)
 			return s
 		}(),
 		want: true,
 	}, {
-		name: "mark sink and deployed and event types",
+		name: "mark sink and sufficient permissions and deployed and event types",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink("uri://example")
+			s.MarkSufficientPermissions()
 			s.PropagateDeploymentAvailability(availableDeployment)
 			s.MarkEventTypes()
 			return s
 		}(),
 		want: true,
+	}, {
+		name: "mark sink and not enough permissions",
+		s: func() *ApiServerSourceStatus {
+			s := &ApiServerSourceStatus{}
+			s.InitializeConditions()
+			s.MarkSink("uri://example")
+			s.MarkNoSufficientPermissions("areason", "amessage")
+			return s
+		}(),
+		want: false,
 	}}
 
 	for _, test := range tests {
@@ -166,11 +187,12 @@ func TestApiServerSourceStatusGetCondition(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 		},
 	}, {
-		name: "mark sink and deployed",
+		name: "mark sink and enough permissions and deployed",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink("uri://example")
+			s.MarkSufficientPermissions()
 			s.PropagateDeploymentAvailability(availableDeployment)
 			return s
 		}(),
@@ -180,11 +202,12 @@ func TestApiServerSourceStatusGetCondition(t *testing.T) {
 			Status: corev1.ConditionTrue,
 		},
 	}, {
-		name: "mark sink and deployed and event types",
+		name: "mark sink and enough permissions and deployed and event types",
 		s: func() *ApiServerSourceStatus {
 			s := &ApiServerSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink("uri://example")
+			s.MarkSufficientPermissions()
 			s.PropagateDeploymentAvailability(availableDeployment)
 			s.MarkEventTypes()
 			return s

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -482,7 +482,7 @@ func (r *Reconciler) runAccessCheck(src *v1alpha1.ApiServerSource) error {
 		sep1 := ""
 		for _, verb := range verbs {
 			sar := &authorizationv1.SubjectAccessReview{
-				// Name is not strictly needed but adding it to be able to run tests
+				// Name is not strictly needed but adding it to be able to track test objects
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("%s-%s-%s", src.Name, res.Kind, verb),
 				},

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -24,13 +24,22 @@ import (
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
+	pkgLogging "knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/resolver"
+
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
@@ -38,9 +47,6 @@ import (
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/eventing/pkg/reconciler/apiserversource/resources"
-	pkgLogging "knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
-	"knative.dev/pkg/resolver"
 )
 
 const (
@@ -78,9 +84,14 @@ type Reconciler struct {
 	receiveAdapterImage string
 
 	// listers index properties about resources
-	apiserversourceLister listers.ApiServerSourceLister
-	deploymentLister      appsv1listers.DeploymentLister
-	eventTypeLister       eventinglisters.EventTypeLister
+	apiserversourceLister    listers.ApiServerSourceLister
+	deploymentLister         appsv1listers.DeploymentLister
+	eventTypeLister          eventinglisters.EventTypeLister
+	roleLister               rbacv1listers.RoleLister
+	roleBindingLister        rbacv1listers.RoleBindingLister
+	clusterRoleLister        rbacv1listers.ClusterRoleLister
+	clusterRoleBindingLister rbacv1listers.ClusterRoleBindingLister
+	serviceAccountLister     corev1listers.ServiceAccountLister
 
 	source         string
 	sinkResolver   *resolver.URIResolver
@@ -177,6 +188,12 @@ func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha1.ApiServerSo
 		source.Status.MarkSinkWarnRefDeprecated(sinkURI)
 	} else {
 		source.Status.MarkSink(sinkURI)
+	}
+
+	err = r.runAccessCheck(source)
+	if err != nil {
+		logging.FromContext(ctx).Error("Not enough permission", zap.Error(err))
+		return err
 	}
 
 	ra, err := r.createReceiveAdapter(ctx, source, sinkURI)
@@ -432,4 +449,75 @@ func (r *Reconciler) UpdateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
 		ConfigMap: cfg.Data,
 	}
 	logging.FromContext(r.loggingContext).Info("Update from metrics ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+func (r *Reconciler) runAccessCheck(src *v1alpha1.ApiServerSource) error {
+	if src.Spec.Resources == nil || len(src.Spec.Resources) == 0 {
+		src.Status.MarkSufficientPermissions()
+		return nil
+	}
+
+	user := "system:serviceaccount:" + src.Namespace + ":"
+	if src.Spec.ServiceAccountName == "" {
+		user += "default"
+	} else {
+		user += src.Spec.ServiceAccountName
+	}
+
+	verbs := []string{"get", "list", "watch"}
+	resources := src.Spec.Resources
+	lastReason := ""
+
+	// Collect all missing permissions.
+	missing := ""
+	sep := ""
+
+	for _, res := range resources {
+		gv, err := schema.ParseGroupVersion(res.APIVersion)
+		if err != nil { // shouldn't happened after #2134 is fixed
+			return err
+		}
+		gvr, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: res.Kind, Group: gv.Group, Version: gv.Version})
+		missingVerbs := ""
+		sep1 := ""
+		for _, verb := range verbs {
+			sar := &authorizationv1.SubjectAccessReview{
+				// Name is not strictly needed but adding it to be able to run tests
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-%s", src.Name, res.Kind, verb),
+				},
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{
+						Namespace: src.Namespace,
+						Verb:      verb,
+						Group:     gv.Group,
+						Resource:  gvr.Resource,
+					},
+					User: user,
+				},
+			}
+
+			response, err := r.KubeClientSet.AuthorizationV1().SubjectAccessReviews().Create(sar)
+			if err != nil {
+				return err
+			}
+
+			if !response.Status.Allowed {
+				missingVerbs += sep1 + verb
+				sep1 = ", "
+			}
+		}
+		if missingVerbs != "" {
+			missing += sep + missingVerbs + ` resource "` + gvr.Resource + `" in API group "` + gv.Group + `"`
+			sep = ", "
+		}
+	}
+	if missing == "" {
+		src.Status.MarkSufficientPermissions()
+		return nil
+	}
+
+	src.Status.MarkNoSufficientPermissions(lastReason, "User %s cannot %s", user, missing)
+	return fmt.Errorf("Insufficient permission: user %s cannot %s", user, missing)
+
 }

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -482,10 +482,6 @@ func (r *Reconciler) runAccessCheck(src *v1alpha1.ApiServerSource) error {
 		sep1 := ""
 		for _, verb := range verbs {
 			sar := &authorizationv1.SubjectAccessReview{
-				// Name is not strictly needed but adding it to be able to track test objects
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%s-%s", src.Name, res.Kind, verb),
-				},
 				Spec: authorizationv1.SubjectAccessReviewSpec{
 					ResourceAttributes: &authorizationv1.ResourceAttributes{
 						Namespace: src.Namespace,

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -167,9 +167,9 @@ func TestReconcile(t *testing.T) {
 				),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -232,9 +232,9 @@ func TestReconcile(t *testing.T) {
 				),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -295,9 +295,9 @@ func TestReconcile(t *testing.T) {
 				),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -355,9 +355,9 @@ func TestReconcile(t *testing.T) {
 				Object: makeReceiveAdapter(),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -417,9 +417,9 @@ func TestReconcile(t *testing.T) {
 				Object: makeReceiveAdapterWithDifferentServiceAccount("malin"),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "malin"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "malin"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "malin"),
+				makeSubjectAccessReview("namespaces", "get", "malin"),
+				makeSubjectAccessReview("namespaces", "list", "malin"),
+				makeSubjectAccessReview("namespaces", "watch", "malin"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -477,9 +477,9 @@ func TestReconcile(t *testing.T) {
 				Object: makeReceiveAdapter(),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -538,9 +538,9 @@ func TestReconcile(t *testing.T) {
 				{Name: "name-1"},
 			},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -601,9 +601,9 @@ func TestReconcile(t *testing.T) {
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -664,9 +664,9 @@ func TestReconcile(t *testing.T) {
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -736,9 +736,9 @@ func TestReconcile(t *testing.T) {
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -874,11 +874,8 @@ func makeEventType(eventType string) *v1alpha1.EventType {
 	}
 }
 
-func makeSubjectAccessReview(name, resource, verb, sa string) *authorizationv1.SubjectAccessReview {
+func makeSubjectAccessReview(resource, verb, sa string) *authorizationv1.SubjectAccessReview {
 	return &authorizationv1.SubjectAccessReview{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
 		Spec: authorizationv1.SubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace: testNS,

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -660,6 +661,9 @@ func TestReconcile(t *testing.T) {
 				{Name: "name-1"},
 			},
 			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch"),
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateEventType),
@@ -795,6 +799,23 @@ func makeEventType(eventType string) *v1alpha1.EventType {
 			Type:   eventType,
 			Source: source,
 			Broker: sinkName,
+		},
+	}
+}
+
+func makeSubjectAccessReview(name, resource, verb string) *authorizationv1.SubjectAccessReview {
+	return &authorizationv1.SubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: testNS,
+				Verb:      verb,
+				Group:     "",
+				Resource:  resource,
+			},
+			User: "system:serviceaccount:" + testNS + ":default",
 		},
 	}
 }

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -161,10 +161,18 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with deprecated sink fields",
@@ -218,10 +226,18 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSinkDepRef(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with relative uri reference",
@@ -273,10 +289,18 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkTargetURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "deployment update due to env",
@@ -321,6 +345,7 @@ func TestReconcile(t *testing.T) {
 					// Status Update:
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceDeploymentUnavailable,
 					WithApiServerSourceStatusObservedGeneration(generation),
@@ -329,6 +354,13 @@ func TestReconcile(t *testing.T) {
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: makeReceiveAdapter(),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "deployment update due to service account",
@@ -376,6 +408,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeploymentUnavailable,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -383,6 +416,13 @@ func TestReconcile(t *testing.T) {
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: makeReceiveAdapterWithDifferentServiceAccount("malin"),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "malin"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "malin"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "malin"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "deployment update due to container count",
@@ -428,6 +468,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeploymentUnavailable,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -435,6 +476,13 @@ func TestReconcile(t *testing.T) {
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: makeReceiveAdapter(),
 			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with event types to delete",
@@ -481,6 +529,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -488,6 +537,13 @@ func TestReconcile(t *testing.T) {
 			WantDeletes: []clientgotesting.DeleteActionImpl{
 				{Name: "name-1"},
 			},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with broker sink",
@@ -533,6 +589,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -544,7 +601,12 @@ func TestReconcile(t *testing.T) {
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
 			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with broker sink and missing event types",
@@ -593,6 +655,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -601,7 +664,12 @@ func TestReconcile(t *testing.T) {
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
 			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 		{
 			Name: "valid with broker sink and event types to delete",
@@ -653,6 +721,7 @@ func TestReconcile(t *testing.T) {
 					WithInitApiServerSourceConditions,
 					WithApiServerSourceDeployed,
 					WithApiServerSourceSink(sinkURI),
+					WithApiServerSourceSufficientPermissions,
 					WithApiServerSourceEventTypes,
 					WithApiServerSourceStatusObservedGeneration(generation),
 				),
@@ -661,16 +730,18 @@ func TestReconcile(t *testing.T) {
 				{Name: "name-1"},
 			},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list"),
-				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch"),
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceAddRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceDeleteRefEventType),
 				makeEventType(sourcesv1alpha1.ApiServerSourceUpdateRefEventType),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-get", "namespaces", "get", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-list", "namespaces", "list", "default"),
+				makeSubjectAccessReview("test-apiserver-source-Namespace-watch", "namespaces", "watch", "default"),
 			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor()},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
 	}
 
@@ -803,7 +874,7 @@ func makeEventType(eventType string) *v1alpha1.EventType {
 	}
 }
 
-func makeSubjectAccessReview(name, resource, verb string) *authorizationv1.SubjectAccessReview {
+func makeSubjectAccessReview(name, resource, verb, sa string) *authorizationv1.SubjectAccessReview {
 	return &authorizationv1.SubjectAccessReview{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -815,7 +886,7 @@ func makeSubjectAccessReview(name, resource, verb string) *authorizationv1.Subje
 				Group:     "",
 				Resource:  resource,
 			},
-			User: "system:serviceaccount:" + testNS + ":default",
+			User: "system:serviceaccount:" + testNS + ":" + sa,
 		},
 	}
 }
@@ -833,4 +904,15 @@ func makeApiServerSource() *sourcesv1alpha1.ApiServerSource {
 		}),
 		WithApiServerSourceUID(sourceUID),
 	)
+}
+
+func subjectAccessReviewCreateReactor() clientgotesting.ReactionFunc {
+	return func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "subjectaccessreviews" {
+			ret := action.(clientgotesting.CreateAction).GetObject().DeepCopyObject().(*authorizationv1.SubjectAccessReview)
+			ret.Status.Allowed = true
+			return true, ret, nil
+		}
+		return false, nil, nil
+	}
 }

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -67,9 +67,8 @@ func NewController(
 		apiserversourceLister: apiServerSourceInformer.Lister(),
 		deploymentLister:      deploymentInformer.Lister(),
 		eventTypeLister:       eventTypeInformer.Lister(),
-
-		source:         GetCfgHost(ctx),
-		loggingContext: ctx,
+		source:                GetCfgHost(ctx),
+		loggingContext:        ctx,
 	}
 
 	env := &envConfig{}

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -31,6 +31,7 @@ import (
 	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventtype"
 	apiserversourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha1/apiserversource"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+
 	"knative.dev/pkg/logging"
 )
 
@@ -66,8 +67,9 @@ func NewController(
 		apiserversourceLister: apiServerSourceInformer.Lister(),
 		deploymentLister:      deploymentInformer.Lister(),
 		eventTypeLister:       eventTypeInformer.Lister(),
-		source:                GetCfgHost(ctx),
-		loggingContext:        ctx,
+
+		source:         GetCfgHost(ctx),
+		loggingContext: ctx,
 	}
 
 	env := &envConfig{}

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -85,6 +85,10 @@ func WithApiServerSourceEventTypes(s *v1alpha1.ApiServerSource) {
 	s.Status.MarkEventTypes()
 }
 
+func WithApiServerSourceSufficientPermissions(s *v1alpha1.ApiServerSource) {
+	s.Status.MarkSufficientPermissions()
+}
+
 func WithApiServerSourceDeleted(c *v1alpha1.ApiServerSource) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	c.ObjectMeta.SetDeletionTimestamp(&t)

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -89,6 +89,10 @@ func WithApiServerSourceSufficientPermissions(s *v1alpha1.ApiServerSource) {
 	s.Status.MarkSufficientPermissions()
 }
 
+func WithApiServerSourceNoSufficientPermissions(s *v1alpha1.ApiServerSource) {
+	s.Status.MarkNoSufficientPermissions("", `User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group ""`)
+}
+
 func WithApiServerSourceDeleted(c *v1alpha1.ApiServerSource) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	c.ObjectMeta.SetDeletionTimestamp(&t)


### PR DESCRIPTION
Fixes #2112 

## Proposed Changes

- add SufficientPermission condition on APIServerSource
 

**Release Note**

```release-note
The APIServer source now reports whether there is enough permission to get/watch/list configured resources 
```


