### PR TITLE
update subscriblestatus in imc controller instead of imc dispatcher

### DIFF
--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	clientgotesting "k8s.io/client-go/testing"
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
@@ -59,16 +58,6 @@ func TestAllCases(t *testing.T) {
 		Generation:    2,
 		SubscriberURI: apis.HTTP("call2"),
 		ReplyURI:      apis.HTTP("sink2"),
-	}}
-
-	subscriberStatuses := []duckv1alpha1.SubscriberStatus{{
-		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-		ObservedGeneration: 1,
-		Ready:              "True",
-	}, {
-		UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-		ObservedGeneration: 2,
-		Ready:              "True",
 	}}
 
 	imcKey := testNS + "/" + imcName
@@ -107,17 +96,6 @@ func TestAllCases(t *testing.T) {
 					reconciletesting.WithInMemoryChannelSubscribers(subscribers),
 					reconciletesting.WithInMemoryChannelAddress(channelServiceAddress)),
 			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: reconciletesting.NewInMemoryChannel(imcName, testNS,
-					reconciletesting.WithInitInMemoryChannelConditions,
-					reconciletesting.WithInMemoryChannelDeploymentReady(),
-					reconciletesting.WithInMemoryChannelServiceReady(),
-					reconciletesting.WithInMemoryChannelEndpointsReady(),
-					reconciletesting.WithInMemoryChannelChannelServiceReady(),
-					reconciletesting.WithInMemoryChannelSubscribers(subscribers),
-					reconciletesting.WithInMemoryChannelStatusSubscribers(subscriberStatuses),
-					reconciletesting.WithInMemoryChannelAddress(channelServiceAddress)),
-			}},
 			WantErr: false,
 		}, {},
 	}


### PR DESCRIPTION
Helps towards scaling down in-memory dispatcher to zero.

## Proposed Changes

- The in-mem channel subscriblableStatus is now set by the imc controller


This is part of a multi-steps plan to make the imc-dispatcher a Deployment or a KService installed in the user-namespace. 
step 1: this commit
step 2: install the dispatcher in the user-ns, dispatcher still read global configmaps
step 3: disaptcher is a receive adapter, controller set configmaps 
step 4: controller deploys the dispatcher as a Kservice.