### PR TITLE
Cloudevent 1.0 - Part1: Updating source to produce 1.0 payload

### DIFF
--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -106,7 +106,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 		Namespace:  obj.GetNamespace(),
 	})
 
-	event := cloudevents.NewEvent(cloudevents.VersionV03)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetType(eventType)
 	event.SetSource(source)
 	event.SetSubject(subject)

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package events_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -41,6 +42,11 @@ func simplePod(name, namespace string) *unstructured.Unstructured {
 			},
 		},
 	}
+}
+
+func simpleSubject(name, namespace string) *string {
+	subject := fmt.Sprintf("/apis/v1/namespaces/%s/pods/%s", namespace, name)
+	return &subject
 }
 
 func simpleOwnedPod(name, namespace string) *unstructured.Unstructured {
@@ -84,13 +90,11 @@ func TestMakeAddEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.resource.add",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
@@ -122,13 +126,11 @@ func TestMakeUpdateEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.resource.update",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
@@ -160,13 +162,11 @@ func TestMakeDeleteEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.resource.delete",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
@@ -199,13 +199,11 @@ func TestMakeAddRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.add",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
@@ -215,13 +213,11 @@ func TestMakeAddRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.add",
-					ContentType: &contentType,
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/owned",
-					},
+					DataContentType: &contentType,
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("owned", "test"),
 				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
@@ -254,13 +250,11 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.update",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
@@ -270,13 +264,11 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.update",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/owned",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("owned", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
@@ -309,13 +301,11 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			source: "unit-test",
 			obj:    simplePod("unit", "test"),
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.delete",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/unit",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("unit", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
@@ -325,13 +315,11 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 			obj:          simpleOwnedPod("unit", "test"),
 			asController: true,
 			want: &cloudevents.Event{
-				Context: cloudevents.EventContextV02{
+				Context: cloudevents.EventContextV1{
 					Type:        "dev.knative.apiserver.ref.delete",
-					Source:      *cloudevents.ParseURLRef("unit-test"),
-					ContentType: &contentType,
-					Extensions: map[string]interface{}{
-						"subject": "/apis/v1/namespaces/test/pods/owned",
-					},
+					Source:      *cloudevents.ParseURIRef("unit-test"),
+					Subject:     simpleSubject("owned", "test"),
+					DataContentType: &contentType,
 				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -91,7 +91,7 @@ func TestMakeAddEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -129,7 +129,7 @@ func TestMakeUpdateEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -167,7 +167,7 @@ func TestMakeDeleteEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"unit","namespace":"test"}}`,
 		},
@@ -206,7 +206,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -222,7 +222,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},
@@ -261,7 +261,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -277,7 +277,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},
@@ -316,7 +316,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/unit",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"Pod","namespace":"test","name":"unit","apiVersion":"v1"}`,
 		},
@@ -332,7 +332,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 					Extensions: map[string]interface{}{
 						"subject": "/apis/v1/namespaces/test/pods/owned",
 					},
-				}.AsV03(),
+				}.AsV1(),
 			},
 			wantData: `{"kind":"ReplicaSet","namespace":"test","name":"unit","apiVersion":"apps/v1"}`,
 		},

--- a/pkg/adapter/cronjobevents/adapter.go
+++ b/pkg/adapter/cronjobevents/adapter.go
@@ -101,7 +101,7 @@ func (a *cronJobAdapter) Start(stopCh <-chan struct{}) error {
 func (a *cronJobAdapter) cronTick() {
 	logger := logging.FromContext(context.TODO())
 
-	event := cloudevents.NewEvent(cloudevents.VersionV03)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetType(sourcesv1alpha1.CronJobEventType)
 	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))


### PR DESCRIPTION
Fixes #

## Proposed Changes

- make the soruces produce CE 1.0

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ApiServersource and CronjobSource produce CE 1.0 payload
```
