### PR TITLE
Adding unit test on subscription generation.

### DIFF
--- a/pkg/reconciler/trigger/resources/subscription_test.go
+++ b/pkg/reconciler/trigger/resources/subscription_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"encoding/json"
+	corev1 "k8s.io/api/core/v1"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+
+	_ "knative.dev/pkg/system/testing"
+)
+
+func TestMakeFilterDeployment(t *testing.T) {
+	testCases := map[string]struct {
+		trigger       *v1alpha1.Trigger
+		brokerTrigger *corev1.ObjectReference
+		brokerIngress *corev1.ObjectReference
+		uri           *url.URL
+		want          []byte
+	}{
+		"happy": {
+			trigger: &v1alpha1.Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "happy",
+					Namespace: "Bar",
+					UID:       "abc-uid",
+				},
+				Spec: v1alpha1.TriggerSpec{
+					Broker: "broker",
+				},
+			},
+			brokerTrigger: &corev1.ObjectReference{
+				Kind:      "Foo",
+				Namespace: "Bar",
+				Name:      "Baz",
+			},
+			brokerIngress: &corev1.ObjectReference{
+				Kind:      "Aoo",
+				Namespace: "Bar",
+				Name:      "Caz",
+			},
+			uri: func() *url.URL {
+				u, _ := url.Parse("http://example.com/uid")
+				return u
+			}(),
+			want: []byte(`{
+  "metadata": {
+    "name": "broker-happy-abc-uid",
+    "namespace": "Bar",
+    "creationTimestamp": null,
+    "labels": {
+      "eventing.knative.dev/broker": "broker",
+      "eventing.knative.dev/trigger": "happy"
+    },
+    "ownerReferences": [
+      {
+        "apiVersion": "eventing.knative.dev/v1alpha1",
+        "kind": "Trigger",
+        "name": "happy",
+        "uid": "abc-uid",
+        "controller": true,
+        "blockOwnerDeletion": true
+      }
+    ]
+  },
+  "spec": {
+    "channel": {
+      "kind": "Foo",
+      "name": "Baz"
+    },
+    "subscriber": {
+      "uri": "http://example.com/uid"
+    },
+    "reply": {
+      "ref": {
+        "kind": "Aoo",
+        "name": "Caz"
+      }
+    }
+  },
+  "status": {
+    "physicalSubscription": {}
+  }
+}`),
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			dep := NewSubscription(tc.trigger, tc.brokerTrigger, tc.brokerIngress, tc.uri)
+
+			got, err := json.MarshalIndent(dep, "", "  ")
+			if err != nil {
+				t.Errorf("failed to marshal, %s", err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Log(string(got))
+				t.Errorf("unexpected (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestSubscriptionLabels(t *testing.T) {
+	testCases := map[string]struct {
+		trigger *v1alpha1.Trigger
+		want    map[string]string
+	}{
+		"happy trigger": {
+			trigger: &v1alpha1.Trigger{
+				TypeMeta: v1.TypeMeta{},
+				ObjectMeta: v1.ObjectMeta{
+					Name: "happy",
+				},
+				Spec: v1alpha1.TriggerSpec{
+					Broker: "brokerName",
+				},
+				Status: v1alpha1.TriggerStatus{},
+			},
+			want: map[string]string{
+				"eventing.knative.dev/broker":  "brokerName",
+				"eventing.knative.dev/trigger": "happy",
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			got := SubscriptionLabels(tc.trigger)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected labels (-want, +got) = %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- Add unit test for subscription resource generation for triggers.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
