### PR TITLE
Fix Channel spec on retrying logic

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -216,8 +216,8 @@ which is expected to change as the span id will be altered at every network hop.
 
 ##### Retries
 
-Channels SHOULD retry resending CloudEvents when they fail to either connect or
-send CloudEvents to subscribers.
+Channels SHOULD retry on 5xx responses but SHOULD NOT retry on 4xx responses when
+sending CloudEvents to subscribers.
 
 Channels SHOULD support various retry configuration parameters, including, but
 not limited to:


### PR DESCRIPTION
## Proposed Changes
As pointed out by @grantr in https://github.com/knative/eventing/pull/2264#issuecomment-565661753, Channels should retry on 5xx responses but not on 4xx responses. Fix the channel spec to reflect it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @grantr 
/cc @matzew 
