### PR TITLE
ConfigMapPropagation should keep other owner references when abandoning a copy configmap

### DIFF
--- a/pkg/reconciler/configmappropagation/configmappropagation.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation.go
@@ -277,6 +277,13 @@ func (r *Reconciler) reconcileConfigMap(ctx context.Context, cmp *v1alpha1.Confi
 	return errs
 }
 
+////  patchStringValue specifies a patch operation for a uint32.
+//type patchUInt32Value struct {
+//	Op    string `json:"op"`
+//	Path  string `json:"path"`
+//	Value uint32 `json:"value"`
+//}
+
 // createOrUpdateConfigMaps will return error and bool (represents whether a create/update action is successful or not).
 func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1.ConfigMapPropagation, configMap *corev1.ConfigMap) (error, bool) {
 	expected := resources.MakeConfigMap(resources.ConfigMapArgs{
@@ -299,6 +306,14 @@ func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1
 			//  so that this copy configmap will not be deleted if cmp is deleted.
 			expected = current.DeepCopy()
 			expected.OwnerReferences = nil
+			//payload := []patchUInt32Value{{
+			//	Op:    "remove",
+			//	Path:  "/metadata/ownerReferences/uid/" + string(cmp.UID),
+			//}}
+			//payloadBytes, _ := json.Marshal(payload)
+			//if current, err = r.KubeClientSet.CoreV1().ConfigMaps(expected.Namespace).Patch(current.Name, types.StrategicMergePatchType, payloadBytes); err != nil {
+			//	return fmt.Errorf("error updating ConfigMap in current namespace: %w", err), false
+			//}
 			// It will return false for the create/update action is not successful, due to removed copy label.
 			// But it is not an error for ConfigMapPropagation for not propagating successfully.
 			succeed = false

--- a/pkg/reconciler/configmappropagation/configmappropagation.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation.go
@@ -299,7 +299,7 @@ func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1
 			//  so that this copy configmap will not be deleted if cmp is deleted.
 			expected = current.DeepCopy()
 			// Delete the CMP owner reference, and keep all other owner references (if any).
-			expected.OwnerReferences = r.removeOwnerReference(expected.OwnerReferences, cmp.UID)
+			expected.OwnerReferences = removeOwnerReference(expected.OwnerReferences, cmp.UID)
 			// It will return false for the create/update action is not successful, due to removed copy label.
 			// But it is not an error for ConfigMapPropagation for not propagating successfully.
 			succeed = false
@@ -318,7 +318,7 @@ func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1
 
 // deleteOrKeepConfigMap will return error and bool (represents whether a delete action is successful or not).
 func (r *Reconciler) deleteOrKeepConfigMap(ctx context.Context, cmp *v1alpha1.ConfigMapPropagation, copyConfigMap *corev1.ConfigMap, originalConfigMapName string, originalConfigMapList []*corev1.ConfigMap) (error, bool) {
-	originalConfigMap, contains := r.contains(originalConfigMapName, originalConfigMapList)
+	originalConfigMap, contains := contains(originalConfigMapName, originalConfigMapList)
 	expectedSelector := resources.ExpectedOriginalSelector(cmp.Spec.Selector)
 	if !contains || !expectedSelector.Matches(labels.Set(originalConfigMap.Labels)) {
 		// If Original ConfigMap no longer exists or no longer has the required label, delete copy ConfigMap.
@@ -334,7 +334,7 @@ func (r *Reconciler) deleteOrKeepConfigMap(ctx context.Context, cmp *v1alpha1.Co
 }
 
 // contains returns a configmap object if its name is in a configmaplist.
-func (r *Reconciler) contains(name string, list []*corev1.ConfigMap) (*corev1.ConfigMap, bool) {
+func contains(name string, list []*corev1.ConfigMap) (*corev1.ConfigMap, bool) {
 	for _, configMap := range list {
 		if configMap.Name == name {
 			return configMap, true
@@ -344,11 +344,11 @@ func (r *Reconciler) contains(name string, list []*corev1.ConfigMap) (*corev1.Co
 }
 
 // removeOwnerReference removes the target ownerReference and returns a new slice of ownerReferences.
-func (r *Reconciler) removeOwnerReference(ownerReferences []metav1.OwnerReference, uid types.UID) []metav1.OwnerReference {
+func removeOwnerReference(ownerReferences []metav1.OwnerReference, uid types.UID) []metav1.OwnerReference {
 	var expected []metav1.OwnerReference
 	for _, owner := range ownerReferences {
 		if owner.UID != uid {
-			expected = append(expected, *owner.DeepCopy())
+			expected = append(expected, owner)
 		}
 	}
 	return expected

--- a/pkg/reconciler/configmappropagation/configmappropagation.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation.go
@@ -277,13 +277,6 @@ func (r *Reconciler) reconcileConfigMap(ctx context.Context, cmp *v1alpha1.Confi
 	return errs
 }
 
-////  patchStringValue specifies a patch operation for a uint32.
-//type patchUInt32Value struct {
-//	Op    string `json:"op"`
-//	Path  string `json:"path"`
-//	Value uint32 `json:"value"`
-//}
-
 // createOrUpdateConfigMaps will return error and bool (represents whether a create/update action is successful or not).
 func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1.ConfigMapPropagation, configMap *corev1.ConfigMap) (error, bool) {
 	expected := resources.MakeConfigMap(resources.ConfigMapArgs{
@@ -305,15 +298,20 @@ func (r *Reconciler) createOrUpdateConfigMaps(ctx context.Context, cmp *v1alpha1
 			//  OwnerReference will be removed when the knative.dev/config-propagation:copy label is not set in copy configmap
 			//  so that this copy configmap will not be deleted if cmp is deleted.
 			expected = current.DeepCopy()
-			expected.OwnerReferences = nil
-			//payload := []patchUInt32Value{{
-			//	Op:    "remove",
-			//	Path:  "/metadata/ownerReferences/uid/" + string(cmp.UID),
-			//}}
-			//payloadBytes, _ := json.Marshal(payload)
-			//if current, err = r.KubeClientSet.CoreV1().ConfigMaps(expected.Namespace).Patch(current.Name, types.StrategicMergePatchType, payloadBytes); err != nil {
-			//	return fmt.Errorf("error updating ConfigMap in current namespace: %w", err), false
-			//}
+			// Delete the CMP owner reference, and keep all other owner references (if any)
+			if len(expected.OwnerReferences) > 0 {
+				index := -1
+				for i, owner := range expected.OwnerReferences {
+					if owner.UID == cmp.UID {
+						index = i
+						break
+					}
+				}
+				if index != -1 {
+					expected.OwnerReferences[len(expected.OwnerReferences)-1], expected.OwnerReferences[index] = expected.OwnerReferences[index], expected.OwnerReferences[len(expected.OwnerReferences)-1]
+					expected.OwnerReferences = expected.OwnerReferences[:len(expected.OwnerReferences)-1]
+				}
+			}
 			// It will return false for the create/update action is not successful, due to removed copy label.
 			// But it is not an error for ConfigMapPropagation for not propagating successfully.
 			succeed = false

--- a/pkg/reconciler/configmappropagation/configmappropagation_test.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation_test.go
@@ -352,7 +352,7 @@ func TestAllCase(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, configMapPropagationReadinessChanged, "ConfigMapPropagation %q became ready", configMapPropagationName),
 			},
 		}, {
-			Name: "Copy ConfigMap no longer has required labels",
+			Name: "Copy ConfigMap no longer has required labels, with only one owner reference",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewConfigMapPropagation(configMapPropagationName, currentNS,
@@ -377,6 +377,55 @@ func TestAllCase(t *testing.T) {
 					WithConfigMapLabels(metav1.LabelSelector{
 						MatchLabels: map[string]string{},
 					}),
+				),
+			}},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewConfigMapPropagation(configMapPropagationName, currentNS,
+					WithInitConfigMapPropagationConditions,
+					WithConfigMapPropagationSelector(selector),
+					WithConfigMapPropagationPropagated,
+					WithInitConfigMapStatus(),
+					WithCopyConfigMapStatus("test-cmp-test-original-cm", "knative-eventing/test-original-cm",
+						"Stop", "True", `copy ConfigMap doesn't have copy label, stop propagating this ConfigMap`),
+				),
+			}},
+			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, configMapPropagationPropagateSingleConfigMapSucceed,
+					`Stop propagating ConfigMap: test-original-cm`),
+				Eventf(corev1.EventTypeNormal, configMapPropagationReadinessChanged, "ConfigMapPropagation %q became ready", configMapPropagationName),
+			},
+		}, {
+			Name: "Copy ConfigMap no longer has required labels, with multiple owner references",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewConfigMapPropagation(configMapPropagationName, currentNS,
+					WithInitConfigMapPropagationConditions,
+					WithConfigMapPropagationSelector(selector),
+				),
+				NewConfigMapPropagation("default", currentNS,
+					WithInitConfigMapPropagationConditions,
+				),
+				NewConfigMap(originalConfigMapName, originalNS,
+					WithConfigMapLabels(originalSelector),
+				),
+				NewConfigMap(copyConfigMapName, currentNS,
+					WithConfigMapLabels(metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					}),
+					WithConfigMapOwnerReference(NewConfigMapPropagation(configMapPropagationName, currentNS,
+						WithInitConfigMapPropagationConditions,
+						WithConfigMapPropagationSelector(selector),
+					)),
+					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions)),
+				),
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewConfigMap(copyConfigMapName, currentNS,
+					WithConfigMapLabels(metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					}),
+					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions)),
 				),
 			}},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/configmappropagation/configmappropagation_test.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation_test.go
@@ -405,6 +405,7 @@ func TestAllCase(t *testing.T) {
 				),
 				NewConfigMapPropagation("default", currentNS,
 					WithInitConfigMapPropagationConditions,
+					WithConfigMapPropagationUID("1234"),
 				),
 				NewConfigMap(originalConfigMapName, originalNS,
 					WithConfigMapLabels(originalSelector),
@@ -417,7 +418,7 @@ func TestAllCase(t *testing.T) {
 						WithInitConfigMapPropagationConditions,
 						WithConfigMapPropagationSelector(selector),
 					)),
-					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions)),
+					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions, WithConfigMapPropagationUID("1234"))),
 				),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -425,7 +426,7 @@ func TestAllCase(t *testing.T) {
 					WithConfigMapLabels(metav1.LabelSelector{
 						MatchLabels: map[string]string{},
 					}),
-					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions)),
+					WithConfigMapOwnerReference(NewConfigMapPropagation("additional", currentNS, WithInitConfigMapPropagationConditions, WithConfigMapPropagationUID("1234"))),
 				),
 			}},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -49,9 +49,10 @@ func WithConfigMapLabels(labels metav1.LabelSelector) ConfigMapOption {
 
 func WithConfigMapOwnerReference(ConfigMapPropagation *v1alpha1.ConfigMapPropagation) ConfigMapOption {
 	return func(cm *v1.ConfigMap) {
-		cm.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			*kmeta.NewControllerRef(ConfigMapPropagation),
+		if cm.ObjectMeta.OwnerReferences == nil {
+			cm.ObjectMeta.OwnerReferences = []metav1.OwnerReference{}
 		}
+		cm.ObjectMeta.OwnerReferences = append(cm.ObjectMeta.OwnerReferences, *kmeta.NewControllerRef(ConfigMapPropagation))
 	}
 }
 

--- a/pkg/reconciler/testing/configmappropagation.go
+++ b/pkg/reconciler/testing/configmappropagation.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/eventing/pkg/apis/configs/v1alpha1"
 )
 
@@ -86,6 +88,12 @@ func WithConfigMapPropagationGeneration(gen int64) ConfigMapPropagationOption {
 func WithConfigMapPropagationStatusObservedGeneration(gen int64) ConfigMapPropagationOption {
 	return func(cmp *v1alpha1.ConfigMapPropagation) {
 		cmp.Status.ObservedGeneration = gen
+	}
+}
+
+func WithConfigMapPropagationUID(uid string) ConfigMapPropagationOption {
+	return func(cmp *v1alpha1.ConfigMapPropagation) {
+		cmp.UID = types.UID(uid)
 	}
 }
 


### PR DESCRIPTION
Fixes #2437

## Proposed Changes

- ConfigMapPropagation controller only deletes the CMP owner reference from the ConfigMap, and keeps other owner references (if any)
- A unit test
-

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.

-->

```release-note
```
