### PR TITLE
Fix performance tests setup

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -48,30 +48,13 @@ function update_benchmark() {
   local benchmark_path="${BENCHMARK_ROOT_PATH}/$1"
   # TODO(chizhg): add update_environment function in test-infra/scripts/performance-tests.sh and move the below code there
   echo ">> Updating configmap"
-  local temp_dir="$(mktemp -d)"
-  cp "${benchmark_path}/prod.config" "${temp_dir}"
-  cp "${benchmark_path}/dev.config" "${temp_dir}"
-  sed -i -e 's/^/      /' "${temp_dir}/prod.config"
-  sed -i -e 's/^/      /' "${temp_dir}/dev.config"
-  local prod_config=$(cat ${temp_dir}/prod.config)
-  local dev_config=$(cat ${temp_dir}/dev.config)
-  local patch="
-  data:
-    prod.config: |
-$(echo "${prod_config}")
-    dev.config: |
-$(echo "${dev_config}")"
-
-  kubectl patch configmap/config-mako \
-    --type merge \
-    -p $"${patch}"
-
-  echo ">> Updating benchmark $1"
-  ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT}
-  ko apply -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
   kubectl delete configmap config-mako -n "${TEST_NAMESPACE}" --ignore-not-found=true
   kubectl create configmap config-mako -n "${TEST_NAMESPACE}" --from-file="${benchmark_path}/prod.config" || abort "failed to create config-mako configmap"
   kubectl patch configmap config-mako -n "${TEST_NAMESPACE}" -p '{"data":{"env":"prod"}}' || abort "failed to patch config-mako configmap"
+
+  echo ">> Updating benchmark $1"
+  ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true
+  ko apply -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
 }
 
 main $@

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -50,7 +50,7 @@ function update_benchmark() {
   echo ">> Updating configmap"
   kubectl delete configmap config-mako -n "${TEST_NAMESPACE}" --ignore-not-found=true
   kubectl create configmap config-mako -n "${TEST_NAMESPACE}" --from-file="${benchmark_path}/prod.config" || abort "failed to create config-mako configmap"
-  kubectl patch configmap config-mako -n "${TEST_NAMESPACE}" -p '{"data":{"env":"prod"}}' || abort "failed to patch config-mako configmap"
+  kubectl patch configmap config-mako -n "${TEST_NAMESPACE}" -p '{"data":{"environment":"prod"}}' || abort "failed to patch config-mako configmap"
 
   echo ">> Updating benchmark $1"
   ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true

--- a/test/test_images/performance/kodata/prod.config
+++ b/test/test_images/performance/kodata/prod.config
@@ -1,1 +1,0 @@
-../prod.config


### PR DESCRIPTION
## Proposed Changes
- Remove the redundant patch command
- Remove the symbolic link for `prod.config` in kodata, as the file has been deleted

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
