### PR TITLE
Mount config-mako volume for mako stub sidercar container.

### DIFF
--- a/test/performance/benchmarks/broker-imc/200-broker-perf.yaml
+++ b/test/performance/benchmarks/broker-imc/200-broker-perf.yaml
@@ -92,6 +92,9 @@ spec:
     ports:
     - name: quickstore
       containerPort: 9813
+    volumeMounts:
+      - name: config-mako
+        mountPath: /etc/config-mako
     terminationMessagePolicy: FallbackToLogsOnError
     resources:
       requests:


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Mount `config-mako` volume for mako stub sidercar container. 

Otherwise the container gives an error: `unable to determine benchmark info: lstat /etc/config-mako: no such file or directory`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

cc @grac3gao Did you run into this error?