### PR TITLE
nit: remove old provisioner/ccp reference

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_validation.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation.go
@@ -36,7 +36,7 @@ func (bs *BrokerSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(cte.ViaField("channelTemplateSpec"))
 	}
 
-	// TODO validate that the channelTemplate only specifies the provisioner and arguments.
+	// TODO validate that the channelTemplate only specifies the channel and arguments.
 	return errs
 }
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- provisioner is no longer a thing...

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
