### PR TITLE
Switch the spec to require Binary HTTP mode, rather than Structured HTTP mode.

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -205,7 +205,7 @@ CloudEvent, then it MUST respond with `400 Bad Request`.
 Channels MUST output CloudEvents. The output MUST be via a binding specified in
 the
 [CloudEvents specification](https://github.com/cloudevents/spec/tree/v0.3#cloudevents-documents).
-Every Channel MUST support sending events via Structured Content Mode HTTP
+Every Channel MUST support sending events via Binary Content Mode HTTP
 Transport Binding.
 
 Channels MUST NOT alter an event that goes through them. All CloudEvent


### PR DESCRIPTION
## Proposed Changes

- Switch the spec to require Binary HTTP mode, rather than Structured HTTP mode.
    - Changing to structured HTTP mode was considered aspirational. It is clear that none of the implementations are doing so. Therefore, make the spec match the de facto standard.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
