### PR TITLE
only update ConfigMap namespace for zipkin if not already set

### DIFF
--- a/test/conformance/helpers/tracing/zipkin.go
+++ b/test/conformance/helpers/tracing/zipkin.go
@@ -50,7 +50,7 @@ var setTracingConfigOnce = sync.Once{}
 // TODO Do we need a tear down method to revert the config map to its original state?
 func setTracingConfigToZipkin(t *testing.T, client *lib.Client) {
 	setTracingConfigOnce.Do(func() {
-		// Get the namespace fron the env key directly as system.Namespace() panics if unset
+		// Get the namespace from the env key directly as system.Namespace() panics if unset
 		ns := os.Getenv(system.NamespaceEnvKey)
 		if ns == "" {
 			ns = "istio-system"

--- a/test/conformance/testdata/config-tracing.yaml
+++ b/test/conformance/testdata/config-tracing.yaml
@@ -1,0 +1,57 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "zipkin"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"


### PR DESCRIPTION
Fixes #2044

## Proposed Changes

- Conditionally update the ConfigMap for zipkin namespace if one is not already set.
- Provides support for running tests in alternate environments with zipkin installed in a different namespace

Checked e2e tests pass and behavior matches previous behavior. I'm not super familiar with how to properly verify the exit criteria for  #2044 (tests pass with zipkin in an alternate namespace). If there is a simple way to run tests with an alternate namespace please let me know and I will verify.
