### PR TITLE
Make the cluster smaller for performance testing

### DIFF
--- a/test/performance/benchmarks/broker-imc/cluster.yaml
+++ b/test/performance/benchmarks/broker-imc/cluster.yaml
@@ -16,6 +16,6 @@
 
 GKECluster:
   location: "us-central1"
-  nodeCount: 3
+  nodeCount: 1
   nodeType: "n1-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"

--- a/test/performance/benchmarks/channel-imc/cluster.yaml
+++ b/test/performance/benchmarks/channel-imc/cluster.yaml
@@ -16,6 +16,6 @@
 
 GKECluster:
   location: "us-central1"
-  nodeCount: 3
+  nodeCount: 1
   nodeType: "n1-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"


### PR DESCRIPTION
## Proposed Changes
The current performance benchmarks does not require much resource. The following is the peak usage:
```
chizhg@chizhg-macbookpro:~/Downloads$ ku top node
NAME                                                  CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
gke-eventing--broker-imc-default-pool-49ebcbe4-dlnv   102m         2%     730Mi           5%
gke-eventing--broker-imc-default-pool-49ebcbe4-m4x7   871m         22%    997Mi           8%
gke-eventing--broker-imc-default-pool-49ebcbe4-nzc1   1587m        40%    1081Mi          8%
gke-eventing--broker-imc-default-pool-76ee586b-3q2z   51m          1%     857Mi           6%
gke-eventing--broker-imc-default-pool-76ee586b-nfnx   592m         15%    905Mi           7%
gke-eventing--broker-imc-default-pool-76ee586b-vhgd   971m         24%    866Mi           6%
gke-eventing--broker-imc-default-pool-84422278-78t3   49m          1%     716Mi           5%
gke-eventing--broker-imc-default-pool-84422278-hd3t   97m          2%     997Mi           8%
gke-eventing--broker-imc-default-pool-84422278-hrds   122m         3%     672Mi           5%
``` 

So 3 nodes (1 node in 3 zones for regional cluster) should be enough.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @grantr 
