### PR TITLE
POC: auto configmap update for alternate broker

### DIFF
--- a/config/100-config-broker.yaml
+++ b/config/100-config-broker.yaml
@@ -29,7 +29,11 @@ data:
         },
         "initialDelaySeconds":5,
         "periodSeconds":2
-      }
+      },
+      "maxIdleConns":1000,
+      "maxIdleConnsPerHost":1000,
+      "ttl": 255,
+      "metricsPort": 9092
     }
   filter-config: |
     {

--- a/config/100-config-broker.yaml
+++ b/config/100-config-broker.yaml
@@ -48,5 +48,8 @@ data:
         },
         "initialDelaySeconds":5,
         "periodSeconds":2
-      }
+      },
+      "maxIdleConns":1000,
+      "maxIdleConnsPerHost":100,
+      "metricsPort": 9092
     }

--- a/config/100-config-broker.yaml
+++ b/config/100-config-broker.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }
+  filter-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      },
+      "readinessProbe":{
+        "httpGet":{
+          "path":"/readyz",
+          "port":8080
+        },
+        "initialDelaySeconds":5,
+        "periodSeconds":2
+      }
+    }

--- a/pkg/broker/config/store.go
+++ b/pkg/broker/config/store.go
@@ -47,6 +47,16 @@ var DefaultBrokerConfig = BrokerConfig{
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       2,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			// Defaults for the underlying HTTP Client transport. These would enable better connection reuse.
+			// Purposely set them to be equal, as the ingress only connects to its channel.
+			// These are magic numbers, partly set based on empirical evidence running performance workloads, and partly
+			// based on what serving is doing. See https://github.com/knative/serving/blob/master/pkg/network/transports.go.
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 1000,
+		},
+		TTL: 255,
+		MetricsPort: 9092,
 	},
 	FilterConfig: FilterConfig{
 		LivenessProbe: corev1.Probe{
@@ -84,6 +94,9 @@ var DefaultBrokerConfig = BrokerConfig{
 // IngressConfig holds the configuration parameters for the broker ingress.
 type IngressConfig struct {
 	LivenessProbe corev1.Probe
+	kncloudevents.ConnectionArgs
+	TTL         int32
+	MetricsPort int
 }
 
 // FilterConfig holds the configuration parameters for the broker filter.

--- a/pkg/broker/config/store.go
+++ b/pkg/broker/config/store.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	knconfigmap "knative.dev/pkg/configmap"
+)
+
+const (
+	// BrokerConfigMap is the name of the configmap for the broker.
+	BrokerConfigMap = "config-broker"
+	// IngressConfigKey is the key in the "Data" field of the configmap for the broker ingress.
+	IngressConfigKey = "ingress-config"
+	// FilterConfigKey is the key in the "Data" field of the configmap for the broker filter.
+	FilterConfigKey = "filter-config"
+)
+
+// DefaultBrokerConfig is the default config for the broker.
+var DefaultBrokerConfig = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+}
+
+// IngressConfig holds the configuration parameters for the broker ingress.
+type IngressConfig struct {
+	LivenessProbe corev1.Probe
+}
+
+// FilterConfig holds the configuration parameters for the broker filter.
+type FilterConfig struct {
+	LivenessProbe  corev1.Probe
+	ReadinessProbe corev1.Probe
+}
+
+// BrokerConfig is the in memory representation of the broker configmap.
+type BrokerConfig struct {
+	IngressConfig IngressConfig
+	FilterConfig  FilterConfig
+}
+
+// NewConfigFromConfigMap converts a k8s configmap into BrokerConfig.
+func NewConfigFromConfigMap(config *corev1.ConfigMap) (BrokerConfig, error) {
+	// Initialize with default config so that if a field is missing in the configmap, its default
+	// value will be applied.
+	c := DefaultBrokerConfig
+	err := json.Unmarshal([]byte(config.Data[IngressConfigKey]), &c.IngressConfig)
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal([]byte(config.Data[FilterConfigKey]), &c.FilterConfig)
+	return c, err
+}
+
+// Store loads/unloads untyped configuration from configmap.
+type Store struct {
+	logger knconfigmap.Logger
+	*knconfigmap.UntypedStore
+}
+
+// NewStore creates a new broker configuration store.
+func NewStore(logger knconfigmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
+	return &Store{
+		logger: logger,
+		UntypedStore: knconfigmap.NewUntypedStore(
+			"broker_config",
+			logger,
+			knconfigmap.Constructors{
+				BrokerConfigMap: NewConfigFromConfigMap,
+			},
+			onAfterStore...,
+		),
+	}
+}
+
+// GetConfig returns the current config in the store.
+func (s *Store) GetConfig() BrokerConfig {
+	config := s.UntypedStore.UntypedLoad(BrokerConfigMap)
+	if config == nil {
+		// This should only happen in tests where we don't watch for the configmap and therefore the
+		// store is not populated with data.
+		s.logger.Errorf("Failed to load config from store, returning default config: %v.", DefaultBrokerConfig)
+		return DefaultBrokerConfig
+	}
+	return config.(BrokerConfig)
+}

--- a/pkg/broker/config/store.go
+++ b/pkg/broker/config/store.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/eventing/pkg/kncloudevents"
 	knconfigmap "knative.dev/pkg/configmap"
 )
 
@@ -68,6 +69,15 @@ var DefaultBrokerConfig = BrokerConfig{
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       2,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			// Defaults for the underlying HTTP Client transport. These would enable better connection reuse.
+			// Set them on a 10:1 ratio, but this would actually depend on the Triggers' subscribers and the workload itself.
+			// These are magic numbers, partly set based on empirical evidence running performance workloads, and partly
+			// based on what serving is doing. See https://github.com/knative/serving/blob/master/pkg/network/transports.go.
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 100,
+		},
+		MetricsPort: 9092,
 	},
 }
 
@@ -80,6 +90,8 @@ type IngressConfig struct {
 type FilterConfig struct {
 	LivenessProbe  corev1.Probe
 	ReadinessProbe corev1.Probe
+	kncloudevents.ConnectionArgs
+	MetricsPort int
 }
 
 // BrokerConfig is the in memory representation of the broker configmap.

--- a/pkg/broker/config/store_test.go
+++ b/pkg/broker/config/store_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"knative.dev/eventing/pkg/kncloudevents"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -62,6 +63,11 @@ var wantFromFullConfigMap = BrokerConfig{
 			InitialDelaySeconds: 50,
 			PeriodSeconds:       20,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 1,
+		},
+		MetricsPort: 10,
 	},
 }
 
@@ -101,6 +107,11 @@ var wantFromPartialConfigMap = BrokerConfig{
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       2,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 1,
+		},
+		MetricsPort: 10,
 	},
 }
 

--- a/pkg/broker/config/store_test.go
+++ b/pkg/broker/config/store_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	configmaptesting "knative.dev/pkg/configmap/testing"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// expected config corresponding to `config-broker.yaml`
+var wantFromFullConfigMap = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+}
+
+// expected config corresponding to `config-broker-partial.yaml`
+var wantFromPartialConfigMap = BrokerConfig{
+	IngressConfig: IngressConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+	},
+	FilterConfig: FilterConfig{
+		LivenessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 50,
+			PeriodSeconds:       20,
+		},
+		// ReadinessProbe not provided in configmap. Defaults should be applied.
+		ReadinessProbe: corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+		},
+	},
+}
+
+func TestGetConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		configmap string
+		want      BrokerConfig
+	}{
+		{
+			name:      "full config provided in configmap",
+			configmap: "config-broker",
+			want:      wantFromFullConfigMap,
+		},
+		{
+			name:      "readiness probe not provided in configmap",
+			configmap: "config-broker-partial",
+			want:      wantFromPartialConfigMap,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(logtesting.TestLogger(t))
+			configmap := configmaptesting.ConfigMapFromTestFile(t, tt.configmap, IngressConfigKey, FilterConfigKey)
+			store.OnConfigChanged(configmap)
+			got := store.GetConfig()
+			if dif := cmp.Diff(got, tt.want); dif != "" {
+				fmt.Println("Dif:", dif)
+				t.Errorf("BrokerConfig mismatch. Dif: %+v \n", dif)
+			}
+		})
+	}
+}

--- a/pkg/broker/config/store_test.go
+++ b/pkg/broker/config/store_test.go
@@ -41,6 +41,12 @@ var wantFromFullConfigMap = BrokerConfig{
 			InitialDelaySeconds: 50,
 			PeriodSeconds:       20,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 10,
+		},
+		TTL:         10,
+		MetricsPort: 10,
 	},
 	FilterConfig: FilterConfig{
 		LivenessProbe: corev1.Probe{
@@ -84,6 +90,12 @@ var wantFromPartialConfigMap = BrokerConfig{
 			InitialDelaySeconds: 50,
 			PeriodSeconds:       20,
 		},
+		ConnectionArgs: kncloudevents.ConnectionArgs{
+			MaxIdleConns:        10,
+			MaxIdleConnsPerHost: 10,
+		},
+		TTL:         10,
+		MetricsPort: 10,
 	},
 	FilterConfig: FilterConfig{
 		LivenessProbe: corev1.Probe{

--- a/pkg/broker/config/testdata/config-broker-partial.yaml
+++ b/pkg/broker/config/testdata/config-broker-partial.yaml
@@ -32,7 +32,11 @@ data:
         },
         "initialDelaySeconds":50,
         "periodSeconds":20
-      }
+      },
+      "maxIdleConns":10,
+      "maxIdleConnsPerHost":10,
+      "ttl": 10,
+      "metricsPort": 10
     }
   filter-config: | # The readiness probe is intentionally left blank to test that default values are applied.
     {

--- a/pkg/broker/config/testdata/config-broker-partial.yaml
+++ b/pkg/broker/config/testdata/config-broker-partial.yaml
@@ -43,5 +43,8 @@ data:
         },
         "initialDelaySeconds":50,
         "periodSeconds":20
-      }
+      },
+      "maxIdleConns":10,
+      "maxIdleConnsPerHost":1,
+      "metricsPort": 10
     }

--- a/pkg/broker/config/testdata/config-broker-partial.yaml
+++ b/pkg/broker/config/testdata/config-broker-partial.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  # The ConfigMapFromTestFile helper method expects a key named "_example" and it's dummy here.
+  _example: |
+    dummy: "nothing"
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }
+  filter-config: | # The readiness probe is intentionally left blank to test that default values are applied.
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }

--- a/pkg/broker/config/testdata/config-broker.yaml
+++ b/pkg/broker/config/testdata/config-broker.yaml
@@ -32,7 +32,11 @@ data:
         },
         "initialDelaySeconds":50,
         "periodSeconds":20
-      }
+      },
+      "maxIdleConns":10,
+      "maxIdleConnsPerHost":10,
+      "ttl": 10,
+      "metricsPort": 10
     }
   filter-config: |
     {

--- a/pkg/broker/config/testdata/config-broker.yaml
+++ b/pkg/broker/config/testdata/config-broker.yaml
@@ -51,5 +51,8 @@ data:
         },
         "initialDelaySeconds":50,
         "periodSeconds":20
-      }
+      },
+      "maxIdleConns":10,
+      "maxIdleConnsPerHost":1,
+      "metricsPort": 10
     }

--- a/pkg/broker/config/testdata/config-broker.yaml
+++ b/pkg/broker/config/testdata/config-broker.yaml
@@ -1,0 +1,55 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-broker
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+data:
+  # The ConfigMapFromTestFile helper method expects a key named "_example" and it's dummy here.
+  _example: |
+    dummy: "nothing"
+  ingress-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }
+  filter-config: |
+    {
+      "livenessProbe":{
+        "httpGet":{
+          "path":"/healthz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      },
+      "readinessProbe":{
+        "httpGet":{
+          "path":"/readyz",
+          "port":8080
+        },
+        "initialDelaySeconds":50,
+        "periodSeconds":20
+      }
+    }

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/broker"
+	"knative.dev/eventing/pkg/broker/config"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/logging"
@@ -46,15 +47,6 @@ const (
 
 	// readyz is the HTTP path that will be used for readiness checks.
 	readyz = "/readyz"
-
-	// TODO make these constants configurable (either as env variables, config map, or part of broker spec).
-	//  Issue: https://github.com/knative/eventing/issues/1777
-	// Constants for the underlying HTTP Client transport. These would enable better connection reuse.
-	// Set them on a 10:1 ratio, but this would actually depend on the Triggers' subscribers and the workload itself.
-	// These are magic numbers, partly set based on empirical evidence running performance workloads, and partly
-	// based on what serving is doing. See https://github.com/knative/serving/blob/master/pkg/network/transports.go.
-	defaultMaxIdleConnections        = 1000
-	defaultMaxIdleConnectionsPerHost = 100
 )
 
 // Handler parses Cloud Events, determines if they pass a filter, and sends them to a subscriber.
@@ -84,17 +76,13 @@ type FilterResult string
 
 // NewHandler creates a new Handler and its associated MessageReceiver. The caller is responsible for
 // Start()ing the returned Handler.
-func NewHandler(logger *zap.Logger, triggerLister eventinglisters.TriggerNamespaceLister, reporter StatsReporter) (*Handler, error) {
+func NewHandler(logger *zap.Logger, triggerLister eventinglisters.TriggerNamespaceLister, reporter StatsReporter, c config.FilterConfig) (*Handler, error) {
 	httpTransport, err := cloudevents.NewHTTPTransport(cloudevents.WithBinaryEncoding(), cloudevents.WithMiddleware(pkgtracing.HTTPSpanIgnoringPaths(readyz)))
 	if err != nil {
 		return nil, err
 	}
 
-	connectionArgs := kncloudevents.ConnectionArgs{
-		MaxIdleConns:        defaultMaxIdleConnections,
-		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,
-	}
-	ceClient, err := kncloudevents.NewDefaultClientGivenHttpTransport(httpTransport, &connectionArgs)
+	ceClient, err := kncloudevents.NewDefaultClientGivenHttpTransport(httpTransport, &c.ConnectionArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"knative.dev/eventing/pkg/broker/config"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/broker"
 	"knative.dev/eventing/pkg/client/clientset/versioned/fake"
@@ -337,10 +338,7 @@ func TestReceiver(t *testing.T) {
 				correctURI = append(correctURI, trig)
 			}
 			reporter := &mockReporter{}
-			r, err := NewHandler(
-				zap.NewNop(),
-				getFakeTriggerLister(correctURI),
-				reporter)
+			r, err := NewHandler(zap.NewNop(), getFakeTriggerLister(correctURI), reporter, config.DefaultBrokerConfig.FilterConfig)
 			if tc.expectNewToFail {
 				if err == nil {
 					t.Fatal("Expected New to fail, it didn't")

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -40,6 +40,7 @@ import (
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/duck"
@@ -70,6 +71,7 @@ type Reconciler struct {
 
 	channelableTracker duck.ListableTracker
 
+	configStore               *config.Store
 	ingressImage              string
 	ingressServiceAccountName string
 	filterImage               string
@@ -78,14 +80,6 @@ type Reconciler struct {
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*Reconciler)(nil)
-
-// ReconcilerArgs are the arguments needed to create a broker.Reconciler.
-type ReconcilerArgs struct {
-	IngressImage              string
-	IngressServiceAccountName string
-	FilterImage               string
-	FilterServiceAccountName  string
-}
 
 // Reconcile compares the actual state with the desired, and attempts to
 // converge the two. It then updates the Status block of the Broker resource
@@ -275,6 +269,7 @@ func (r *Reconciler) reconcileFilterDeployment(ctx context.Context, b *v1alpha1.
 		Broker:             b,
 		Image:              r.filterImage,
 		ServiceAccountName: r.filterServiceAccountName,
+		FilterConfig:       r.configStore.GetConfig().FilterConfig,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }
@@ -406,6 +401,7 @@ func (r *Reconciler) reconcileIngressDeployment(ctx context.Context, b *v1alpha1
 		Image:              r.ingressImage,
 		ServiceAccountName: r.ingressServiceAccountName,
 		ChannelAddress:     c.Status.Address.GetURL().Host,
+		IngressConfig:      r.configStore.GetConfig().IngressConfig,
 	})
 	return r.reconcileDeployment(ctx, expected)
 }

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelable"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler"
@@ -565,6 +566,7 @@ func TestReconcile(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		ctx = channelable.WithDuck(ctx)
+		configStore := config.NewStore(logger)
 		return &Reconciler{
 			Base:                      reconciler.NewBase(ctx, controllerAgentName, cmw),
 			subscriptionLister:        listers.GetSubscriptionLister(),
@@ -576,6 +578,7 @@ func TestReconcile(t *testing.T) {
 			ingressImage:              ingressImage,
 			ingressServiceAccountName: ingressSA,
 			channelableTracker:        duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
+			configStore:               configStore,
 		}
 	},
 		false,

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
@@ -98,6 +99,18 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 								{
 									Name:  "BROKER",
 									Value: args.Broker.Name,
+								},
+								{
+									Name:  "MAX_IDLE_CONNS",
+									Value: strconv.Itoa(args.MaxIdleConns),
+								},
+								{
+									Name:  "MAX_IDLE_CONNS_PER_HOST",
+									Value: strconv.Itoa(args.MaxIdleConnsPerHost),
+								},
+								{
+									Name:  "METRICS_PORT",
+									Value: strconv.Itoa(args.MetricsPort),
 								},
 								// Used for StackDriver only.
 								{

--- a/pkg/reconciler/broker/resources/filter_test.go
+++ b/pkg/reconciler/broker/resources/filter_test.go
@@ -125,6 +125,18 @@ func TestMakeFilterDeployment(t *testing.T) {
                 "value": "happy"
               },
               {
+                "name": "MAX_IDLE_CONNS",
+                "value": "1000"
+              },
+              {
+                "name": "MAX_IDLE_CONNS_PER_HOST",
+                "value": "100"
+              },
+              {
+                "name": "METRICS_PORT",
+                "value": "9092"
+              },
+              {
                 "name": "METRICS_DOMAIN",
                 "value": "knative.dev/internal/eventing"
               }

--- a/pkg/reconciler/broker/resources/filter_test.go
+++ b/pkg/reconciler/broker/resources/filter_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"encoding/json"
+	"knative.dev/eventing/pkg/broker/config"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -43,6 +44,7 @@ func TestMakeFilterDeployment(t *testing.T) {
 				},
 				Image:              "image-uri",
 				ServiceAccountName: "service-account-name",
+				FilterConfig:       config.DefaultBrokerConfig.FilterConfig,
 			},
 			want: []byte(`{
   "metadata": {

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
@@ -106,6 +107,22 @@ func MakeIngress(args *IngressArgs) *appsv1.Deployment {
 								{
 									Name:  "BROKER",
 									Value: args.Broker.Name,
+								},
+								{
+									Name:  "MAX_IDLE_CONNS",
+									Value: strconv.Itoa(args.MaxIdleConns),
+								},
+								{
+									Name:  "MAX_IDLE_CONNS_PER_HOST",
+									Value: strconv.Itoa(args.MaxIdleConnsPerHost),
+								},
+								{
+									Name:  "TTL",
+									Value: strconv.FormatInt(int64(args.TTL), 10),
+								},
+								{
+									Name:  "METRICS_PORT",
+									Value: strconv.Itoa(args.MetricsPort),
 								},
 								// Used for StackDriver only.
 								{

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/broker/config"
 )
 
 const (
@@ -40,6 +41,7 @@ type IngressArgs struct {
 	Image              string
 	ServiceAccountName string
 	ChannelAddress     string
+	config.IngressConfig
 }
 
 // MakeIngress creates the in-memory representation of the Broker's ingress Deployment.
@@ -65,18 +67,9 @@ func MakeIngress(args *IngressArgs) *appsv1.Deployment {
 					ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Image: args.Image,
-							Name:  ingressContainerName,
-							LivenessProbe: &corev1.Probe{
-								Handler: corev1.Handler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/healthz",
-										Port: intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
-									},
-								},
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
-							},
+							Image:         args.Image,
+							Name:          ingressContainerName,
+							LivenessProbe: &args.LivenessProbe,
 							Env: []corev1.EnvVar{
 								{
 									Name:  system.NamespaceEnvKey,


### PR DESCRIPTION
This PR shows a possible solution to dynamically watch configmap changes for brokers assuming brokers are implemented based on the [Alternate Broker Proposal](https://docs.google.com/document/d/1pBLkMptwbdEHUgjn1K5Obf7Xe-G9PFGChQcDCZE9vMQ/edit).

This PR builds on top of #2394. You only need to review the **latest commit** to get an idea.

### Proposed changes to the broker reconciler:
- get configmap from broker spec
- watch the configmap
- if changes in configmap detected, re-enqueue the brokers CRs that refers to the configmap for reconciliation

### Caveats
The broker reconciler maintains a map of configmap names to `ConfigStores`. Current implementation doesn't delete entries from the map if no brokers refers to the configmap any more.  Certain "garbage collection" logic can be developed if this becomes an issue.