### PR TITLE
Update names of trigger status types to be more accurate.

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_lifecycle.go
@@ -29,11 +29,11 @@ const (
 	// TriggerConditionReady has status True when all subconditions below have been set to True.
 	TriggerConditionReady = apis.ConditionReady
 
-	TriggerConditionBroker apis.ConditionType = "Broker"
+	TriggerConditionBroker apis.ConditionType = "BrokerReady"
 
 	TriggerConditionSubscribed apis.ConditionType = "Subscribed"
 
-	TriggerConditionDependency apis.ConditionType = "Dependency"
+	TriggerConditionDependency apis.ConditionType = "DependencyReady"
 
 	TriggerConditionSubscriberResolved apis.ConditionType = "SubscriberResolved"
 


### PR DESCRIPTION
Fixes #2260

## Proposed Changes
Update trigger's status type 
- `Broker` -> `BrokerReady`
- `Dependency` -> `DependencyReady`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Trigger's "Broker" status type is updated to "BrokerReady"; Trigger's "Dependency" status type is updated to "DependencyReady".
```
