### PR TITLE
Use original namespace in label on copy ConfigMap

### DIFF
--- a/pkg/reconciler/configmappropagation/configmappropagation_test.go
+++ b/pkg/reconciler/configmappropagation/configmappropagation_test.go
@@ -61,7 +61,7 @@ var (
 	copySelector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			resources.PropagationLabelKey: resources.PropagationLabelValueCopy,
-			resources.CopyLabelKey:        resources.MakeCopyConfigMapLabel(currentNS, originalConfigMapName),
+			resources.CopyLabelKey:        resources.MakeCopyConfigMapLabel(originalNS, originalConfigMapName),
 		},
 	}
 	copyConfigMapName = resources.MakeCopyConfigMapName(configMapPropagationName, originalConfigMapName)

--- a/pkg/reconciler/configmappropagation/resources/configmap.go
+++ b/pkg/reconciler/configmappropagation/resources/configmap.go
@@ -36,7 +36,7 @@ func MakeConfigMap(args ConfigMapArgs) *corev1.ConfigMap {
 			Namespace: args.ConfigMapPropagation.Namespace,
 			Labels: map[string]string{
 				PropagationLabelKey: PropagationLabelValueCopy,
-				CopyLabelKey:        MakeCopyConfigMapLabel(args.ConfigMapPropagation.Namespace, args.Original.Name),
+				CopyLabelKey:        MakeCopyConfigMapLabel(args.Original.Namespace, args.Original.Name),
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(args.ConfigMapPropagation),
@@ -52,6 +52,6 @@ func MakeCopyConfigMapName(configMapPropagationName, configMapName string) strin
 
 // MakeCopyCOnfigMapLabel uses '-' to separate namespace and configmap name instead of '/',
 // for label values only accept '-', '.', '_'.
-func MakeCopyConfigMapLabel(configMapPropagationNamespace, configMapName string) string {
-	return configMapPropagationNamespace + "-" + configMapName
+func MakeCopyConfigMapLabel(originalNamespace, originalName string) string {
+	return originalNamespace + "-" + originalName
 }

--- a/pkg/reconciler/configmappropagation/resources/configmap_test.go
+++ b/pkg/reconciler/configmappropagation/resources/configmap_test.go
@@ -34,13 +34,14 @@ func TestMakeConfigMap(t *testing.T) {
 		"general configmap": {
 			original: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "original-config-map",
+					Name:      "original-config-map",
+					Namespace: "system",
 				},
 			},
 			configmappropagation: &configsv1alpha1.ConfigMapPropagation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cmp",
-					Namespace: "testing",
+					Namespace: "default",
 				},
 			},
 		},
@@ -67,7 +68,7 @@ func TestMakeConfigMap(t *testing.T) {
 			// If labels are correct.
 			expectedLabels := map[string]string{
 				PropagationLabelKey: PropagationLabelValueCopy,
-				CopyLabelKey:        "testing-original-config-map",
+				CopyLabelKey:        "system-original-config-map",
 			}
 			if labels := configmap.Labels; !reflect.DeepEqual(labels, expectedLabels) {
 				t.Errorf("want %v, got %q", expectedLabels, labels)


### PR DESCRIPTION
This label is used to identify the original ConfigMap, so the namespace used should be the namespace of the original ConfigMap instead of the namespace of the CMP.

This should fix the test failure in #2570 because the names won't be too long anymore: current usage of CMP will only create copies with certain names (e.g. `knative-eventing-config-tracing`) in test and other environments.

A fix for names that are too long is still needed, but that can be deferred to a future PR.

Fixes #2570.

## Proposed Changes

- Correct the copy ConfigMap label to use the namespace of the original ConfigMap.

/cc @n3wscott @vaikas @grac3gao 