### PR TITLE
Subscription controller needs to track Channels directly, when used.

### DIFF
--- a/pkg/duck/listable.go
+++ b/pkg/duck/listable.go
@@ -119,7 +119,13 @@ func (t *listableTracker) TrackInNamespace(obj metav1.Object) Track {
 		if err := t.ensureTracking(ref); err != nil {
 			return err
 		}
-		return t.tracker.Track(ref, obj)
+
+		return t.tracker.TrackReference(tracker.Reference{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+			Namespace:  obj.GetNamespace(),
+			Name:       ref.Name,
+		}, obj)
 	}
 }
 

--- a/pkg/duck/sinks.go
+++ b/pkg/duck/sinks.go
@@ -61,7 +61,12 @@ func (r *SinkReconciler) GetSinkURI(sinkObjRef *corev1.ObjectReference, source i
 		return "", fmt.Errorf("sink ref is nil")
 	}
 
-	if err := r.tracker.Track(*sinkObjRef, source); err != nil {
+	if err := r.tracker.TrackReference(tracker.Reference{
+		APIVersion: sinkObjRef.APIVersion,
+		Kind:       sinkObjRef.Kind,
+		Namespace:  sinkObjRef.Namespace,
+		Name:       sinkObjRef.Name,
+	}, source); err != nil {
 		return "", fmt.Errorf("Error tracking sink '%+v' for source %q: %+v", sinkObjRef, sourceDesc, err)
 	}
 

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -18,6 +18,8 @@ package subscription
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -62,6 +64,14 @@ func NewController(
 	// Subscription needs to reconcile again.
 	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
 	r.destinationResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
+
+	channelInformer.Informer().AddEventHandler(controller.HandleAll(
+		func(obj interface{}) {
+			if trigger, ok := obj.(*v1alpha1.Trigger); ok {
+				impl.EnqueueKey(types.NamespacedName{Namespace: trigger.Namespace, Name: trigger.Spec.Broker})
+			}
+		},
+	))
 
 	return impl
 }

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -18,19 +18,19 @@ package subscription
 
 import (
 	"context"
-	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
+
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 
-	"knative.dev/eventing/pkg/duck"
-	"knative.dev/eventing/pkg/reconciler"
-	"knative.dev/pkg/resolver"
-
+	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelable"
 	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1alpha1/channel"
 	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1alpha1/subscription"
 	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/subscription"
+	"knative.dev/eventing/pkg/duck"
+	"knative.dev/eventing/pkg/reconciler"
 )
 
 const (

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -18,9 +18,6 @@ package subscription
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
-
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
@@ -64,14 +61,6 @@ func NewController(
 	// Subscription needs to reconcile again.
 	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
 	r.destinationResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
-
-	channelInformer.Informer().AddEventHandler(controller.HandleAll(
-		func(obj interface{}) {
-			if trigger, ok := obj.(*v1alpha1.Trigger); ok {
-				impl.EnqueueKey(types.NamespacedName{Namespace: trigger.Namespace, Name: trigger.Spec.Broker})
-			}
-		},
-	))
 
 	return impl
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -19,7 +19,6 @@ package subscription
 import (
 	"context"
 	"fmt"
-	"knative.dev/pkg/tracker"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -28,8 +27,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/tracker"
 
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
@@ -39,8 +42,6 @@ import (
 	eventingduck "knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
 const (

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -337,6 +337,9 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription)
 	// to have a "backing" channel that is what we need to actually operate on
 	// as well as keep track of.
 	if channelGVK.Group == gvk.Group && channelGVK.Kind == gvk.Kind {
+
+		r.trackAndFetchChannel()
+
 		logging.FromContext(ctx).Warn("fetching backing channel", zap.Any("channel", sub.Spec.Channel))
 		// Because the above (trackAndFetchChannel) gives us back a Channelable
 		// the status of it will not have the extra bits we need (namely, pointer
@@ -350,7 +353,7 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription)
 		realz, err := r.EventingClientSet.MessagingV1alpha1().Channels(sub.Namespace).Get(sub.Spec.Channel.Name, metav1.GetOptions{})
 
 		if diff := cmp.Diff(realz, channel); diff != "" {
-			logging.FromContext(ctx).Error("Unexpected difference (-want, +got): %v", zap.String("diff", diff))
+			logging.FromContext(ctx).Error("Unexpected difference (-want, +got):", zap.String("diff", diff))
 		}
 
 		if !channel.Status.IsReady() || channel.Status.Channel == nil {

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -340,6 +340,15 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription)
 	// as well as keep track of.
 	if channelGVK.Group == gvk.Group && channelGVK.Kind == gvk.Kind {
 		// Track changes on Channel.
+		// Ref: https://github.com/knative/eventing/issues/2641
+		// NOTE: There is a race condition with using the channelableTracker
+		// for Channel when mixed with the usage of channelLister. The
+		// channelableTracker has a different cache than the channelLister,
+		// when channelLister.Channels is called because the channelableTracker
+		// caused an enqueue, the Channels cache my not have had time to
+		// re-sync therefore we have to track Channels using a tracker linked
+		// to the cache we intend to use to pull the Channel from. This linkage
+		// is setup in NewController for r.tracker.
 		apiVersion, kind := gvk.ToAPIVersionAndKind()
 		if err := r.tracker.TrackReference(tracker.Reference{
 			APIVersion: apiVersion,

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -1034,6 +1034,7 @@ func TestAllCases(t *testing.T) {
 			channelLister:       listers.GetMessagingChannelLister(),
 			channelableTracker:  duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
 			destinationResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
+			tracker:             &FakeTracker{},
 		}
 		return subscription.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetSubscriptionLister(), r.Recorder, r)
 	}, false, logger))

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -53,6 +53,20 @@ function knative_teardown() {
   wait_until_object_does_not_exist namespaces knative-eventing
 }
 
+# Add function call to trap
+# Parameters: $1 - Function to call
+#             $2...$n - Signals for trap
+function add_trap() {
+  local cmd=$1
+  shift
+  for trap_signal in $@; do
+    local current_trap="$(trap -p $trap_signal | cut -d\' -f2)"
+    local new_cmd="($cmd)"
+    [[ -n "${current_trap}" ]] && new_cmd="${current_trap};${new_cmd}"
+    trap -- "${new_cmd}" $trap_signal
+  done
+}
+
 # Setup resources common to all eventing tests.
 function test_setup() {
   echo ">> Setting up logging..."

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -55,6 +55,19 @@ function knative_teardown() {
 
 # Setup resources common to all eventing tests.
 function test_setup() {
+  echo ">> Setting up logging..."
+
+  # Install kail if needed.
+  if ! which kail > /dev/null; then
+    bash <( curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"
+  fi
+
+  # Capture all logs.
+  kail > ${ARTIFACTS}/k8s.log.txt &
+  local kail_pid=$!
+  # Clean up kail so it doesn't interfere with job shutting down
+  add_trap "kill $kail_pid || true" EXIT
+
   install_test_resources || return 1
 
   # Publish test images.


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/2641

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add controller logs to prow e2e test output artifacts.
- Track `Channels.messaging.knative.dev` in Subscription's `reconciler.getChannel` method.
- Minor migrations off deprecated `tracker.Track` method.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```