### PR TITLE
Change deprecation warning from 0.11 to say future instead

### DIFF
--- a/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_lifecycle.go
@@ -76,7 +76,7 @@ func (s *ApiServerSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
 			Type:     ApiServerConditionSinkProvided,
 			Status:   corev1.ConditionTrue,
 			Severity: apis.ConditionSeverityError,
-			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
+			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in the future.",
 		}
 		apiserverCondSet.Manage(s).SetCondition(c)
 	} else {

--- a/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/containersource_lifecycle.go
@@ -70,7 +70,7 @@ func (s *ContainerSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
 			Type:     ContainerConditionSinkProvided,
 			Status:   corev1.ConditionTrue,
 			Severity: apis.ConditionSeverityError,
-			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
+			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in the future.",
 		}
 		apiserverCondSet.Manage(s).SetCondition(c)
 	} else {

--- a/pkg/apis/sources/v1alpha1/cron_job_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/cron_job_lifecycle.go
@@ -95,7 +95,7 @@ func (s *CronJobSourceStatus) MarkSinkWarnRefDeprecated(uri string) {
 			Type:     CronJobConditionSinkProvided,
 			Status:   corev1.ConditionTrue,
 			Severity: apis.ConditionSeverityError,
-			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in 0.11.",
+			Message:  "Using deprecated object ref fields when specifying spec.sink. Update to spec.sink.ref. These will be removed in the future.",
 		}
 		apiserverCondSet.Manage(s).SetCondition(c)
 	} else {

--- a/pkg/reconciler/parallel/parallel.go
+++ b/pkg/reconciler/parallel/parallel.go
@@ -123,11 +123,11 @@ func (r *Reconciler) reconcile(ctx context.Context, p *v1alpha1.Parallel) error 
 	p.Status.InitializeConditions()
 
 	if reply := p.Spec.Reply; reply != nil && (reply.DeprecatedAPIVersion != "" || reply.DeprecatedKind != "" || reply.DeprecatedName != "" || reply.DeprecatedNamespace != "") {
-		p.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.reply.ref instead.")
+		p.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.reply.ref instead.")
 	} else if len(p.Spec.Branches) > 0 {
 		for _, branch := range p.Spec.Branches {
 			if branch.Reply != nil && (branch.Reply.DeprecatedAPIVersion != "" || branch.Reply.DeprecatedKind != "" || branch.Reply.DeprecatedName != "" || branch.Reply.DeprecatedNamespace != "") {
-				p.Status.MarkDeprecated("branchReplyDeprecatedRef", "spec.branches[*].reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.branches[*].reply.ref instead.")
+				p.Status.MarkDeprecated("branchReplyDeprecatedRef", "spec.branches[*].reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.branches[*].reply.ref instead.")
 				break
 			}
 		}

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -125,7 +125,7 @@ func (r *Reconciler) reconcile(ctx context.Context, s *v1alpha1.Sequence) error 
 
 	if s.Spec.Reply != nil {
 		if reply := s.Spec.Reply; reply.DeprecatedAPIVersion != "" || reply.DeprecatedKind != "" || reply.DeprecatedName != "" || reply.DeprecatedNamespace != "" {
-			s.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.reply.ref instead.")
+			s.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.reply.ref instead.")
 		} else {
 			s.Status.ClearDeprecated()
 		}

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -240,7 +240,7 @@ func (r *Reconciler) reconcile(ctx context.Context, subscription *v1alpha1.Subsc
 			destination.DeprecatedNamespace = subscription.Namespace
 			if !hasDeprecatedReplyStatus {
 				// Add a condition warning that the fields are deprecated.
-				subscription.Status.MarkReplyDeprecatedRef(replyFieldsDeprecated, "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in 0.11")
+				subscription.Status.MarkReplyDeprecatedRef(replyFieldsDeprecated, "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in the future.")
 			}
 		}
 		replyURIStr, err := r.destinationResolver.URIFromDestination(*destination, subscription)

--- a/pkg/reconciler/testing/parallel.go
+++ b/pkg/reconciler/testing/parallel.go
@@ -80,7 +80,7 @@ func WithParallelBranchStatuses(branchStatuses []v1alpha1.ParallelBranchStatus) 
 
 func WithParallelDeprecatedReplyStatus() ParallelOption {
 	return func(p *v1alpha1.Parallel) {
-		p.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.reply.ref instead.")
+		p.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.reply.ref instead.")
 	}
 }
 
@@ -92,7 +92,7 @@ func WithParallelDeprecatedStatus() ParallelOption {
 
 func WithParallelDeprecatedBranchReplyStatus() ParallelOption {
 	return func(p *v1alpha1.Parallel) {
-		p.Status.MarkDeprecated("branchReplyDeprecatedRef", "spec.branches[*].reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.branches[*].reply.ref instead.")
+		p.Status.MarkDeprecated("branchReplyDeprecatedRef", "spec.branches[*].reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.branches[*].reply.ref instead.")
 	}
 }
 

--- a/pkg/reconciler/testing/sequence.go
+++ b/pkg/reconciler/testing/sequence.go
@@ -80,7 +80,7 @@ func WithSequenceSubscriptionStatuses(subscriptionStatuses []v1alpha1.SequenceSu
 
 func WithSequenceDeprecatedReplyStatus() SequenceOption {
 	return func(s *v1alpha1.Sequence) {
-		s.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in 0.11. Use spec.reply.ref instead.")
+		s.Status.MarkDeprecated("replyDeprecatedRef", "spec.reply.{apiVersion,kind,name} are deprecated and will be removed in the future. Use spec.reply.ref instead.")
 	}
 }
 

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -197,6 +197,6 @@ func WithSubscriptionReplyNotDeprecated(gvk metav1.GroupVersionKind, name string
 
 func WithSubscriptionReplyDeprecated() SubscriptionOption {
 	return func(s *v1alpha1.Subscription) {
-		s.Status.MarkReplyDeprecatedRef("ReplyFieldsDeprecated", "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in 0.11")
+		s.Status.MarkReplyDeprecatedRef("ReplyFieldsDeprecated", "Using deprecated object ref fields when specifying spec.reply. Update to spec.reply.ref. These will be removed in the future.")
 	}
 }


### PR DESCRIPTION

## Proposed Changes

- Previously some of the deprecation messages explicitly stated that they will be removed in 0.11, change that to just say future instead.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
