### PR TITLE
Change the remaining uri strings to apis.url

### DIFF
--- a/pkg/apis/duck/v1alpha1/channelable_types.go
+++ b/pkg/apis/duck/v1alpha1/channelable_types.go
@@ -81,13 +81,13 @@ func (c *Channelable) Populate() {
 		Subscribers: []SubscriberSpec{{
 			UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			Generation:    1,
-			SubscriberURI: "call1",
-			ReplyURI:      "sink2",
+			SubscriberURI: apis.HTTP("call1"),
+			ReplyURI:      apis.HTTP("sink2"),
 		}, {
 			UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 			Generation:    2,
-			SubscriberURI: "call2",
-			ReplyURI:      "sink2",
+			SubscriberURI: apis.HTTP("call2"),
+			ReplyURI:      apis.HTTP("sink2"),
 		}},
 	}
 	retry := int32(5)

--- a/pkg/apis/duck/v1alpha1/channelable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/channelable_types_test.go
@@ -50,13 +50,13 @@ func TestChannelablePopulate(t *testing.T) {
 					Subscribers: []SubscriberSpec{{
 						UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 						Generation:    1,
-						SubscriberURI: "call1",
-						ReplyURI:      "sink2",
+						SubscriberURI: apis.HTTP("call1"),
+						ReplyURI:      apis.HTTP("sink2"),
 					}, {
 						UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 						Generation:    2,
-						SubscriberURI: "call2",
-						ReplyURI:      "sink2",
+						SubscriberURI: apis.HTTP("call2"),
+						ReplyURI:      apis.HTTP("sink2"),
 					}},
 				},
 			},

--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -55,11 +55,11 @@ type SubscriberSpec struct {
 	// +optional
 	Generation int64 `json:"generation,omitempty"`
 	// +optional
-	SubscriberURI string `json:"subscriberURI,omitempty"`
+	SubscriberURI *apis.URL `json:"subscriberURI,omitempty"`
 	// +optional
-	ReplyURI string `json:"replyURI,omitempty"`
+	ReplyURI *apis.URL `json:"replyURI,omitempty"`
 	// +optional
-	DeadLetterSinkURI string `json:"deadLetterSink,omitempty"`
+	DeadLetterSinkURI *apis.URL `json:"deadLetterSink,omitempty"`
 }
 
 // SubscribableStatus is the schema for the subscribable's status portion of the status
@@ -157,13 +157,13 @@ func (c *SubscribableType) Populate() {
 		Subscribers: []SubscriberSpec{{
 			UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			Generation:    1,
-			SubscriberURI: "call1",
-			ReplyURI:      "sink2",
+			SubscriberURI: apis.HTTP("call1"),
+			ReplyURI:      apis.HTTP("sink2"),
 		}, {
 			UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 			Generation:    2,
-			SubscriberURI: "call2",
-			ReplyURI:      "sink2",
+			SubscriberURI: apis.HTTP("call2"),
+			ReplyURI:      apis.HTTP("sink2"),
 		}},
 	}
 	c.Status.SetSubscribableTypeStatus(SubscribableStatus{

--- a/pkg/apis/duck/v1alpha1/subscribable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestSubscribableGetFullType(t *testing.T) {
@@ -52,13 +53,13 @@ func TestSubscribablePopulate(t *testing.T) {
 				Subscribers: []SubscriberSpec{{
 					UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 					Generation:    1,
-					SubscriberURI: "call1",
-					ReplyURI:      "sink2",
+					SubscriberURI: apis.HTTP("call1"),
+					ReplyURI:      apis.HTTP("sink2"),
 				}, {
 					UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 					Generation:    2,
-					SubscriberURI: "call2",
-					ReplyURI:      "sink2",
+					SubscriberURI: apis.HTTP("call2"),
+					ReplyURI:      apis.HTTP("sink2"),
 				}},
 			},
 		},

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	apis "knative.dev/pkg/apis"
 	v1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
@@ -464,6 +465,21 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 		in, out := &in.DeprecatedRef, &out.DeprecatedRef
 		*out = new(v1.ObjectReference)
 		**out = **in
+	}
+	if in.SubscriberURI != nil {
+		in, out := &in.SubscriberURI, &out.SubscriberURI
+		*out = new(apis.URL)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ReplyURI != nil {
+		in, out := &in.ReplyURI, &out.ReplyURI
+		*out = new(apis.URL)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.DeadLetterSinkURI != nil {
+		in, out := &in.DeadLetterSinkURI, &out.DeadLetterSinkURI
+		*out = new(apis.URL)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/messaging/v1alpha1/channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation.go
@@ -45,7 +45,7 @@ func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	if cs.Subscribable != nil {
 		for i, subscriber := range cs.Subscribable.Subscribers {
-			if subscriber.ReplyURI == "" && subscriber.SubscriberURI == "" {
+			if subscriber.ReplyURI == nil && subscriber.SubscriberURI == nil {
 				fe := apis.ErrMissingField("replyURI", "subscriberURI")
 				fe.Details = "expected at least one of, got none"
 				errs = errs.Also(fe.ViaField(fmt.Sprintf("subscriber[%d]", i)).ViaField("subscribable"))

--- a/pkg/apis/messaging/v1alpha1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/channel_validation_test.go
@@ -78,8 +78,8 @@ func TestChannelValidation(t *testing.T) {
 				},
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "resultendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("resultendpoint"),
 					}},
 				}},
 		},
@@ -96,8 +96,8 @@ func TestChannelValidation(t *testing.T) {
 				},
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "replyendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("replyendpoint"),
 					}, {}},
 				}},
 		},
@@ -112,8 +112,8 @@ func TestChannelValidation(t *testing.T) {
 			Spec: ChannelSpec{
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "replyendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("replyendpoint"),
 					}, {}},
 				}},
 		},
@@ -256,8 +256,8 @@ func TestChannelImmutableFields(t *testing.T) {
 				},
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "replyendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("replyendpoint"),
 					}},
 				},
 			},

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_validation.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_validation.go
@@ -32,7 +32,7 @@ func (imcs *InMemoryChannelSpec) Validate(ctx context.Context) *apis.FieldError 
 
 	if imcs.Subscribable != nil {
 		for i, subscriber := range imcs.Subscribable.Subscribers {
-			if subscriber.ReplyURI == "" && subscriber.SubscriberURI == "" {
+			if subscriber.ReplyURI == nil && subscriber.SubscriberURI == nil {
 				fe := apis.ErrMissingField("replyURI", "subscriberURI")
 				fe.Details = "expected at least one of, got none"
 				errs = errs.Also(fe.ViaField(fmt.Sprintf("subscriber[%d]", i)).ViaField("subscribable"))

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_validation_test.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_validation_test.go
@@ -36,8 +36,8 @@ func TestInMemoryChannelValidation(t *testing.T) {
 			Spec: InMemoryChannelSpec{
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "resultendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("resultendpoint"),
 					}},
 				}},
 		},
@@ -48,8 +48,8 @@ func TestInMemoryChannelValidation(t *testing.T) {
 			Spec: InMemoryChannelSpec{
 				Subscribable: &eventingduck.Subscribable{
 					Subscribers: []eventingduck.SubscriberSpec{{
-						SubscriberURI: "subscriberendpoint",
-						ReplyURI:      "replyendpoint",
+						SubscriberURI: apis.HTTP("subscriberendpoint"),
+						ReplyURI:      apis.HTTP("replyendpoint"),
 					}, {}},
 				}},
 		},

--- a/pkg/channel/fanout/fanout_handler.go
+++ b/pkg/channel/fanout/fanout_handler.go
@@ -132,5 +132,5 @@ func (f *Handler) dispatch(ctx context.Context, event cloudevents.Event) error {
 // makeFanoutRequest sends the request to exactly one subscription. It handles both the `call` and
 // the `sink` portions of the subscription.
 func (f *Handler) makeFanoutRequest(ctx context.Context, event cloudevents.Event, sub eventingduck.SubscriberSpec) error {
-	return f.dispatcher.DispatchEventWithDelivery(ctx, event, sub.SubscriberURI, sub.ReplyURI, &channel.DeliveryOptions{DeadLetterSink: sub.DeadLetterSinkURI})
+	return f.dispatcher.DispatchEventWithDelivery(ctx, event, sub.SubscriberURI.String(), sub.ReplyURI.String(), &channel.DeliveryOptions{DeadLetterSink: sub.DeadLetterSinkURI.String()})
 }

--- a/pkg/channel/fanout/fanout_handler_test.go
+++ b/pkg/channel/fanout/fanout_handler_test.go
@@ -30,13 +30,14 @@ import (
 	"go.uber.org/zap"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel"
+	"knative.dev/pkg/apis"
 )
 
 // Domains used in subscriptions, which will be replaced by the real domains of the started HTTP
 // servers.
-const (
-	replaceSubscriber = "replaceSubscriber"
-	replaceChannel    = "replaceChannel"
+var (
+	replaceSubscriber = apis.HTTP("replaceSubscriber")
+	replaceChannel    = apis.HTTP("replaceChannel")
 )
 
 func makeCloudEvent() cloudevents.Event {
@@ -218,10 +219,10 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs := make([]eventingduck.SubscriberSpec, 0)
 			for _, sub := range tc.subs {
 				if sub.SubscriberURI == replaceSubscriber {
-					sub.SubscriberURI = callableServer.URL[7:] // strip the leading 'http://'
+					sub.SubscriberURI = apis.HTTP(callableServer.URL[7:]) // strip the leading 'http://'
 				}
 				if sub.ReplyURI == replaceChannel {
-					sub.ReplyURI = channelServer.URL[7:] // strip the leading 'http://'
+					sub.ReplyURI = apis.HTTP(channelServer.URL[7:]) // strip the leading 'http://'
 				}
 				subs = append(subs, sub)
 			}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
@@ -28,11 +28,12 @@ import (
 	"go.uber.org/zap"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel/fanout"
+	"knative.dev/pkg/apis"
 )
 
-const (
+var (
 	// The httptest.Server's host name will replace this value in all ChannelConfigs.
-	replaceDomain = "replaceDomain"
+	replaceDomain = apis.HTTP("replaceDomain")
 )
 
 func TestNewHandler(t *testing.T) {
@@ -83,7 +84,7 @@ func TestCopyWithNewConfig(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []eventingduck.SubscriberSpec{
 						{
-							SubscriberURI: "subscriberdomain",
+							SubscriberURI: apis.HTTP("subscriberdomain"),
 						},
 					},
 				},
@@ -98,7 +99,7 @@ func TestCopyWithNewConfig(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []eventingduck.SubscriberSpec{
 						{
-							ReplyURI: "replydomain",
+							ReplyURI: apis.HTTP("replydomain"),
 						},
 					},
 				},
@@ -136,7 +137,7 @@ func TestConfigDiff(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []eventingduck.SubscriberSpec{
 						{
-							SubscriberURI: "subscriberdomain",
+							SubscriberURI: apis.HTTP("subscriberdomain"),
 						},
 					},
 				},
@@ -166,7 +167,7 @@ func TestConfigDiff(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
-									SubscriberURI: "different",
+									SubscriberURI: apis.HTTP("different"),
 								},
 							},
 						},
@@ -241,7 +242,7 @@ func TestServeHTTP(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
-									ReplyURI: "first-to-domain",
+									ReplyURI: apis.HTTP("first-to-domain"),
 								},
 							},
 						},
@@ -306,10 +307,10 @@ func replaceDomains(config Config, replacement string) {
 	for i, cc := range config.ChannelConfigs {
 		for j, sub := range cc.FanoutConfig.Subscriptions {
 			if sub.SubscriberURI == replaceDomain {
-				sub.SubscriberURI = replacement
+				sub.SubscriberURI = apis.HTTP(replacement)
 			}
 			if sub.ReplyURI == replaceDomain {
-				sub.ReplyURI = replacement
+				sub.ReplyURI = apis.HTTP(replacement)
 			}
 			cc.FanoutConfig.Subscriptions[j] = sub
 		}

--- a/pkg/channel/multichannelfanout/parse_test.go
+++ b/pkg/channel/multichannelfanout/parse_test.go
@@ -25,6 +25,7 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/utils"
+	"knative.dev/pkg/apis"
 )
 
 func TestConfigMapData(t *testing.T) {
@@ -65,20 +66,20 @@ func TestConfigMapData(t *testing.T) {
 					name: c1
 					fanoutConfig:
 					  subscriptions:
-						- subscriberURI: event-changer.default.svc.` + utils.GetClusterDomainName() + `
-						  replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
-						- subscriberURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
-						- replyURI: message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
+						- subscriberURI: http://event-changer.default.svc.` + utils.GetClusterDomainName() + `
+						  replyURI: http://message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
+						- subscriberURI: http://message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
+						- replyURI: http://message-dumper-bar.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: default
 					name: c2
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
+						- replyURI: http://message-dumper-foo.default.svc.` + utils.GetClusterDomainName() + `
 				  - namespace: other
 					name: c3
 					fanoutConfig:
 					  subscriptions:
-						- replyURI: message-dumper-foo.default.svc.` + utils.GetClusterDomainName(),
+						- replyURI: http://message-dumper-foo.default.svc.` + utils.GetClusterDomainName(),
 
 			expected: &Config{
 				ChannelConfigs: []ChannelConfig{
@@ -88,14 +89,14 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
-									SubscriberURI: "event-changer.default.svc." + utils.GetClusterDomainName(),
-									ReplyURI:      "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
+									SubscriberURI: apis.HTTP("event-changer.default.svc." + utils.GetClusterDomainName()),
+									ReplyURI:      apis.HTTP("message-dumper-bar.default.svc." + utils.GetClusterDomainName()),
 								},
 								{
-									SubscriberURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
+									SubscriberURI: apis.HTTP("message-dumper-foo.default.svc." + utils.GetClusterDomainName()),
 								},
 								{
-									ReplyURI: "message-dumper-bar.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI: apis.HTTP("message-dumper-bar.default.svc." + utils.GetClusterDomainName()),
 								},
 							},
 						},
@@ -106,7 +107,7 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI: apis.HTTP("message-dumper-foo.default.svc." + utils.GetClusterDomainName()),
 								},
 							},
 						},
@@ -117,7 +118,7 @@ func TestConfigMapData(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
-									ReplyURI: "message-dumper-foo.default.svc." + utils.GetClusterDomainName(),
+									ReplyURI: apis.HTTP("message-dumper-foo.default.svc." + utils.GetClusterDomainName()),
 								},
 							},
 						},

--- a/pkg/channel/swappable/swappable_test.go
+++ b/pkg/channel/swappable/swappable_test.go
@@ -28,11 +28,13 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
+	"knative.dev/pkg/apis"
 )
 
+var replaceDomain = apis.HTTP("replaceDomain")
+
 const (
-	replaceDomain = "replaceDomain"
-	hostName      = "a.b.c.d"
+	hostName = "a.b.c.d"
 )
 
 func TestHandler(t *testing.T) {
@@ -207,10 +209,10 @@ func replaceDomains(c multichannelfanout.Config, replacement string) multichanne
 	for i, cc := range c.ChannelConfigs {
 		for j, sub := range cc.FanoutConfig.Subscriptions {
 			if sub.ReplyURI == replaceDomain {
-				sub.ReplyURI = replacement
+				sub.ReplyURI = apis.HTTP(replacement)
 			}
 			if sub.SubscriberURI == replaceDomain {
-				sub.SubscriberURI = replacement
+				sub.SubscriberURI = apis.HTTP(replacement)
 			}
 			cc.FanoutConfig.Subscriptions[j] = sub
 		}

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -36,6 +36,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler"
 	. "knative.dev/eventing/pkg/reconciler/testing"
 	"knative.dev/eventing/pkg/utils"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -272,13 +273,13 @@ func subscribers() []eventingduckv1alpha1.SubscriberSpec {
 	return []eventingduckv1alpha1.SubscriberSpec{{
 		UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    1,
-		SubscriberURI: "call1",
-		ReplyURI:      "sink2",
+		SubscriberURI: apis.HTTP("call1"),
+		ReplyURI:      apis.HTTP("sink2"),
 	}, {
 		UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    2,
-		SubscriberURI: "call2",
-		ReplyURI:      "sink2",
+		SubscriberURI: apis.HTTP("call2"),
+		ReplyURI:      apis.HTTP("sink2"),
 	}}
 }
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,13 +52,13 @@ func TestAllCases(t *testing.T) {
 	subscribers := []duckv1alpha1.SubscriberSpec{{
 		UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    1,
-		SubscriberURI: "call1",
-		ReplyURI:      "sink2",
+		SubscriberURI: apis.HTTP("call1"),
+		ReplyURI:      apis.HTTP("sink2"),
 	}, {
 		UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    2,
-		SubscriberURI: "call2",
-		ReplyURI:      "sink2",
+		SubscriberURI: apis.HTTP("call2"),
+		ReplyURI:      apis.HTTP("sink2"),
 	}}
 
 	subscriberStatuses := []duckv1alpha1.SubscriberStatus{{

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -533,9 +533,9 @@ func (r *Reconciler) createSubscribable(subs []v1alpha1.Subscription) *eventingd
 				},
 				UID:               sub.UID,
 				Generation:        sub.Generation,
-				SubscriberURI:     sub.Status.PhysicalSubscription.SubscriberURI.String(),
-				ReplyURI:          sub.Status.PhysicalSubscription.ReplyURI.String(),
-				DeadLetterSinkURI: sub.Status.PhysicalSubscription.DeadLetterSinkURI.String(),
+				SubscriberURI:     sub.Status.PhysicalSubscription.SubscriberURI,
+				ReplyURI:          sub.Status.PhysicalSubscription.ReplyURI,
+				DeadLetterSinkURI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
 			})
 		}
 	}

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -18,7 +18,7 @@ package testing
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -131,23 +131,21 @@ func WithSubscriptionSubscriberRef(gvk metav1.GroupVersionKind, name string) Sub
 	}
 }
 
-func WithSubscriptionPhysicalSubscriptionSubscriber(uri string) SubscriptionOption {
+func WithSubscriptionPhysicalSubscriptionSubscriber(uri *apis.URL) SubscriptionOption {
 	return func(s *v1alpha1.Subscription) {
-		u, err := apis.ParseURL(uri)
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse URL: %s", err))
+		if uri == nil {
+			panic(errors.New("nil URI"))
 		}
-		s.Status.PhysicalSubscription.SubscriberURI = u
+		s.Status.PhysicalSubscription.SubscriberURI = uri
 	}
 }
 
-func WithSubscriptionPhysicalSubscriptionReply(uri string) SubscriptionOption {
+func WithSubscriptionPhysicalSubscriptionReply(uri *apis.URL) SubscriptionOption {
 	return func(s *v1alpha1.Subscription) {
-		u, err := apis.ParseURL(uri)
-		if err != nil {
-			panic(fmt.Sprintf("failed to parse URL: %s", err))
+		if uri == nil {
+			panic(errors.New("nil URI"))
 		}
-		s.Status.PhysicalSubscription.ReplyURI = u
+		s.Status.PhysicalSubscription.ReplyURI = uri
 	}
 }
 


### PR DESCRIPTION

## Proposed Changes

- Change URIs that were strings to apis.URL objects.
- Wire compatible, so no user visible changes

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
