### PR TITLE
Configure probe parameters for the broker.

### DIFF
--- a/config/100-config-broker.yaml
+++ b/config/100-config-broker.yaml
@@ -1,0 +1,1 @@
+brokers/channel-broker/configmaps/config-broker.yaml

--- a/config/brokers/channel-broker/configmaps/config-broker.yaml
+++ b/config/brokers/channel-broker/configmaps/config-broker.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }
+  filter-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      },
+      "readinessProbe":{
+        "httpGet":{
+          "path":"/readyz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }

--- a/pkg/broker/config/store.go
+++ b/pkg/broker/config/store.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/eventing/pkg/logging"
+	knconfigmap "knative.dev/pkg/configmap"
+)
+
+const (
+	// BrokerConfigMap is the name of the configmap for the broker.
+	BrokerConfigMap = "config-broker"
+	// IngressConfigKey is the key in the "Data" field of the configmap for the broker ingress.
+	IngressConfigKey = "ingress-config"
+	// FilterConfigKey is the key in the "Data" field of the configmap for the broker filter.
+	FilterConfigKey = "filter-config"
+)
+
+// DefaultBrokerConfig is the default config for the broker.
+var DefaultBrokerConfig = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+}
+
+// IngressConfig holds the configuration parameters for the broker ingress.
+type IngressConfig struct {
+	LivenessProbe corev1.Probe
+}
+
+// FilterConfig holds the configuration parameters for the broker filter.
+type FilterConfig struct {
+	LivenessProbe  corev1.Probe
+	ReadinessProbe corev1.Probe
+}
+
+// BrokerConfig is the in memory representation of the broker configmap.
+type BrokerConfig struct {
+	IngressConfig IngressConfig
+	FilterConfig  FilterConfig
+}
+
+// NewConfigFromConfigMap converts a k8s configmap into BrokerConfig.
+func NewConfigFromConfigMap(config *corev1.ConfigMap) (BrokerConfig, error) {
+	// Initialize with default config so that if a field is missing in the configmap, its default
+	// value will be applied.
+	c := DefaultBrokerConfig
+	err := json.Unmarshal([]byte(config.Data[IngressConfigKey]), &c.IngressConfig)
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal([]byte(config.Data[FilterConfigKey]), &c.FilterConfig)
+	return c, err
+}
+
+// Store loads/unloads untyped configuration from configmap.
+type Store struct {
+	logger knconfigmap.Logger
+	*knconfigmap.UntypedStore
+}
+
+// NewStore creates a new broker configuration store.
+func NewStore(logger knconfigmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
+	return &Store{
+		logger: logger,
+		UntypedStore: knconfigmap.NewUntypedStore(
+			"broker_config",
+			logger,
+			knconfigmap.Constructors{
+				BrokerConfigMap: NewConfigFromConfigMap,
+			},
+			onAfterStore...,
+		),
+	}
+}
+
+// GetConfig returns the current config in the store.
+func (s *Store) GetConfig() BrokerConfig {
+	config := s.UntypedStore.UntypedLoad(BrokerConfigMap)
+	if config == nil {
+		// This should only happen in tests where we don't watch for the configmap and therefore the
+		// store is not populated with data.
+		s.logger.Errorf("Failed to load config from store, returning default config: %v.", DefaultBrokerConfig)
+		return DefaultBrokerConfig
+	}
+	return config.(BrokerConfig)
+}
+
+type cfgKey struct{}
+
+// FromContextOrDefault extracts a BrokerConfig from the provided context. It it doesn't exits, it
+// returns the default.
+func FromContextOrDefault(ctx context.Context) BrokerConfig {
+	c, ok := ctx.Value(cfgKey{}).(BrokerConfig)
+	if !ok {
+		logging.FromContext(ctx).Warn(fmt.Sprintf("Using default BrokerConfig since no BrokerConfig in context: %+v", ctx))
+		return DefaultBrokerConfig
+	}
+	return c
+}
+
+// ToContext attaches the provided BrokerConfig to the provided context, returning the
+// new context with the BrokerConfig attached.
+func ToContext(ctx context.Context, c BrokerConfig) context.Context {
+	return context.WithValue(ctx, cfgKey{}, c)
+}
+
+// ConfigStore is used to attach the frozen configuration to the context.
+func (s *Store) ToContext(ctx context.Context) context.Context {
+	return ToContext(ctx, s.GetConfig())
+}

--- a/pkg/broker/config/store_test.go
+++ b/pkg/broker/config/store_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	configmaptesting "knative.dev/pkg/configmap/testing"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// expected config corresponding to `config-broker.yaml`
+var wantFromFullConfigMap = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+}
+
+// expected config corresponding to `config-broker-partial.yaml`
+var wantFromPartialConfigMap = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+		// ReadinessProbe not provided in configmap. Defaults should be applied.
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+}
+
+func TestGetConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		configmap string
+		want      BrokerConfig
+	}{
+		{
+			name:      "full config provided in configmap",
+			configmap: "config-broker",
+			want:      wantFromFullConfigMap,
+		},
+		{
+			name:      "readiness probe not provided in configmap",
+			configmap: "config-broker-partial",
+			want:      wantFromPartialConfigMap,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(logtesting.TestLogger(t))
+			configmap := configmaptesting.ConfigMapFromTestFile(t, tt.configmap, IngressConfigKey, FilterConfigKey)
+			store.OnConfigChanged(configmap)
+			got := store.GetConfig()
+			if dif := cmp.Diff(got, tt.want); dif != "" {
+				fmt.Println("Dif:", dif)
+				t.Errorf("BrokerConfig mismatch. Dif: %+v \n", dif)
+			}
+		})
+	}
+}

--- a/pkg/broker/config/testdata/config-broker-partial.yaml
+++ b/pkg/broker/config/testdata/config-broker-partial.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  # The ConfigMapFromTestFile helper method expects a key named "_example" and it's dummy here.
+  _example: |
+    dummy: "nothing"
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }
+  filter-config: | # The readiness probe is intentionally left blank to test that default values are applied.
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }

--- a/pkg/broker/config/testdata/config-broker.yaml
+++ b/pkg/broker/config/testdata/config-broker.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  # The ConfigMapFromTestFile helper method expects a key named "_example" and it's dummy here.
+  _example: |
+    dummy: "nothing"
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }
+  filter-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      },
+      "readinessProbe":{
+        "httpGet":{
+          "path":"/readyz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -39,6 +39,7 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing/pkg/broker/config"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1alpha1"
@@ -297,6 +298,7 @@ func (r *Reconciler) reconcileFilterDeployment(ctx context.Context, b *v1alpha1.
 		Broker:             b,
 		Image:              r.filterImage,
 		ServiceAccountName: r.filterServiceAccountName,
+		FilterConfig:       config.FromContextOrDefault(ctx).FilterConfig,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }
@@ -415,6 +417,7 @@ func (r *Reconciler) reconcileIngressDeployment(ctx context.Context, b *v1alpha1
 		Image:              r.ingressImage,
 		ServiceAccountName: r.ingressServiceAccountName,
 		ChannelAddress:     c.Status.Address.GetURL().Host,
+		IngressConfig:      config.FromContextOrDefault(ctx).IngressConfig,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -20,6 +20,9 @@ import (
 	"os"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/broker/config"
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
@@ -41,7 +44,39 @@ func TestNew(t *testing.T) {
 	_ = os.Setenv("BROKER_FILTER_IMAGE", "FILTER_IMAGE")
 	_ = os.Setenv("BROKER_FILTER_SERVICE_ACCOUNT", "FILTER_SERVICE_ACCOUNT")
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: config.BrokerConfigMap,
+		},
+		Data: map[string]string{
+			config.FilterConfigKey: `
+ {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }
+`,
+			config.IngressConfigKey: `
+{
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }
+`,
+		},
+	}
+	c := NewController(ctx, configmap.NewStaticWatcher(cm))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -26,6 +26,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 )
@@ -39,6 +40,7 @@ type FilterArgs struct {
 	Broker             *eventingv1alpha1.Broker
 	Image              string
 	ServiceAccountName string
+	config.FilterConfig
 }
 
 // MakeFilterDeployment creates the in-memory representation of the Broker's filter Deployment.
@@ -64,28 +66,10 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 					ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Name:  filterContainerName,
-							Image: args.Image,
-							LivenessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
-							ReadinessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/readyz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
+							Name:           filterContainerName,
+							Image:          args.Image,
+							LivenessProbe:  &args.LivenessProbe,
+							ReadinessProbe: &args.ReadinessProbe,
 							Env: []corev1.EnvVar{
 								{
 									Name:  system.NamespaceEnvKey,

--- a/pkg/reconciler/broker/resources/filter_test.go
+++ b/pkg/reconciler/broker/resources/filter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 
 	_ "knative.dev/pkg/system/testing"
 )
@@ -43,6 +44,7 @@ func TestMakeFilterDeployment(t *testing.T) {
 				},
 				Image:              "image-uri",
 				ServiceAccountName: "service-account-name",
+				FilterConfig:       config.DefaultBrokerConfig.FilterConfig,
 			},
 			want: []byte(`{
   "metadata": {

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -26,6 +26,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 )
@@ -40,6 +41,7 @@ type IngressArgs struct {
 	Image              string
 	ServiceAccountName string
 	ChannelAddress     string
+	config.IngressConfig
 }
 
 // MakeIngress creates the in-memory representation of the Broker's ingress Deployment.
@@ -65,18 +67,9 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 					ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Image: args.Image,
-							Name:  ingressContainerName,
-							LivenessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
+							Image:         args.Image,
+							Name:          ingressContainerName,
+							LivenessProbe: &args.LivenessProbe,
 							Env: []corev1.EnvVar{
 								{
 									Name:  system.NamespaceEnvKey,


### PR DESCRIPTION
Fixes #2060 

## Proposed Changes

- Configure liveness and readiness probes for broker ingress and filter via a configmap in `knative-eventing` namespace.
- If a per-broker configuration is desired, we can have a follow up PR that first looks at the configuration under `broker.Spec.Config`, and then default to the cluster wide configmap.

## Testing
Tested in a real cluster and verified that if the configmap changes, broker reconciler will create new instances of filter/ingress with new config applied.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Configure liveness and readiness probes for broker ingress and filter via a configmap.
```
