### PR TITLE
Fix performance tests by passing the publishResults flag value

### DIFF
--- a/test/common/performance/aggregator/aggregator.go
+++ b/test/common/performance/aggregator/aggregator.go
@@ -80,6 +80,7 @@ func NewAggregator(listenAddr string, expectRecords uint, makoTags []string, pub
 		notifyEventsReceived: make(chan struct{}),
 		makoTags:             makoTags,
 		expectRecords:        expectRecords,
+		publishResults:       publishResults,
 	}
 
 	// --- Create GRPC server


### PR DESCRIPTION
Proposed Changes
https://github.com/knative/eventing/pull/2229 broke performance test continuous runs, this PR fixes it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @slinkydeveloper 
/cc @grantr 
