### PR TITLE
No wait in ko delete for performance tests

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -53,6 +53,7 @@ function update_benchmark() {
   kubectl patch configmap config-mako -n "${TEST_NAMESPACE}" -p '{"data":{"environment":"prod"}}' || abort "failed to patch config-mako configmap"
 
   echo ">> Updating benchmark $1"
+  # TODO(chizhg): remove --wait=false once https://github.com/knative/eventing/issues/2633 is fixed
   ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true --wait=false
   ko apply -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
 }

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -53,7 +53,7 @@ function update_benchmark() {
   kubectl patch configmap config-mako -n "${TEST_NAMESPACE}" -p '{"data":{"environment":"prod"}}' || abort "failed to patch config-mako configmap"
 
   echo ">> Updating benchmark $1"
-  ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true
+  ko delete -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} --ignore-not-found=true --wait=false
   ko apply -f "${benchmark_path}"/${TEST_CONFIG_VARIANT} || abort "failed to apply benchmark $1"
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Started from Feb 21st, `ko delete` failed for the channel-imc benchmark with hanging forever, see https://prow.knative.dev/?job=ci-knative-eventing-update-clusters. Add `--wait=false` option to skip waiting. 

Note:
The error should be due to some changes on Feb 21st in https://github.com/knative/eventing/commits/master but I'm not sure which one can cause it. It also might be a bug as customers may also get stuck in deleting resources (in this case subscription).

/cc @nachocano  