### PR TITLE
Backport fix to e2e tests infra - Cherry-pick #2176

### DIFF
--- a/test/common/config.go
+++ b/test/common/config.go
@@ -17,16 +17,23 @@ limitations under the License.
 package common
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/test/base/resources"
 )
 
 // DefaultChannel is the default channel we will run tests against.
-const DefaultChannel = resources.InMemoryChannelKind
+var DefaultChannel = InMemoryChannelTypeMeta
+
+// InMemoryChannelTypeMeta is the metav1.TypeMeta for InMemoryChannel.
+var InMemoryChannelTypeMeta = metav1.TypeMeta{
+	APIVersion: resources.MessagingAPIVersion,
+	Kind:       resources.InMemoryChannelKind,
+}
 
 // ChannelFeatureMap saves the channel-features mapping.
 // Each pair means the channel support the list of features.
-var ChannelFeatureMap = map[string][]Feature{
-	resources.InMemoryChannelKind: {FeatureBasic},
+var ChannelFeatureMap = map[metav1.TypeMeta][]Feature{
+	InMemoryChannelTypeMeta: {FeatureBasic},
 }
 
 // Feature is the feature supported by the channel.

--- a/test/common/test_runner.go
+++ b/test/common/test_runner.go
@@ -45,8 +45,8 @@ const TestPullSecretName = "kn-eventing-test-pull-secret"
 
 // ChannelTestRunner is used to run tests against channels.
 type ChannelTestRunner struct {
-	ChannelFeatureMap map[string][]Feature
-	ChannelsToTest    []string
+	ChannelFeatureMap map[metav1.TypeMeta][]Feature
+	ChannelsToTest    []metav1.TypeMeta
 }
 
 // RunTests will use all channels that support the given feature, to run
@@ -54,12 +54,16 @@ type ChannelTestRunner struct {
 func (tr *ChannelTestRunner) RunTests(
 	t *testing.T,
 	feature Feature,
-	testFunc func(st *testing.T, channel string),
+	testFunc func(st *testing.T, channel metav1.TypeMeta),
 ) {
 	t.Parallel()
 	for _, channel := range tr.ChannelsToTest {
-		features := tr.ChannelFeatureMap[channel]
-		if contains(features, feature) {
+		// If a Channel is not present in the map, then assume it has all properties. This is so an
+		// unknown Channel can be specified via the --channel flag and have tests run.
+		// TODO Use a flag to specify the features of the flag based Channel, rather than assuming
+		// it supports all features.
+		features, present := tr.ChannelFeatureMap[channel]
+		if !present || contains(features, feature) {
 			t.Run(fmt.Sprintf("%s-%s", t.Name(), channel), func(st *testing.T) {
 				testFunc(st, channel)
 			})

--- a/test/common/typemeta.go
+++ b/test/common/typemeta.go
@@ -55,11 +55,6 @@ func SourcesTypeMeta(kind string) *metav1.TypeMeta {
 	}
 }
 
-// GetChannelTypeMeta gets the actual typemeta of the typed channel.
-func GetChannelTypeMeta(channelKind string) *metav1.TypeMeta {
-	return MessagingTypeMeta(channelKind)
-}
-
 // ChannelTypeMeta is the TypeMeta ref for Channel.
 var ChannelTypeMeta = MessagingTypeMeta(resources.ChannelKind)
 

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -37,13 +37,12 @@ func BrokerTracingTestHelperWithChannelTestRunner(
 	channelTestRunner common.ChannelTestRunner,
 	setupClient SetupClientFunc,
 ) {
-	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
 		t := struct{}{}
 		_ = fmt.Sprintf("%s", t)
 
-		channelTypeMeta := common.GetChannelTypeMeta(channel)
-		BrokerTracingTestHelper(st, *channelTypeMeta, setupClient)
+		BrokerTracingTestHelper(st, channel, setupClient)
 	})
 }
 

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -67,13 +67,12 @@ func ChannelTracingTestHelperWithChannelTestRunner(
 	channelTestRunner common.ChannelTestRunner,
 	setupClient SetupClientFunc,
 ) {
-	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
 		t := struct{}{}
 		_ = fmt.Sprintf("%s", t)
 
-		channelTypeMeta := common.GetChannelTypeMeta(channel)
-		ChannelTracingTestHelper(st, *channelTypeMeta, setupClient)
+		ChannelTracingTestHelper(st, channel, setupClient)
 	})
 }
 

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -25,16 +25,11 @@ import (
 	"knative.dev/pkg/test/zipkin"
 )
 
-var setup = common.Setup
-var tearDown = common.TearDown
-var getChannelTypeMeta = common.GetChannelTypeMeta
-var channels test.Channels
 var channelTestRunner common.ChannelTestRunner
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeEventingFlags()
-		channels = test.EventingFlags.Channels
 		channelTestRunner = common.ChannelTestRunner{
 			ChannelFeatureMap: common.ChannelFeatureMap,
 			ChannelsToTest:    test.EventingFlags.Channels,

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/test/base/resources"
@@ -45,16 +46,15 @@ func EventTransformationForTriggerTestHelper(t *testing.T, channelTestRunner com
 		loggerPodName         = "logger-pod"
 	)
 
-	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		client := common.Setup(st, true)
 		defer common.TearDown(client)
-		channelTypeMeta := common.GetChannelTypeMeta(channel)
 
 		// create required RBAC resources including ServiceAccounts and ClusterRoleBindings for Brokers
 		client.CreateRBACResourcesForBrokers()
 
 		// create a new broker
-		client.CreateBrokerOrFail(brokerName, channelTypeMeta)
+		client.CreateBrokerOrFail(brokerName, &channel)
 		client.WaitForResourceReady(brokerName, common.BrokerTypeMeta)
 
 		// create the event we want to transform to

--- a/test/e2e/helpers/channel_event_tranformation_test_helper.go
+++ b/test/e2e/helpers/channel_event_tranformation_test_helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/eventing/test/base/resources"
 	"knative.dev/eventing/test/common"
@@ -36,14 +37,13 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T, channelTestRunne
 	transformationPodName := "e2e-eventtransformation-transformation-pod"
 	loggerPodName := "e2e-eventtransformation-logger-pod"
 
-	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		client := common.Setup(st, true)
 		defer common.TearDown(client)
 
 		// create channels
-		channelTypeMeta := common.GetChannelTypeMeta(channel)
-		client.CreateChannelsOrFail(channelNames, channelTypeMeta)
-		client.WaitForResourcesReady(channelTypeMeta)
+		client.CreateChannelsOrFail(channelNames, &channel)
+		client.WaitForResourcesReady(&channel)
 
 		// create transformation pod and service
 		transformedEventBody := fmt.Sprintf("eventBody %s", uuid.NewUUID())
@@ -64,15 +64,15 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T, channelTestRunne
 		client.CreateSubscriptionsOrFail(
 			subscriptionNames1,
 			channelNames[0],
-			channelTypeMeta,
+			&channel,
 			resources.WithSubscriberForSubscription(transformationPodName),
-			resources.WithReplyForSubscription(channelNames[1], channelTypeMeta),
+			resources.WithReplyForSubscription(channelNames[1], &channel),
 		)
 		// create subscriptions that subscribe the second channel, and forward the received events to the logger service
 		client.CreateSubscriptionsOrFail(
 			subscriptionNames2,
 			channelNames[1],
-			channelTypeMeta,
+			&channel,
 			resources.WithSubscriberForSubscription(loggerPodName),
 		)
 
@@ -89,7 +89,7 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T, channelTestRunne
 			Data:     fmt.Sprintf(`{"msg":%q}`, eventBody),
 			Encoding: resources.CloudEventDefaultEncoding,
 		}
-		if err := client.SendFakeEventToAddressable(senderName, channelNames[0], channelTypeMeta, eventToSend); err != nil {
+		if err := client.SendFakeEventToAddressable(senderName, channelNames[0], &channel, eventToSend); err != nil {
 			st.Fatalf("Failed to send fake CloudEvent to the channel %q", channelNames[0])
 		}
 

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/eventing/test/base/resources"
 	"knative.dev/eventing/test/common"
@@ -32,14 +33,13 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding string, channelTestR
 	subscriptionName := "e2e-singleevent-subscription-" + encoding
 	loggerPodName := "e2e-singleevent-logger-pod-" + encoding
 
-	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel string) {
+	channelTestRunner.RunTests(t, common.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		st.Logf("Run test with channel %q", channel)
 		client := common.Setup(st, true)
 		defer common.TearDown(client)
 
 		// create channel
-		channelTypeMeta := common.GetChannelTypeMeta(channel)
-		client.CreateChannelOrFail(channelName, channelTypeMeta)
+		client.CreateChannelOrFail(channelName, &channel)
 
 		// create logger service as the subscriber
 		pod := resources.EventLoggerPod(loggerPodName)
@@ -49,7 +49,7 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding string, channelTestR
 		client.CreateSubscriptionOrFail(
 			subscriptionName,
 			channelName,
-			channelTypeMeta,
+			&channel,
 			resources.WithSubscriberForSubscription(loggerPodName),
 		)
 
@@ -67,7 +67,7 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding string, channelTestR
 			Encoding: encoding,
 		}
 
-		if err := client.SendFakeEventToAddressable(senderName, channelName, channelTypeMeta, event); err != nil {
+		if err := client.SendFakeEventToAddressable(senderName, channelName, &channel, event); err != nil {
 			st.Fatalf("Failed to send fake CloudEvent to the channel %q", channelName)
 		}
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -25,13 +25,10 @@ import (
 
 var setup = common.Setup
 var tearDown = common.TearDown
-var getChannelTypeMeta = common.GetChannelTypeMeta
-var channels test.Channels
 var channelTestRunner common.ChannelTestRunner
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
-	channels = test.EventingFlags.Channels
 	channelTestRunner = common.ChannelTestRunner{
 		ChannelFeatureMap: common.ChannelFeatureMap,
 		ChannelsToTest:    test.EventingFlags.Channels,

--- a/test/e2e/parallel_test.go
+++ b/test/e2e/parallel_test.go
@@ -54,7 +54,7 @@ func TestParallel(t *testing.T) {
 			expected: "parallel-two-branches-pass-first-branch-only-branch-0-sub",
 		},
 	}
-	channelTypeMeta := getChannelTypeMeta(common.DefaultChannel)
+	channelTypeMeta := &common.DefaultChannel
 
 	client := setup(t, true)
 	defer tearDown(client)

--- a/test/e2e/sequence_test.go
+++ b/test/e2e/sequence_test.go
@@ -55,7 +55,7 @@ func TestSequence(t *testing.T) {
 		podName:     "e2e-stepper3",
 		msgAppender: "-step3",
 	}}
-	channelTypeMeta := getChannelTypeMeta(common.DefaultChannel)
+	channelTypeMeta := &common.DefaultChannel
 
 	client := setup(t, true)
 	defer tearDown(client)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,10 +22,10 @@ package test
 import (
 	"flag"
 	"fmt"
+	"log"
 	"strings"
 
-	"log"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/test/common"
 	pkgTest "knative.dev/pkg/test"
 	testLogging "knative.dev/pkg/test/logging"
@@ -35,7 +35,7 @@ import (
 var EventingFlags *EventingEnvironmentFlags
 
 // Channels holds the Channels we want to run test against.
-type Channels []string
+type Channels []metav1.TypeMeta
 
 func (channels *Channels) String() string {
 	return fmt.Sprint(*channels)
@@ -46,11 +46,19 @@ func (channels *Channels) String() string {
 func (channels *Channels) Set(value string) error {
 	for _, channel := range strings.Split(value, ",") {
 		channel := strings.TrimSpace(channel)
-		if !isValid(channel) {
+		split := strings.Split(channel, ":")
+		if len(split) != 2 {
+			log.Fatalf("The given Channel name %q is invalid, it needs to be in the form \"apiVersion:Kind\".", channel)
+		}
+		tm := metav1.TypeMeta{
+			APIVersion: split[0],
+			Kind:       split[1],
+		}
+		if !isValid(tm.Kind) {
 			log.Fatalf("The given channel name %q is invalid, tests cannot be run.\n", channel)
 		}
 
-		*channels = append(*channels, channel)
+		*channels = append(*channels, tm)
 	}
 	return nil
 }
@@ -70,12 +78,12 @@ type EventingEnvironmentFlags struct {
 func InitializeEventingFlags() {
 	f := EventingEnvironmentFlags{}
 
-	flag.Var(&f.Channels, "channels", "The names of the channels, which are separated by comma.")
+	flag.Var(&f.Channels, "channels", "The names of the channel type metas, separated by comma. Example: \"messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.cloud.google.com/v1alpha1:Channel,messaging.knative.dev/v1alpha1:KafkaChannel\".")
 	flag.Parse()
 
 	// If no channel is passed through the flag, initialize it as the DefaultChannel.
 	if f.Channels == nil || len(f.Channels) == 0 {
-		f.Channels = []string{common.DefaultChannel}
+		f.Channels = []metav1.TypeMeta{common.DefaultChannel}
 	}
 
 	testLogging.InitializeLogger(pkgTest.Flags.LogVerbose)


### PR DESCRIPTION
Cherry-picked https://github.com/knative/eventing/pull/2176

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
