### PR TITLE
Revert "Update the signature of ResolveChannelFromHostFunc to take in…

### DIFF
--- a/pkg/channel/event_receiver.go
+++ b/pkg/channel/event_receiver.go
@@ -62,9 +62,6 @@ type ReceiverOptions func(*EventReceiver) error
 
 // ResolveChannelFromHostFunc function enables EventReceiver to get the Channel Reference from incoming request HostHeader
 // before calling receiverFunc.
-// TODO change this to take in a URL, rather than just the host string.
-//  That will allow us to use the path to distinguish between Channels too.
-//  Issue: https://github.com/knative/eventing/issues/1952
 type ResolveChannelFromHostFunc func(string) (ChannelReference, error)
 
 // ResolveChannelFromHostHeader is a ReceiverOption for NewEventReceiver which enables the caller to overwrite the

--- a/pkg/channel/event_receiver.go
+++ b/pkg/channel/event_receiver.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -63,7 +62,10 @@ type ReceiverOptions func(*EventReceiver) error
 
 // ResolveChannelFromHostFunc function enables EventReceiver to get the Channel Reference from incoming request HostHeader
 // before calling receiverFunc.
-type ResolveChannelFromHostFunc func(url.URL) (ChannelReference, error)
+// TODO change this to take in a URL, rather than just the host string.
+//  That will allow us to use the path to distinguish between Channels too.
+//  Issue: https://github.com/knative/eventing/issues/1952
+type ResolveChannelFromHostFunc func(string) (ChannelReference, error)
 
 // ResolveChannelFromHostHeader is a ReceiverOption for NewEventReceiver which enables the caller to overwrite the
 // default behaviour defined by ParseChannel function.
@@ -148,13 +150,7 @@ func (r *EventReceiver) ServeHTTP(ctx context.Context, event cloudevents.Event, 
 
 	host := tctx.Host
 	r.logger.Debug("Received request", zap.String("host", host))
-	hostURL, err := url.Parse(host)
-	if err != nil {
-		r.logger.Info("Could not parse host as URL", zap.Error(err))
-		resp.Status = http.StatusInternalServerError
-		return err
-	}
-	channel, err := r.hostToChannelFunc(*hostURL)
+	channel, err := r.hostToChannelFunc(host)
 	if err != nil {
 		r.logger.Info("Could not extract channel", zap.Error(err))
 		resp.Status = http.StatusInternalServerError
@@ -182,10 +178,10 @@ func (r *EventReceiver) ServeHTTP(ctx context.Context, event cloudevents.Event, 
 
 // ParseChannel converts the channel's hostname into a channel
 // reference.
-func ParseChannel(host url.URL) (ChannelReference, error) {
-	chunks := strings.Split(host.Path, ".")
+func ParseChannel(host string) (ChannelReference, error) {
+	chunks := strings.Split(host, ".")
 	if len(chunks) < 2 {
-		return ChannelReference{}, fmt.Errorf("bad host format %v", host)
+		return ChannelReference{}, fmt.Errorf("bad host format %q", host)
 	}
 	return ChannelReference{
 		Name:      chunks[0],

--- a/pkg/channel/event_receiver_test.go
+++ b/pkg/channel/event_receiver_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -53,10 +52,6 @@ func TestEventReceiver_ServeHTTP(t *testing.T) {
 		},
 		"invalid host name": {
 			host:     "no-dot",
-			expected: http.StatusInternalServerError,
-		},
-		"unparseable host name": {
-			host:     ":abc.def.ghi",
 			expected: http.StatusInternalServerError,
 		},
 		"unknown channel error": {
@@ -161,19 +156,5 @@ func TestEventReceiver_ServeHTTP(t *testing.T) {
 				t.Fatalf("Unexpected status code. Expected %v. Actual %v", tc.expected, eventResponse.Status)
 			}
 		})
-	}
-}
-
-func TestEventReceiver_ParseChannel(t *testing.T) {
-	url, _ := url.Parse("test-channel.test-namespace.svc.")
-	c, err := ParseChannel(*url)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	if c.Name != "test-channel" {
-		t.Errorf("Expected Name: test-channel. Got: %q", c.Name)
-	}
-	if c.Namespace != "test-namespace" {
-		t.Errorf("Expected Name: test-namespace. Got: %q", c.Namespace)
 	}
 }


### PR DESCRIPTION
After the change was made, we realized that the TransportContext (https://github.com/cloudevents/sdk-go/blob/e1f5919ca32388a76b30a230facea51af3dd76c6/pkg/cloudevents/transport/http/context.go#L13-L18) host field is just the actual host from the request (https://golang.org/pkg/net/http/#Request). This means we cannot get the full URL (path, scheme, etc.) in the ServeHTTP method. Therefore, it doesn't really make sense to use a URL. Reverting the CL to change it back to a string.

Issue #1952 

I'll make the corresponding change in eventing-contrib once this goes in.