### PR TITLE
Adding namespace and configmappropagations finalizers for the configmappropagations

### DIFF
--- a/config/brokers/channel-broker/roles/controller-clusterroles.yaml
+++ b/config/brokers/channel-broker/roles/controller-clusterroles.yaml
@@ -33,3 +33,9 @@ rules:
       - "delete"
       - "patch"
       - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces/finalizers"
+    verbs:
+      - "update"

--- a/config/brokers/channel-broker/roles/controller-clusterroles.yaml
+++ b/config/brokers/channel-broker/roles/controller-clusterroles.yaml
@@ -34,6 +34,12 @@ rules:
       - "patch"
       - "watch"
   - apiGroups:
+      - "configs.internal.knative.dev"
+    resources:
+      - "configmappropagations/finalizers"
+    verbs:
+      - "update"
+  - apiGroups:
       - ""
     resources:
       - "namespaces/finalizers"


### PR DESCRIPTION
Fixes #2642 

## Proposed Changes

- adding `namespaces/finalizers` for ConfigMapPropagation

See the `OwnerReference` of it:
https://github.com/openshift/knative-eventing/blob/release-next/pkg/reconciler/namespace/resources/configmappropagation.go#L32-L35