### PR TITLE
Add an option to specify sinkbinding webhook selector.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"knative.dev/eventing/pkg/reconciler/sinkbinding"
 
@@ -40,6 +41,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler/legacysinkbinding"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
@@ -162,43 +164,49 @@ func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 	)
 }
 
-func NewSinkBindingWebhook(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	sbresolver := sinkbinding.WithContextFactory(ctx, func(types.NamespacedName) {})
+func NewSinkBindingWebhook(opts ...psbinding.ReconcilerOption) injection.ControllerConstructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		sbresolver := sinkbinding.WithContextFactory(ctx, func(types.NamespacedName) {})
 
-	return psbinding.NewAdmissionController(ctx,
+		return psbinding.NewAdmissionController(ctx,
 
-		// Name of the resource webhook.
-		"sinkbindings.webhook.sources.knative.dev",
+			// Name of the resource webhook.
+			"sinkbindings.webhook.sources.knative.dev",
 
-		// The path on which to serve the webhook.
-		"/sinkbindings",
+			// The path on which to serve the webhook.
+			"/sinkbindings",
 
-		// How to get all the Bindables for configuring the mutating webhook.
-		sinkbinding.ListAll,
+			// How to get all the Bindables for configuring the mutating webhook.
+			sinkbinding.ListAll,
 
-		// How to setup the context prior to invoking Do/Undo.
-		sbresolver,
-	)
+			// How to setup the context prior to invoking Do/Undo.
+			sbresolver,
+			opts...,
+		)
+	}
 }
 
 // TODO(#2312): Remove this after v0.13.
-func NewLegacySinkBindingWebhook(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	sbresolver := legacysinkbinding.WithContextFactory(ctx, func(types.NamespacedName) {})
+func NewLegacySinkBindingWebhook(opts ...psbinding.ReconcilerOption) injection.ControllerConstructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		sbresolver := legacysinkbinding.WithContextFactory(ctx, func(types.NamespacedName) {})
 
-	return psbinding.NewAdmissionController(ctx,
+		return psbinding.NewAdmissionController(ctx,
 
-		// Name of the resource webhook.
-		"legacysinkbindings.webhook.sources.knative.dev",
+			// Name of the resource webhook.
+			"legacysinkbindings.webhook.sources.knative.dev",
 
-		// The path on which to serve the webhook.
-		"/legacysinkbindings",
+			// The path on which to serve the webhook.
+			"/legacysinkbindings",
 
-		// How to get all the Bindables for configuring the mutating webhook.
-		legacysinkbinding.ListAll,
+			// How to get all the Bindables for configuring the mutating webhook.
+			legacysinkbinding.ListAll,
 
-		// How to setup the context prior to invoking Do/Undo.
-		sbresolver,
-	)
+			// How to setup the context prior to invoking Do/Undo.
+			sbresolver,
+			opts...,
+		)
+	}
 }
 
 func NewConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -286,6 +294,10 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 }
 
 func main() {
+	sbSelector := psbinding.WithSelector(psbinding.ExclusionSelector)
+	if os.Getenv("SINK_BINDING_OPT_OUT_SELECTOR") == "true" {
+		sbSelector = psbinding.WithSelector(psbinding.InclusionSelector)
+	}
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: logconfig.WebhookName(),
@@ -302,8 +314,8 @@ func main() {
 		NewConversionController,
 
 		// For each binding we have a controller and a binding webhook.
-		sinkbinding.NewController, NewSinkBindingWebhook,
+		sinkbinding.NewController, NewSinkBindingWebhook(sbSelector),
 		// TODO(#2312): Remove this after v0.13.
-		legacysinkbinding.NewController, NewLegacySinkBindingWebhook,
+		legacysinkbinding.NewController, NewLegacySinkBindingWebhook(sbSelector),
 	)
 }

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -60,6 +60,8 @@ spec:
           value: knative.dev/eventing
         - name: WEBHOOK_NAME
           value: eventing-webhook
+        - name: SINK_BINDING_OPT_OUT_SELECTOR
+          value: "false"
 
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes #2350

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Depending on PR in pkg: https://github.com/knative/pkg/pull/1123
- Add a `SINK_BINDING_OPT_OUT_SELECTOR` env var in webhook main
- You can override the selector by providing the env var in `500-webhook.yaml`

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->
- 🎁 Add new feature to specify OptIn or OptOut selector for sinkbinding webhook via a env var.

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Add new feature to specify OptIn or OptOut selector for sinkbinding webhook via a env var.
```

**Docs**
Opened an issue to follow up on: https://github.com/knative/docs/issues/2246
<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
 

## Testing
Update `500-webhook.yaml` with `SINK_BINDING_OPT_OUT_SELECTOR` set to `true`.  Observed that the `sinkbinding` and `legacysindbinding` webhook selectors are updated.

@vaikas @patrickshan @matzew @grantr 