### PR TITLE
Consistent observed generation

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -121,6 +121,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		logging.FromContext(ctx).Debug("Broker reconciled")
 	}
 
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	broker.Status.ObservedGeneration = original.Generation
+
 	if _, updateStatusErr := r.updateStatus(ctx, broker); updateStatusErr != nil {
 		logging.FromContext(ctx).Warn("Failed to update the Broker status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(broker, corev1.EventTypeWarning, brokerUpdateStatusFailed, "Failed to update Broker's status: %v", updateStatusErr)

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -59,6 +59,8 @@ const (
 	ingressContainerName = "ingress"
 
 	triggerChannel channelType = "TriggerChannel"
+
+	brokerGeneration = 79
 )
 
 var (
@@ -378,7 +380,9 @@ func TestReconcile(t *testing.T) {
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
 					WithBrokerChannel(channel()),
-					WithInitBrokerConditions),
+					WithInitBrokerConditions,
+					WithBrokerGeneration(brokerGeneration),
+				),
 				createChannel(testNS, triggerChannel, true),
 				NewDeployment(filterDeploymentName, testNS,
 					WithDeploymentOwnerReferences(ownerReferences()),
@@ -409,6 +413,8 @@ func TestReconcile(t *testing.T) {
 				Object: NewBroker(brokerName, testNS,
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
+					WithBrokerGeneration(brokerGeneration),
+					WithBrokerStatusObservedGeneration(brokerGeneration),
 					WithTriggerChannelReady(),
 					WithFilterDeploymentAvailable(),
 					WithBrokerTriggerChannel(createTriggerChannelRef()),

--- a/pkg/reconciler/flowsparallel/parallel.go
+++ b/pkg/reconciler/flowsparallel/parallel.go
@@ -100,6 +100,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Recorder.Eventf(parallel, corev1.EventTypeNormal, reconciled, "Parallel reconciled")
 	}
 
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	parallel.Status.ObservedGeneration = original.Generation
+
 	if _, updateStatusErr := r.updateStatus(ctx, parallel); updateStatusErr != nil {
 		logging.FromContext(ctx).Warn("Error updating Parallel status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(parallel, corev1.EventTypeWarning, updateStatusFailed, "Failed to update parallel status: %s", key)

--- a/pkg/reconciler/flowsparallel/parallel_test.go
+++ b/pkg/reconciler/flowsparallel/parallel_test.go
@@ -47,10 +47,11 @@ import (
 )
 
 const (
-	testNS           = "test-namespace"
-	parallelName     = "test-parallel"
-	parallelUID      = "test-parallel-uid"
-	replyChannelName = "reply-channel"
+	testNS             = "test-namespace"
+	parallelName       = "test-parallel"
+	parallelUID        = "test-parallel-uid"
+	replyChannelName   = "reply-channel"
+	parallelGeneration = 79
 )
 
 func init() {
@@ -106,6 +107,7 @@ func TestAllBranches(t *testing.T) {
 			Objects: []runtime.Object{
 				reconciletesting.NewFlowsParallel(parallelName, testNS,
 					reconciletesting.WithInitFlowsParallelConditions,
+					reconciletesting.WithFlowsParallelGeneration(parallelGeneration),
 					reconciletesting.WithFlowsParallelChannelTemplateSpec(imc),
 					reconciletesting.WithFlowsParallelBranches([]v1alpha1.ParallelBranch{
 						{Subscriber: createSubscriber(0)},
@@ -127,6 +129,8 @@ func TestAllBranches(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewFlowsParallel(parallelName, testNS,
 					reconciletesting.WithInitFlowsParallelConditions,
+					reconciletesting.WithFlowsParallelGeneration(parallelGeneration),
+					reconciletesting.WithFlowsParallelStatusObservedGeneration(parallelGeneration),
 					reconciletesting.WithFlowsParallelChannelTemplateSpec(imc),
 					reconciletesting.WithFlowsParallelBranches([]v1alpha1.ParallelBranch{{Subscriber: createSubscriber(0)}}),
 					reconciletesting.WithFlowsParallelChannelsNotReady("ChannelsNotReady", "Channels are not ready yet, or there are none"),

--- a/pkg/reconciler/flowssequence/sequence.go
+++ b/pkg/reconciler/flowssequence/sequence.go
@@ -99,6 +99,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Recorder.Eventf(sequence, corev1.EventTypeNormal, reconciled, "Sequence reconciled")
 	}
 
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	sequence.Status.ObservedGeneration = original.Generation
+
 	if _, updateStatusErr := r.updateStatus(ctx, sequence); updateStatusErr != nil {
 		logging.FromContext(ctx).Warn("Error updating Sequence status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(sequence, corev1.EventTypeWarning, updateStatusFailed, "Failed to update sequence status: %s", key)

--- a/pkg/reconciler/flowssequence/sequence_test.go
+++ b/pkg/reconciler/flowssequence/sequence_test.go
@@ -47,10 +47,11 @@ import (
 )
 
 const (
-	testNS           = "test-namespace"
-	sequenceName     = "test-sequence"
-	sequenceUID      = "test-sequence-uid"
-	replyChannelName = "reply-channel"
+	testNS             = "test-namespace"
+	sequenceName       = "test-sequence"
+	sequenceUID        = "test-sequence-uid"
+	replyChannelName   = "reply-channel"
+	sequenceGeneration = 7
 )
 
 func init() {
@@ -256,6 +257,7 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				reconciletesting.NewFlowsSequence(sequenceName, testNS,
 					reconciletesting.WithInitFlowsSequenceConditions,
+					reconciletesting.WithFlowsSequenceGeneration(sequenceGeneration),
 					reconciletesting.WithFlowsSequenceChannelTemplateSpec(imc),
 					reconciletesting.WithFlowsSequenceSteps([]duckv1.Destination{
 						createDestination(0),
@@ -275,6 +277,8 @@ func TestAllCases(t *testing.T) {
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: reconciletesting.NewFlowsSequence(sequenceName, testNS,
 					reconciletesting.WithInitFlowsSequenceConditions,
+					reconciletesting.WithFlowsSequenceGeneration(sequenceGeneration),
+					reconciletesting.WithFlowsSequenceStatusObservedGeneration(sequenceGeneration),
 					reconciletesting.WithFlowsSequenceChannelTemplateSpec(imc),
 					reconciletesting.WithFlowsSequenceSteps([]duckv1.Destination{
 						createDestination(0),

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -122,6 +122,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Recorder.Event(channel, corev1.EventTypeNormal, reconciled, "InMemoryChannel reconciled")
 	}
 
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	channel.Status.ObservedGeneration = original.Generation
+
 	if _, updateStatusErr := r.updateStatus(ctx, channel); updateStatusErr != nil {
 		logging.FromContext(ctx).Error("Failed to update InMemoryChannel status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(channel, corev1.EventTypeWarning, updateStatusFailed, "Failed to update InMemoryChannel's status: %v", err)

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -53,6 +53,8 @@ const (
 	subscriberKind       = "Service"
 	subscriberName       = "subscriberName"
 	subscriberURI        = "http://example.com/subscriber"
+
+	imcGeneration = 7
 )
 
 var (
@@ -180,7 +182,8 @@ func TestAllCases(t *testing.T) {
 				makeReadyDeployment(),
 				makeService(),
 				makeReadyEndpoints(),
-				reconciletesting.NewInMemoryChannel(imcName, testNS),
+				reconciletesting.NewInMemoryChannel(imcName, testNS,
+					reconciletesting.WithInMemoryChannelGeneration(imcGeneration)),
 			},
 			WantErr: false,
 			WantCreates: []runtime.Object{
@@ -190,6 +193,8 @@ func TestAllCases(t *testing.T) {
 				Object: reconciletesting.NewInMemoryChannel(imcName, testNS,
 					reconciletesting.WithInitInMemoryChannelConditions,
 					reconciletesting.WithInMemoryChannelDeploymentReady(),
+					reconciletesting.WithInMemoryChannelGeneration(imcGeneration),
+					reconciletesting.WithInMemoryChannelStatusObservedGeneration(imcGeneration),
 					reconciletesting.WithInMemoryChannelServiceReady(),
 					reconciletesting.WithInMemoryChannelEndpointsReady(),
 					reconciletesting.WithInMemoryChannelChannelServiceReady(),

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -115,7 +115,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Recorder.Eventf(subscription, corev1.EventTypeNormal, subscriptionReconciled, "Subscription reconciled: %q", subscription.Name)
 	}
 
-	if _, updateStatusErr := r.updateStatus(ctx, subscription.DeepCopy()); updateStatusErr != nil {
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	subscription.Status.ObservedGeneration = original.Generation
+
+	if _, updateStatusErr := r.updateStatus(ctx, subscription); updateStatusErr != nil {
 		logging.FromContext(ctx).Warn("Failed to update the Subscription", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(subscription, corev1.EventTypeWarning, subscriptionUpdateStatusFailed, "Failed to update Subscription's status: %v", updateStatusErr)
 		return updateStatusErr

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -636,6 +636,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionStatusObservedGeneration(subscriptionGeneration),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -686,6 +687,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionStatusObservedGeneration(subscriptionGeneration),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{

--- a/pkg/reconciler/testing/broker.go
+++ b/pkg/reconciler/testing/broker.go
@@ -50,6 +50,18 @@ func WithInitBrokerConditions(b *v1alpha1.Broker) {
 	b.Status.InitializeConditions()
 }
 
+func WithBrokerGeneration(gen int64) BrokerOption {
+	return func(s *v1alpha1.Broker) {
+		s.Generation = gen
+	}
+}
+
+func WithBrokerStatusObservedGeneration(gen int64) BrokerOption {
+	return func(s *v1alpha1.Broker) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 func WithBrokerDeletionTimestamp(b *v1alpha1.Broker) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	b.ObjectMeta.SetDeletionTimestamp(&t)

--- a/pkg/reconciler/testing/flowsparallel.go
+++ b/pkg/reconciler/testing/flowsparallel.go
@@ -49,6 +49,18 @@ func WithInitFlowsParallelConditions(p *v1alpha1.Parallel) {
 	p.Status.InitializeConditions()
 }
 
+func WithFlowsParallelGeneration(gen int64) FlowsParallelOption {
+	return func(s *v1alpha1.Parallel) {
+		s.Generation = gen
+	}
+}
+
+func WithFlowsParallelStatusObservedGeneration(gen int64) FlowsParallelOption {
+	return func(s *v1alpha1.Parallel) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 func WithFlowsParallelDeleted(p *v1alpha1.Parallel) {
 	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
 	p.ObjectMeta.SetDeletionTimestamp(&deleteTime)

--- a/pkg/reconciler/testing/flowssequence.go
+++ b/pkg/reconciler/testing/flowssequence.go
@@ -45,6 +45,18 @@ func NewFlowsSequence(name, namespace string, popt ...FlowsSequenceOption) *v1al
 	return p
 }
 
+func WithFlowsSequenceGeneration(gen int64) FlowsSequenceOption {
+	return func(s *v1alpha1.Sequence) {
+		s.Generation = gen
+	}
+}
+
+func WithFlowsSequenceStatusObservedGeneration(gen int64) FlowsSequenceOption {
+	return func(s *v1alpha1.Sequence) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 func WithInitFlowsSequenceConditions(p *v1alpha1.Sequence) {
 	p.Status.InitializeConditions()
 }

--- a/pkg/reconciler/testing/inmemorychannel.go
+++ b/pkg/reconciler/testing/inmemorychannel.go
@@ -51,6 +51,18 @@ func WithInitInMemoryChannelConditions(imc *v1alpha1.InMemoryChannel) {
 	imc.Status.InitializeConditions()
 }
 
+func WithInMemoryChannelGeneration(gen int64) InMemoryChannelOption {
+	return func(s *v1alpha1.InMemoryChannel) {
+		s.Generation = gen
+	}
+}
+
+func WithInMemoryChannelStatusObservedGeneration(gen int64) InMemoryChannelOption {
+	return func(s *v1alpha1.InMemoryChannel) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 func WithInMemoryChannelDeleted(imc *v1alpha1.InMemoryChannel) {
 	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
 	imc.ObjectMeta.SetDeletionTimestamp(&deleteTime)

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -76,6 +76,12 @@ func WithSubscriptionGeneration(gen int64) SubscriptionOption {
 	}
 }
 
+func WithSubscriptionStatusObservedGeneration(gen int64) SubscriptionOption {
+	return func(s *v1alpha1.Subscription) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 func WithSubscriptionGenerateName(generateName string) SubscriptionOption {
 	return func(c *v1alpha1.Subscription) {
 		c.ObjectMeta.GenerateName = generateName

--- a/pkg/reconciler/testing/trigger.go
+++ b/pkg/reconciler/testing/trigger.go
@@ -96,6 +96,18 @@ func WithInitTriggerConditions(t *v1alpha1.Trigger) {
 	t.Status.InitializeConditions()
 }
 
+func WithTriggerGeneration(gen int64) TriggerOption {
+	return func(s *v1alpha1.Trigger) {
+		s.Generation = gen
+	}
+}
+
+func WithTriggerStatusObservedGeneration(gen int64) TriggerOption {
+	return func(s *v1alpha1.Trigger) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
 // WithTriggerBrokerReady initializes the Triggers's conditions.
 func WithTriggerBrokerReady() TriggerOption {
 	return func(t *v1alpha1.Trigger) {

--- a/pkg/reconciler/trigger/trigger.go
+++ b/pkg/reconciler/trigger/trigger.go
@@ -118,6 +118,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		r.Recorder.Event(trigger, corev1.EventTypeNormal, triggerReconciled, "Trigger reconciled")
 	}
 
+	// Since the reconciler took a crack at this, make sure it's reflected
+	// in the status correctly.
+	trigger.Status.ObservedGeneration = original.Generation
+
 	if _, updateStatusErr := r.updateStatus(ctx, trigger); updateStatusErr != nil {
 		logging.FromContext(ctx).Error("Failed to update Trigger status", zap.Error(updateStatusErr))
 		r.Recorder.Eventf(trigger, corev1.EventTypeWarning, triggerUpdateStatusFailed, "Failed to update Trigger's status: %v", updateStatusErr)

--- a/pkg/reconciler/trigger/trigger_test.go
+++ b/pkg/reconciler/trigger/trigger_test.go
@@ -121,6 +121,7 @@ const (
 
 	currentGeneration  = 1
 	outdatedGeneration = 0
+	triggerGeneration  = 7
 )
 
 var (
@@ -392,6 +393,7 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithTriggerUID(triggerUID),
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					reconciletesting.WithInitTriggerConditions,
+					reconciletesting.WithTriggerGeneration(triggerGeneration),
 				),
 			},
 			WantErr: true,
@@ -405,6 +407,8 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithTriggerSubscriberURI(subscriberURI),
 					// The first reconciliation will initialize the status conditions.
 					reconciletesting.WithInitTriggerConditions,
+					reconciletesting.WithTriggerGeneration(triggerGeneration),
+					reconciletesting.WithTriggerStatusObservedGeneration(triggerGeneration),
 					reconciletesting.WithTriggerBrokerReady(),
 				),
 			}},


### PR DESCRIPTION

## Proposed Changes

- After reconcile loop (regardless of the result), set the ObservedGeneration to the original.Generation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ObservedGeneration now reflects reality for: Broker, Trigger, InMemoryChannel, Subscription, Parallel/Sequence (in flows apigroup).
```
