### PR TITLE
Add clearer release notes guidance to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -8,9 +8,17 @@ Fixes #
 
 **Release Note**
 
-<!-- Enter your extended release note in the below block. If the PR requires
-additional action from users switching to the new release, include the string
-"action required". If no release note is required, write "NONE". -->
+<!--
+In the following cases, write a brief release note describing the
+user-visible impact of this change in the release-note block:
+
+- 🎁 Add new feature
+- 🐛 Fix bug
+- 🧽 Update or clean up currrent behaviour
+- 🗑️ Remove feature or internal logic
+
+Write as if you are speaking to users, not other Knative contributors. If this
+change has no user-visible impact, no release-note is required.
 
 ```release-note
 

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -17,9 +17,11 @@ user-visible impact of this change in the release-note block:
 - 🧽 Update or clean up currrent behaviour
 - 🗑️ Remove feature or internal logic
 
-Write as if you are speaking to users, not other Knative contributors. If this
-change has no user-visible impact, no release-note is required.
+Include the string "action required" if additional action is required of
+users switching to the new release, for example in case of a breaking change.
 
+Write as if you are speaking to users, not other Knative contributors. If this
+change has no user-visible impact, no release-note is needed.
 ```release-note
 
 ```


### PR DESCRIPTION
To prepare for a future release notes compilation bot/process, here's an update to the PR template clarifying how people should write their own release notes.

The list of change types came from the [PR template used in knative/client](https://raw.githubusercontent.com/knative/client/master/.github/pull-request-template.md). I removed the requirement to edit the changelog file directly because I think that would cause merge conflicts. We can use automated processes to update that file instead. 

I added some words about focusing on user-visible impact, since IMO users don't care about `updated some internal Go interface` and having too many notes make the release harder to understand. 

/cc @vaikas