### PR TITLE
make namespace reconciler work for broker recreation

### DIFF
--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/kelseyhightower/envconfig"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/reconciler"
 
 	"knative.dev/eventing/pkg/client/injection/informers/configs/v1alpha1/configmappropagation"
@@ -80,21 +80,21 @@ func NewController(
 	// Watch all the resources that this reconciler reconciles.
 	serviceAccountInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Namespace")),
+			FilterFunc: controller.FilterGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 	roleBindingInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Namespace")),
+			FilterFunc: controller.FilterGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 	brokerInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Namespace")),
+			FilterFunc: controller.FilterGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 	configMapPropagationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Namespace")),
+		FilterFunc: controller.FilterGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -165,7 +165,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
 
 			// Test if namespace reconciler would recreate broker once it was deleted
-			if err := client.Eventing.EventingV1beta1().Brokers(client.namespace).Delete(defaultBrokerName); err != nil {
+			if err := client.Eventing.EventingV1beta1().Brokers(client.Namespace).Delete(defaultBrokerName); err != nil {
 				t.Fatalf("Can't delete broker: %v in namespace: ", defaultBrokerName, client.Namespace)
 			}
 			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"knative.dev/pkg/test/logging"
 
@@ -164,9 +165,9 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			// Wait for default broker ready.
 			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
 
-			// Test if namespace reconciler would recreate broker once it was deleted
-			if err := client.Eventing.EventingV1beta1().Brokers(client.Namespace).Delete(defaultBrokerName); err != nil {
-				t.Fatalf("Can't delete broker: %v in namespace: ", defaultBrokerName, client.Namespace)
+			// Test if namespace reconciler would recreate broker once broker was deleted.
+			if err := client.Eventing.EventingV1beta1().Brokers(client.Namespace).Delete(defaultBrokerName, &metav1.DeleteOptions{}); err != nil {
+				t.Fatalf("Can't delete default broker in namespace: %v", client.Namespace)
 			}
 			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
 

--- a/test/e2e/broker_default_test.go
+++ b/test/e2e/broker_default_test.go
@@ -164,6 +164,12 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 			// Wait for default broker ready.
 			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
 
+			// Test if namespace reconciler would recreate broker once it was deleted
+			if err := client.Eventing.EventingV1beta1().Brokers(client.namespace).Delete(defaultBrokerName); err != nil {
+				t.Fatalf("Can't delete broker: %v in namespace: ", defaultBrokerName, client.Namespace)
+			}
+			client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
+
 			// Create subscribers.
 			for _, event := range test.eventsToReceive {
 				subscriberName := name("dumper", event.context.Type, event.context.Source, event.context.Extensions)


### PR DESCRIPTION
Fixes #2624

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change informer handler logic
- Add e2e test
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
