### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -19,8 +19,9 @@ package pingsource
 import (
 	"context"
 	"fmt"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"testing"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/resolver"

--- a/pkg/reconciler/pingsource/resources/receive_adapter.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"knative.dev/pkg/apis"
 
 	v1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -18,8 +18,9 @@ package resources
 
 import (
 	"fmt"
-	"knative.dev/pkg/apis"
 	"testing"
+
+	"knative.dev/pkg/apis"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/reconciler/testing/pingsource.go
+++ b/pkg/reconciler/testing/pingsource.go
@@ -17,8 +17,9 @@ limitations under the License.
 package testing
 
 import (
-	"knative.dev/pkg/apis"
 	"time"
+
+	"knative.dev/pkg/apis"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign n3wscott
/cc n3wscott
