### PR TITLE
Add docs link to PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,31 +1,43 @@
 Fixes #
 
 <!-- Please include the 'why' behind your changes if no issue exists -->
+
 ## Proposed Changes
 
 -
 -
 -
 
-**Release Note**
-
 <!--
-In the following cases, write a brief release note describing the
-user-visible impact of this change in the release-note block:
+If this change has user-visible impact, follow the instructions below.
+Examples include:
 
 - 🎁 Add new feature
 - 🐛 Fix bug
 - 🧽 Update or clean up current behavior
 - 🗑️ Remove feature or internal logic
 
-Include the string "action required" if additional action is required of
+Otherwise delete the rest of this template.
+-->
+
+**Release Note**
+
+<!--
+🗒️ If this change has user-visible impact, write a release note in the block
+below. Include the string "action required" if additional action is required of
 users switching to the new release, for example in case of a breaking change.
 
 Write as if you are speaking to users, not other Knative contributors. If this
 change has no user-visible impact, no release-note is needed.
-
 -->
 
 ```release-note
 
 ```
+
+**Docs**
+
+<!--
+📖 If this change has user-visible impact, link to an issue or PR in
+https://github.com/knative/docs.
+-->


### PR DESCRIPTION
As requested in today's eventing WG, this adds a reminder to link to a docs issue/PR when making a user-visible change.

/cc @vaikas @lionelvillard 