### PR TITLE
Adding CloudEvents Overrides to SinkBinding.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bazel-*
 .DS_Store
 *.swp
 .history
+tmp/

--- a/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle.go
@@ -123,7 +123,7 @@ func (sb *SinkBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		if len(c.Env) == 0 {
 			continue
 		}
-		env := make([]corev1.EnvVar, 0)
+		env := make([]corev1.EnvVar, 0, len(spec.InitContainers[i].Env))
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "K_SINK", "K_CE_OVERRIDES":
@@ -138,7 +138,7 @@ func (sb *SinkBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 		if len(c.Env) == 0 {
 			continue
 		}
-		env := make([]corev1.EnvVar, 0)
+		env := make([]corev1.EnvVar, 0, len(spec.Containers[i].Env))
 		for j, ev := range c.Env {
 			switch ev.Name {
 			case "K_SINK", "K_CE_OVERRIDES":

--- a/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -84,11 +85,24 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 		return
 	}
 
+	var ceOverrides string
+	if sb.Spec.CloudEventOverrides != nil {
+		if co, err := json.Marshal(sb.Spec.SourceSpec.CloudEventOverrides); err != nil {
+			logging.FromContext(ctx).Error(fmt.Sprintf("Failed to marshal CloudEventOverrides into JSON for %+v, %v", sb, err))
+		} else if len(co) > 0 {
+			ceOverrides = string(co)
+		}
+	}
+
 	spec := ps.Spec.Template.Spec
 	for i := range spec.InitContainers {
 		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
 			Name:  "K_SINK",
 			Value: uri.String(),
+		})
+		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
+			Name:  "K_CE_OVERRIDES",
+			Value: ceOverrides,
 		})
 	}
 	for i := range spec.Containers {
@@ -96,25 +110,43 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			Name:  "K_SINK",
 			Value: uri.String(),
 		})
+		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+			Name:  "K_CE_OVERRIDES",
+			Value: ceOverrides,
+		})
 	}
 }
 
 func (sb *SinkBinding) Undo(ctx context.Context, ps *duckv1.WithPod) {
 	spec := ps.Spec.Template.Spec
 	for i, c := range spec.InitContainers {
+		if len(c.Env) == 0 {
+			continue
+		}
+		env := make([]corev1.EnvVar, 0)
 		for j, ev := range c.Env {
-			if ev.Name == "K_SINK" {
-				spec.InitContainers[i].Env = append(spec.InitContainers[i].Env[:j], spec.InitContainers[i].Env[j+1:]...)
-				break
+			switch ev.Name {
+			case "K_SINK", "K_CE_OVERRIDES":
+				continue
+			default:
+				env = append(env, spec.InitContainers[i].Env[j])
 			}
 		}
+		spec.InitContainers[i].Env = env
 	}
 	for i, c := range spec.Containers {
+		if len(c.Env) == 0 {
+			continue
+		}
+		env := make([]corev1.EnvVar, 0)
 		for j, ev := range c.Env {
-			if ev.Name == "K_SINK" {
-				spec.Containers[i].Env = append(spec.Containers[i].Env[:j], spec.Containers[i].Env[j+1:]...)
-				break
+			switch ev.Name {
+			case "K_SINK", "K_CE_OVERRIDES":
+				continue
+			default:
+				env = append(env, spec.Containers[i].Env[j])
 			}
 		}
+		spec.Containers[i].Env = env
 	}
 }

--- a/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle_test.go
@@ -170,6 +170,9 @@ func TestSinkBindingUndo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: "http://localhost:8080",
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -184,6 +187,9 @@ func TestSinkBindingUndo(t *testing.T) {
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}, {
 							Name:  "sidecar",
@@ -194,6 +200,9 @@ func TestSinkBindingUndo(t *testing.T) {
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 					},
@@ -253,6 +262,8 @@ func TestSinkBindingDo(t *testing.T) {
 		Path:   "/a/path",
 	}
 
+	overrides := duckv1.CloudEventOverrides{Extensions: map[string]string{"foo": "bar"}}
+
 	tests := []struct {
 		name string
 		in   *duckv1.WithPod
@@ -269,6 +280,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 					},
@@ -285,6 +299,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 					},
@@ -303,6 +320,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: "the wrong value",
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"wrong":"value"}}`,
 							}},
 						}},
 					},
@@ -319,6 +339,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 					},
@@ -326,7 +349,7 @@ func TestSinkBindingDo(t *testing.T) {
 			},
 		},
 	}, {
-		name: "lots of uris",
+		name: "lots to add",
 		in: &duckv1.WithPod{
 			Spec: duckv1.WithPodSpec{
 				Template: duckv1.PodSpecable{
@@ -367,6 +390,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -381,6 +407,9 @@ func TestSinkBindingDo(t *testing.T) {
 							}, {
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}, {
 							Name:  "sidecar",
@@ -391,6 +420,9 @@ func TestSinkBindingDo(t *testing.T) {
 							}, {
 								Name:  "K_SINK",
 								Value: sinkURI.String(),
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
 						}},
 					},
@@ -405,7 +437,11 @@ func TestSinkBindingDo(t *testing.T) {
 
 			ctx := WithSinkURI(context.Background(), sinkURI)
 
-			sb := &SinkBinding{}
+			sb := &SinkBinding{Spec: SinkBindingSpec{
+				SourceSpec: duckv1.SourceSpec{
+					CloudEventOverrides: &overrides,
+				},
+			}}
 			sb.Do(ctx, got)
 
 			if !cmp.Equal(got, test.want) {
@@ -439,6 +475,9 @@ func TestSinkBindingDoNoURI(t *testing.T) {
 						Env: []corev1.EnvVar{{
 							Name:  "K_SINK",
 							Value: "this should be removed",
+						}, {
+							Name:  "K_CE_OVERRIDES",
+							Value: `{"extensions":{"tobe":"removed"}}`,
 						}},
 					}},
 				},

--- a/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/sinkbinding_lifecycle_test.go
@@ -168,8 +168,14 @@ func TestSinkBindingUndo(t *testing.T) {
 							Name:  "setup",
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
+								Name:  "FOO",
+								Value: "BAR",
+							}, {
 								Name:  "K_SINK",
 								Value: "http://localhost:8080",
+							}, {
+								Name:  "BAZ",
+								Value: "INGA",
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -216,7 +222,13 @@ func TestSinkBindingUndo(t *testing.T) {
 						InitContainers: []corev1.Container{{
 							Name:  "setup",
 							Image: "busybox",
-							Env:   []corev1.EnvVar{},
+							Env: []corev1.EnvVar{{
+								Name:  "FOO",
+								Value: "BAR",
+							}, {
+								Name:  "BAZ",
+								Value: "INGA",
+							}},
 						}},
 						Containers: []corev1.Container{{
 							Name:  "blah",

--- a/pkg/reconciler/testing/containersource.go
+++ b/pkg/reconciler/testing/containersource.go
@@ -92,6 +92,13 @@ func WithSink(sink duckv1.Destination) SinkBindingOption {
 	}
 }
 
+// WithCloudEventOverrides assigns the CloudEventsOverrides of the SinkBinding.
+func WithCloudEventOverrides(overrides duckv1.CloudEventOverrides) SinkBindingOption {
+	return func(sb *sourcesv1alpha1.SinkBinding) {
+		sb.Spec.CloudEventOverrides = &overrides
+	}
+}
+
 // ContainerSourceOption enables further configuration of a ContainerSource.
 type ContainerSourceOption func(*legacysourcesv1alpha1.ContainerSource)
 

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -18,14 +18,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"log"
 	"os"
 	"strconv"
 	"time"
-
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 
 	"knative.dev/eventing/pkg/kncloudevents"
 
@@ -54,6 +54,9 @@ type envConfig struct {
 	// Sink URL where to send heartbeat cloudevents
 	Sink string `envconfig:"K_SINK"`
 
+	// Environment variable containing the name of the adapter.
+	CEOverrides string `envconfig:"K_CE_OVERRIDES"`
+
 	// Name of this pod.
 	Name string `envconfig:"POD_NAME" required:"true"`
 
@@ -76,6 +79,17 @@ func main() {
 		sink = env.Sink
 	}
 
+	var ceOverrides *duckv1.CloudEventOverrides
+	if len(env.CEOverrides) > 0 {
+		overrides := duckv1.CloudEventOverrides{}
+		err := json.Unmarshal([]byte(env.CEOverrides), &overrides)
+		if err != nil {
+			log.Printf("[ERROR] Unparseable CloudEvents overrides %s: %v", env.CEOverrides, err)
+			os.Exit(1)
+		}
+		ceOverrides = &overrides
+	}
+
 	c, err := kncloudevents.NewDefaultClient(sink)
 	if err != nil {
 		log.Fatalf("failed to create client: %s", err.Error())
@@ -88,8 +102,7 @@ func main() {
 		period = time.Duration(p) * time.Second
 	}
 
-	source := types.ParseURLRef(
-		fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", env.Namespace, env.Name))
+	source := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", env.Namespace, env.Name)
 	log.Printf("Heartbeats Source: %s", source)
 
 	hb := &Heartbeat{
@@ -100,19 +113,19 @@ func main() {
 	for {
 		hb.Sequence++
 
-		event := cloudevents.Event{
-			Context: cloudevents.EventContextV02{
-				Type:   "dev.knative.eventing.samples.heartbeat",
-				Source: *source,
-				Extensions: map[string]interface{}{
-					"the":   42,
-					"heart": "yes",
-					"beats": true,
-				},
-			}.AsV1(),
-			Data: hb,
-		}
+		event := cloudevents.NewEvent("1.0")
+		event.SetType("dev.knative.eventing.samples.heartbeat")
+		event.SetSource(source)
 		event.SetDataContentType(cloudevents.ApplicationJSON)
+		event.SetExtension("the", 42)
+		event.SetExtension("heart", "yes")
+		event.SetExtension("beats", true)
+
+		if ceOverrides != nil && ceOverrides.Extensions != nil {
+			for n, v := range ceOverrides.Extensions {
+				event.SetExtension(n, v)
+			}
+		}
 
 		log.Printf("sending cloudevent to %s", sink)
 		if _, _, err := c.Send(context.Background(), event); err != nil {

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -127,6 +127,10 @@ func main() {
 			}
 		}
 
+		if err := event.SetData(hb); err != nil {
+			log.Printf("failed to set cloudevents data: %s", err.Error())
+		}
+
 		log.Printf("sending cloudevent to %s", sink)
 		if _, _, err := c.Send(context.Background(), event); err != nil {
 			log.Printf("failed to send cloudevent: %s", err.Error())

--- a/test/test_images/heartbeats/main.go
+++ b/test/test_images/heartbeats/main.go
@@ -54,7 +54,7 @@ type envConfig struct {
 	// Sink URL where to send heartbeat cloudevents
 	Sink string `envconfig:"K_SINK"`
 
-	// Environment variable containing the name of the adapter.
+	// CEOverrides are the CloudEvents overrides to be applied to the outbound event.
 	CEOverrides string `envconfig:"K_CE_OVERRIDES"`
 
 	// Name of this pod.

--- a/test/test_images/logevents/main.go
+++ b/test/test_images/logevents/main.go
@@ -29,7 +29,7 @@ import (
 
 func handler(event cloudevents.Event) {
 	if err := event.Validate(); err == nil {
-		log.Printf("%s", event.Data.([]byte))
+		log.Printf("%s", event.String())
 	} else {
 		log.Printf("error validating the event: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes

- Propagate the CloudEvent Overrides to the subject for SinkBinding.

**Release Note**

```release-note
SinkBinding now propagates the `sinkBinding.spec.ceOverrides` values as json into an env var called `K_CE_OVERRIDES`. See the Source ducktype to unmarshal this value.
```

/assign @mattmoor 