### PR TITLE
Use cloudevents V01 in eventing tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,8 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:902544577dcb868a5ae31529d73a1ce5031e224923290caedf6176241ee304e0"
+  branch = "master"
+  digest = "1:f030b3fe4eb560bf1743ab344695282b2fc0ae1a2722daf93e2aaedeeee34a16"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     ".",
@@ -120,8 +121,7 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "2fa4bb1fbb4aac4d906b0173a2a408f701439b82"
-  version = "v0.10.0"
+  revision = "423680168ea46409121b5ef13ad563d4f0539fcb"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,9 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  version = "0.10.0"
+  # HEAD as of 2019-12-13. Needed the master for this fix: https://github.com/cloudevents/sdk-go/pull/272.
+  # Should be switched back to a release, once a new one is available.
+  branch = "master"
 
 # needed because pkg upgraded
 [[override]]

--- a/test/common/performance/sender/http_load_generator.go
+++ b/test/common/performance/sender/http_load_generator.go
@@ -74,8 +74,8 @@ func (cet CloudEventsTargeter) VegetaTargeter() vegeta.Targeter {
 
 	ceType := []string{cet.eventType}
 	ceSource := []string{cet.eventSource}
-	ceSpecVersion := []string{"1.0"}
-	ceContentType := []string{"application/json"}
+	ceSpecVersion := []string{cloudevents.VersionV1}
+	ceContentType := []string{cloudevents.ApplicationJSON}
 
 	return func(t *vegeta.Target) error {
 		t.Method = http.MethodPost
@@ -200,8 +200,9 @@ func (h HttpLoadGenerator) RunPace(i int, pace common.PaceSpec, msgSize uint) {
 }
 
 func (h HttpLoadGenerator) SendGCEvent() {
-	event := cloudevents.NewEvent(cloudevents.VersionV02)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(uuid.New().String())
+	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetType(common.GCEventType)
 	event.SetSource(h.eventSource)
 
@@ -209,8 +210,9 @@ func (h HttpLoadGenerator) SendGCEvent() {
 }
 
 func (h HttpLoadGenerator) SendEndEvent() {
-	event := cloudevents.NewEvent(cloudevents.VersionV02)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(uuid.New().String())
+	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetType(common.EndEventType)
 	event.SetSource(h.eventSource)
 

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -49,6 +49,8 @@ const (
 	extensionValue1 = "extval1"
 	extensionName2  = "extname2"
 	extensionValue2 = "extvalue2"
+	nonMatchingExtensionName = "nonmatchingextname"
+	nonMatchingExtensionValue = "nonmatchingextval"
 )
 
 type eventContext struct {
@@ -123,10 +125,10 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 				{Type: eventType1, Source: eventSource1, Extensions: map[string]interface{}{extensionName1: extensionValue1, extensionName2: extensionValue2}},
 				{Type: eventType1, Source: eventSource1, Extensions: map[string]interface{}{extensionName2: extensionValue2}},
 				{Type: eventType1, Source: eventSource2, Extensions: map[string]interface{}{extensionName1: extensionValue1}},
-				{Type: eventType2, Source: eventSource1, Extensions: map[string]interface{}{extensionName1: "non.matching.ext.val"}},
-				{Type: eventType2, Source: eventSource2, Extensions: map[string]interface{}{"non.matching.ext.name": extensionValue1}},
+				{Type: eventType2, Source: eventSource1, Extensions: map[string]interface{}{extensionName1: nonMatchingExtensionValue}},
+				{Type: eventType2, Source: eventSource2, Extensions: map[string]interface{}{nonMatchingExtensionName: extensionValue1}},
 				{Type: eventType2, Source: eventSource2, Extensions: map[string]interface{}{extensionName1: extensionValue1, extensionName2: extensionValue2}},
-				{Type: eventType2, Source: eventSource2, Extensions: map[string]interface{}{extensionName1: extensionValue1, "non.matching.ext.name": extensionValue2}},
+				{Type: eventType2, Source: eventSource2, Extensions: map[string]interface{}{extensionName1: extensionValue1, nonMatchingExtensionName: extensionValue2}},
 			},
 			deprecatedTriggerFilter: false,
 		},

--- a/test/test_images/filterevents/main.go
+++ b/test/test_images/filterevents/main.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx := event.Context.AsV03()
+	ctx := event.Context.AsV1()
 
 	dataBytes, err := event.DataBytes()
 	if err != nil {

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -108,9 +108,10 @@ func main() {
 					"heart": "yes",
 					"beats": true,
 				},
-			}.AsV03(),
+			}.AsV1(),
 			Data: hb,
 		}
+		event.SetDataContentType(cloudevents.ApplicationJSON)
 
 		log.Printf("sending cloudevent to %s", sink)
 		if _, _, err := c.Send(context.Background(), event); err != nil {

--- a/test/test_images/sendevents/main.go
+++ b/test/test_images/sendevents/main.go
@@ -158,10 +158,11 @@ func main() {
 		sequence++
 		untyped["sequence"] = fmt.Sprintf("%d", sequence)
 
-		event := cloudevents.NewEvent()
+		event := cloudevents.NewEvent(cloudevents.VersionV1)
 		if eventID != "" {
 			event.SetID(eventID)
 		}
+		event.SetDataContentType(cloudevents.ApplicationJSON)
 		event.SetType(eventType)
 		event.SetSource(eventSource)
 

--- a/test/test_images/sequencestepper/main.go
+++ b/test/test_images/sequencestepper/main.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx := event.Context.AsV03()
+	ctx := event.Context.AsV1()
 
 	data := &resources.CloudEventBaseData{}
 	if err := event.DataAs(data); err != nil {

--- a/test/test_images/transformevents/main.go
+++ b/test/test_images/transformevents/main.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
-	ctx := event.Context.AsV03()
+	ctx := event.Context.AsV1()
 
 	dataBytes, err := event.DataBytes()
 	if err != nil {
@@ -63,6 +63,7 @@ func gotEvent(event cloudevents.Event, resp *cloudevents.EventResponse) error {
 		Context: ctx,
 		Data:    string(dataBytes),
 	}
+	r.SetDataContentType(cloudevents.ApplicationJSON)
 
 	log.Println("Transform the event to: ")
 	log.Printf("[%s] %s %s: %s", ctx.Time.String(), ctx.GetSource(), ctx.GetType(), dataBytes)

--- a/vendor/github.com/cloudevents/sdk-go/alias.go
+++ b/vendor/github.com/cloudevents/sdk-go/alias.go
@@ -95,10 +95,11 @@ var (
 
 	// Client Options
 
-	WithEventDefaulter = client.WithEventDefaulter
-	WithUUIDs          = client.WithUUIDs
-	WithTimeNow        = client.WithTimeNow
-	WithConverterFn    = client.WithConverterFn
+	WithEventDefaulter  = client.WithEventDefaulter
+	WithUUIDs           = client.WithUUIDs
+	WithTimeNow         = client.WithTimeNow
+	WithConverterFn     = client.WithConverterFn
+	WithDataContentType = client.WithDataContentType
 
 	// Event Creation
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/client.go
@@ -55,14 +55,15 @@ func New(t transport.Transport, opts ...Option) (Client, error) {
 // Transport client. The http transport has had WithBinaryEncoding http
 // transport option applied to it. The client will always send Binary
 // encoding but will inspect the outbound event context and match the version.
-// The WithtimeNow and WithUUIDs client options are also applied to the client,
-// all outbound events will have a time and id set if not already present.
+// The WithTimeNow, WithUUIDs and WithDataContentType("application/json")
+// client options are also applied to the client, all outbound events will have
+// a time and id set if not already present.
 func NewDefault() (Client, error) {
 	t, err := http.New(http.WithBinaryEncoding())
 	if err != nil {
 		return nil, err
 	}
-	c, err := New(t, WithTimeNow(), WithUUIDs())
+	c, err := New(t, WithTimeNow(), WithUUIDs(), WithDataContentType(cloudevents.ApplicationJSON))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/defaulters.go
@@ -35,3 +35,17 @@ func DefaultTimeToNowIfNotSet(ctx context.Context, event cloudevents.Event) clou
 	}
 	return event
 }
+
+// NewDefaultDataContentTypeIfNotSet returns a defaulter that will inspect the
+// provided event and set the provided content type if content type is found
+// to be empty.
+func NewDefaultDataContentTypeIfNotSet(contentType string) EventDefaulter {
+	return func(ctx context.Context, event cloudevents.Event) cloudevents.Event {
+		if event.Context != nil {
+			if event.DataContentType() == "" {
+				event.SetDataContentType(contentType)
+			}
+		}
+		return event
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/client/options.go
@@ -27,6 +27,16 @@ func WithUUIDs() Option {
 	}
 }
 
+// WithDataContentType adds the resulting defaulter from
+// NewDefaultDataContentTypeIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithDataContentType(contentType string) Option {
+	return func(c *ceClient) error {
+		c.eventDefaulterFns = append(c.eventDefaulterFns, NewDefaultDataContentTypeIfNotSet(contentType))
+		return nil
+	}
+}
+
 // WithTimeNow adds DefaultTimeToNowIfNotSet event defaulter to the end of the
 // defaulter chain.
 func WithTimeNow() Option {

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/codec.go
@@ -112,7 +112,7 @@ func (c *Codec) convertEvent(event *cloudevents.Event) (*cloudevents.Event, erro
 		event.Context = ca
 		return event, nil
 	case BinaryV1, StructuredV1, BatchedV1:
-		ca := event.Context.AsV03()
+		ca := event.Context.AsV1()
 		event.Context = ca
 		return event, nil
 	default:


### PR DESCRIPTION
## Proposed Changes
1. Use cloudevents V01 in all eventing tests
2. Update cloudevents sdk to master, similar as https://github.com/google/knative-gcp/pull/448

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 
