### PR TITLE
correcting JSON to camelCase for Uri...

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -123,7 +123,7 @@ type TriggerStatus struct {
 	duckv1.Status `json:",inline"`
 
 	// SubscriberURI is the resolved URI of the receiver for this Trigger.
-	SubscriberURI *apis.URL `json:"subscriberURI,omitempty"`
+	SubscriberURI *apis.URL `json:"subscriberUri,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
/cc @vaikas 

based on #2373 comment.

I have NOT changed existing `v1alpha1` bit that are using `URI`, where your PR already moved their counterparts to `beta1`...

Only doing it on trigger now - I will check same on `eventing-contrib` for consistency ... 