### PR TITLE
Move webhooks onto new sharedmain methods

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1312,7 +1312,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f44b87ebe4aefb51530107b1d09dce6b81fc35c45117e4025f1dbcb33315a4a8"
+  digest = "1:0ef5900b861d1a580ec02438c991f7b241efa83151bf2d29db3055ff390a2b1f"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1415,7 +1415,7 @@
     "webhook/resourcesemantics/validation",
   ]
   pruneopts = "T"
-  revision = "d9a38f13e8b9aa736f714b793ee28788de1b30e0"
+  revision = "1d60dd6107fb4348f28e2a7b7f35e7d4299b33c6"
 
 [[projects]]
   branch = "master"

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -276,7 +276,7 @@ func main() {
 		SecretName: "eventing-webhook-certs",
 	})
 
-	sharedmain.MainWithContext(ctx, logconfig.WebhookName(),
+	sharedmain.WebhookMainWithContext(ctx, logconfig.WebhookName(),
 		certificates.NewController,
 		NewConfigValidationController,
 		NewValidationAdmissionController,


### PR DESCRIPTION
Related to knative/pkg#1007, migrates webhook processes onto new WebhookMain methods in the `sharedmain` package that will retain the existing behavior for now while we decide how to scale webhooks horizontally.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move webhook main onto `WebHookMain` methods from knative/pkg#1084

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
