### PR TITLE
Make upgrades from 0.10 (and downgrades) smoother.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -88,10 +88,12 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 	return defaulting.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
-		"defaulting.webhook.eventing.knative.dev",
+		"webhook.eventing.knative.dev",
 
 		// The path on which to serve the webhook.
-		"/defaulting",
+		// TODO(mattmoor): This can be changed after 0.11 once
+		// we have release reconciliation-based webhooks.
+		"/",
 
 		// The resources to validate and default.
 		ourTypes,
@@ -111,7 +113,9 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		"validation.webhook.eventing.knative.dev",
 
 		// The path on which to serve the webhook.
-		"/validation",
+		// TODO(mattmoor): This can be changed after 0.11 once
+		// we have release reconciliation-based webhooks.
+		"/",
 
 		// The resources to validate and default.
 		ourTypes,

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -15,7 +15,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaulting.webhook.eventing.knative.dev
+  name: webhook.eventing.knative.dev
   labels:
     eventing.knative.dev/release: devel
 webhooks:
@@ -26,7 +26,7 @@ webhooks:
       name: eventing-webhook
       namespace: knative-eventing
   failurePolicy: Fail
-  name: defaulting.webhook.eventing.knative.dev
+  name: webhook.eventing.knative.dev
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
This should address an issue that came up in slack where a breaking change was inadvertently introduced to the Eventing webhook when upgrading from 0.10 (it was renamed, and nothing cleans up the old one).  This basically ports over what we did in knative/serving to fix issues with both upgrade and downgrade.

Contributors running HEAD will unfortunately be broken (again) and need to run:

```shell
kubectl delete mutatingwebhookconfigurations defaulting.webhook.eventing.knative.dev
```

cc @grantr @akashrv 

/hold
Want to confirm that this fixes upgrade for @akashrv 