### PR TITLE
Update vendor/knative.dev/test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1352,14 +1352,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2cd00bc33160e185bcfea41d6fddcc345145cd930c02876d878481cd3d00864d"
+  digest = "1:e4a2fd481bd2d6dcac5ae03c55d6104a0953d0a78cb45fdd4d20a116ed2a5218"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "a6a34418ff337bec6e3191d4497d0e0936ebb44d"
+  revision = "1eeefabf8db963589ccb65b3284a216a1351b919"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/e2e-tests.sh
@@ -325,6 +325,9 @@ function setup_test_cluster() {
   set -o errexit
   set -o pipefail
 
+  header "Test cluster setup"
+  kubectl get nodes
+
   header "Setting up test cluster"
 
   # Set the actual project the test cluster resides in

--- a/vendor/knative.dev/test-infra/scripts/release.sh
+++ b/vendor/knative.dev/test-infra/scripts/release.sh
@@ -212,7 +212,7 @@ function prepare_dot_release() {
     echo "Dot release will be generated for ${version_filter}"
     releases="$(echo "${releases}" | grep ^${version_filter})"
   fi
-  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r | head -1)"
+  local last_version="$(echo "${releases}" | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -r -V | head -1)"
   [[ -n "${last_version}" ]] || abort "no previous release exist"
   local major_minor_version=""
   if [[ -z "${RELEASE_BRANCH}" ]]; then


### PR DESCRIPTION
Major changes:
* display E2E cluster setup during tests
* fix parsing error for autogenerated code in flaky test reporter
* fix automatic dot releases for 0.10+ branches

Part of https://github.com/knative/test-infra/issues/1542

/cc @grantr 