### PR TITLE
Set defaultMaxIdleConnections and defaultMaxIdleConnectionsPerHost for channel event dispatcher

### DIFF
--- a/pkg/kncloudevents/good_client.go
+++ b/pkg/kncloudevents/good_client.go
@@ -20,6 +20,22 @@ type ConnectionArgs struct {
 }
 
 func NewDefaultClient(target ...string) (cloudevents.Client, error) {
+	t, err := newHTTPTransport(target...)
+	if err != nil {
+		return nil, err
+	}
+	return NewDefaultClientGivenHttpTransport(t)
+}
+
+func NewDefaultClientGivenConnectionArgs(connectionArgs ConnectionArgs, target ...string) (cloudevents.Client, error) {
+	t, err := newHTTPTransport(target...)
+	if err != nil {
+		return nil, err
+	}
+	return NewDefaultClientGivenHttpTransport(t, connectionArgs)
+}
+
+func newHTTPTransport(target ...string) (*http.Transport, error) {
 	tOpts := []http.Option{
 		cloudevents.WithBinaryEncoding(),
 		// Add input tracing.
@@ -30,11 +46,7 @@ func NewDefaultClient(target ...string) (cloudevents.Client, error) {
 	}
 
 	// Make an http transport for the CloudEvents client.
-	t, err := cloudevents.NewHTTPTransport(tOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return NewDefaultClientGivenHttpTransport(t)
+	return cloudevents.NewHTTPTransport(tOpts...)
 }
 
 // NewDefaultClientGivenHttpTransport creates a new CloudEvents client using the provided cloudevents HTTP

--- a/pkg/kncloudevents/good_client.go
+++ b/pkg/kncloudevents/good_client.go
@@ -20,22 +20,6 @@ type ConnectionArgs struct {
 }
 
 func NewDefaultClient(target ...string) (cloudevents.Client, error) {
-	t, err := newHTTPTransport(target...)
-	if err != nil {
-		return nil, err
-	}
-	return NewDefaultClientGivenHttpTransport(t)
-}
-
-func NewDefaultClientGivenConnectionArgs(connectionArgs ConnectionArgs, target ...string) (cloudevents.Client, error) {
-	t, err := newHTTPTransport(target...)
-	if err != nil {
-		return nil, err
-	}
-	return NewDefaultClientGivenHttpTransport(t, connectionArgs)
-}
-
-func newHTTPTransport(target ...string) (*http.Transport, error) {
 	tOpts := []http.Option{
 		cloudevents.WithBinaryEncoding(),
 		// Add input tracing.
@@ -46,7 +30,11 @@ func newHTTPTransport(target ...string) (*http.Transport, error) {
 	}
 
 	// Make an http transport for the CloudEvents client.
-	return cloudevents.NewHTTPTransport(tOpts...)
+	t, err := cloudevents.NewHTTPTransport(tOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return NewDefaultClientGivenHttpTransport(t)
 }
 
 // NewDefaultClientGivenHttpTransport creates a new CloudEvents client using the provided cloudevents HTTP


### PR DESCRIPTION
## Proposed Changes
- Similar as https://github.com/knative/eventing/pull/2054, we need to set `defaultMaxIdleConnections` and `defaultMaxIdleConnectionsPerHost` as higher values to get better performance

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
/cc @grantr 

This is related to part of https://github.com/knative/eventing/issues/2238.
