### PR TITLE
fix incorrect error tacked to event when status fails

### DIFF
--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -120,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	if _, updateStatusErr := r.updateStatus(ctx, trigger); updateStatusErr != nil {
 		logging.FromContext(ctx).Error("Failed to update Trigger status", zap.Error(updateStatusErr))
-		r.Recorder.Eventf(trigger, corev1.EventTypeWarning, triggerUpdateStatusFailed, "Failed to update Trigger's status: %v", err)
+		r.Recorder.Eventf(trigger, corev1.EventTypeWarning, triggerUpdateStatusFailed, "Failed to update Trigger's status: %v", updateStatusErr)
 		return updateStatusErr
 	}
 


### PR DESCRIPTION

## Proposed Changes

- Log the correct error in the k8s Event emitted when Status Update fails.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 * Fix incorrect error message in Trigger.UpdateStatus.
```
