### PR TITLE
Trigger conversion function (v1alpha1 <-> v1beta1)

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/pkg/apis"
+)
+
+// ConvertUp implements apis.Convertible.
+// Converts source (from v1alpha1.Trigger) into v1beta1.Trigger
+func (source *Trigger) ConvertUp(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *v1beta1.Trigger:
+		sink.ObjectMeta = source.ObjectMeta
+		sink.Spec.Broker = source.Spec.Broker
+		sink.Spec.Subscriber = source.Spec.Subscriber
+		if source.Spec.Filter != nil {
+			sink.Spec.Filter = &v1beta1.TriggerFilter{}
+			if source.Spec.Filter.Attributes != nil {
+				for k, v := range *source.Spec.Filter.Attributes {
+					sink.Spec.Filter.Attributes[k] = v
+				}
+			}
+			if source.Spec.Filter.DeprecatedSourceAndType != nil {
+				sink.Spec.Filter.Attributes["source"] = source.Spec.Filter.DeprecatedSourceAndType.Source
+				sink.Spec.Filter.Attributes["type"] = source.Spec.Filter.DeprecatedSourceAndType.Type
+			}
+		}
+		sink.Status.Status = source.Status.Status
+		sink.Status.SubscriberURI = source.Status.SubscriberURI
+		return nil
+	default:
+		return fmt.Errorf("Unknown conversion, got: %T", sink)
+
+	}
+}
+
+// ConvertDown implements apis.Convertible.
+// Converts obj from v1beta1.Trigger into v1alpha1.Trigger
+func (sink *Trigger) ConvertDown(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *v1beta1.Trigger:
+		sink.ObjectMeta = source.ObjectMeta
+		sink.Spec.Broker = source.Spec.Broker
+		sink.Spec.Subscriber = source.Spec.Subscriber
+		if source.Spec.Filter != nil {
+			sink.Spec.Filter = &TriggerFilter{}
+			tfa := TriggerFilterAttributes{}
+			for k, v := range source.Spec.Filter.Attributes {
+				tfa[k] = v
+			}
+		}
+
+		sink.Status.Status = source.Status.Status
+		sink.Status.SubscriberURI = source.Status.SubscriberURI
+		return nil
+	default:
+		return fmt.Errorf("Unknown conversion, got: %T", source)
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -33,7 +33,9 @@ func (source *Trigger) ConvertUp(ctx context.Context, obj apis.Convertible) erro
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
-			sink.Spec.Filter = &v1beta1.TriggerFilter{}
+			sink.Spec.Filter = &v1beta1.TriggerFilter{
+				Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+			}
 			if source.Spec.Filter.Attributes != nil {
 				for k, v := range *source.Spec.Filter.Attributes {
 					sink.Spec.Filter.Attributes[k] = v
@@ -62,10 +64,12 @@ func (sink *Trigger) ConvertDown(ctx context.Context, obj apis.Convertible) erro
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
-			sink.Spec.Filter = &TriggerFilter{}
-			tfa := TriggerFilterAttributes{}
+			attributes := TriggerFilterAttributes{}
 			for k, v := range source.Spec.Filter.Attributes {
-				tfa[k] = v
+				attributes[k] = v
+			}
+			sink.Spec.Filter = &TriggerFilter{
+				Attributes: &attributes,
 			}
 		}
 

--- a/pkg/apis/eventing/v1alpha1/trigger_conversion_test.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// TODO: Replace dummy some other Eventing object once they
+// implement apis.Convertible
+type dummy struct{}
+
+func (*dummy) ConvertUp(ctx context.Context, obj apis.Convertible) error {
+	return errors.New("Won't go")
+}
+
+func (*dummy) ConvertDown(ctx context.Context, obj apis.Convertible) error {
+	return errors.New("Won't go")
+}
+
+func TestTriggerConversionBadType(t *testing.T) {
+	good, bad := &Trigger{}, &dummy{}
+
+	if err := good.ConvertUp(context.Background(), bad); err == nil {
+		t.Errorf("ConvertUp() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertDown(context.Background(), bad); err == nil {
+		t.Errorf("ConvertDown() = %#v, wanted error", good)
+	}
+}
+
+func TestTriggerConversion(t *testing.T) {
+	// Just one for now, just adding the for loop for ease of future changes.
+	versions := []apis.Convertible{&v1beta1.Trigger{}}
+
+	tests := []struct {
+		name string
+		in   *Trigger
+	}{{name: "simple configuration",
+		in: &Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "trigger-name",
+				Namespace:  "trigger-ns",
+				Generation: 17,
+			},
+			Spec: TriggerSpec{
+				Broker: "default",
+			},
+			Status: TriggerStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}, {name: "filter rules, deprecated",
+		in: &Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "trigger-name",
+				Namespace:  "trigger-ns",
+				Generation: 17,
+			},
+			Spec: TriggerSpec{
+				Broker: "default",
+				Filter: &TriggerFilter{
+					DeprecatedSourceAndType: &TriggerFilterSourceAndType{
+						Source: "mysource",
+						Type:   "mytype",
+					},
+				},
+			},
+			Status: TriggerStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}, {name: "filter rules",
+		in: &Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "trigger-name",
+				Namespace:  "trigger-ns",
+				Generation: 17,
+			},
+			Spec: TriggerSpec{
+				Broker: "default",
+				Filter: &TriggerFilter{
+					Attributes: &TriggerFilterAttributes{"source": "mysource", "type": "mytype"},
+				},
+			},
+			Status: TriggerStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}, {name: "filter rules, many",
+		in: &Trigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "trigger-name",
+				Namespace:  "trigger-ns",
+				Generation: 17,
+			},
+			Spec: TriggerSpec{
+				Broker: "default",
+				Filter: &TriggerFilter{
+					Attributes: &TriggerFilterAttributes{"source": "mysource", "type": "mytype", "customkey": "customvalue"},
+				},
+			},
+			Status: TriggerStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertUp(context.Background(), ver); err != nil {
+					t.Errorf("ConvertUp() = %v", err)
+				}
+				got := &Trigger{}
+				if err := got.ConvertDown(context.Background(), ver); err != nil {
+					t.Errorf("ConvertDown() = %v", err)
+				}
+				// Since on the way down, we lose the DeprecatedSourceAndType,
+				// convert the in to equivalent out.
+				fixed := fixDeprecated(test.in)
+				if diff := cmp.Diff(fixed, got); diff != "" {
+					t.Errorf("roundtrip (-want, +got) = %v", diff)
+				}
+			})
+		}
+	}
+}
+
+// Since DeprecatedSourceAndType is lossy but semanctically equivalent
+// if source,type are present and equivalent in the attributes map,
+// fix that so diff works.
+func fixDeprecated(in *Trigger) *Trigger {
+	if in.Spec.Filter != nil && in.Spec.Filter.DeprecatedSourceAndType != nil {
+		// attributes must be nil, can't have both Deprecated / Attributes
+		attributes := TriggerFilterAttributes{}
+		attributes["source"] = in.Spec.Filter.DeprecatedSourceAndType.Source
+		attributes["type"] = in.Spec.Filter.DeprecatedSourceAndType.Type
+		in.Spec.Filter.DeprecatedSourceAndType = nil
+		in.Spec.Filter.Attributes = &attributes
+	}
+	return in
+}

--- a/pkg/apis/eventing/v1alpha1/trigger_types.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_types.go
@@ -61,6 +61,9 @@ var (
 	// Check that Trigger can return its spec untyped.
 	_ apis.HasSpec = (*Trigger)(nil)
 
+	// Check that Service can be converted to higher versions.
+	_ apis.Convertible = (*Trigger)(nil)
+
 	_ runtime.Object = (*Trigger)(nil)
 
 	// Check that we can create OwnerReferences to a Trigger.

--- a/pkg/apis/eventing/v1beta1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1beta1/broker_lifecycle.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"knative.dev/pkg/apis"
+)
+
+var brokerCondSet = apis.NewLivingConditionSet(BrokerConditionAddressable)
+
+const (
+	BrokerConditionReady                          = apis.ConditionReady
+	BrokerConditionAddressable apis.ConditionType = "Addressable"
+)
+
+// GetTopLevelCondition returns the top level Condition.
+func (bs *BrokerStatus) GetTopLevelCondition() *apis.Condition {
+	return brokerCondSet.Manage(bs).GetTopLevelCondition()
+}
+
+// SetAddress makes this Broker addressable by setting the URI. It also
+// sets the BrokerConditionAddressable to true.
+func (bs *BrokerStatus) SetAddress(url *apis.URL) {
+	bs.Address.URL = url
+	if url != nil {
+		brokerCondSet.Manage(bs).MarkTrue(BrokerConditionAddressable)
+	} else {
+		brokerCondSet.Manage(bs).MarkFalse(BrokerConditionAddressable, "nil URL", "URL is nil")
+	}
+}

--- a/pkg/apis/eventing/v1beta1/test_helper.go
+++ b/pkg/apis/eventing/v1beta1/test_helper.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgduckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
@@ -65,12 +64,9 @@ func (testHelper) ReadyChannelStatus() *duckv1alpha1.ChannelableStatus {
 	return cs
 }
 
-func (t testHelper) ReadyBrokerStatus() *eventingv1alpha1.BrokerStatus {
-	bs := &eventingv1alpha1.BrokerStatus{}
-	bs.PropagateIngressDeploymentAvailability(t.AvailableDeployment())
-	bs.PropagateTriggerChannelReadiness(t.ReadyChannelStatus())
-	bs.PropagateFilterDeploymentAvailability(t.AvailableDeployment())
-	bs.SetAddress(&apis.URL{Scheme: "http", Host: "foo"})
+func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
+	bs := &BrokerStatus{}
+	bs.SetAddress(apis.HTTP("example.com"))
 	return bs
 }
 
@@ -86,17 +82,13 @@ func (t testHelper) AvailableDeployment() *v1.Deployment {
 	return d
 }
 
-func (t testHelper) UnknownBrokerStatus() *eventingv1alpha1.BrokerStatus {
-	bs := &eventingv1alpha1.BrokerStatus{}
-	bs.InitializeConditions()
+func (t testHelper) UnknownBrokerStatus() *BrokerStatus {
+	bs := &BrokerStatus{}
 	return bs
 }
 
-func (t testHelper) FalseBrokerStatus() *eventingv1alpha1.BrokerStatus {
-	bs := &eventingv1alpha1.BrokerStatus{}
-	bs.MarkIngressFailed("DeploymentUnavailable", "The Deployment is unavailable.")
-	bs.MarkTriggerChannelFailed("ChannelNotReady", "trigger Channel is not ready: not addressalbe")
-	bs.MarkFilterFailed("DeploymentUnavailable", "The Deployment is unavailable.")
+func (t testHelper) FalseBrokerStatus() *BrokerStatus {
+	bs := &BrokerStatus{}
 	bs.SetAddress(nil)
 	return bs
 }

--- a/pkg/apis/eventing/v1beta1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion.go
@@ -30,5 +30,5 @@ func (source *Trigger) ConvertUp(ctx context.Context, sink apis.Convertible) err
 
 // ConvertDown implements apis.Convertible
 func (sink *Trigger) ConvertDown(ctx context.Context, source apis.Convertible) error {
-	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
 }

--- a/pkg/apis/eventing/v1beta1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertUp implements apis.Convertible
+func (source *Trigger) ConvertUp(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertDown implements apis.Convertible
+func (sink *Trigger) ConvertDown(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/eventing/v1beta1/trigger_conversion_test.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTriggerConversionBadType(t *testing.T) {
+	good, bad := &Trigger{}, &Trigger{}
+
+	if err := good.ConvertUp(context.Background(), bad); err == nil {
+		t.Errorf("ConvertUp() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertDown(context.Background(), bad); err == nil {
+		t.Errorf("ConvertDown() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/eventing/v1beta1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1beta1/trigger_lifecycle.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -72,7 +71,7 @@ func (ts *TriggerStatus) InitializeConditions() {
 	triggerCondSet.Manage(ts).InitializeConditions()
 }
 
-func (ts *TriggerStatus) PropagateBrokerStatus(bs *eventingv1alpha1.BrokerStatus) {
+func (ts *TriggerStatus) PropagateBrokerStatus(bs *BrokerStatus) {
 	bc := bs.GetTopLevelCondition()
 	if bc == nil {
 		ts.MarkBrokerNotConfigured()

--- a/pkg/apis/eventing/v1beta1/trigger_lifecycle_test.go
+++ b/pkg/apis/eventing/v1beta1/trigger_lifecycle_test.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"testing"
 
-	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
@@ -234,7 +233,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 func TestTriggerConditionStatus(t *testing.T) {
 	tests := []struct {
 		name                        string
-		brokerStatus                *eventingv1alpha1.BrokerStatus
+		brokerStatus                *BrokerStatus
 		markKubernetesServiceExists bool
 		markVirtualServiceExists    bool
 		subscriptionCondition       *apis.Condition


### PR DESCRIPTION
Addresses #1869 

## Proposed Changes

- Add conversion functions for Trigger (v1alpha1 <-> v1beta1)
- Decouple (clean-up) broker v1beta1 / v1alpha1 dependency

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.

-->

```release-note

```
