### PR TITLE
Preparing for v0.13 release, point pkg to release-0.13.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1311,7 +1311,7 @@
   revision = "8d271d903fe4c290aa361acfb242cff7bcee96f1"
 
 [[projects]]
-  branch = "master"
+  branch = "release-0.13"
   digest = "1:efd99f16d7b5337b1cce9ac8576e2f65c2c2f7b759f64cd235b82f42e0f86f09"
   name = "knative.dev/pkg"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@ required = [
 # Our master branch tracks knative/pkg master or a release.
 [[override]]
   name = "knative.dev/pkg"
-  branch = "master"
+  branch = "release-0.13"
 
 # TODO why is this overridden?
 [[override]]


### PR DESCRIPTION
<!---->
<!--Preparing for v0.13 release, point pkg to release-0.13.-->
## Proposed Changes

- Prepping for `v0.13` release.
- Point `knative.dev/pkg` to branch `release-0.13`.

**Release Note**

```release-note
NONE
```

/cc @mattmoor
