### PR TITLE
Use the common function to install Knative monitoring

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1353,14 +1353,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e4a2fd481bd2d6dcac5ae03c55d6104a0953d0a78cb45fdd4d20a116ed2a5218"
+  digest = "1:85fe0cadd6ab83f3d7f948c60b6d422dc9cd16664246249968dab5d828ae8dfd"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "6faacbd40140c782d8a1261321b99a402967a6a8"
+  revision = "fad831028edbe066665977ea7bf366c3d5c0a2d1"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -42,7 +42,7 @@ function knative_setup() {
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing did not come up"
 
   echo "Installing Knative Monitoring"
-  start_knative_monitoring || fail_test "Knative Monitoring did not come up"
+  start_knative_monitoring "${KNATIVE_MONITORING_RELEASE}" || fail_test "Knative Monitoring did not come up"
 }
 
 # Teardown the Knative environment after tests finish.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -42,9 +42,7 @@ function knative_setup() {
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing did not come up"
 
   echo "Installing Knative Monitoring"
-  kubectl create namespace istio-system
-  kubectl apply --filename "${KNATIVE_MONITORING_RELEASE}" || return 1
-  wait_until_pods_running istio-system || fail_test "Knative Monitoring did not come up"
+  start_knative_monitoring || fail_test "Knative Monitoring did not come up"
 }
 
 # Teardown the Knative environment after tests finish.

--- a/vendor/knative.dev/test-infra/scripts/library.sh
+++ b/vendor/knative.dev/test-infra/scripts/library.sh
@@ -426,9 +426,7 @@ function start_knative_monitoring() {
   # mentioned in
   # https://github.com/knative/serving/blob/4202efc0dc12052edc0630515b101cbf8068a609/config/monitoring/tracing/zipkin/100-zipkin.yaml#L21
   kubectl create namespace istio-system 2>/dev/null
-  echo "Installing Monitoring CRDs from $1"
-  kubectl apply --selector knative.dev/crd-install=true -f "$1" || return 1
-  echo "Installing the rest of monitoring components from $1"
+  echo "Installing Monitoring from $1"
   kubectl apply -f "$1" || return 1
   wait_until_pods_running knative-monitoring || return 1
   wait_until_pods_running istio-system || return 1


### PR DESCRIPTION
## Proposed Changes
- Use the common function to install Knative monitoring for eventing e2e tests - step3 of https://github.com/knative/serving/issues/5971

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @adrcunha 