### PR TITLE
fix downgrade to CE 0.3.0

### DIFF
--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -171,8 +171,7 @@ func (r *Handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *
 	}
 
 	// Remove the TTL attribute that is used by the Broker.
-	originalV3 := event.Context.AsV03()
-	ttl, ttlKey := broker.GetTTL(event.Context)
+	ttl, ttlKey := broker.GetTTL(event.Context.AsV03())
 	if ttl == nil {
 		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
 		// event wasn't sent by the Broker, so we can drop it.
@@ -182,8 +181,7 @@ func (r *Handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *
 		// framework returns a 500 to the caller, so the Channel would send this repeatedly.
 		return nil
 	}
-	delete(originalV3.Extensions, ttlKey)
-	event.Context = originalV3
+	delete(event.Context.Extensions, ttlKey)
 
 	r.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))
 

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -181,7 +181,7 @@ func (r *Handler) serveHTTP(ctx context.Context, event cloudevents.Event, resp *
 		// framework returns a 500 to the caller, so the Channel would send this repeatedly.
 		return nil
 	}
-	delete(event.Context.Extensions, ttlKey)
+	event.SetExtension(ttlKey, nil)
 
 	r.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))
 

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	cloudevents "github.com/cloudevents/sdk-go"
+	cepkg "github.com/cloudevents/sdk-go/pkg/cloudevents"
 	cehttp "github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
@@ -366,7 +367,11 @@ func TestReceiver(t *testing.T) {
 			if tc.expectedEventProcessingTime != reporter.eventProcessingTimeReported {
 				t.Errorf("Incorrect event processing time reported metric. Expected %v, Actual %v", tc.expectedEventProcessingTime, reporter.eventProcessingTimeReported)
 			}
-
+			if tc.returnedEvent != nil {
+				if tc.returnedEvent.SpecVersion() != cepkg.CloudEventsVersionV1 {
+					t.Errorf("Incorrect event processing time reported metric. Expected %v, Actual %v", tc.expectedEventProcessingTime, reporter.eventProcessingTimeReported)
+				}
+			}
 			// Compare the returned event.
 			if tc.returnedEvent == nil {
 				if resp.Event != nil {
@@ -580,7 +585,7 @@ func makeDifferentEvent() *cloudevents.Event {
 				},
 			},
 			ContentType: cloudevents.StringOfApplicationJSON(),
-		}.AsV03(),
+		}.AsV1(),
 	}
 }
 
@@ -597,7 +602,7 @@ func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
 			Extensions: map[string]interface{}{
 				extName: extValue,
 			},
-		}.AsV03(),
+		}.AsV1(),
 	}
 	e := addTTLToEvent(*noTTL)
 	return &e


### PR DESCRIPTION
## Proposed Changes

I noticed that knative eventing brokers are (somewhere) accepting my CloudEvent 1.0 events and delivering 0.3.0 events on the other side of the broker. I trust this is not an intentional downgrade? I *think* this code is the cause. (I plan to verify soon)

**Release Note**

```release-note
- Fix downgrade of CloudEvents to 0.3.0
```
