### PR TITLE
Update service port's name based on istio naming convention

### DIFF
--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -22,7 +22,8 @@ metadata:
   namespace: knative-eventing
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     role: eventing-webhook

--- a/config/channels/in-memory-channel/200-dispatcher-service.yaml
+++ b/config/channels/in-memory-channel/200-dispatcher-service.yaml
@@ -25,6 +25,7 @@ spec:
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: dispatcher
   ports:
-    - port: 80
+    - name: http-dispatcher
+      port: 80
       protocol: TCP
       targetPort: 8080

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -967,7 +967,7 @@ func servicePorts(httpInternal int) []corev1.ServicePort {
 			Port:       80,
 			TargetPort: intstr.FromInt(httpInternal),
 		}, {
-			Name: "metrics",
+			Name: "http-metrics",
 			Port: 9090,
 		},
 	}

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -159,7 +159,7 @@ func MakeFilterService(b *eventingv1alpha1.Broker) *corev1.Service {
 					TargetPort: intstr.FromInt(8080),
 				},
 				{
-					Name: "metrics",
+					Name: "http-metrics",
 					Port: 9090,
 				},
 			},

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -159,7 +159,7 @@ func MakeIngressService(b *eventingv1alpha1.Broker) *corev1.Service {
 					TargetPort: intstr.FromInt(8080),
 				},
 				{
-					Name: "metrics",
+					Name: "http-metrics",
 					Port: 9090,
 				},
 			},


### PR DESCRIPTION
To be on safer side when using hand in hand with Istio, we follow service port naming convention as stated here ->https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
Serving part already merged.

We have seen issue with istio as been discussed over here -> https://github.com/istio/istio/issues/14520

Fixes #

## Proposed Changes
- Service port name should follow the istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Service port name should follow the istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
```
