### PR TITLE
Fix for missing pull secrets in auto created namespaces

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -57,7 +57,7 @@ spec:
           - name: BROKER_FILTER_SERVICE_ACCOUNT
             value: eventing-broker-filter
           - name: BROKER_IMAGE_PULL_SECRET_NAME
-            value: broker-image-pull-secret
+            value:
         ports:
           - containerPort: 9090
             name: metrics

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -56,6 +56,8 @@ spec:
             value: knative.dev/eventing/cmd/broker/filter
           - name: BROKER_FILTER_SERVICE_ACCOUNT
             value: eventing-broker-filter
+          - name: BROKER_IMAGE_PULL_SECRET_NAME
+            value: broker-image-pull-secret
         ports:
           - containerPort: 9090
             name: metrics

--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -32,6 +32,10 @@ import (
 	"knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 )
 
+type envConfig struct {
+	BrokerPullSecretName string `envconfig:"BROKER_IMAGE_PULL_SECRET_NAME" required:"false"`
+}
+
 const (
 	// ReconcilerName is the name of the reconciler
 	ReconcilerName = "Namespace" // TODO: Namespace is not a very good name for this controller.

--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"context"
 
+	"github.com/kelseyhightower/envconfig"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/tracker"
@@ -56,6 +57,13 @@ func NewController(
 		Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
 		namespaceLister: namespaceInformer.Lister(),
 	}
+
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		r.Logger.Info("no broker image pull secret name defined")
+	}
+	r.brokerPullSecretName = env.BrokerPullSecretName
+
 	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 	// TODO: filter label selector: on InjectionEnabledLabels()
 

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -179,6 +179,7 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 	}
 
 	if sa.Name == resources.IngressServiceAccountName || sa.Name == resources.FilterServiceAccountName {
+		// check for existence of brokerPullSecret, and skip copy if it already exists
 		for _, v := range sa.ImagePullSecrets {
 			if fmt.Sprintf("%s", v) == ("{" + r.brokerPullSecretName + "}") {
 				return nil

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -180,22 +180,18 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 
 	if sa.Name == resources.IngressServiceAccountName || sa.Name == resources.FilterServiceAccountName {
 		// check for existence of brokerPullSecret, and skip copy if it already exists
-		secretFound := false
 		for _, v := range sa.ImagePullSecrets {
 			if fmt.Sprintf("%s", v) == ("{" + r.brokerPullSecretName + "}") {
-				secretFound = true
-				break
+				return nil
 			}
 		}
-		if (!secretFound) {
-			_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
-			if err != nil {
-				r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
-					fmt.Sprintf("Error copying secret: %s", err))
-			} else {
-				r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
-					fmt.Sprintf("Secret copied into namespace: %s", sa.Name))
-			}
+		_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
+		if err != nil {
+			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
+				fmt.Sprintf("Error copying secret: %s", err))
+		} else {
+			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
+				fmt.Sprintf("Secret copied into namespace: %s", sa.Name))
 		}
 	}
 

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -180,18 +180,22 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 
 	if sa.Name == resources.IngressServiceAccountName || sa.Name == resources.FilterServiceAccountName {
 		// check for existence of brokerPullSecret, and skip copy if it already exists
+		secretFound := false
 		for _, v := range sa.ImagePullSecrets {
 			if fmt.Sprintf("%s", v) == ("{" + r.brokerPullSecretName + "}") {
-				return nil
+				secretFound = true
+				break
 			}
 		}
-		_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
-		if err != nil {
-			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
-				fmt.Sprintf("Error copying secret: %s", err))
-		} else {
-			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
-				fmt.Sprintf("Secret copied into namespace: %s", sa.Name))
+		if (!secretFound) {
+			_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
+			if err != nil {
+				r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
+					fmt.Sprintf("Error copying secret: %s", err))
+			} else {
+				r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
+					fmt.Sprintf("Secret copied into namespace: %s", sa.Name))
+			}
 		}
 	}
 

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/reconciler"
@@ -43,7 +44,8 @@ import (
 )
 
 const (
-	testNS = "test-namespace"
+	testNS                    = "test-namespace"
+	brokerImagePullSecretName = "broker-image-pull-secret"
 )
 
 var (
@@ -80,8 +82,15 @@ func TestAllCases(t *testing.T) {
 	rbFilterConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-broker-filter-test-namespace' created for the Broker")
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 	nsEvent := Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\"")
+	secretEventFilter := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-filter")
+	secretEventIngress := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-ingress")
+
+	// Patches
+	ingressPatch := createPatch(testNS, "eventing-broker-ingress")
+	filterPatch := createPatch(testNS, "eventing-broker-filter")
 
 	// Object
+	secret := resources.MakeSecret(brokerImagePullSecretName)
 	broker := resources.MakeBroker(testNS)
 	saIngress := resources.MakeServiceAccount(testNS, resources.IngressServiceAccountName)
 	rbIngress := resources.MakeRoleBinding(resources.IngressRoleBindingName, testNS, resources.MakeServiceAccount(testNS, resources.IngressServiceAccountName), resources.IngressClusterRoleName)
@@ -137,20 +146,29 @@ func TestAllCases(t *testing.T) {
 			saIngressEvent,
 			rbIngressEvent,
 			rbIngressConfigEvent,
+			secretEventIngress,
 			saFilterEvent,
 			rbFilterEvent,
 			rbFilterConfigEvent,
+			secretEventFilter,
 			brokerEvent,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
 			broker,
+			secret,
 			saIngress,
 			rbIngress,
 			rbIngressConfig,
+			secret,
 			saFilter,
 			rbFilter,
 			rbFilterConfig,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	}, {
 		Name: "Namespace enabled, broker exists",
@@ -167,18 +185,27 @@ func TestAllCases(t *testing.T) {
 			saIngressEvent,
 			rbIngressEvent,
 			rbIngressConfigEvent,
+			secretEventIngress,
 			saFilterEvent,
 			rbFilterEvent,
 			rbFilterConfigEvent,
+			secretEventFilter,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
+			secret,
 			saIngress,
 			rbIngress,
 			rbIngressConfig,
+			secret,
 			saFilter,
 			rbFilter,
 			rbFilterConfig,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	}, {
 		Name: "Namespace enabled, broker exists with no label",
@@ -210,19 +237,28 @@ func TestAllCases(t *testing.T) {
 		WantEvents: []string{
 			rbIngressEvent,
 			rbIngressConfigEvent,
+			secretEventIngress,
 			saFilterEvent,
 			rbFilterEvent,
 			rbFilterConfigEvent,
+			secretEventFilter,
 			brokerEvent,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
 			broker,
+			secret,
 			rbIngress,
 			rbIngressConfig,
+			secret,
 			saFilter,
 			rbFilter,
 			rbFilterConfig,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	}, {
 		Name: "Namespace enabled, ingress role binding exists",
@@ -238,18 +274,27 @@ func TestAllCases(t *testing.T) {
 		WantErr:                 false,
 		WantEvents: []string{
 			saIngressEvent,
+			secretEventIngress,
 			saFilterEvent,
 			rbFilterEvent,
 			rbFilterConfigEvent,
+			secretEventFilter,
 			brokerEvent,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
 			broker,
+			secret,
 			saIngress,
+			secret,
 			saFilter,
 			rbFilter,
 			rbFilterConfig,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	}, {
 		Name: "Namespace enabled, filter service account exists",
@@ -266,18 +311,27 @@ func TestAllCases(t *testing.T) {
 			saIngressEvent,
 			rbIngressEvent,
 			rbIngressConfigEvent,
+			secretEventIngress,
 			rbFilterEvent,
 			rbFilterConfigEvent,
+			secretEventFilter,
 			brokerEvent,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
 			broker,
+			secret,
 			saIngress,
 			rbIngress,
 			rbIngressConfig,
+			secret,
 			rbFilter,
 			rbFilterConfig,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	}, {
 		Name: "Namespace enabled, filter role binding exists",
@@ -295,30 +349,67 @@ func TestAllCases(t *testing.T) {
 			saIngressEvent,
 			rbIngressEvent,
 			rbIngressConfigEvent,
+			secretEventIngress,
 			saFilterEvent,
+			secretEventFilter,
 			brokerEvent,
 			nsEvent,
 		},
 		WantCreates: []runtime.Object{
 			broker,
+			secret,
 			saIngress,
 			rbIngress,
 			rbIngressConfig,
+			secret,
 			saFilter,
+			secret,
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			ingressPatch,
+			filterPatch,
 		},
 	},
 	// TODO: we need a existing default un-owned test.
 	}
 
 	logger := logtesting.TestLogger(t)
+	// used to determine which test we are on
+	testNum := 0
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
-		return &Reconciler{
+
+		r := &Reconciler{
 			Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
 			namespaceLister:      listers.GetNamespaceLister(),
 			brokerLister:         listers.GetBrokerLister(),
 			serviceAccountLister: listers.GetServiceAccountLister(),
 			roleBindingLister:    listers.GetRoleBindingLister(),
 			tracker:              tracker.New(func(types.NamespacedName) {}, 0),
+			brokerPullSecretName: brokerImagePullSecretName,
 		}
+
+		// only create secret in required tests
+		createSecretTests := []string{"Namespace enabled", "Namespace enabled, broker exists",
+			"Namespace enabled, ingress service account exists", "Namespace enabled, ingress role binding exists",
+			"Namespace enabled, filter service account exists", "Namespace enabled, filter role binding exists"}
+
+		for _, theTest := range createSecretTests {
+			if theTest == table[testNum].Name {
+				// create the required secret in knative-eventing to be copied into required namespaces
+				tgtNSSecrets := r.KubeClientSet.CoreV1().Secrets(system.Namespace())
+				tgtNSSecrets.Create(resources.MakeSecret(brokerImagePullSecretName))
+				break
+			}
+		}
+		testNum++
+		return r
 	}, false, logger))
+}
+
+func createPatch(namespace string, name string) clientgotesting.PatchActionImpl {
+	patch := clientgotesting.PatchActionImpl{}
+	patch.Namespace = namespace
+	patch.Name = name
+	patch.Patch = []byte(`{"imagePullSecrets":[{"name":"` + brokerImagePullSecretName + `"}]}`)
+	return patch
 }

--- a/pkg/reconciler/namespace/resources/secret.go
+++ b/pkg/reconciler/namespace/resources/secret.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MakeServiceAccount creates a ServiceAccount object for the Namespace 'ns'.
+func MakeSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}

--- a/pkg/reconciler/namespace/resources/secret.go
+++ b/pkg/reconciler/namespace/resources/secret.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MakeServiceAccount creates a ServiceAccount object for the Namespace 'ns'.
+// MakeSecret creates a Secret object.
 func MakeSecret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/secret.go
+++ b/pkg/utils/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/secret.go
+++ b/pkg/utils/secret.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// CopySecret will copy a secret from one namespace into another.
+// If a ServiceAccount name is provided then it'll add it as a PullSecret to
+// it.
+// It'll either return a pointer to the new Secret or and error indicating
+// why it couldn't do it.
+func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecretName string, tgtNS string, svcAccount string) (*corev1.Secret, error) {
+	tgtNamespaceSvcAcct := corev1Input.ServiceAccounts(tgtNS)
+	srcSecrets := corev1Input.Secrets(srcNS)
+	tgtNamespaceSecrets := corev1Input.Secrets(tgtNS)
+
+	// First try to find the secret we're supposed to copy
+	srcSecret, err := srcSecrets.Get(srcSecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// check for nil source secret
+	if srcSecret == nil {
+		return nil, errors.New("error copying secret; there is no error but secret is nil")
+	}
+
+	// Found the secret, so now make a copy in our new namespace
+	newSecret, err := tgtNamespaceSecrets.Create(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: srcSecretName,
+			},
+			Data: srcSecret.Data,
+			Type: srcSecret.Type,
+		})
+
+	// If the secret already exists then that's ok - may have already been created
+	if err != nil && !apierrs.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("error copying the Secret: %s", err)
+	}
+
+	_, err = tgtNamespaceSvcAcct.Patch(svcAccount, types.StrategicMergePatchType,
+		[]byte(`{"imagePullSecrets":[{"name":"`+srcSecretName+`"}]}`))
+	if err != nil {
+		return nil, fmt.Errorf("patch failed on NS/SA (%s/%s): %s",
+			tgtNS, srcSecretName, err)
+	}
+	return newSecret, nil
+}

--- a/pkg/utils/secret_test.go
+++ b/pkg/utils/secret_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/utils/secret_test.go
+++ b/pkg/utils/secret_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	// "errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"knative.dev/eventing/pkg/reconciler/namespace/resources"
+)
+
+const (
+	srcNamespace   = "src-namespace"
+	tgtNamespace   = "tgt-namespace"
+	svcAccountName = "svc-account"
+	pullSecretName = "pull-secret-name"
+)
+
+type KubernetesAPI struct {
+	Client kubernetes.Interface
+}
+
+func TestCopySecret(t *testing.T) {
+
+	api := &KubernetesAPI{
+		Client: fake.NewSimpleClientset(),
+	}
+
+	testCases := map[string]struct {
+		corev1Input   clientcorev1.CoreV1Interface
+		srcNS         string
+		srcSecretName string
+		tgtNS         string
+		svcAccount    string
+		errorExpected bool
+	}{
+		"copy secret": {
+			corev1Input:   api.Client.CoreV1(),
+			srcNS:         srcNamespace,
+			srcSecretName: pullSecretName,
+			tgtNS:         tgtNamespace,
+			svcAccount:    svcAccountName,
+			errorExpected: false,
+		},
+		"tgt namespace does not exist": {
+			corev1Input:   api.Client.CoreV1(),
+			srcNS:         srcNamespace,
+			srcSecretName: pullSecretName,
+			tgtNS:         "does-not-exist",
+			svcAccount:    svcAccountName,
+			errorExpected: true,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			// set up src namespace secret
+			srcNamespaceSecrets := tc.corev1Input.Secrets(srcNamespace)
+			_, secretCreateError := srcNamespaceSecrets.Create(resources.MakeSecret(pullSecretName))
+			if secretCreateError != nil {
+				t.Errorf("error creating secret resources for test case: %s", secretCreateError)
+
+			}
+
+			// set up tgt namespace and service account to copy secret into.
+			tgtNamespaceServiceAccts := tc.corev1Input.ServiceAccounts(tgtNamespace)
+			_, saCreateError := tgtNamespaceServiceAccts.Create(resources.MakeServiceAccount(tgtNamespace, svcAccountName))
+			if saCreateError != nil {
+				t.Errorf("error creating service account resources for test case %s", saCreateError)
+			}
+
+			// try copying the secret
+			copiedSecret, err := CopySecret(tc.corev1Input, tc.srcNS, tc.srcSecretName, tc.tgtNS, tc.svcAccount)
+			if !tc.errorExpected {
+				if err != nil {
+					t.Errorf("unexpected error on copying secret %v", err)
+				}
+				if copiedSecret.Name != tc.srcSecretName {
+					t.Errorf("Expected %s, actually %s", tc.srcSecretName, copiedSecret.Name)
+				}
+				if copiedSecret.Namespace != tc.tgtNS {
+					t.Errorf("Expected %s, actually %s", tc.tgtNS, copiedSecret.Namespace)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error on copying secret, none found")
+				}
+			}
+
+			// clean up after test
+			tc.corev1Input.ServiceAccounts(tgtNamespace).Delete(svcAccountName, &metav1.DeleteOptions{})
+			tc.corev1Input.Secrets(srcNamespace).Delete(pullSecretName, &metav1.DeleteOptions{})
+			tc.corev1Input.Secrets(tc.tgtNS).Delete(pullSecretName, &metav1.DeleteOptions{})
+		})
+	}
+}

--- a/pkg/utils/secret_test.go
+++ b/pkg/utils/secret_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	// "errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/common/creation.go
+++ b/test/common/creation.go
@@ -29,6 +29,7 @@ import (
 	flowsv1alpha1 "knative.dev/eventing/pkg/apis/flows/v1alpha1"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
+	"knative.dev/eventing/pkg/utils"
 	"knative.dev/eventing/test/base"
 	"knative.dev/eventing/test/base/resources"
 	"knative.dev/pkg/test/helpers"
@@ -310,7 +311,7 @@ func (client *Client) CreateServiceAccountOrFail(saName string) {
 	// "kn-eventing-test-pull-secret" then use that as the ImagePullSecret
 	// on the new ServiceAccount we just created.
 	// This is needed for cases where the images are in a private registry.
-	_, err := CopySecret(client, "default", TestPullSecretName, namespace, saName)
+	_, err := utils.CopySecret(client.Kube.Kube.CoreV1(), "default", TestPullSecretName, namespace, saName)
 	if err != nil && !errors.IsNotFound(err) {
 		client.T.Fatalf("Error copying the secret: %s", err)
 	}

--- a/test/common/test_runner.go
+++ b/test/common/test_runner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -25,10 +24,11 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/eventing/pkg/utils"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	pkgTest "knative.dev/pkg/test"
@@ -129,63 +129,6 @@ func TearDown(client *Client) {
 	}
 }
 
-// CopySecret will copy a secret from one namespace into another.
-// If a ServiceAccount name is provided then it'll add it as a PullSecret to
-// it.
-// It'll either return a pointer to the new Secret or and error indicating
-// why it couldn't do it.
-func CopySecret(client *Client, srcNS string, srcSecretName string, tgtNS string, svcAccount string) (*corev1.Secret, error) {
-	// Get the Interfaces we need to access the resources in the cluster
-	srcSecI := client.Kube.Kube.CoreV1().Secrets(srcNS)
-	tgtNSSvcAccI := client.Kube.Kube.CoreV1().ServiceAccounts(tgtNS)
-	tgtNSSecI := client.Kube.Kube.CoreV1().Secrets(tgtNS)
-
-	// First try to find the secret we're supposed to copy
-	srcSecret, err := srcSecI.Get(srcSecretName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	// Just double checking
-	if srcSecret == nil {
-		return nil, errors.New("error copying Secret, it's nil w/o error")
-	}
-
-	// Found the secret, so now make a copy in our new namespace
-	newSecret, err := tgtNSSecI.Create(
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: srcSecretName,
-			},
-			Data: srcSecret.Data,
-			Type: srcSecret.Type,
-		})
-
-	// If the secret already exists then that's ok - some other test
-	// must have created it
-	if err != nil && !apierrs.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("error copying the Secret: %s", err)
-	}
-
-	client.T.Logf("Copied Secret %q into Namespace %q",
-		srcSecretName, tgtNS)
-
-	// If a ServiceAccount was provided then add it as an ImagePullSecret.
-	// Note: if the SA aleady has it then this is no-op
-	if svcAccount != "" {
-		_, err = tgtNSSvcAccI.Patch(svcAccount, types.StrategicMergePatchType,
-			[]byte(`{"imagePullSecrets":[{"name":"`+srcSecretName+`"}]}`))
-		if err != nil {
-			return nil, fmt.Errorf("patch failed on NS/SA (%s/%s): %s",
-				tgtNS, srcSecretName, err)
-		}
-		client.T.Logf("Added Secret %q as ImagePullSecret to SA %q in NS %q",
-			srcSecretName, svcAccount, tgtNS)
-	}
-
-	return newSecret, nil
-}
-
 // CreateNamespaceIfNeeded creates a new namespace if it does not exist.
 func CreateNamespaceIfNeeded(t *testing.T, client *Client, namespace string) {
 	_, err := client.Kube.Kube.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
@@ -209,7 +152,7 @@ func CreateNamespaceIfNeeded(t *testing.T, client *Client, namespace string) {
 		// "kn-eventing-test-pull-secret" then use that as the ImagePullSecret
 		// on the "default" ServiceAccount in this new Namespace.
 		// This is needed for cases where the images are in a private registry.
-		_, err := CopySecret(client, "default", TestPullSecretName, namespace, "default")
+		_, err := utils.CopySecret(client.Kube.Kube.CoreV1(), "default", TestPullSecretName, namespace, "default")
 		if err != nil && !apierrs.IsNotFound(err) {
 			t.Fatalf("error copying the secret into ns %q: %s", namespace, err)
 		}


### PR DESCRIPTION
Fixes #1862 

## Proposed Changes

- Check for a pull secret named broker-image-pull-secret in default namespace
- Copy broker-image-pull-secret into eventing-broker-ingress & eventing-broker-filter namespaces to be used when pulling from private registry.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
