### PR TITLE
Fix the nil ref for when using deprecated fields

### DIFF
--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -198,7 +198,7 @@ func (r *Reconciler) setSinkURIArg(ctx context.Context, source *v1alpha1.Contain
 
 	sinkURI, err := r.sinkResolver.URIFromDestination(*dest, source)
 	if err != nil {
-		source.Status.MarkNoSink("NotFound", `Couldn't get Sink URI from "%s/%s"`, dest.Ref.Namespace, dest.Ref.Name)
+		source.Status.MarkNoSink("NotFound", `Couldn't get Sink URI from %+v`, dest)
 		return fmt.Errorf("getting sink URI: %v", err)
 	}
 	if source.Spec.Sink.DeprecatedAPIVersion != "" &&


### PR DESCRIPTION
Fixes #2267

## Proposed Changes

- Fix nil ref in containersource if using deprecated fields and sink is not resolvable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Fix nil ref in containersource if using deprecated fields and sink is not resolvable.

```
