### PR TITLE
 Adding temp file to scale old sources controller to zero.

### DIFF
--- a/config/core/deployments/sources-controller.yaml
+++ b/config/core/deployments/sources-controller.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO(n3wscott): DELETE THIS FILE AFTER v0.13 CUTS
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sources-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: sources-controller
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: sources-controller
+    spec:
+      containers:
+      - name: controller
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: knative.dev/eventing/cmd/sources_controller
+


### PR DESCRIPTION
## Proposed Changes

- Sources controller was merged into eventing controller, but I deleted the deployment file. This adds back the deployment file (trimmed) and scales it to zero.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Sources controller (sources-controller deployment) has been scaled to zero. Safe to delete.
```

