### PR TITLE
Move certificate and sink binding control loops from webhook to controller

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/pkg/signals"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/pkg/webhook"
-	"knative.dev/pkg/webhook/certificates"
 	"knative.dev/pkg/webhook/configmaps"
 	"knative.dev/pkg/webhook/psbinding"
 	"knative.dev/pkg/webhook/resourcesemantics"
@@ -205,14 +204,12 @@ func main() {
 	})
 
 	sharedmain.MainWithContext(ctx, logconfig.WebhookName(),
-		certificates.NewController,
 		NewConfigValidationController,
 		NewValidationAdmissionController,
 		NewDefaultingAdmissionController,
 
-		// For each binding we have a controller and a binding webhook.
-		sinkbinding.NewController, NewSinkBindingWebhook,
+		NewSinkBindingWebhook,
 		// TODO(#2312): Remove this after v0.13.
-		legacysinkbinding.NewController, NewLegacySinkBindingWebhook,
+		NewLegacySinkBindingWebhook,
 	)
 }


### PR DESCRIPTION
## Proposed Changes

* Webhooks should be stateless; moves the cert and sink binding control loops (which do API writes) from the webhook to the controller binary

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
