### PR TITLE
Remove ClusterChannelProvisioner leftover

### DIFF
--- a/docs/broker/example_brokers.yaml
+++ b/docs/broker/example_brokers.yaml
@@ -17,7 +17,6 @@
 ---
 
 # By not specifying a spec, the default Channel for the namespace will be used.
-# This will change with the 0.8.0 version, since CCP is being removed than
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Broker
 metadata:


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1912

## Proposed Changes

- Remove ClusterChannelProvisioner naming from code
- Only file where I can still find it is <https://github.com/knative/eventing/blob/cce73feedf0770a06799cf637096f4edbe00299a/docs/spec/channel_060.md#L58> which describes the channel at version 0.6 which is fine because it used CCP.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
