### PR TITLE
Channel spec: Data Plane updates

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -187,13 +187,19 @@ exclusively communicate using CloudEvents.
 #### Input
 
 Every Channel MUST expose either an HTTP or HTTPS endpoint. It MAY expose both.
-The endpoint(s) MUST conform to CloudEvents
-[Version 1.0](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md).
+The endpoint(s) MUST conform to one of the following versions of the specification:
+
+* [CloudEvents 0.2 specification](https://github.com/cloudevents/spec/blob/v0.2/http-transport-binding.md)
+* [CloudEvents 0.3 specification](https://github.com/cloudevents/spec/blob/v0.3/http-transport-binding.md)
+* [CloudEvents 1.0 specification](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md)
+
 The Channel MUST NOT perform an upgrade of the passed in version. It MUST emit
-the event with the same version. It MUST support both Binary Content mode and
-Structured Content mode. The HTTP(S) endpoint MAY be on any port, not just the
-standard 80 and 443. Channels MAY expose other, non-HTTP endpoints in addition
-to HTTP at their discretion (e.g. expose a gRPC endpoint to accept events).
+the event with the same version. It MUST support both _Binary Content Mode_ or
+_Structured Content Mode_ of the HTTP Protocol Binding for CloudEvents.
+
+The HTTP(S) endpoint MAY be on any port, not just the standard 80 and 443.
+Channels MAY expose other, non-HTTP endpoints in addition to HTTP at their
+discretion (e.g. expose a gRPC endpoint to accept events).
 
 ##### Generic
 
@@ -202,9 +208,9 @@ CloudEvent, then it MUST reject the request.
 
 The Channel MUST pass through all tracing information as CloudEvents attributes.
 In particular, it MUST translate any incoming OpenTracing or B3 headers to the
-[Distributed Tracing Extension](https://github.com/cloudevents/spec/blob/v0.3/extensions/distributed-tracing.md).
+[Distributed Tracing Extension](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md).
 The Channel SHOULD sample and write traces to the location specified in
-[`config-tracing`](https://github.com/cloudevents/spec/blob/v0.3/extensions/distributed-tracing.md).
+[`config-tracing`](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md).
 
 ##### HTTP
 
@@ -227,11 +233,14 @@ CloudEvent, then it MUST respond with `400 Bad Request`.
 
 #### Output
 
-Channels MUST output CloudEvents. The output MUST be via a binding specified in
-the
-[CloudEvents specification](https://github.com/cloudevents/spec/tree/v0.3#cloudevents-documents).
-Every Channel MUST support sending events via Binary Content Mode HTTP Transport
-Binding.
+Channels MUST output CloudEvents. The output MUST match the CloudEvent version of the [Input](#input).
+Channels MUST NOT alter an event that goes through them. All CloudEvent attributes, including the
+data attribute, MUST be received at the subscriber identical to how they were received by the Channel.
+The only exception is the [Distributed Tracing Extension Attribute](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md),
+which is expected to change as the span id will be altered at every network hop.
+
+Every Channel SHOULD support sending events via _Binary Content Mode_ or _Structured Content Mode_ of the HTTP
+Protocol Binding for CloudEvents.
 
 Channels MUST send events to all subscribers which are marked with a status of
 `ready: "True"` in the channel's `status.subscribableStatus.subscribers`. The
@@ -239,12 +248,6 @@ events must be sent to the `subscriberURI` field of
 `spec.subscribable.subscribers`. Each channel implementation will have its own
 quality of service guarantees (e.g. at least once, at most once, etc) which
 SHOULD be documented.
-
-Channels MUST NOT alter an event that goes through them. All CloudEvent
-attributes, including the data attribute, MUST be received at the subscriber
-identical to how they were received by the Channel. The only exception is the
-[Distributed Tracing Extension Attribute](https://github.com/cloudevents/spec/blob/v0.3/extensions/distributed-tracing.md),
-which is expected to change as the span id will be altered at every network hop.
 
 ##### Retries
 

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -189,12 +189,13 @@ exclusively communicate using CloudEvents.
 Every Channel MUST expose either an HTTP or HTTPS endpoint. It MAY expose both.
 The endpoint(s) MUST conform to one of the following versions of the specification:
 
-* [CloudEvents 0.2 specification](https://github.com/cloudevents/spec/blob/v0.2/http-transport-binding.md)
 * [CloudEvents 0.3 specification](https://github.com/cloudevents/spec/blob/v0.3/http-transport-binding.md)
 * [CloudEvents 1.0 specification](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md)
 
+The usage of CloudEvents version `1.0` is RECOMMENDED.
+
 The Channel MUST NOT perform an upgrade of the passed in version. It MUST emit
-the event with the same version. It MUST support both _Binary Content Mode_ or
+the event with the same version. It MUST support both _Binary Content Mode_ and
 _Structured Content Mode_ of the HTTP Protocol Binding for CloudEvents.
 
 The HTTP(S) endpoint MAY be on any port, not just the standard 80 and 443.


### PR DESCRIPTION
* updates to allow future updates of different protocols
* be (more) explicit that we support input of several CE versions and that output has to match the incomming version

/assign @lionelvillard 
/assign @vaikas 