### PR TITLE
golang format tools

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+
 	"knative.dev/eventing/pkg/reconciler/sinkbinding"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/apis/legacysources/v1alpha1/deprecated.go
+++ b/pkg/apis/legacysources/v1alpha1/deprecated.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"time"
 )
 
 const (

--- a/pkg/apis/legacysources/v1alpha1/deprecated_test.go
+++ b/pkg/apis/legacysources/v1alpha1/deprecated_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"testing"
 
 	"knative.dev/eventing/pkg/apis/legacysources/v1alpha1"
 )


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign n3wscott
/cc n3wscott
