### PR TITLE
Adding group for PERF owners, based on perf WG/taskforce

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,15 @@ aliases:
   # These aliases are for OWNERS of the various Channel implementations. These
   # Are in addition to the repo level OWNERS.
 
+  performance-approvers:
+  - adrcunha
+  - chaodaiG
+  - slinkydeveloper
+  performance-reviewers:
+  - adrcunha
+  - chaodaiG
+  - slinkydeveloper
+
   productivity-approvers:
   - adrcunha
   - chaodaiG

--- a/test/common/performance/OWNERS
+++ b/test/common/performance/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- performance-approvers
+
+reviewers:
+- performance-reviewers
+
+labels:
+- area/performance

--- a/test/test_images/performance/OWNERS
+++ b/test/test_images/performance/OWNERS
@@ -1,0 +1,10 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- performance-approvers
+
+reviewers:
+- performance-reviewers
+
+labels:
+- area/performance


### PR DESCRIPTION
based on thread/discussions here:
https://github.com/knative/eventing/pull/2218#issuecomment-558508392

I generally think that for `perf` (like productivity) we could have some more fine grain approvers for submodules.



## Proposed Changes

- adding group for perf.
- adding @slinkydeveloper  to that too

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
