### PR TITLE
Performance test infra issue fixes and improvements

### DIFF
--- a/test/common/performance/aggregator/aggregator.go
+++ b/test/common/performance/aggregator/aggregator.go
@@ -276,12 +276,12 @@ func eventsToTimestampsArray(events *map[string]*timestamp.Timestamp) []time.Tim
 func publishThpt(timestamps []time.Time, q *quickstore.Quickstore, metricName string) error {
 	if len(timestamps) >= 2 {
 		sort.Slice(timestamps, func(x, y int) bool { return timestamps[x].Before(timestamps[y]) })
-		for i, t := range timestamps[1:] {
-			var thpt uint
-			j := i - 1
-			for j >= 0 && t.Sub(timestamps[j]) <= time.Second {
-				thpt++
-				j--
+		var i, thpt int
+		for j, t := range timestamps[1:] {
+			thpt++
+			for i < j && t.Sub(timestamps[i]) > time.Second {
+				i++
+				thpt--
 			}
 			if qerr := q.AddSamplePoint(mako.XTime(t), map[string]float64{metricName: float64(thpt)}); qerr != nil {
 				return qerr

--- a/test/common/performance/common/pace.go
+++ b/test/common/performance/common/pace.go
@@ -36,11 +36,9 @@ func CalculateMemoryConstraintsForPaceSpecs(paceSpecs []PaceSpec) (estimatedNumb
 		totalMessages := uint64(pacer.Rps * int(pacer.Duration.Seconds()))
 		// Add a bit more, just to be sure that we don't under allocate
 		totalMessages = totalMessages + uint64(float64(totalMessages)*0.1)
-		// Queueing theory: given our channels can process 50 rps, queueLength = arrival rps / 50 rps = pacer.rps / 50
-		queueLength := uint64(pacer.Rps / 50)
-		if queueLength < 10 {
-			queueLength = 10
-		}
+		// Aggressively set the queue length so enqueue operation won't be blocked
+		// as the total number of messages grows.
+		queueLength := uint64(pacer.Rps * 5)
 		estimatedNumberOfTotalMessages += totalMessages
 		if queueLength > estimatedNumberOfMessagesInsideAChannel {
 			estimatedNumberOfMessagesInsideAChannel = queueLength

--- a/test/performance/benchmarks/broker-imc/continuous/200-broker-imc.yaml
+++ b/test/performance/benchmarks/broker-imc/continuous/200-broker-imc.yaml
@@ -15,10 +15,8 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: broker-imc-receiver
+  name: broker-imc-sender-receiver
   namespace: default
-  labels:
-    role: broker-imc-receiver
 spec:
   schedule: "0/15 * * * *"
   # History must be zero to ensure no failed pods stick around and block the next job
@@ -39,29 +37,48 @@ spec:
           serviceAccountName: perf-eventing
           restartPolicy: Never
           containers:
-          - name: sender-receiver
-            image: knative.dev/eventing/test/test_images/performance
-            args:
-            - "--roles=sender,receiver"
-            - "--sink=http://imc-broker"
-            - "--aggregator=broker-imc-aggregator:10000"
-            - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60"
-            env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 2Gi
-            ports:
-            - name: cloudevents
-              containerPort: 8080
+            - name: sender
+              image: knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=sender"
+                - "--sink=http://imc-broker"
+                - "--aggregator=broker-imc-aggregator:10000"
+                - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60"
+              env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              resources:
+                requests:
+                  cpu: 1200m
+                  memory: 3Gi
+            - name: receiver
+              image: knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=receiver"
+                - "--aggregator=broker-imc-aggregator:10000"
+                - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60"
+              env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              resources:
+                requests:
+                  cpu: 1200m
+                  memory: 3Gi
+              ports:
+                - name: cloudevents
+                  containerPort: 8080
 
 ---
 
@@ -70,8 +87,6 @@ kind: CronJob
 metadata:
   name: broker-imc-aggregator
   namespace: default
-  labels:
-    role: broker-imc-aggregator
 spec:
   schedule: "0/15 * * * *"
   # History must be zero to ensure no failed pods stick around and block the next job
@@ -92,40 +107,40 @@ spec:
           serviceAccountName: perf-eventing
           restartPolicy: Never
           containers:
-          - name: aggregator
-            image: knative.dev/eventing/test/test_images/performance
-            args:
-            - "--roles=aggregator"
-              # set to the number of sender + receiver (same image that does both counts 2)
-            - "--expect-records=2"
-            - "--mako-tags=channel=imc"
-            ports:
-            - name: grpc
-              containerPort: 10000
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 2Gi
-            volumeMounts:
-            - name: config-mako
-              mountPath: /etc/config-mako
-            terminationMessagePolicy: FallbackToLogsOnError
-          - name: mako
-            image: gcr.io/knative-performance/mako-microservice:latest
-            env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /var/secret/robot.json
-            volumeMounts:
-            - name: mako-secrets
-              mountPath: /var/secret
-            ports:
-            - name: quickstore
-              containerPort: 9813
-            terminationMessagePolicy: FallbackToLogsOnError
+            - name: aggregator
+              image: knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=aggregator"
+                # set to the number of sender + receiver (same image that does both counts 2)
+                - "--expect-records=2"
+                - "--mako-tags=channel=imc"
+              ports:
+                - name: grpc
+                  containerPort: 10000
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 2Gi
+              volumeMounts:
+                - name: config-mako
+                  mountPath: /etc/config-mako
+              terminationMessagePolicy: FallbackToLogsOnError
+            - name: mako
+              image: gcr.io/knative-performance/mako-microservice:latest
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /var/secret/robot.json
+              volumeMounts:
+                - name: mako-secrets
+                  mountPath: /var/secret
+              ports:
+                - name: quickstore
+                  containerPort: 9813
+              terminationMessagePolicy: FallbackToLogsOnError
           volumes:
-          - name: config-mako
-            configMap:
-              name: config-mako
-          - name: mako-secrets
-            secret:
-              secretName: mako-secrets
+            - name: config-mako
+              configMap:
+                name: config-mako
+            - name: mako-secrets
+              secret:
+                secretName: mako-secrets

--- a/test/performance/benchmarks/channel-imc/continuous/200-channel-imc.yaml
+++ b/test/performance/benchmarks/channel-imc/continuous/200-channel-imc.yaml
@@ -15,10 +15,8 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: channel-imc-send-receive
+  name: channel-imc-sender-receiver
   namespace: default
-  labels:
-    role: channel-imc-consumer
 spec:
   schedule: "0/15 * * * *"
   # History must be zero to ensure no failed pods stick around and block the next job
@@ -39,11 +37,32 @@ spec:
           serviceAccountName: perf-eventing
           restartPolicy: Never
           containers:
-            - name: sender-receiver
+            - name: sender
               image: knative.dev/eventing/test/test_images/performance
               args:
-                - "--roles=sender,receiver"
+                - "--roles=sender"
+                - "--aggregator=channel-imc-aggregator:10000"
                 - "--sink=http://channel-imc-kn-channel.default.svc.cluster.local"
+                - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60,1500:60"
+              env:
+                - name: GOGC
+                  value: "off"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              resources:
+                requests:
+                  cpu: 1200m
+                  memory: 3Gi
+            - name: receiver
+              image: knative.dev/eventing/test/test_images/performance
+              args:
+                - "--roles=receiver"
                 - "--aggregator=channel-imc-aggregator:10000"
                 - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60,1500:60"
               env:
@@ -59,8 +78,8 @@ spec:
                       fieldPath: metadata.namespace
               resources:
                 requests:
-                  cpu: 1000m
-                  memory: 6Gi
+                  cpu: 1200m
+                  memory: 3Gi
               ports:
                 - name: cloudevents
                   containerPort: 8080
@@ -72,8 +91,6 @@ kind: CronJob
 metadata:
   name: channel-imc-aggregator
   namespace: default
-  labels:
-    role: channel-imc-aggregator
 spec:
   schedule: "0/15 * * * *"
   # History must be zero to ensure no failed pods stick around and block the next job


### PR DESCRIPTION
## Proposed Changes
This PR contains a couple of optimizations, and has been proven to be able to provide more consistent results in the continuous benchmarking runs, see https://mako.dev/benchmark?benchmark_key=5683818216292352&tseconds=604800

- Run sender and receiver in two different containers, so there will be fewer race conditions for resources (I initially thought about using two pods, but since the two pods can be scheduled on two different nodes, the delivery latency will be inaccurate due to clock skews)

- When the number of events grows, the speed we read events from the channel sometimes cannot catch up with the speed we write, so the events in the channel will be quickly piled up, which makes the receive operation be blocking. This PR aggressively set the queue length so enqueue operation won't be blocked as the total number of messages grows.

- As we talked in one previous PR, change the way we calculate throughput to use sliding window algorithm, which reduces the time complexity from O(m*n) to O(m*logm), where m is the total number of events, and n is the average throughput.

- A couple of other cosmetic changes. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @slinkydeveloper 
