### PR TITLE
Use e2 VMs instead of n1 for for performance tests

### DIFF
--- a/test/performance/benchmarks/broker-imc/cluster.yaml
+++ b/test/performance/benchmarks/broker-imc/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-central1"
   nodeCount: 1
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"

--- a/test/performance/benchmarks/channel-imc/cluster.yaml
+++ b/test/performance/benchmarks/channel-imc/cluster.yaml
@@ -17,5 +17,5 @@
 GKECluster:
   location: "us-central1"
   nodeCount: 1
-  nodeType: "n1-standard-4"
+  nodeType: "e2-standard-4"
   addons: "HorizontalPodAutoscaling,HttpLoadBalancing"


### PR DESCRIPTION
It's more efficient on Google Cloud.