### PR TITLE
Validate labels created by trigger in webhook

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_validation.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 
 	corev1 "k8s.io/api/core/v1"
+	validationutil "k8s.io/apimachinery/pkg/util/validation"
 )
 
 var (
@@ -36,6 +38,7 @@ var (
 // Validate the Trigger.
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs := t.Spec.Validate(ctx).ViaField("spec")
+	errs = t.validateSubscriptionLabels(errs)
 	errs = t.validateAnnotation(errs, DependencyAnnotation, t.validateDependencyAnnotation)
 	errs = t.validateAnnotation(errs, InjectionAnnotation, t.validateInjectionAnnotation)
 	return errs
@@ -131,6 +134,33 @@ func (t *Trigger) validateAnnotation(errs *apis.FieldError, annotation string, f
 		annotationPrefix := fmt.Sprintf("metadata.annotations[%s]", annotation)
 		errs = errs.Also(function(annotationValue).ViaField(annotationPrefix))
 	}
+	return errs
+}
+
+// validateSubscriptionLabels ensures that the labels for the subscription
+// (created by trigger reconciler, see SubscriptionLabels) will be not too long
+func (t *Trigger) validateSubscriptionLabels(errs *apis.FieldError) *apis.FieldError {
+
+	// validate trigger name
+	nameErrors := validationutil.IsValidLabelValue(t.Name)
+	if len(nameErrors) > 0 {
+		fe := &apis.FieldError{
+			Message: strings.Join(nameErrors, ","),
+			Paths:   []string{"name"},
+		}
+		errs = errs.Also(fe).ViaField("metadata")
+	}
+
+	// validate broker name
+	brokerErrors := validationutil.IsValidLabelValue(t.Spec.Broker)
+	if len(brokerErrors) > 0 {
+		fe := &apis.FieldError{
+			Message: strings.Join(brokerErrors, ","),
+			Paths:   []string{"broker"},
+		}
+		errs = errs.Also(fe).ViaField("spec")
+	}
+
 	return errs
 }
 

--- a/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
@@ -75,8 +75,8 @@ var (
 	injectionAnnotationPath    = fmt.Sprintf("metadata.annotations[%s]", InjectionAnnotation)
 )
 const (
-	validLabelName   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	invalidLabelName = validLabelName + "b"
+	validLabelNameMaxCharsNotReached = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	invalidLabelNameMaxCharsReached  = validLabelNameMaxCharsNotReached + "b"
 )
 
 func TestTriggerValidation(t *testing.T) {
@@ -100,7 +100,7 @@ func TestTriggerValidation(t *testing.T) {
 		t:    &Trigger{
 			ObjectMeta: v1.ObjectMeta{
 				// ups ... name too long
-				Name:      invalidLabelName,
+				Name:      invalidLabelNameMaxCharsReached,
 				Namespace: "dummy",
 			},
 			Spec: TriggerSpec{
@@ -118,12 +118,12 @@ func TestTriggerValidation(t *testing.T) {
 		name: "invalid broker name",
 		t:    &Trigger{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      validLabelName,
+				Name:      validLabelNameMaxCharsNotReached,
 				Namespace: "dummy",
 			},
 			Spec: TriggerSpec{
 				// ups ... name too long
-				Broker:     invalidLabelName,
+				Broker:     invalidLabelNameMaxCharsReached,
 				Filter:     validEmptyFilter,
 				Subscriber: validSubscriber,
 			},

--- a/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_validation_test.go
@@ -75,8 +75,8 @@ var (
 	injectionAnnotationPath    = fmt.Sprintf("metadata.annotations[%s]", InjectionAnnotation)
 )
 const (
-	labelNameOk = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	labelNameNok = labelNameOk + "b"
+	validLabelName   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	invalidLabelName = validLabelName + "b"
 )
 
 func TestTriggerValidation(t *testing.T) {
@@ -100,8 +100,8 @@ func TestTriggerValidation(t *testing.T) {
 		t:    &Trigger{
 			ObjectMeta: v1.ObjectMeta{
 				// ups ... name too long
-				Name:                       labelNameNok,
-				Namespace:                  "dummy",
+				Name:      invalidLabelName,
+				Namespace: "dummy",
 			},
 			Spec: TriggerSpec{
 				Broker:     "test_broker",
@@ -118,12 +118,12 @@ func TestTriggerValidation(t *testing.T) {
 		name: "invalid broker name",
 		t:    &Trigger{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      labelNameOk,
+				Name:      validLabelName,
 				Namespace: "dummy",
 			},
 			Spec: TriggerSpec{
 				// ups ... name too long
-				Broker:     labelNameNok,
+				Broker:     invalidLabelName,
 				Filter:     validEmptyFilter,
 				Subscriber: validSubscriber,
 			},


### PR DESCRIPTION
## Proposed Changes

- Validate labels created by trigger in webhook

## Description

A broker internally creates a subscription. The labels for the subscription are:
1. the trigger name
1. the broker name

Check code [here](https://github.com/knative/eventing/blob/27a00f551413988364f5804f0ca8dde3d7c290b1/pkg/reconciler/trigger/resources/subscription.go#L76).

There is a [restriction](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) on the format of a k8s label value. This PR introduces a check in the webook for the labels in order to provide fast user feedback.

## How to test

```bash
$ k apply -f trigger_length_nok.yaml
Error from server (BadRequest): error when creating "trigger_length_nok.yaml": admission webhook "validation.webhook.eventing.knative.dev" denied the request: validation failed: must be no more than 63 characters: metadata.name

$ k apply -f trigger_length_ok.yaml
trigger.eventing.knative.dev/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa created
```

```shell
$ cat trigger_length_nok.yaml
apiVersion: eventing.knative.dev/v1alpha1
kind: Trigger
metadata:
  name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
spec:
  broker: default
  filter:
    attributes:
      eventtypeversion: v1
      source: nilsseventmeshapp
      type: foo
  subscriber:
    uri: http://test-kk.test-nils:8080/
````

```shell
$ cat trigger_length_ok.yaml
apiVersion: eventing.knative.dev/v1alpha1
kind: Trigger
metadata:
  name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
spec:
  broker: default
  filter:
    attributes:
      eventtypeversion: v1
      source: nilsseventmeshapp
      type: foo
  subscriber:
    uri: http://test-kk.test-nils:8080/
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Validate labels created by trigger in webhook
```
