### PR TITLE
Remove config-logging volume mount from imc dispatcher YAML.

### DIFF
--- a/config/channels/in-memory-channel/500-dispatcher.yaml
+++ b/config/channels/in-memory-channel/500-dispatcher.yaml
@@ -47,9 +47,6 @@ spec:
         ports:
           - containerPort: 9090
             name: metrics
-        volumeMounts:
-          - name: config-logging
-            mountPath: /etc/config-logging
         resources:
           # Set resource requests and limits based on the benchmarking results in
           # https://github.com/knative/eventing/issues/2311#issuecomment-565311345
@@ -59,7 +56,4 @@ spec:
           limits:
             cpu: 2200m
             memory: 300Mi
-      volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
+


### PR DESCRIPTION
Fixes #2186

## Proposed Changes

- Remove configmap volume mount from imc dispatcher deployment. SharedMain will read it.

**Testing** 
Manually modified config-logging and verified that new config reflected in imc dispatcher logs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
