### PR TITLE
Updating RBAC for new flows API group

### DIFF
--- a/config/200-controller-clusterrole.yaml
+++ b/config/200-controller-clusterrole.yaml
@@ -106,6 +106,15 @@ rules:
     verbs:
       - "update"
 
+  # Flows resources and finalizers we care about.
+  - apiGroups:
+      - "flows.knative.dev"
+    resources:
+      - "sequences/finalizers"
+      - "parallels/finalizers"
+    verbs:
+      - "update"
+
   # The subscription controller needs to retrieve and watch CustomResourceDefinitions.
   - apiGroups:
       - "apiextensions.k8s.io"


### PR DESCRIPTION
Related to #1495

Openshift we see

```
cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```

for the `Sequence`/`Parallel`, that is in the `flows.knative` APIgroup.


Hence applying the previous change to the new API group 