### PR TITLE
Rename eventing release artifact release.yaml => eventing.yaml

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,14 +22,14 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/release.sh
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["eventing.yaml"]="config"
+  ["eventing-core.yaml"]="config"
   ["in-memory-channel.yaml"]="config/channels/in-memory-channel"
 )
 readonly COMPONENTS
 
 declare -A RELEASES
 RELEASES=(
-  ["release.yaml"]="eventing.yaml in-memory-channel.yaml"
+  ["eventing.yaml"]="eventing-core.yaml in-memory-channel.yaml"
 )
 readonly RELEASES
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1987
Docs PR: https://github.com/knative/docs/pull/2103

```release-note
Renamed eventing release artifact release.yaml => eventing.yaml
```