### PR TITLE
Knative flows namespaced admin

### DIFF
--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -39,6 +39,18 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: knative-flows-namespaced-admin
+  labels:
+    eventing.knative.dev/release: devel
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["flows.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: knative-eventing-sources-namespaced-admin
   labels:
     eventing.knative.dev/release: devel

--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -81,7 +81,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     eventing.knative.dev/release: devel
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.eventing.knative.dev", "sources.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.eventing.knative.dev", "sources.knative.dev", "flows.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---
@@ -93,6 +93,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     eventing.knative.dev/release: devel
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.eventing.knative.dev", "sources.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.eventing.knative.dev", "sources.knative.dev", flows.knative.dev]
     resources: ["*"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION

- namespeaced CR for `flows.knative.dev`

Related to this this:
* https://github.com/knative/eventing/pull/1993

and see https://github.com/knative/eventing/commit/052bd9e178aefd0b14fc9dc9014d59aa532396ed#diff-bc901b9d7f4a101d28344eca9f094d84R36-R72  as well, where the one for the new `sources.knative.dev` was added 
