### PR TITLE
when secret copy fails, emit warning event

### DIFF
--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -51,6 +51,7 @@ const (
 	serviceAccountCreated     = "BrokerServiceAccountCreated"
 	serviceAccountRBACCreated = "BrokerServiceAccountRBACCreated"
 	secretCopied              = "SecretCopied"
+	secretCopyFailure         = "SecretCopyFailure"
 )
 
 var (
@@ -187,7 +188,7 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 		}
 		_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
 		if err != nil {
-			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
+			r.Recorder.Event(ns, corev1.EventTypeWarning, secretCopyFailure,
 				fmt.Sprintf("Error copying secret: %s", err))
 		} else {
 			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -205,12 +205,6 @@ func TestAllCases(t *testing.T) {
 			rbFilter,
 			rbFilterConfig,
 		},
-		/*
-			WantPatches: []clientgotesting.PatchActionImpl{
-				ingressPatch,
-				filterPatch,
-			},
-		*/
 	}, {
 		Name: "Namespace enabled, broker exists",
 		Objects: []runtime.Object{

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -84,6 +84,7 @@ func TestAllCases(t *testing.T) {
 	nsEvent := Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\"")
 	secretEventFilter := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-filter")
 	secretEventIngress := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-ingress")
+	secretEventFailure := Eventf(corev1.EventTypeWarning, "SecretCopyFailure", "Error copying secret: secrets \"broker-image-pull-secret\" not found")
 
 	// Patches
 	ingressPatch := createPatch(testNS, "eventing-broker-ingress")
@@ -170,6 +171,46 @@ func TestAllCases(t *testing.T) {
 			ingressPatch,
 			filterPatch,
 		},
+	}, {
+		Name: "Namespace enabled - secret copy fails",
+		Objects: []runtime.Object{
+			NewNamespace(testNS,
+				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
+			),
+		},
+		Key:                     testNS,
+		SkipNamespaceValidation: true,
+		WantErr:                 false,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "secrets"),
+		},
+		WantEvents: []string{
+			saIngressEvent,
+			rbIngressEvent,
+			rbIngressConfigEvent,
+			secretEventFailure,
+			saFilterEvent,
+			rbFilterEvent,
+			rbFilterConfigEvent,
+			secretEventFailure,
+			brokerEvent,
+			nsEvent,
+		},
+		WantCreates: []runtime.Object{
+			broker,
+			saIngress,
+			rbIngress,
+			rbIngressConfig,
+			saFilter,
+			rbFilter,
+			rbFilterConfig,
+		},
+		/*
+			WantPatches: []clientgotesting.PatchActionImpl{
+				ingressPatch,
+				filterPatch,
+			},
+		*/
 	}, {
 		Name: "Namespace enabled, broker exists",
 		Objects: []runtime.Object{


### PR DESCRIPTION
## Proposed Changes

- When trying to copy a secret and it fails, emit Warning event.
- Follow up to #2245 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
