### PR TITLE
Trigger natschannel reconciliation if previous fails

### DIFF
--- a/contrib/natss/pkg/reconciler/dispatcher/natsschannel.go
+++ b/contrib/natss/pkg/reconciler/dispatcher/natsschannel.go
@@ -130,7 +130,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		logging.FromContext(ctx).Error("Failed to update NatssChannel status", zap.Error(updateStatusErr))
 		return updateStatusErr
 	}
-	return nil
+
+	// trigger new reconciliation if the previous one failed
+	return reconcileErr
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, natssChannel *v1alpha1.NatssChannel) error {


### PR DESCRIPTION
Restarting the natss dispatcher rendered channels unready if the connection to nats cannot be established before the reconciliation starts

## Proposed Changes

- Rerun reconciliation in case of an error during the previous reconciliation