### PR TITLE
Set release label on ConfigMaps

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 data:
   # Common configuration for all Knative codebase
   zap-logger-config: |

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 data:
   _example: |
     ################################

--- a/config/config-tracing.yaml
+++ b/config/config-tracing.yaml
@@ -17,7 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-tracing
   namespace: knative-eventing
-
+  labels:
+    eventing.knative.dev/release: devel
 data:
   _example: |
     ################################


### PR DESCRIPTION
## Proposed Changes

- Set the `eventing.knative.dev/release` label on all eventing ConfigMaps (logging, observability, tracing)

It makes those particular ConfigMaps easier to filter in informer factories, and keeps them consistent with Serving, which ConfigMaps already include a `serving.knative.dev/release` label.

**Release Note**

```release-note
NONE
```