### PR TITLE
Refactor broker to have plugable way to reconcile a service

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1alpha1/broker_lifecycle.go
@@ -101,6 +101,14 @@ func (bs *BrokerStatus) PropagateFilterDeploymentAvailability(d *appsv1.Deployme
 	}
 }
 
+func (bs *BrokerStatus) MarkIngressReady() {
+	brokerCondSet.Manage(bs).MarkTrue(BrokerConditionIngress)
+}
+
+func (bs *BrokerStatus) MarkFilterReady() {
+	brokerCondSet.Manage(bs).MarkTrue(BrokerConditionFilter)
+}
+
 // SetAddress makes this Broker addressable by setting the hostname. It also
 // sets the BrokerConditionAddressable to true.
 func (bs *BrokerStatus) SetAddress(url *apis.URL) {

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -34,8 +34,10 @@ import (
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler"
+	kubeservice "knative.dev/eventing/pkg/reconciler/internal/service/kube"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
@@ -79,10 +81,13 @@ func NewController(
 	serviceInformer := serviceinformer.Get(ctx)
 
 	r := &Reconciler{
-		Base:                      reconciler.NewBase(ctx, controllerAgentName, cmw),
+		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
+		serviceReconciler: &kubeservice.ServiceReconciler{
+			KubeClientSet:    kubeclient.Get(ctx),
+			DeploymentLister: deploymentInformer.Lister(),
+			ServiceLister:    serviceInformer.Lister(),
+		},
 		brokerLister:              brokerInformer.Lister(),
-		serviceLister:             serviceInformer.Lister(),
-		deploymentLister:          deploymentInformer.Lister(),
 		subscriptionLister:        subscriptionInformer.Lister(),
 		triggerLister:             triggerInformer.Lister(),
 		ingressImage:              env.IngressImage,

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -19,14 +19,12 @@ package resources
 import (
 	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
-	"knative.dev/pkg/kmeta"
+	"knative.dev/eventing/pkg/reconciler/internal/service"
 	"knative.dev/pkg/system"
 )
 
@@ -41,126 +39,83 @@ type FilterArgs struct {
 	ServiceAccountName string
 }
 
-// MakeFilterDeployment creates the in-memory representation of the Broker's filter Deployment.
-func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: args.Broker.Namespace,
-			Name:      fmt.Sprintf("%s-broker-filter", args.Broker.Name),
-			OwnerReferences: []metav1.OwnerReference{
-				*kmeta.NewControllerRef(args.Broker),
-			},
-			Labels: FilterLabels(args.Broker.Name),
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: FilterLabels(args.Broker.Name),
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: FilterLabels(args.Broker.Name),
-				},
-				Spec: corev1.PodSpec{
-					ServiceAccountName: args.ServiceAccountName,
-					Containers: []corev1.Container{
-						{
-							Name:  filterContainerName,
-							Image: args.Image,
-							LivenessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
-							ReadinessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/readyz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name:  system.NamespaceEnvKey,
-									Value: system.Namespace(),
-								},
-								{
-									Name: "NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-								{
-									Name: "POD_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.name",
-										},
-									},
-								},
-								{
-									Name:  "CONTAINER_NAME",
-									Value: filterContainerName,
-								},
-								{
-									Name:  "BROKER",
-									Value: args.Broker.Name,
-								},
-								// Used for StackDriver only.
-								{
-									Name:  "METRICS_DOMAIN",
-									Value: "knative.dev/internal/eventing",
-								},
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: 8080,
-									Name:          "http",
-								},
-								{
-									ContainerPort: 9090,
-									Name:          "metrics",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+func MakeFilterServiceMeta(b *eventingv1alpha1.Broker) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: b.Namespace,
+		Name:      fmt.Sprintf("%s-broker-filter", b.Name),
+		Labels:    FilterLabels(b.Name),
 	}
 }
 
-// MakeFilterService creates the in-memory representation of the Broker's filter Service.
-func MakeFilterService(b *eventingv1alpha1.Broker) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: b.Namespace,
-			Name:      fmt.Sprintf("%s-broker-filter", b.Name),
-			Labels:    FilterLabels(b.Name),
-			OwnerReferences: []metav1.OwnerReference{
-				*kmeta.NewControllerRef(b),
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: FilterLabels(b.Name),
-			Ports: []corev1.ServicePort{
+// MakeFilterServiceArgs creates the in-memory representation of the Broker's filter service arguments.
+func MakeFilterServiceArgs(args *FilterArgs) *service.Args {
+	return &service.Args{
+		ServiceMeta: MakeFilterServiceMeta(args.Broker),
+		DeployMeta:  MakeFilterServiceMeta(args.Broker),
+		PodSpec: corev1.PodSpec{
+			ServiceAccountName: args.ServiceAccountName,
+			Containers: []corev1.Container{
 				{
-					Name:       "http",
-					Port:       80,
-					TargetPort: intstr.FromInt(8080),
-				},
-				{
-					Name: "http-metrics",
-					Port: 9090,
+					Name:  filterContainerName,
+					Image: args.Image,
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz",
+								// Port should be the same as the container port.
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       2,
+						FailureThreshold:    3,
+						TimeoutSeconds:      10,
+						SuccessThreshold:    1,
+					},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/readyz",
+								// Port should be the same as the container port.
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       2,
+						FailureThreshold:    3,
+						TimeoutSeconds:      10,
+						SuccessThreshold:    1,
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  system.NamespaceEnvKey,
+							Value: system.Namespace(),
+						},
+						{
+							Name:  "NAMESPACE",
+							Value: args.Broker.Namespace,
+						},
+						{
+							Name:  "POD_NAME",
+							Value: fmt.Sprintf("%s-broker-filter", args.Broker.Name),
+						},
+						{
+							Name:  "CONTAINER_NAME",
+							Value: filterContainerName,
+						},
+						{
+							Name:  "BROKER",
+							Value: args.Broker.Name,
+						},
+						// Used for StackDriver only.
+						{
+							Name:  "METRICS_DOMAIN",
+							Value: "knative.dev/internal/eventing",
+						},
+					},
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 8080,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/reconciler/internal/service/base.go
+++ b/pkg/reconciler/internal/service/base.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+// Status represents the status of an addressable service.
+type Status struct {
+	IsReady bool
+	URL     *apis.URL
+	Reason  string
+	Message string
+}
+
+// Args is the arguments to reconcile an addressable service.
+type Args struct {
+	ServiceMeta metav1.ObjectMeta
+	DeployMeta  metav1.ObjectMeta
+	PodSpec     corev1.PodSpec
+}
+
+// Reconciler is the interface to reconcile addressable services.
+type Reconciler interface {
+	// Reconcile reconciles a service.
+	Reconcile(context.Context, metav1.OwnerReference, Args) (*Status, error)
+	// GetStatus get the status of a service.
+	GetStatus(context.Context, metav1.ObjectMeta) (*Status, error)
+}

--- a/pkg/reconciler/internal/service/kube/kube.go
+++ b/pkg/reconciler/internal/service/kube/kube.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/eventing/pkg/apis/duck"
+	"knative.dev/eventing/pkg/reconciler/internal/service"
+	"knative.dev/eventing/pkg/reconciler/names"
+	"knative.dev/pkg/apis"
+)
+
+// ServiceReconciler reconciles addressable services implemented with
+// k8s services and deployments.
+type ServiceReconciler struct {
+	KubeClientSet    kubernetes.Interface
+	ServiceLister    corev1listers.ServiceLister
+	DeploymentLister appsv1listers.DeploymentLister
+}
+
+var _ service.Reconciler = (*ServiceReconciler)(nil)
+
+// Reconcile reconciles an addressable service with k8s service and deployment.
+func (r *ServiceReconciler) Reconcile(ctx context.Context, owner metav1.OwnerReference, args service.Args) (*service.Status, error) {
+	if err := validateArgs(args); err != nil {
+		return nil, err
+	}
+	fillDefaults(&args, owner)
+
+	d := &v1.Deployment{
+		ObjectMeta: args.DeployMeta,
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: args.DeployMeta.Labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: args.DeployMeta.Labels,
+				},
+				Spec: args.PodSpec,
+			},
+		},
+	}
+	rd, err := r.reconcileDeployment(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: args.ServiceMeta,
+		Spec: corev1.ServiceSpec{
+			Selector: args.DeployMeta.Labels,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(int(args.PodSpec.Containers[0].Ports[0].ContainerPort)),
+				},
+			},
+		},
+	}
+	rsvc, err := r.reconcileService(ctx, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	if duck.DeploymentIsAvailable(&rd.Status, true) {
+		return &service.Status{
+			IsReady: true,
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   names.ServiceHostName(rsvc.Name, rsvc.Namespace),
+			},
+		}, nil
+	}
+
+	return &service.Status{
+		IsReady: false,
+		Reason:  "DeploymentUnavailable",
+		Message: fmt.Sprintf("The Deployment %q is unavailable", rd.Name),
+		URL: &apis.URL{
+			Scheme: "http",
+			Host:   names.ServiceHostName(svc.Name, svc.Namespace),
+		},
+	}, nil
+}
+
+func validateArgs(args service.Args) error {
+	if !strings.HasPrefix(args.DeployMeta.Name, args.ServiceMeta.Name) {
+		return fmt.Errorf("service name must be a prefix of deployment name")
+	}
+	if len(args.PodSpec.Containers[0].Ports) == 0 {
+		args.PodSpec.Containers[0].Ports = []corev1.ContainerPort{
+			{
+				ContainerPort: 8080,
+			},
+		}
+	}
+	return nil
+}
+
+// GetStatus returns the status of a k8s service.
+func (r *ServiceReconciler) GetStatus(ctx context.Context, svcMeta metav1.ObjectMeta) (*service.Status, error) {
+	existing, err := r.ServiceLister.Services(svcMeta.Namespace).Get(svcMeta.Name)
+	if err != nil {
+		return nil, err
+	}
+	return &service.Status{
+		IsReady: true,
+		URL: &apis.URL{
+			Scheme: "http",
+			Host:   names.ServiceHostName(existing.Name, existing.Namespace),
+		},
+	}, nil
+}
+
+func fillDefaults(args *service.Args, owner metav1.OwnerReference) {
+	// Make sure the service metadata has proper owner reference.
+	args.ServiceMeta.OwnerReferences = append(args.ServiceMeta.OwnerReferences, owner)
+	args.DeployMeta.OwnerReferences = append(args.DeployMeta.OwnerReferences, owner)
+	args.PodSpec.Containers[0].Ports[0].Name = "http"
+	userPort := args.PodSpec.Containers[0].Ports[0].ContainerPort
+
+	if args.PodSpec.Containers[0].LivenessProbe != nil {
+		if args.PodSpec.Containers[0].LivenessProbe.HTTPGet != nil {
+			args.PodSpec.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(userPort))
+		}
+	}
+	if args.PodSpec.Containers[0].ReadinessProbe != nil {
+		if args.PodSpec.Containers[0].ReadinessProbe.HTTPGet != nil {
+			args.PodSpec.Containers[0].ReadinessProbe.HTTPGet.Port = intstr.FromInt(int(userPort))
+		}
+	}
+}
+
+func (r *ServiceReconciler) reconcileDeployment(ctx context.Context, d *v1.Deployment) (*v1.Deployment, error) {
+	existing, err := r.DeploymentLister.Deployments(d.Namespace).Get(d.Name)
+	if apierrors.IsNotFound(err) {
+		existing, err = r.KubeClientSet.AppsV1().Deployments(d.Namespace).Create(d)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create deployment: %w", err)
+		}
+		return existing, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get existing deployment: %w", err)
+	}
+
+	if !equality.Semantic.DeepDerivative(d.Spec, existing.Spec) {
+		// Don't modify the informers copy.
+		desired := existing.DeepCopy()
+		desired.Spec = d.Spec
+		existing, err = r.KubeClientSet.AppsV1().Deployments(existing.Namespace).Update(desired)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update deployment: %w", err)
+		}
+	}
+	return existing, nil
+}
+
+// reconcileService reconciles the K8s Service 'svc'.
+func (r *ServiceReconciler) reconcileService(ctx context.Context, svc *corev1.Service) (*corev1.Service, error) {
+	existing, err := r.ServiceLister.Services(svc.Namespace).Get(svc.Name)
+	if apierrors.IsNotFound(err) {
+		existing, err = r.KubeClientSet.CoreV1().Services(svc.Namespace).Create(svc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create service: %w", err)
+		}
+		return existing, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to get existing service: %w", err)
+	}
+
+	// spec.clusterIP is immutable and is set on existing services. If we don't set this to the same value, we will
+	// encounter an error while updating.
+	svc.Spec.ClusterIP = existing.Spec.ClusterIP
+	if !equality.Semantic.DeepDerivative(svc.Spec, existing.Spec) {
+		// Don't modify the informers copy.
+		desired := existing.DeepCopy()
+		desired.Spec = svc.Spec
+		existing, err = r.KubeClientSet.CoreV1().Services(existing.Namespace).Update(desired)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update service: %w", err)
+		}
+	}
+	return existing, nil
+}

--- a/pkg/reconciler/internal/service/kube/kube_test.go
+++ b/pkg/reconciler/internal/service/kube/kube_test.go
@@ -1,0 +1,563 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/eventing/pkg/reconciler/internal/service"
+	"knative.dev/pkg/apis"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	. "knative.dev/eventing/pkg/reconciler/testing"
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+func TestReconcile(t *testing.T) {
+	cases := []struct {
+		name        string
+		objects     []runtime.Object
+		args        service.Args
+		reactors    []clientgotesting.ReactionFunc
+		wantCreates []runtime.Object
+		wantUpdates []runtime.Object
+		wantStatus  *service.Status
+		wantErr     bool
+	}{{
+		name: "already reconciled do nothing",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantStatus: &service.Status{
+			IsReady: true,
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   "my-svc.my-ns.svc.cluster.local",
+			},
+		},
+	}, {
+		name: "successful create",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		wantCreates: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantStatus: &service.Status{
+			IsReady: true,
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   "my-svc.my-ns.svc.cluster.local",
+			},
+		},
+	}, {
+		name: "successful update",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image2.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantUpdates: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image2.example.com", WithPodContainerPort("http", 8000))),
+			),
+		},
+		wantStatus: &service.Status{
+			IsReady: true,
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   "my-svc.my-ns.svc.cluster.local",
+			},
+		},
+	}, {
+		name: "deployment not available",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+				WithDeploymentNotAvailable(),
+			),
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantStatus: &service.Status{
+			IsReady: false,
+			Message: `The Deployment "my-svc-deploy" is unavailable`,
+			Reason:  "DeploymentUnavailable",
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   "my-svc.my-ns.svc.cluster.local",
+			},
+		},
+	}, {
+		name: "create deployment error",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		reactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "deployments"),
+		},
+		wantCreates: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+		},
+		wantErr: true,
+	}, {
+		name: "update deployment error",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image2.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		reactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "deployments"),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+		},
+		wantUpdates: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image2.example.com", WithPodContainerPort("http", 8000))),
+			),
+		},
+		wantErr: true,
+	}, {
+		name: "create service error",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8000),
+			),
+		},
+		reactors: []clientgotesting.ReactionFunc{
+			InduceFailure("create", "services"),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8000))),
+			),
+		},
+		wantCreates: []runtime.Object{
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantErr: true,
+	}, {
+		name: "update service error",
+		args: service.Args{
+			ServiceMeta: metav1.ObjectMeta{
+				Name:      "my-svc",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			DeployMeta: metav1.ObjectMeta{
+				Name:      "my-svc-deploy",
+				Namespace: "my-ns",
+				Labels:    map[string]string{"app": "test"},
+			},
+			PodSpec: MakePodSpec(
+				"user-container",
+				"image.example.com",
+				WithPodContainerPort("", 8001),
+			),
+		},
+		reactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "services"),
+		},
+		objects: []runtime.Object{
+			NewDeployment("my-svc-deploy", "my-ns",
+				WithDeploymentOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithDeploymentLabels(map[string]string{"app": "test"}),
+				WithDeploymentPodSpec(MakePodSpec("user-container", "image.example.com", WithPodContainerPort("http", 8001))),
+			),
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		wantUpdates: []runtime.Object{
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8001)}}),
+			),
+		},
+		wantErr: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, logtesting.TestLogger(t))
+
+			ls := NewListers(tc.objects)
+			ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
+
+			for _, reactor := range tc.reactors {
+				kubeClient.PrependReactor("*", "*", reactor)
+			}
+			recorderList := ActionRecorderList{kubeClient}
+
+			svcReconciler := &ServiceReconciler{
+				KubeClientSet:    kubeClient,
+				DeploymentLister: ls.GetDeploymentLister(),
+				ServiceLister:    ls.GetServiceLister(),
+			}
+
+			status, err := svcReconciler.Reconcile(ctx, MakeOwnerReference(), tc.args)
+			if (err != nil) != tc.wantErr {
+				t.Error("Service reconcile got err=nil want err")
+			}
+
+			if diff := cmp.Diff(tc.wantStatus, status, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected create (-want, +got): %s", diff)
+			}
+
+			actions, err := recorderList.ActionsByVerb()
+			if err != nil {
+				t.Errorf("Error capturing actions by verb: %q", err)
+			}
+
+			for i, want := range tc.wantCreates {
+				if i >= len(actions.Creates) {
+					t.Errorf("Missing create: %#v", want)
+					continue
+				}
+				got := actions.Creates[i]
+				obj := got.GetObject()
+
+				if diff := cmp.Diff(want, obj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected create (-want, +got): %s", diff)
+				}
+			}
+			if got, want := len(actions.Creates), len(tc.wantCreates); got > want {
+				for _, extra := range actions.Creates[want:] {
+					t.Errorf("Extra create: %#v", extra.GetObject())
+				}
+			}
+
+			for i, want := range tc.wantUpdates {
+				if i >= len(actions.Updates) {
+					t.Errorf("Missing update: %#v", want)
+					continue
+				}
+				got := actions.Updates[i]
+				obj := got.GetObject()
+
+				if diff := cmp.Diff(want, obj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("Unexpected update (-want, +got): %s", diff)
+				}
+			}
+			if got, want := len(actions.Updates), len(tc.wantUpdates); got > want {
+				for _, extra := range actions.Updates[want:] {
+					t.Errorf("Extra update: %#v", extra.GetObject())
+				}
+			}
+		})
+	}
+}
+
+func TestGetStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		objects    []runtime.Object
+		reactors   []clientgotesting.ReactionFunc
+		svcMeta    metav1.ObjectMeta
+		wantStatus *service.Status
+		wantErr    bool
+	}{{
+		name: "successfully get status",
+		objects: []runtime.Object{
+			NewService("my-svc", "my-ns",
+				WithServiceOwnerReferences([]metav1.OwnerReference{MakeOwnerReference()}),
+				WithServiceLabels(map[string]string{"app": "test"}),
+				WithServicePorts([]corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromInt(8000)}}),
+			),
+		},
+		svcMeta: metav1.ObjectMeta{
+			Name:      "my-svc",
+			Namespace: "my-ns",
+			Labels:    map[string]string{"app": "test"},
+		},
+		wantStatus: &service.Status{
+			IsReady: true,
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   "my-svc.my-ns.svc.cluster.local",
+			},
+		},
+	}, {
+		name: "not found",
+		svcMeta: metav1.ObjectMeta{
+			Name:      "my-svc",
+			Namespace: "my-ns",
+			Labels:    map[string]string{"app": "test"},
+		},
+		wantErr: true,
+	}, {
+		name: "get service error",
+		svcMeta: metav1.ObjectMeta{
+			Name:      "my-svc",
+			Namespace: "my-ns",
+			Labels:    map[string]string{"app": "test"},
+		},
+		reactors: []clientgotesting.ReactionFunc{
+			InduceFailure("get", "services"),
+		},
+		wantErr: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, logtesting.TestLogger(t))
+
+			ls := NewListers(tc.objects)
+			ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
+
+			for _, reactor := range tc.reactors {
+				kubeClient.PrependReactor("*", "*", reactor)
+			}
+
+			svcReconciler := &ServiceReconciler{
+				KubeClientSet:    kubeClient,
+				DeploymentLister: ls.GetDeploymentLister(),
+				ServiceLister:    ls.GetServiceLister(),
+			}
+
+			status, err := svcReconciler.GetStatus(ctx, tc.svcMeta)
+			if (err != nil) != tc.wantErr {
+				t.Error("Service reconcile got err=nil want err")
+			}
+			if diff := cmp.Diff(tc.wantStatus, status, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected create (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func MakeOwnerReference() metav1.OwnerReference {
+	trueVal := true
+	return metav1.OwnerReference{
+		APIVersion:         "test.example.com/v1",
+		Kind:               "owner",
+		Name:               "owner",
+		BlockOwnerDeletion: &trueVal,
+		Controller:         &trueVal,
+	}
+}
+
+type PodSpecOption func(*corev1.PodSpec)
+
+func MakePodSpec(name, image string, opts ...PodSpecOption) corev1.PodSpec {
+	p := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  name,
+				Image: image,
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+	return *p
+}
+
+func WithPodContainerPort(name string, port int32) PodSpecOption {
+	return func(p *corev1.PodSpec) {
+		p.Containers[0].Ports = []corev1.ContainerPort{
+			{
+				Name:          name,
+				ContainerPort: port,
+			},
+		}
+	}
+}
+
+func WithPodContainerProbes(liveness, readiness *corev1.Probe) PodSpecOption {
+	return func(p *corev1.PodSpec) {
+		p.Containers[0].LivenessProbe = liveness
+		p.Containers[0].ReadinessProbe = readiness
+	}
+}
+
+var (
+	ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.HasSuffix(p.String(), "LastTransitionTime.Inner.Time")
+	}, cmp.Ignore())
+
+	safeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
+)

--- a/pkg/reconciler/testing/deployment.go
+++ b/pkg/reconciler/testing/deployment.go
@@ -96,3 +96,20 @@ func WithDeploymentAvailable() DeploymentOption {
 		}
 	}
 }
+
+func WithDeploymentPodSpec(podSpec corev1.PodSpec) DeploymentOption {
+	return func(d *appsv1.Deployment) {
+		d.Spec.Template.Spec = podSpec
+	}
+}
+
+func WithDeploymentNotAvailable() DeploymentOption {
+	return func(d *appsv1.Deployment) {
+		d.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionFalse,
+			},
+		}
+	}
+}


### PR DESCRIPTION
As multiple people have suggested, this is an attempt to split https://github.com/knative/eventing/pull/2425
The ksvc implementation will be contributed to `eventing-contrib` as well as the ksvc broker controller.

With the ongoing work for [broker class](https://docs.google.com/document/d/1pBLkMptwbdEHUgjn1K5Obf7Xe-G9PFGChQcDCZE9vMQ/edit), this change clears the way to enable the ksvc broker controller (to be contributed to `eventing-contrib`) with other eventing core controllers.

To be clear, this is just a local refactoring.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
