### PR TITLE
Enable further setups for test client in e2e and conformance tests

### DIFF
--- a/test/conformance/broker_tracing_test.go
+++ b/test/conformance/broker_tracing_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
+	"knative.dev/eventing/test/lib"
 )
 
 func TestBrokerTracing(t *testing.T) {
-	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, channelTestRunner, helpers.SetupClientFuncNoop)
+	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_tracing_test.go
+++ b/test/conformance/channel_tracing_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
+	"knative.dev/eventing/test/lib"
 )
 
 func TestChannelTracingWithReply(t *testing.T) {
-	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, helpers.SetupClientFuncNoop)
+	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
 }

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -38,7 +38,7 @@ import (
 func BrokerTracingTestHelperWithChannelTestRunner(
 	t *testing.T,
 	channelTestRunner lib.ChannelTestRunner,
-	setupClient SetupClientFunc,
+	setupClient lib.SetupClientOption,
 ) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// Don't accidentally use t, use st instead. To ensure this, shadow 't' to a useless type.
@@ -50,7 +50,7 @@ func BrokerTracingTestHelperWithChannelTestRunner(
 }
 
 // BrokerTracingTestHelper runs the Broker tracing test using the given TypeMeta.
-func BrokerTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient SetupClientFunc) {
+func BrokerTracingTestHelper(t *testing.T, channel metav1.TypeMeta, setupClient lib.SetupClientOption) {
 	testCases := map[string]TracingTestCase{
 		"includes incoming trace id": {
 			IncomingTraceId: true,

--- a/test/conformance/helpers/channel_header_single_event_helper.go
+++ b/test/conformance/helpers/channel_header_single_event_helper.go
@@ -36,7 +36,10 @@ EventSource ---> Channel ---> Subscription ---> Service(Logger)
 */
 
 // SingleEventHelperForChannelTestHelper is the helper function for header_test
-func SingleEventHelperForChannelTestHelper(t *testing.T, encoding string, channelTestRunner lib.ChannelTestRunner) {
+func SingleEventHelperForChannelTestHelper(t *testing.T, encoding string,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption,
+) {
 	channelName := "conformance-headers-channel-" + encoding
 	senderName := "conformance-headers-sender-" + encoding
 	subscriptionName := "conformance-headers-subscription-" + encoding
@@ -44,7 +47,7 @@ func SingleEventHelperForChannelTestHelper(t *testing.T, encoding string, channe
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		st.Logf("Running header conformance test with channel %q", channel)
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create channel

--- a/test/e2e/helpers/broker_channel_flow_test_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_test_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // BrokerChannelFlowTestHelper is the helper function for broker_channel_flow_test
-func BrokerChannelFlowTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func BrokerChannelFlowTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	const (
 		senderName = "e2e-brokerchannel-sender"
 		brokerName = "e2e-brokerchannel-broker"
@@ -54,7 +56,7 @@ func BrokerChannelFlowTestHelper(t *testing.T, channelTestRunner lib.ChannelTest
 	)
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create required RBAC resources including ServiceAccounts and ClusterRoleBindings for Brokers

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // EventTransformationForTriggerTestHelper is the helper function for broker_event_tranformation_test
-func EventTransformationForTriggerTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func EventTransformationForTriggerTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	const (
 		senderName = "e2e-eventtransformation-sender"
 		brokerName = "e2e-eventtransformation-broker"
@@ -49,7 +51,7 @@ func EventTransformationForTriggerTestHelper(t *testing.T, channelTestRunner lib
 	)
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create required RBAC resources including ServiceAccounts and ClusterRoleBindings for Brokers

--- a/test/e2e/helpers/channel_chain_test_helper.go
+++ b/test/e2e/helpers/channel_chain_test_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // ChannelChainTestHelper is the helper function for channel_chain_test
-func ChannelChainTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func ChannelChainTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	const (
 		senderName    = "e2e-channelchain-sender"
 		loggerPodName = "e2e-channelchain-logger-pod"
@@ -41,7 +43,7 @@ func ChannelChainTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunne
 	subscriptionNames2 := []string{"e2e-channelchain-subs21"}
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create channels

--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -45,10 +45,12 @@ const (
 )
 
 // ChannelClusterDefaulterTestHelper is the helper function for channel_defaulter_test
-func ChannelClusterDefaulterTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func ChannelClusterDefaulterTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// these tests cannot be run in parallel as they have cluster-wide impact
-		client := lib.Setup(st, false)
+		client := lib.Setup(st, false, options...)
 		defer lib.TearDown(client)
 
 		if err := updateDefaultChannelCM(client, func(conf *defaultchannel.Config) {
@@ -62,11 +64,13 @@ func ChannelClusterDefaulterTestHelper(t *testing.T, channelTestRunner lib.Chann
 }
 
 // ChannelNamespaceDefaulterTestHelper is the helper function for channel_defaulter_test
-func ChannelNamespaceDefaulterTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func ChannelNamespaceDefaulterTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// we cannot run these tests in parallel as the updateDefaultChannelCM function is not thread-safe
 		// TODO(chizhg): make updateDefaultChannelCM thread-safe and run in parallel if the tests are taking too long to finish
-		client := lib.Setup(st, false)
+		client := lib.Setup(st, false, options...)
 		defer lib.TearDown(client)
 
 		if err := updateDefaultChannelCM(client, func(conf *defaultchannel.Config) {

--- a/test/e2e/helpers/channel_dls_test_helper.go
+++ b/test/e2e/helpers/channel_dls_test_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // ChannelDeadLetterSinkTestHelper is the helper function for channel_deadlettersink_test
-func ChannelDeadLetterSinkTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func ChannelDeadLetterSinkTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	const (
 		senderName    = "e2e-channelchain-sender"
 		loggerPodName = "e2e-channel-dls-logger-pod"
@@ -39,7 +41,7 @@ func ChannelDeadLetterSinkTestHelper(t *testing.T, channelTestRunner lib.Channel
 	subscriptionNames := []string{"e2e-channel-dls-subs1"}
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create channels

--- a/test/e2e/helpers/channel_event_tranformation_test_helper.go
+++ b/test/e2e/helpers/channel_event_tranformation_test_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // EventTransformationForSubscriptionTestHelper is the helper function for channel_event_tranformation_test
-func EventTransformationForSubscriptionTestHelper(t *testing.T, channelTestRunner lib.ChannelTestRunner) {
+func EventTransformationForSubscriptionTestHelper(t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	senderName := "e2e-eventtransformation-sender"
 	channelNames := []string{"e2e-eventtransformation1", "e2e-eventtransformation2"}
 	// subscriptionNames1 corresponds to Subscriptions on channelNames[0]
@@ -40,7 +42,7 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T, channelTestRunne
 	loggerPodName := "e2e-eventtransformation-logger-pod"
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create channels

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -29,7 +29,9 @@ import (
 )
 
 // SingleEventForChannelTestHelper is the helper function for channel_single_event_test
-func SingleEventForChannelTestHelper(t *testing.T, encoding string, channelTestRunner lib.ChannelTestRunner) {
+func SingleEventForChannelTestHelper(t *testing.T, encoding string,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption) {
 	channelName := "e2e-singleevent-channel-" + encoding
 	senderName := "e2e-singleevent-sender-" + encoding
 	subscriptionName := "e2e-singleevent-subscription-" + encoding
@@ -37,7 +39,7 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding string, channelTestR
 
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		st.Logf("Run test with channel %q", channel)
-		client := lib.Setup(st, true)
+		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
 		// create channel


### PR DESCRIPTION
## Proposed Changes
1. To run the e2e tests in eventing, sometimes it's not enough to run the tests directly, like for `Channel` in knative-gcp, which needs to duplicate a secret to the test namespace before running the tests.  This PR enables passing options to further configure the test client.
2. Now each time we run the tests, we create namespaces with random names for each tests, it would be fine to break the tests in the middle, as there will be no conflicts if the user wants to run the tests again after a short time. So remove the logic to disallow people break the tests in the middle.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nachocano 