### PR TITLE
secret copy is a failure, return error

### DIFF
--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -190,6 +190,7 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 		if err != nil {
 			r.Recorder.Event(ns, corev1.EventTypeWarning, secretCopyFailure,
 				fmt.Sprintf("Error copying secret: %s", err))
+			return fmt.Errorf("Error copying secret: %s", err)
 		} else {
 			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
 				fmt.Sprintf("Secret copied into namespace: %s", sa.Name))

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -179,6 +179,11 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 		return fmt.Errorf("track role binding '%s': %v", rb.Name, err)
 	}
 
+	// If the Broker pull secret has not been specified, then nothing to copy.
+	if r.brokerPullSecretName == "" {
+		return nil
+	}
+
 	if sa.Name == resources.IngressServiceAccountName || sa.Name == resources.FilterServiceAccountName {
 		// check for existence of brokerPullSecret, and skip copy if it already exists
 		for _, v := range sa.ImagePullSecrets {
@@ -189,11 +194,11 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 		_, err := utils.CopySecret(r.KubeClientSet.CoreV1(), system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name)
 		if err != nil {
 			r.Recorder.Event(ns, corev1.EventTypeWarning, secretCopyFailure,
-				fmt.Sprintf("Error copying secret: %s", err))
-			return fmt.Errorf("Error copying secret: %s", err)
+				fmt.Sprintf("Error copying secret %s/%s => %s/%s : %s", system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name, err))
+			return fmt.Errorf("Error copying secret %s/%s => %s/%s : %s", system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name, err)
 		} else {
 			r.Recorder.Event(ns, corev1.EventTypeNormal, secretCopied,
-				fmt.Sprintf("Secret copied into namespace: %s", sa.Name))
+				fmt.Sprintf("Secret copied into namespace %s/%s => %s/%s", system.Namespace(), r.brokerPullSecretName, ns.Name, sa.Name))
 		}
 	}
 

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -82,6 +82,8 @@ func TestAllCases(t *testing.T) {
 	rbFilterConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-broker-filter-test-namespace' created for the Broker")
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 	nsEvent := Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\"")
+	nsEventFailure := Eventf(corev1.EventTypeWarning, "NamespaceReconcileFailure", "Failed to reconcile Namespace: broker ingress: Error copying secret: secrets \"broker-image-pull-secret\" not found")
+
 	secretEventFilter := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-filter")
 	secretEventIngress := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-ingress")
 	secretEventFailure := Eventf(corev1.EventTypeWarning, "SecretCopyFailure", "Error copying secret: secrets \"broker-image-pull-secret\" not found")
@@ -180,7 +182,7 @@ func TestAllCases(t *testing.T) {
 		},
 		Key:                     testNS,
 		SkipNamespaceValidation: true,
-		WantErr:                 false,
+		WantErr:                 true,
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("create", "secrets"),
 		},
@@ -189,21 +191,12 @@ func TestAllCases(t *testing.T) {
 			rbIngressEvent,
 			rbIngressConfigEvent,
 			secretEventFailure,
-			saFilterEvent,
-			rbFilterEvent,
-			rbFilterConfigEvent,
-			secretEventFailure,
-			brokerEvent,
-			nsEvent,
+			nsEventFailure,
 		},
 		WantCreates: []runtime.Object{
-			broker,
 			saIngress,
 			rbIngress,
 			rbIngressConfig,
-			saFilter,
-			rbFilter,
-			rbFilterConfig,
 		},
 	}, {
 		Name: "Namespace enabled, broker exists",

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -82,11 +82,11 @@ func TestAllCases(t *testing.T) {
 	rbFilterConfigEvent := Eventf(corev1.EventTypeNormal, "BrokerServiceAccountRBACCreated", "RoleBinding 'knative-testing/eventing-broker-filter-test-namespace' created for the Broker")
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 	nsEvent := Eventf(corev1.EventTypeNormal, "NamespaceReconciled", "Namespace reconciled: \"test-namespace\"")
-	nsEventFailure := Eventf(corev1.EventTypeWarning, "NamespaceReconcileFailure", "Failed to reconcile Namespace: broker ingress: Error copying secret: secrets \"broker-image-pull-secret\" not found")
+	nsEventFailure := Eventf(corev1.EventTypeWarning, "NamespaceReconcileFailure", "Failed to reconcile Namespace: broker ingress: Error copying secret knative-testing/broker-image-pull-secret => test-namespace/eventing-broker-ingress : secrets \"broker-image-pull-secret\" not found")
 
-	secretEventFilter := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-filter")
-	secretEventIngress := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace: eventing-broker-ingress")
-	secretEventFailure := Eventf(corev1.EventTypeWarning, "SecretCopyFailure", "Error copying secret: secrets \"broker-image-pull-secret\" not found")
+	secretEventFilter := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace knative-testing/broker-image-pull-secret => test-namespace/eventing-broker-filter")
+	secretEventIngress := Eventf(corev1.EventTypeNormal, "SecretCopied", "Secret copied into namespace knative-testing/broker-image-pull-secret => test-namespace/eventing-broker-ingress")
+	secretEventFailure := Eventf(corev1.EventTypeWarning, "SecretCopyFailure", "Error copying secret knative-testing/broker-image-pull-secret => test-namespace/eventing-broker-ingress : secrets \"broker-image-pull-secret\" not found")
 
 	// Patches
 	ingressPatch := createPatch(testNS, "eventing-broker-ingress")


### PR DESCRIPTION

## Proposed Changes

- If we fail to copy the secret return an error because broker should not be marked as ready in that case.
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
When copying secrets to new namespace for broker, treat that as reconcile failure.
```
