### PR TITLE
Send 1.0 cloudevents for perf tests

### DIFF
--- a/test/common/performance/sender/http_load_generator.go
+++ b/test/common/performance/sender/http_load_generator.go
@@ -74,7 +74,7 @@ func (cet CloudEventsTargeter) VegetaTargeter() vegeta.Targeter {
 
 	ceType := []string{cet.eventType}
 	ceSource := []string{cet.eventSource}
-	ceSpecVersion := []string{"0.2"}
+	ceSpecVersion := []string{"1.0"}
 	ceContentType := []string{"application/json"}
 
 	return func(t *vegeta.Target) error {


### PR DESCRIPTION
Proposed Changes
- The Mako benchmarks are broken (all events failed to deliver) since https://github.com/google/knative-gcp/pull/437, send 1.0 cloudevents for perf tests to fix

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @nachocano 

/hold
Let me test it first.