### PR TITLE
EventType conversion v1alpha1 <--> v1beta1

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -230,6 +230,14 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 					eventingv1beta1_:  &baseeventingv1beta1.Broker{},
 				},
 			},
+			baseeventingv1beta1.Kind("EventType"): {
+				DefinitionName: eventing.EventTypesResource.String(),
+				HubVersion:     eventingv1alpha1_,
+				Zygotes: map[string]conversion.ConvertibleObject{
+					eventingv1alpha1_: &baseeventingv1alpha1.EventType{},
+					eventingv1beta1_:  &baseeventingv1beta1.EventType{},
+				},
+			},
 			// messaging
 			/*
 				basemessagingv1beta1.Kind("Subscription"): {

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -87,5 +87,5 @@ spec:
                 type: string
                 description: "Describes the EventType, in any meaningful way."
   - name: v1beta1
-    served: false
+    served: true
     storage: false

--- a/pkg/apis/eventing/register.go
+++ b/pkg/apis/eventing/register.go
@@ -41,4 +41,9 @@ var (
 		Group:    GroupName,
 		Resource: "brokers",
 	}
+	// EventTypesResource respresents a Knative EventType
+	EventTypesResource = schema.GroupResource{
+		Group:    GroupName,
+		Resource: "eventtypes",
+	}
 )

--- a/pkg/apis/eventing/v1alpha1/eventtype_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_conversion.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/pkg/apis"
+)
+
+// ConvertUp implements apis.Convertible.
+// Converts source (from v1alpha1.EventType) into v1beta1.EventType
+func (source *EventType) ConvertUp(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *v1beta1.EventType:
+		b, err := json.Marshal(source)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(b, sink)
+	default:
+		return fmt.Errorf("Unknown conversion, got: %T", sink)
+
+	}
+}
+
+// ConvertDown implements apis.Convertible.
+// Converts obj from v1beta1.EventType into v1alpha1.EventType
+func (sink *EventType) ConvertDown(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *v1beta1.EventType:
+		b, err := json.Marshal(source)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(b, sink)
+	default:
+		return fmt.Errorf("Unknown conversion, got: %T", source)
+	}
+}

--- a/pkg/apis/eventing/v1alpha1/eventtype_conversion_test.go
+++ b/pkg/apis/eventing/v1alpha1/eventtype_conversion_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestEventTypeConversionBadType(t *testing.T) {
+	good, bad := &EventType{}, &dummy{}
+
+	if err := good.ConvertUp(context.Background(), bad); err == nil {
+		t.Errorf("ConvertUp() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertDown(context.Background(), bad); err == nil {
+		t.Errorf("ConvertDown() = %#v, wanted error", good)
+	}
+}
+
+func TestEventTypeConversion(t *testing.T) {
+	// Just one for now, just adding the for loop for ease of future changes.
+	versions := []apis.Convertible{&v1beta1.EventType{}}
+
+	tests := []struct {
+		name string
+		in   *EventType
+	}{{name: "empty",
+		in: &EventType{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "eventtype-name",
+				Namespace:  "eventtype-ns",
+				Generation: 17,
+			},
+			Spec: EventTypeSpec{},
+			Status: EventTypeStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}, {name: "full",
+		in: &EventType{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "eventtype-name",
+				Namespace:  "eventtype-ns",
+				Generation: 17,
+			},
+			Spec: EventTypeSpec{
+				Type:        "type",
+				Source:      "http://some.source/with/path",
+				Schema:      "a.schema",
+				Broker:      "broker",
+				Description: "yada yada",
+			},
+			Status: EventTypeStatus{
+				Status: duckv1.Status{
+					ObservedGeneration: 1,
+					Conditions: duckv1.Conditions{{
+						Type:   "Ready",
+						Status: "True",
+					}},
+				},
+			},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertUp(context.Background(), ver); err != nil {
+					t.Errorf("ConvertUp() = %v", err)
+				}
+				got := &EventType{}
+				if err := got.ConvertDown(context.Background(), ver); err != nil {
+					t.Errorf("ConvertDown() = %v", err)
+				}
+				if diff := cmp.Diff(test.in, got); diff != "" {
+					t.Errorf("roundtrip (-want, +got) = %v", diff)
+				}
+			})
+		}
+	}
+}

--- a/pkg/apis/eventing/v1beta1/eventtype_conversion.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_conversion.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertUp implements apis.Convertible
+func (source *EventType) ConvertUp(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertDown implements apis.Convertible
+func (sink *EventType) ConvertDown(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/eventing/v1beta1/eventtype_conversion_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEventTypeConversionBadType(t *testing.T) {
+	good, bad := &EventType{}, &EventType{}
+
+	if err := good.ConvertUp(context.Background(), bad); err == nil {
+		t.Errorf("ConvertUp() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertDown(context.Background(), bad); err == nil {
+		t.Errorf("ConvertDown() = %#v, wanted error", good)
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- adding conversion webhook support for eventtype
- wire up eventtype into the webhook conversion

**Release Note**

<!--
In the following cases, write a brief release note describing the
user-visible impact of this change in the release-note block:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.

-->

```release-note
Added v1beta1 support for EventType.eventing.knative.dev.
```
