### PR TITLE
Update cloudevents SDK to 0.11.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,7 +114,7 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:f030b3fe4eb560bf1743ab344695282b2fc0ae1a2722daf93e2aaedeeee34a16"
+  digest = "1:3310d38d3fcfca84240997965eaf73d5105611ef4b99580f8ad744eb31df6f2e"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     ".",
@@ -131,8 +131,8 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "423680168ea46409121b5ef13ad563d4f0539fcb"
-  version = "v0.10.2"
+  revision = "d289f68c35e89dd9b6a32b1d41faf60a0d9d090a"
+  version = "v0.11.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,7 +86,7 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  version = "0.10.2"
+  version = "0.11.0"
 
 # needed because pkg upgraded
 [[override]]

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_marshal.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_marshal.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	errors2 "github.com/pkg/errors"
+
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/observability"
 )
 
@@ -222,11 +224,17 @@ func (e *Event) JsonDecodeV02(body []byte, raw map[string]json.RawMessage) error
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			extensions[k] = v
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec
@@ -263,11 +271,17 @@ func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			extensions[k] = v
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec
@@ -312,15 +326,17 @@ func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error 
 
 	if len(raw) > 0 {
 		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
 		for k, v := range raw {
 			k = strings.ToLower(k)
-			var tmp string
+			var tmp interface{}
 			if err := json.Unmarshal(v, &tmp); err != nil {
 				return err
 			}
-			extensions[k] = tmp
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
 		}
-		ec.Extensions = extensions
 	}
 
 	e.Context = &ec

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext.go
@@ -79,6 +79,8 @@ type EventContextWriter interface {
 	// SetExtension sets the given interface onto the extension attributes
 	// determined by the provided name.
 	//
+	// This function fails in V1 if the name doesn't respect the regex ^[a-zA-Z0-9]+$
+	//
 	// Package ./types documents the types that are allowed as extension values.
 	SetExtension(string, interface{}) error
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v1.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/eventcontext_v1.go
@@ -73,8 +73,9 @@ func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
 }
 
 // SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+// This function fails if the name doesn't respect the regex ^[a-zA-Z0-9]+$
 func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
-	if !IsAlphaNumericLowercaseLetters(name) {
+	if !IsAlphaNumeric(name) {
 		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
 	}
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/extensions.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/extensions.go
@@ -27,4 +27,4 @@ func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{
 	return nil, false
 }
 
-var IsAlphaNumericLowercaseLetters = regexp.MustCompile(`^[a-z0-9]+$`).MatchString
+var IsAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString


### PR DESCRIPTION
## Proposed Changes
- Update cloudevents SDK to 0.11.0

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
CloudEvents SDK is updated to 0.11.0
```
