### PR TITLE
Set resource requests and limits for imc-dispatcher

### DIFF
--- a/config/channels/in-memory-channel/500-dispatcher.yaml
+++ b/config/channels/in-memory-channel/500-dispatcher.yaml
@@ -50,6 +50,15 @@ spec:
         volumeMounts:
           - name: config-logging
             mountPath: /etc/config-logging
+        resources:
+          # Set resource requests and limits based on the benchmarking results in
+          # https://github.com/knative/eventing/issues/2311#issuecomment-565311345
+          requests:
+            cpu: 1000m
+            memory: 150Mi
+          limits:
+            cpu: 2200m
+            memory: 300Mi
       volumes:
         - name: config-logging
           configMap:


### PR DESCRIPTION
## Proposed Changes
Based on the benchmarking results in https://github.com/knative/eventing/issues/2311#issuecomment-565311345:
- set CPU request and limit to 1000m ~ 2200m
- set memory request and limit to 150Mi ~ 300Mi

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @nachocano 
