### PR TITLE
dump events in a namespace when tearing down

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -127,6 +127,15 @@ func makeK8sNamespace(baseFuncName string) string {
 
 // TearDown will delete created names using clients.
 func TearDown(client *Client) {
+	// Dump the events in the namespace
+	el, err := client.Kube.Kube.CoreV1().Events(client.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		client.T.Logf("Could not list events in the namespace %q: %v", client.Namespace, err)
+	} else {
+		for _, e := range el.Items {
+			client.T.Logf("EVENT: %v", e)
+		}
+	}
 	client.Tracker.Clean(true)
 	if err := DeleteNameSpace(client); err != nil {
 		client.T.Logf("Could not delete the namespace %q: %v", client.Namespace, err)


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- When tearing down the namespace, dump the k8s events there to aid in debugging

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.

-->

```release-note
no user-visible impact. For testing, will dump the k8s events emitted in the namespace during teardown.
```
