### PR TITLE
Add schemaData field to EventType to allow for a CloudEvent schema to…

### DIFF
--- a/pkg/apis/eventing/v1beta1/eventtype_types.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_types.go
@@ -65,6 +65,11 @@ type EventTypeSpec struct {
 	// It may be a JSON schema, a protobuf schema, etc. It is optional.
 	// +optional
 	Schema *apis.URL `json:"schema,omitempty"`
+	// SchemaData allows the CloudEvents schema to be stored directly in the
+	// EventType. Content is dependent on the encoding. Optional attribute.
+	// The contents are not validated or manipulated by the system.
+	// +optional
+	SchemaData string `json:"schemaData,omitempty"`
 	// Broker refers to the Broker that can provide the EventType.
 	Broker string `json:"broker"`
 	// Description is an optional field used to describe the EventType, in any meaningful way.

--- a/pkg/apis/eventing/v1beta1/eventtype_validation.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_validation.go
@@ -45,6 +45,7 @@ func (ets *EventTypeSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(fe)
 	}
 	// TODO validate Schema is a valid URI.
+	// There is no validation of the SchemaData, it is application specific data.
 	return errs
 }
 

--- a/pkg/apis/eventing/v1beta1/eventtype_validation_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_validation_test.go
@@ -101,6 +101,7 @@ func TestEventTypeImmutableFields(t *testing.T) {
 	differentSource := apis.HTTP("original-source")
 	testSource := apis.HTTP("test-source")
 	testSchema := apis.HTTP("test-schema")
+	testSchemaData := `{"data": "awesome"}`
 	differentSchema := apis.HTTP("original-schema")
 	tests := []struct {
 		name     string
@@ -111,18 +112,20 @@ func TestEventTypeImmutableFields(t *testing.T) {
 		name: "good (no change)",
 		current: &EventType{
 			Spec: EventTypeSpec{
-				Type:   "test-type",
-				Source: *testSource,
-				Broker: "test-broker",
-				Schema: testSchema,
+				Type:       "test-type",
+				Source:     *testSource,
+				Broker:     "test-broker",
+				Schema:     testSchema,
+				SchemaData: testSchemaData,
 			},
 		},
 		original: &EventType{
 			Spec: EventTypeSpec{
-				Type:   "test-type",
-				Source: *testSource,
-				Broker: "test-broker",
-				Schema: testSchema,
+				Type:       "test-type",
+				Source:     *testSource,
+				Broker:     "test-broker",
+				Schema:     testSchema,
+				SchemaData: testSchemaData,
 			},
 		},
 		want: nil,


### PR DESCRIPTION
Related to #2484

## Proposed Changes

- Add schema data to EventType so that CloudEvents schemas can be stored in the control plane without the user needing to stand up hosting for these. 

**Release Note**

```release-note
🎁CloudEvents schemas can be stored in the EventType object. This is useful for creating, storing, retrieving and using scehams for your own custom event types.
```
