### PR TITLE
Remove broker ingress channel

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1alpha1/broker_lifecycle.go
@@ -22,16 +22,13 @@ import (
 
 	"knative.dev/eventing/pkg/apis/duck"
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 )
 
 var brokerCondSet = apis.NewLivingConditionSet(
 	BrokerConditionIngress,
 	BrokerConditionTriggerChannel,
-	BrokerConditionIngressChannel,
 	BrokerConditionFilter,
 	BrokerConditionAddressable,
-	BrokerConditionIngressSubscription,
 )
 
 const (
@@ -39,10 +36,6 @@ const (
 	BrokerConditionIngress apis.ConditionType = "IngressReady"
 
 	BrokerConditionTriggerChannel apis.ConditionType = "TriggerChannelReady"
-
-	BrokerConditionIngressChannel apis.ConditionType = "IngressChannelReady"
-
-	BrokerConditionIngressSubscription apis.ConditionType = "IngressSubscriptionReady"
 
 	BrokerConditionFilter apis.ConditionType = "FilterReady"
 
@@ -89,40 +82,6 @@ func (bs *BrokerStatus) PropagateTriggerChannelReadiness(cs *duckv1alpha1.Channe
 		brokerCondSet.Manage(bs).MarkTrue(BrokerConditionTriggerChannel)
 	} else {
 		bs.MarkTriggerChannelFailed("ChannelNotReady", "trigger Channel is not ready: not addressalbe")
-	}
-}
-
-func (bs *BrokerStatus) MarkIngressChannelFailed(reason, format string, args ...interface{}) {
-	brokerCondSet.Manage(bs).MarkFalse(BrokerConditionIngressChannel, reason, format, args...)
-}
-
-func (bs *BrokerStatus) PropagateIngressChannelReadiness(cs *duckv1alpha1.ChannelableStatus) {
-	// TODO: Once you can get a Ready status from Channelable in a generic way, use it here...
-	address := cs.AddressStatus.Address
-	if address != nil {
-		brokerCondSet.Manage(bs).MarkTrue(BrokerConditionIngressChannel)
-	} else {
-		bs.MarkIngressChannelFailed("ChannelNotReady", "ingress Channel is not ready: not addressable")
-	}
-}
-
-func (bs *BrokerStatus) MarkIngressSubscriptionFailed(reason, format string, args ...interface{}) {
-	brokerCondSet.Manage(bs).MarkFalse(BrokerConditionIngressSubscription, reason, format, args...)
-}
-
-func (bs *BrokerStatus) MarkIngressSubscriptionNotOwned(sub *messagingv1alpha1.Subscription) {
-	bs.MarkIngressSubscriptionFailed("SubscriptionNotOwned", "Subscription %q is not owned by this Broker.", sub.Name)
-}
-
-func (bs *BrokerStatus) PropagateIngressSubscriptionReadiness(ss *messagingv1alpha1.SubscriptionStatus) {
-	if ss.IsReady() {
-		brokerCondSet.Manage(bs).MarkTrue(BrokerConditionIngressSubscription)
-	} else {
-		msg := "nil"
-		if sc := ss.GetCondition(messagingv1alpha1.SubscriptionConditionReady); sc != nil {
-			msg = sc.Message
-		}
-		bs.MarkIngressSubscriptionFailed("SubscriptionNotReady", "ingress Subscription is not ready: %s", msg)
 	}
 }
 

--- a/pkg/apis/eventing/v1alpha1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_lifecycle_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -153,13 +152,7 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Type:   BrokerConditionFilter,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   BrokerConditionIngressChannel,
-					Status: corev1.ConditionUnknown,
-				}, {
 					Type:   BrokerConditionIngress,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   BrokerConditionIngressSubscription,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   BrokerConditionReady,
@@ -189,13 +182,7 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Type:   BrokerConditionFilter,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   BrokerConditionIngressChannel,
-					Status: corev1.ConditionUnknown,
-				}, {
 					Type:   BrokerConditionIngress,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   BrokerConditionIngressSubscription,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   BrokerConditionReady,
@@ -225,13 +212,7 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Type:   BrokerConditionFilter,
 					Status: corev1.ConditionTrue,
 				}, {
-					Type:   BrokerConditionIngressChannel,
-					Status: corev1.ConditionUnknown,
-				}, {
 					Type:   BrokerConditionIngress,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   BrokerConditionIngressSubscription,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   BrokerConditionReady,
@@ -259,7 +240,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name                         string
 		markIngressReady             *bool
 		markTriggerChannelReady      *bool
-		markIngressChannelReady      *bool
 		markFilterReady              *bool
 		address                      *apis.URL
 		markIngressSubscriptionOwned bool
@@ -269,7 +249,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "all happy",
 		markIngressReady:             &trueVal,
 		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
@@ -279,7 +258,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "all happy - deprecated",
 		markIngressReady:             &trueVal,
 		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
@@ -289,7 +267,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "ingress sad",
 		markIngressReady:             &falseVal,
 		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
@@ -299,17 +276,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "trigger channel sad",
 		markIngressReady:             &trueVal,
 		markTriggerChannelReady:      &falseVal,
-		markIngressChannelReady:      &trueVal,
-		markFilterReady:              &trueVal,
-		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
-		markIngressSubscriptionOwned: true,
-		markIngressSubscriptionReady: &trueVal,
-		wantReady:                    false,
-	}, {
-		name:                         "ingress channel sad",
-		markIngressReady:             &trueVal,
-		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &falseVal,
 		markFilterReady:              &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
@@ -319,7 +285,6 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "filter sad",
 		markIngressReady:             &trueVal,
 		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
 		markFilterReady:              &falseVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
@@ -329,35 +294,15 @@ func TestBrokerIsReady(t *testing.T) {
 		name:                         "addressable sad",
 		markIngressReady:             &trueVal,
 		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		address:                      nil,
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
 		wantReady:                    false,
 	}, {
-		name:                         "ingress subscription sad",
-		markIngressReady:             &trueVal,
-		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
-		markFilterReady:              &trueVal,
-		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
-		markIngressSubscriptionReady: &falseVal,
-		wantReady:                    false,
-	}, {
-		name:                         "ingress subscription not owned",
-		markIngressReady:             &trueVal,
-		markTriggerChannelReady:      &trueVal,
-		markIngressChannelReady:      &trueVal,
-		markFilterReady:              &trueVal,
-		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
-		markIngressSubscriptionOwned: false,
-		wantReady:                    false,
-	}, {
 		name:                         "all sad",
 		markIngressReady:             &falseVal,
 		markTriggerChannelReady:      &falseVal,
-		markIngressChannelReady:      &falseVal,
 		markFilterReady:              &falseVal,
 		address:                      nil,
 		markIngressSubscriptionOwned: true,
@@ -387,26 +332,6 @@ func TestBrokerIsReady(t *testing.T) {
 					c = TestHelper.NotReadyChannelStatus()
 				}
 				bs.PropagateTriggerChannelReadiness(c)
-			}
-			if test.markIngressChannelReady != nil {
-				var c *duckv1alpha1.ChannelableStatus
-				if *test.markIngressChannelReady {
-					c = TestHelper.ReadyChannelStatus()
-				} else {
-					c = TestHelper.NotReadyChannelStatus()
-				}
-				bs.PropagateIngressChannelReadiness(c)
-			}
-			if !test.markIngressSubscriptionOwned {
-				bs.MarkIngressSubscriptionNotOwned(&messagingv1alpha1.Subscription{})
-			} else if test.markIngressSubscriptionReady != nil {
-				var sub *messagingv1alpha1.SubscriptionStatus
-				if *test.markIngressSubscriptionReady {
-					sub = TestHelper.ReadySubscriptionStatus()
-				} else {
-					sub = TestHelper.NotReadySubscriptionStatus()
-				}
-				bs.PropagateIngressSubscriptionReadiness(sub)
 			}
 			if test.markFilterReady != nil {
 				var d *v1.Deployment

--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -88,9 +88,6 @@ type BrokerStatus struct {
 
 	// TriggerChannel is an objectref to the object for the TriggerChannel
 	TriggerChannel *corev1.ObjectReference `json:"triggerChannel,omitempty"`
-
-	// IngressChannel is an objectref to the object for the IngressChannel
-	IngressChannel *corev1.ObjectReference `json:"IngressChannel,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/eventing/v1alpha1/test_helper.go
+++ b/pkg/apis/eventing/v1alpha1/test_helper.go
@@ -69,9 +69,7 @@ func (testHelper) NotReadySubscriptionStatus() *messagingv1alpha1.SubscriptionSt
 func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
 	bs := &BrokerStatus{}
 	bs.PropagateIngressDeploymentAvailability(t.AvailableDeployment())
-	bs.PropagateIngressChannelReadiness(t.ReadyChannelStatus())
 	bs.PropagateTriggerChannelReadiness(t.ReadyChannelStatus())
-	bs.PropagateIngressSubscriptionReadiness(t.ReadySubscriptionStatus())
 	bs.PropagateFilterDeploymentAvailability(t.AvailableDeployment())
 	bs.SetAddress(&apis.URL{Scheme: "http", Host: "foo"})
 	return bs
@@ -79,7 +77,6 @@ func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
 
 func (t testHelper) NotReadyBrokerStatus() *BrokerStatus {
 	bs := &BrokerStatus{}
-	bs.PropagateIngressChannelReadiness(&duckv1alpha1.ChannelableStatus{})
 	return bs
 }
 

--- a/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1alpha1/zz_generated.deepcopy.go
@@ -120,11 +120,6 @@ func (in *BrokerStatus) DeepCopyInto(out *BrokerStatus) {
 		*out = new(v1.ObjectReference)
 		**out = **in
 	}
-	if in.IngressChannel != nil {
-		in, out := &in.IngressChannel, &out.IngressChannel
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/reconciler/testing/broker.go
+++ b/pkg/reconciler/testing/broker.go
@@ -100,13 +100,6 @@ func WithIngressFailed(reason, msg string) BrokerOption {
 	}
 }
 
-// WithIngressChannelFailed calls .Status.MarkIngressChannelFailed on the Broker.
-func WithIngressChannelFailed(reason, msg string) BrokerOption {
-	return func(b *v1alpha1.Broker) {
-		b.Status.MarkIngressChannelFailed(reason, msg)
-	}
-}
-
 // WithTriggerChannelReady calls .Status.PropagateTriggerChannelReadiness on the Broker.
 func WithTriggerChannelReady() BrokerOption {
 	return func(b *v1alpha1.Broker) {
@@ -126,26 +119,8 @@ func WithIngressDeploymentAvailable() BrokerOption {
 	}
 }
 
-func WithBrokerIngressChannelReady() BrokerOption {
-	return func(b *v1alpha1.Broker) {
-		b.Status.PropagateIngressChannelReadiness(v1alpha1.TestHelper.ReadyChannelStatus())
-	}
-}
-
-func WithBrokerIngressSubscriptionFailed(reason, msg string) BrokerOption {
-	return func(b *v1alpha1.Broker) {
-		b.Status.MarkIngressSubscriptionFailed(reason, msg)
-	}
-}
-
 func WithBrokerTriggerChannel(c *corev1.ObjectReference) BrokerOption {
 	return func(b *v1alpha1.Broker) {
 		b.Status.TriggerChannel = c
-	}
-}
-
-func WithBrokerIngressChannel(c *corev1.ObjectReference) BrokerOption {
-	return func(b *v1alpha1.Broker) {
-		b.Status.IngressChannel = c
 	}
 }

--- a/pkg/reconciler/trigger/resources/subscription.go
+++ b/pkg/reconciler/trigger/resources/subscription.go
@@ -33,7 +33,7 @@ import (
 
 // NewSubscription returns a placeholder subscription for trigger 't', from brokerTrigger to 'uri'
 // replying to brokerIngress.
-func NewSubscription(t *eventingv1alpha1.Trigger, brokerTrigger, brokerIngress *corev1.ObjectReference, uri *url.URL) *messagingv1alpha1.Subscription {
+func NewSubscription(t *eventingv1alpha1.Trigger, brokerTrigger, brokerRef *corev1.ObjectReference, uri *url.URL) *messagingv1alpha1.Subscription {
 	// TODO: Figure out once Trigger moves to Destination how this changes.
 	tmpURI, err := apis.ParseURL(uri.String())
 	if err != nil {
@@ -60,9 +60,9 @@ func NewSubscription(t *eventingv1alpha1.Trigger, brokerTrigger, brokerIngress *
 			},
 			Reply: &duckv1.Destination{
 				Ref: &corev1.ObjectReference{
-					APIVersion: brokerIngress.APIVersion,
-					Kind:       brokerIngress.Kind,
-					Name:       brokerIngress.Name,
+					APIVersion: brokerRef.APIVersion,
+					Kind:       brokerRef.Kind,
+					Name:       brokerRef.Name,
 				},
 			},
 		},

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -169,7 +169,6 @@ func setupBrokerTracing(
 
 	// Useful constants we will use below.
 	ingressHost := brokerIngressHost(domain, *broker)
-	ingressChanHost := brokerIngressChannelHost(domain, *broker)
 	triggerChanHost := brokerTriggerChannelHost(domain, *broker)
 	filterHost := brokerFilterHost(domain, *broker)
 	loggerTriggerPath := triggerPath(*loggerTrigger)
@@ -356,7 +355,7 @@ func setupBrokerTracing(
 		Tags: map[string]string{
 			"http.method":      http.MethodPost,
 			"http.status_code": "202",
-			"http.url":         fmt.Sprintf("http://%s", ingressChanHost),
+			"http.url":         fmt.Sprintf("http://%s", ingressHost),
 		},
 		Children: []tracinghelper.TestSpanTree{
 			{
@@ -365,7 +364,7 @@ func setupBrokerTracing(
 				Tags: map[string]string{
 					"http.method":      http.MethodPost,
 					"http.status_code": "202",
-					"http.host":        ingressChanHost,
+					"http.host":        ingressHost,
 					"http.path":        "/",
 				},
 				Children: []tracinghelper.TestSpanTree{

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -153,19 +153,17 @@ func setupBrokerTracing(
 	// 9. Broker Filter for the "transformer" trigger sends the event to the transformer pod.
 	// 10. Transformer pod receives the event from the Broker Filter for the "transformer" trigger.
 	// 11. Broker Filter for the "transformer" sends the transformer pod's reply to the Broker
-	//     InChannel (Ingress Channel).
-	// 12. Broker InChannel receives the event from the Broker Filter for the "transformer" trigger.
-	// 13. Broker InChannel sends the event to the Broker Ingress.
-	// 14. Broker Ingress receives the event from the Broker InChannel.
-	// 15. Broker Ingress sends the event to the Broker's TrChannel.
-	// 16. Broker TrChannel receives the event from the Broker Ingress.
-	// 17. Broker TrChannel sends the event to the Broker Filter for the "transformer" trigger.
-	//     18. Broker Filter for the "transformer" trigger receives the event from the Broker
+	//     Ingress.
+	// 12. Broker Ingress receives the event from the Broker Filter for the "transformer" trigger.
+	// 13. Broker Ingress sends the event to the Broker's TrChannel.
+	// 14. Broker TrChannel receives the event from the Broker Ingress.
+	// 15. Broker TrChannel sends the event to the Broker Filter for the "transformer" trigger.
+	//     16. Broker Filter for the "transformer" trigger receives the event from the Broker
 	//        TrChannel. This does not pass the filter, so this 'branch' ends here.
-	// 19. Broker TrChannel sends the event to the Broker Filter for the "logger" trigger.
-	// 20. Broker Filter for the "logger" trigger receives the event from the Broker TrChannel.
-	// 21. Broker Filter for the "logger" trigger sends the event to the logger pod.
-	// 22. Logger pod receives the event from the Broker Filter for the "logger" trigger.
+	// 17. Broker TrChannel sends the event to the Broker Filter for the "logger" trigger.
+	// 18. Broker Filter for the "logger" trigger receives the event from the Broker TrChannel.
+	// 19. Broker Filter for the "logger" trigger sends the event to the logger pod.
+	// 20. Logger pod receives the event from the Broker Filter for the "logger" trigger.
 
 	// Useful constants we will use below.
 	ingressHost := brokerIngressHost(domain, *broker)
@@ -178,9 +176,9 @@ func setupBrokerTracing(
 
 	// This is very hard to read when written directly, so we will build piece by piece.
 
-	// Steps 17-18: 'logger' event being sent to the 'transformer' Trigger.
+	// Steps 15-16: 'logger' event being sent to the 'transformer' Trigger.
 	loggerEventSentFromTrChannelToTransformer := tracinghelper.TestSpanTree{
-		Note: "17. Broker TrChannel sends the event to the Broker Filter for the 'transformer' trigger.",
+		Note: "15. Broker TrChannel sends the event to the Broker Filter for the 'transformer' trigger.",
 		Kind: model.Client,
 		Tags: map[string]string{
 			"http.method":      http.MethodPost,
@@ -189,7 +187,7 @@ func setupBrokerTracing(
 		},
 		Children: []tracinghelper.TestSpanTree{
 			{
-				Note: "18. Broker Filter for the 'transformer' trigger receives the event from the Broker TrChannel. This does not pass the filter, so this 'branch' ends here.",
+				Note: "16. Broker Filter for the 'transformer' trigger receives the event from the Broker TrChannel. This does not pass the filter, so this 'branch' ends here.",
 				Kind: model.Server,
 				Tags: map[string]string{
 					"http.method":      http.MethodPost,
@@ -201,9 +199,9 @@ func setupBrokerTracing(
 		},
 	}
 
-	// Steps 19-22: 'logger' event being sent to the 'logger' Trigger.
+	// Steps 17-20: 'logger' event being sent to the 'logger' Trigger.
 	loggerEventSentFromTrChannelToLogger := tracinghelper.TestSpanTree{
-		Note: "19. Broker TrChannel sends the event to the Broker Filter for the 'logger' trigger.",
+		Note: "17. Broker TrChannel sends the event to the Broker Filter for the 'logger' trigger.",
 		Kind: model.Client,
 		Tags: map[string]string{
 			"http.method":      http.MethodPost,
@@ -212,7 +210,7 @@ func setupBrokerTracing(
 		},
 		Children: []tracinghelper.TestSpanTree{
 			{
-				Note: "20. Broker Filter for the 'logger' trigger receives the event from the Broker TrChannel.",
+				Note: "18. Broker Filter for the 'logger' trigger receives the event from the Broker TrChannel.",
 				Kind: model.Server,
 				Tags: map[string]string{
 					"http.method":      http.MethodPost,
@@ -222,7 +220,7 @@ func setupBrokerTracing(
 				},
 				Children: []tracinghelper.TestSpanTree{
 					{
-						Note: "21. Broker Filter for the 'logger' trigger sends the event to the logger pod.",
+						Note: "19. Broker Filter for the 'logger' trigger sends the event to the logger pod.",
 						Kind: model.Client,
 						Tags: map[string]string{
 							"http.method":      http.MethodPost,
@@ -231,7 +229,7 @@ func setupBrokerTracing(
 						},
 						Children: []tracinghelper.TestSpanTree{
 							{
-								Note: "22. Logger pod receives the event from the Broker Filter for the 'logger' trigger.",
+								Note: "20. Logger pod receives the event from the Broker Filter for the 'logger' trigger.",
 								Kind: model.Server,
 								Tags: map[string]string{
 									"http.method":      http.MethodPost,
@@ -247,55 +245,30 @@ func setupBrokerTracing(
 		},
 	}
 
-	// Steps 13-22. Directly steps 13-16. 17-22 are included as children.
-	// Steps 13-16: Event in the Broker InChannel sent to the Broker Ingress to the Trigger Channel.
+	// Steps 13-20. Directly steps 15-16. 17-20 are included as children.
 	loggerEventIngressToTrigger := tracinghelper.TestSpanTree{
-		Note: "13. Broker InChannel sends the event to the Broker Ingress.",
+		Note: "13. Broker Ingress sends the event to the Broker's TrChannel.",
 		Kind: model.Client,
 		Tags: map[string]string{
 			"http.method":      http.MethodPost,
 			"http.status_code": "202",
-			"http.url":         fmt.Sprintf("http://%s/", ingressHost),
+			"http.url":         fmt.Sprintf("http://%s/", triggerChanHost),
 		},
 		Children: []tracinghelper.TestSpanTree{
 			{
-				Note: "14. Broker Ingress receives the event from the Broker InChannel.",
+				Note: "14. Broker TrChannel receives the event from the Broker Ingress.",
 				Kind: model.Server,
 				Tags: map[string]string{
-
 					"http.method":      http.MethodPost,
-					"http.path":        "/",
 					"http.status_code": "202",
-					"http.host":        ingressHost,
+					"http.host":        triggerChanHost,
+					"http.path":        "/",
 				},
 				Children: []tracinghelper.TestSpanTree{
-					{
-						Note: "15. Broker Ingress sends the event to the Broker's TrChannel.",
-						Kind: model.Client,
-						Tags: map[string]string{
-							"http.method":      http.MethodPost,
-							"http.status_code": "202",
-							"http.url":         fmt.Sprintf("http://%s/", triggerChanHost),
-						},
-						Children: []tracinghelper.TestSpanTree{
-							{
-								Note: "16. Broker TrChannel receives the event from the Broker Ingress.",
-								Kind: model.Server,
-								Tags: map[string]string{
-									"http.method":      http.MethodPost,
-									"http.status_code": "202",
-									"http.host":        triggerChanHost,
-									"http.path":        "/",
-								},
-								Children: []tracinghelper.TestSpanTree{
-									// Steps 17-18.
-									loggerEventSentFromTrChannelToTransformer,
-									// Steps 19-22.
-									loggerEventSentFromTrChannelToLogger,
-								},
-							},
-						},
-					},
+					// Steps 15-16.
+					loggerEventSentFromTrChannelToTransformer,
+					// Steps 17-20.
+					loggerEventSentFromTrChannelToLogger,
 				},
 			},
 		},
@@ -346,11 +319,11 @@ func setupBrokerTracing(
 		},
 	}
 
-	// Step 11-22. Directly steps 11-12. Steps 13-22 are children.
+	// Step 11-20. Directly steps 11-12. Steps 13-20 are children.
 	// Steps 11-12 Reply from the 'transformer' is sent by the Broker TrChannel to the Broker
-	// InChannel.
+	// Ingress.
 	transformerEventResponseFromTrChannel := tracinghelper.TestSpanTree{
-		Note: "11. Broker TrChannel for the 'transformer' sends the transformer pod's reply to the Broker InChannel.",
+		Note: "11. Broker TrChannel for the 'transformer' sends the transformer pod's reply to the Broker Ingress.",
 		Kind: model.Client,
 		Tags: map[string]string{
 			"http.method":      http.MethodPost,
@@ -359,16 +332,17 @@ func setupBrokerTracing(
 		},
 		Children: []tracinghelper.TestSpanTree{
 			{
-				Note: "12. Broker InChannel receives the event from the Broker TrChannel for the 'transformer' trigger.",
+				Note: "12. Broker Ingress receives the event from the Broker Filter for the 'transformer' trigger.",
 				Kind: model.Server,
 				Tags: map[string]string{
+
 					"http.method":      http.MethodPost,
+					"http.path":        "/",
 					"http.status_code": "202",
 					"http.host":        ingressHost,
-					"http.path":        "/",
 				},
 				Children: []tracinghelper.TestSpanTree{
-					// Steps 13-22.
+					// Steps 13-20.
 					loggerEventIngressToTrigger,
 				},
 			},

--- a/test/conformance/helpers/uri.go
+++ b/test/conformance/helpers/uri.go
@@ -30,10 +30,6 @@ func channelHost(domain, namespace, chanName string) string {
 	return fmt.Sprintf("%s-kn-channel.%s.svc.%s", chanName, namespace, domain)
 }
 
-func brokerIngressChannelHost(domain string, broker v1alpha1.Broker) string {
-	return channelHost(domain, broker.Namespace, fmt.Sprintf("%s-kne-ingress", broker.Name))
-}
-
 func brokerTriggerChannelHost(domain string, broker v1alpha1.Broker) string {
 	return channelHost(domain, broker.Namespace, fmt.Sprintf("%s-kne-trigger", broker.Name))
 }


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/2254

## Proposed Changes
Broker ingress channel is fully removed. Trigger `ReplyURL` is changed to the broker ingress directly.

## Perf
A very brief testing shows a roughly 2-5ms roundtrip (from an event got replied until the same event got received) latency improvements with IMC backed broker.
