### PR TITLE
Test does not panic if the default channel config has nil values

### DIFF
--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -167,6 +167,9 @@ func updateDefaultChannelCM(client *common.Client, updateConfig func(config *def
 
 // setClusterDefaultChannel will set the default channel for cluster-wide
 func setClusterDefaultChannel(config *defaultchannel.Config, channel string) {
+	if config.ClusterDefault == nil {
+		config.ClusterDefault = &eventingduck.ChannelTemplateSpec{}
+	}
 	config.ClusterDefault.TypeMeta = *common.GetChannelTypeMeta(channel)
 }
 

--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -172,6 +172,9 @@ func setClusterDefaultChannel(config *defaultchannel.Config, channel string) {
 
 // setNamespaceDefaultChannel will set the default channel for namespace-wide
 func setNamespaceDefaultChannel(config *defaultchannel.Config, namespace, channel string) {
+	if config.NamespaceDefaults == nil {
+		config.NamespaceDefaults = make(map[string]*eventingduck.ChannelTemplateSpec, 1)
+	}
 	namespaceDefaults := config.NamespaceDefaults
 	if spec, exists := namespaceDefaults[namespace]; exists {
 		spec.TypeMeta = *common.GetChannelTypeMeta(channel)


### PR DESCRIPTION
## Proposed Changes

- Test does not panic if the default channel config has nil values.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
