### PR TITLE
attempt to fix race condition

### DIFF
--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -242,6 +243,11 @@ func TestAdapter_StartRef(t *testing.T) {
 		done <- struct{}{}
 	}()
 
+	// Wait for the reflector to be fully initialized.
+	// Ideally we want to check LastSyncResourceVersion is not empty but we
+	// don't have access to it.
+	time.Sleep(5 * time.Second)
+
 	stopCh <- struct{}{}
 	<-done
 
@@ -278,6 +284,11 @@ func TestAdapter_StartResource(t *testing.T) {
 		err = a.Start(stopCh)
 		done <- struct{}{}
 	}()
+
+	// Wait for the reflector to be fully initialized.
+	// Ideally we want to check LastSyncResourceVersion is not empty but we
+	// don't have access to it.
+	time.Sleep(5 * time.Second)
 
 	stopCh <- struct{}{}
 	<-done


### PR DESCRIPTION
Fixes #2045

If ListAndWatch is interrupted too early, the initialization goroutine clashed with the rest of the code. See https://github.com/kubernetes/client-go/blob/master/tools/cache/reflector.go#L228

## Proposed Changes

- Give some time for the reflectors to fully initialized. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
