### PR TITLE
Use cloudevents goland sdk 1.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:3310d38d3fcfca84240997965eaf73d5105611ef4b99580f8ad744eb31df6f2e"
+  digest = "1:865b286da6b65d96df6b6858f282931cb2ccf1032df7f1874510a301e0b3a71d"
   name = "github.com/cloudevents/sdk-go"
   packages = [
     ".",
@@ -139,8 +139,8 @@
     "pkg/cloudevents/types",
   ]
   pruneopts = "NUT"
-  revision = "d289f68c35e89dd9b6a32b1d41faf60a0d9d090a"
-  version = "v0.11.0"
+  revision = "3673e23532dccb38196f600eec7e8b7090ecfb12"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,7 +91,7 @@ required = [
 
 [[constraint]]
   name = "github.com/cloudevents/sdk-go"
-  version = "0.11.0"
+  version = "1.0.0"
 
 # needed because pkg upgraded
 [[override]]

--- a/pkg/tracing/traceparent_test.go
+++ b/pkg/tracing/traceparent_test.go
@@ -19,6 +19,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go"
@@ -71,8 +72,8 @@ func TestAddTraceparentAttributeFromContext(t *testing.T) {
 					t.Fatalf("Unexpected traceparent value. Got %q. Want %q", tp.(string), expected)
 				}
 			} else {
-				if event != eventWithTraceparent {
-					t.Fatalf("Event changed unexpectedly. Got %v. Want %v", eventWithTraceparent, event)
+				if diff := cmp.Diff(event, eventWithTraceparent); diff != "" {
+					t.Fatalf("%s: Event changed unexpectedly (-want, +got) = %v", n, diff)
 				}
 			}
 		})

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event.go
@@ -13,11 +13,25 @@ type Event struct {
 	Data        interface{}
 	DataEncoded bool
 	DataBinary  bool
+	FieldErrors map[string]error
 }
 
 const (
-	defaultEventVersion = CloudEventsVersionV02
+	defaultEventVersion = CloudEventsVersionV1
 )
+
+func (e *Event) fieldError(field string, err error) {
+	if e.FieldErrors == nil {
+		e.FieldErrors = make(map[string]error, 0)
+	}
+	e.FieldErrors[field] = err
+}
+
+func (e *Event) fieldOK(field string) {
+	if e.FieldErrors != nil {
+		delete(e.FieldErrors, field)
+	}
+}
 
 // New returns a new Event, an optional version can be passed to change the
 // default spec version from 0.2 to the provided version.
@@ -51,6 +65,16 @@ func (e Event) ExtensionAs(name string, obj interface{}) error {
 func (e Event) Validate() error {
 	if e.Context == nil {
 		return fmt.Errorf("every event conforming to the CloudEvents specification MUST include a context")
+	}
+
+	if e.FieldErrors != nil {
+		errs := make([]string, 0)
+		for f, e := range e.FieldErrors {
+			errs = append(errs, fmt.Sprintf("%q: %s,", f, e))
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("previous field errors: [%s]", strings.Join(errs, "\n"))
+		}
 	}
 
 	if err := e.Context.Validate(); err != nil {

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_interface.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_interface.go
@@ -45,7 +45,8 @@ type EventReader interface {
 }
 
 // EventWriter is the interface for writing through an event onto attributes.
-// If an error is thrown by a sub-component, EventWriter panics.
+// If an error is thrown by a sub-component, EventWriter caches the error
+// internally and exposes errors with a call to event.Validate().
 type EventWriter interface {
 	// Context Attributes
 

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_writer.go
@@ -20,75 +20,97 @@ func (e *Event) SetSpecVersion(v string) {
 		case CloudEventsVersionV1:
 			e.Context = EventContextV1{}.AsV1()
 		default:
-			panic(fmt.Errorf("a valid spec version is required: [%s, %s, %s, %s]",
+			e.fieldError("specversion", fmt.Errorf("a valid spec version is required: [%s, %s, %s, %s]",
 				CloudEventsVersionV01, CloudEventsVersionV02, CloudEventsVersionV03, CloudEventsVersionV1))
+			return
 		}
+		e.fieldOK("specversion")
 		return
 	}
 	if err := e.Context.SetSpecVersion(v); err != nil {
-		panic(err)
+		e.fieldError("specversion", err)
+	} else {
+		e.fieldOK("specversion")
 	}
 }
 
 // SetType implements EventWriter.SetType
 func (e *Event) SetType(t string) {
 	if err := e.Context.SetType(t); err != nil {
-		panic(err)
+		e.fieldError("type", err)
+	} else {
+		e.fieldOK("type")
 	}
 }
 
 // SetSource implements EventWriter.SetSource
 func (e *Event) SetSource(s string) {
 	if err := e.Context.SetSource(s); err != nil {
-		panic(err)
+		e.fieldError("source", err)
+	} else {
+		e.fieldOK("source")
 	}
 }
 
 // SetSubject implements EventWriter.SetSubject
 func (e *Event) SetSubject(s string) {
 	if err := e.Context.SetSubject(s); err != nil {
-		panic(err)
+		e.fieldError("subject", err)
+	} else {
+		e.fieldOK("subject")
 	}
 }
 
 // SetID implements EventWriter.SetID
 func (e *Event) SetID(id string) {
 	if err := e.Context.SetID(id); err != nil {
-		panic(err)
+		e.fieldError("id", err)
+	} else {
+		e.fieldOK("id")
 	}
 }
 
 // SetTime implements EventWriter.SetTime
 func (e *Event) SetTime(t time.Time) {
 	if err := e.Context.SetTime(t); err != nil {
-		panic(err)
+		e.fieldError("time", err)
+	} else {
+		e.fieldOK("time")
 	}
 }
 
 // SetDataSchema implements EventWriter.SetDataSchema
 func (e *Event) SetDataSchema(s string) {
 	if err := e.Context.SetDataSchema(s); err != nil {
-		panic(err)
+		e.fieldError("dataschema", err)
+	} else {
+		e.fieldOK("dataschema")
 	}
 }
 
 // SetDataContentType implements EventWriter.SetDataContentType
 func (e *Event) SetDataContentType(ct string) {
 	if err := e.Context.SetDataContentType(ct); err != nil {
-		panic(err)
+		e.fieldError("datacontenttype", err)
+	} else {
+		e.fieldOK("datacontenttype")
 	}
 }
 
 // DeprecatedSetDataContentEncoding implements EventWriter.DeprecatedSetDataContentEncoding
 func (e *Event) SetDataContentEncoding(enc string) {
 	if err := e.Context.DeprecatedSetDataContentEncoding(enc); err != nil {
-		panic(err)
+		e.fieldError("datacontentencoding", err)
+	} else {
+		e.fieldOK("datacontentencoding")
 	}
 }
 
 // SetExtension implements EventWriter.SetExtension
 func (e *Event) SetExtension(name string, obj interface{}) {
 	if err := e.Context.SetExtension(name, obj); err != nil {
-		panic(err)
+		e.fieldError("extension:"+name, err)
+	} else {
+		e.fieldOK("extension:" + name)
 	}
 }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/transport/http/transport.go
@@ -170,7 +170,9 @@ func (t *Transport) Send(ctx context.Context, event cloudevents.Event) (context.
 func (t *Transport) obsSend(ctx context.Context, event cloudevents.Event) (context.Context, *cloudevents.Event, error) {
 	if t.Client == nil {
 		t.crMu.Lock()
-		t.Client = &http.Client{}
+		if t.Client == nil {
+			t.Client = &http.Client{}
+		}
 		t.crMu.Unlock()
 	}
 


### PR DESCRIPTION
## Proposed Changes

- Dep on cloudevents/sdk-go v1.0.0
- Fix a test that was using != on an event.

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up currrent behaviour
- 🗑️ Remove feature or internal logic

Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
```release-note
NONE
```
