### PR TITLE
ping used 'legacysources'

### DIFF
--- a/pkg/adapter/ping/adapter.go
+++ b/pkg/adapter/ping/adapter.go
@@ -25,7 +25,7 @@ import (
 	"github.com/robfig/cron"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/adapter"
-	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/legacysources/v1alpha1"
+	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/source"
 )
@@ -102,8 +102,8 @@ func (a *pingAdapter) cronTick() {
 	logger := logging.FromContext(context.TODO())
 
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
-	event.SetType(sourcesv1alpha1.CronJobEventType)
-	event.SetSource(sourcesv1alpha1.CronJobEventSource(a.Namespace, a.Name))
+	event.SetType(sourcesv1alpha1.PingSourceEventType)
+	event.SetSource(sourcesv1alpha1.PingSourceSource(a.Namespace, a.Name))
 	event.SetData(message(a.Data))
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	reportArgs := &source.ReportArgs{


### PR DESCRIPTION
Not sure if that's really an issue - but, I found it confusing.

testing the `PingSource`, I am getting these Cloudevents:

```
☁️  cloudevents.Event
Validation: valid
Context Attributes,
  specversion: 1.0
  type: dev.knative.cronjob.event
  source: /apis/v1/namespaces/default/cronjobsources/test-ping-source
  id: b3393cbd-ab61-4835-a2c3-31f58f06ddf4
  time: 2020-02-11T19:34:00.000876652Z
  datacontenttype: application/json
Data,
  {
    "message": "Hello world!"
  }
```

# Changes

- remove `legacysource` usage, and use actual sources v1alpha1, to update the `type` and `source` to be more consistent

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

