### PR TITLE
subscription lives in messaging

### DIFF
--- a/pkg/reconciler/parallel/parallel_test.go
+++ b/pkg/reconciler/parallel/parallel_test.go
@@ -604,7 +604,7 @@ func createParallelChannelStatus(parallelName string, status corev1.ConditionSta
 func createParallelFilterSubscriptionStatus(parallelName string, caseNumber int, status corev1.ConditionStatus) v1alpha1.ParallelSubscriptionStatus {
 	return v1alpha1.ParallelSubscriptionStatus{
 		Subscription: corev1.ObjectReference{
-			APIVersion: "eventing.knative.dev/v1alpha1",
+			APIVersion: "messaging.knative.dev/v1alpha1",
 			Kind:       "Subscription",
 			Name:       resources.ParallelFilterSubscriptionName(parallelName, caseNumber),
 			Namespace:  testNS,
@@ -615,7 +615,7 @@ func createParallelFilterSubscriptionStatus(parallelName string, caseNumber int,
 func createParallelSubscriptionStatus(parallelName string, caseNumber int, status corev1.ConditionStatus) v1alpha1.ParallelSubscriptionStatus {
 	return v1alpha1.ParallelSubscriptionStatus{
 		Subscription: corev1.ObjectReference{
-			APIVersion: "eventing.knative.dev/v1alpha1",
+			APIVersion: "messaging.knative.dev/v1alpha1",
 			Kind:       "Subscription",
 			Name:       resources.ParallelSubscriptionName(parallelName, caseNumber),
 			Namespace:  testNS,

--- a/pkg/reconciler/parallel/resources/subscription.go
+++ b/pkg/reconciler/parallel/resources/subscription.go
@@ -39,7 +39,7 @@ func NewFilterSubscription(branchNumber int, p *v1alpha1.Parallel) *v1alpha1.Sub
 	r := &v1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Subscription",
-			APIVersion: "eventing.knative.dev/v1alpha1",
+			APIVersion: "messaging.knative.dev/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: p.Namespace,
@@ -73,7 +73,7 @@ func NewSubscription(branchNumber int, p *v1alpha1.Parallel) *v1alpha1.Subscript
 	r := &v1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Subscription",
-			APIVersion: "eventing.knative.dev/v1alpha1",
+			APIVersion: "messaging.knative.dev/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: p.Namespace,

--- a/pkg/reconciler/sequence/resources/subscription.go
+++ b/pkg/reconciler/sequence/resources/subscription.go
@@ -35,7 +35,7 @@ func NewSubscription(stepNumber int, p *v1alpha1.Sequence) *v1alpha1.Subscriptio
 	r := &v1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Subscription",
-			APIVersion: "eventing.knative.dev/v1alpha1",
+			APIVersion: "messaging.knative.dev/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: p.Namespace,

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -193,7 +193,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,
@@ -249,7 +249,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,
@@ -306,7 +306,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,
@@ -395,7 +395,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,
@@ -403,7 +403,7 @@ func TestAllCases(t *testing.T) {
 						},
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 1),
 								Namespace:  testNS,
@@ -411,7 +411,7 @@ func TestAllCases(t *testing.T) {
 						},
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 2),
 								Namespace:  testNS,
@@ -511,7 +511,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,
@@ -519,7 +519,7 @@ func TestAllCases(t *testing.T) {
 						},
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 1),
 								Namespace:  testNS,
@@ -527,7 +527,7 @@ func TestAllCases(t *testing.T) {
 						},
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 2),
 								Namespace:  testNS,
@@ -588,7 +588,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithSequenceSubscriptionStatuses([]v1alpha1.SequenceSubscriptionStatus{
 						{
 							Subscription: corev1.ObjectReference{
-								APIVersion: "eventing.knative.dev/v1alpha1",
+								APIVersion: "messaging.knative.dev/v1alpha1",
 								Kind:       "Subscription",
 								Name:       resources.SequenceSubscriptionName(sequenceName, 0),
 								Namespace:  testNS,


### PR DESCRIPTION


## Proposed Changes

- move resource creation for Subscription from eventing.knative.dev to messaging.knative.dev where it lives.
- I think this worked "in real life" because we use typed clients in the reconcilers and hence they
didn't use this type. But, in any case it's wrong.
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
