### PR TITLE
update to cloudevents sdk 0.10.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,7 +103,6 @@
   version = "v0.2.1"
 
 [[projects]]
-  branch = "master"
   digest = "1:f030b3fe4eb560bf1743ab344695282b2fc0ae1a2722daf93e2aaedeeee34a16"
   name = "github.com/cloudevents/sdk-go"
   packages = [
@@ -122,6 +121,7 @@
   ]
   pruneopts = "NUT"
   revision = "423680168ea46409121b5ef13ad563d4f0539fcb"
+  version = "v0.10.2"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,9 +88,7 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  # HEAD as of 2019-12-13. Needed the master for this fix: https://github.com/cloudevents/sdk-go/pull/272.
-  # Should be switched back to a release, once a new one is available.
-  branch = "master"
+  version = "0.10.2"
 
 # needed because pkg upgraded
 [[override]]


### PR DESCRIPTION
## Proposed Changes

- update to cloudevents sdk 0.10.2

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
