### PR TITLE
Modify sender-receiver sink url for broker-imc perf test

### DIFF
--- a/test/performance/benchmarks/broker-imc/continuous/200-broker-imc.yaml
+++ b/test/performance/benchmarks/broker-imc/continuous/200-broker-imc.yaml
@@ -41,7 +41,7 @@ spec:
               image: knative.dev/eventing/test/test_images/performance
               args:
                 - "--roles=sender"
-                - "--sink=http://imc-broker"
+                - "--sink=http://imc-broker.default.svc.cluster.local"
                 - "--aggregator=broker-imc-aggregator:10000"
                 - "--pace=100:10,400:20,800:30,900:60,1000:60,1100:60,1200:60"
               env:


### PR DESCRIPTION
In broker-imc/continuous, the sink url was `--sink=http://imc-broker`, it works for service. But when did perf test for ksvc, it failed. Changed to `--sink=http://imc-broker.default.svc.cluster.local`, which is consistent with manual perf test's sink format under broker-imc/ and is both working for svc and ksvc.
 
Proposed Changes
- Changed from `--sink=http://imc-broker `to `--sink=http://imc-broker.default.svc.cluster.local`
-
-

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
