### PR TITLE
add ngiraldo to mako configs

### DIFF
--- a/test/performance/benchmarks/broker-imc/dev.config
+++ b/test/performance/benchmarks/broker-imc/dev.config
@@ -15,6 +15,7 @@ owner_list: "xiyue@google.com"
 owner_list: "gracegao@google.com"
 owner_list: "nachocano@google.com"
 owner_list: "cshou@google.com"
+owner_list: "ngiraldo@google.com"
 
 # GCP Service Accounts that can publish data to Mako.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
@@ -23,6 +24,7 @@ owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
 owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
 owner_list: "mako-upload@knative-project-228222.iam.gserviceaccount.com"
 owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
+owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/benchmarks/broker-imc/prod.config
+++ b/test/performance/benchmarks/broker-imc/prod.config
@@ -15,6 +15,7 @@ owner_list: "xiyue@google.com"
 owner_list: "gracegao@google.com"
 owner_list: "nachocano@google.com"
 owner_list: "cshou@google.com"
+owner_list: "ngiraldo@google.com"
 
 # GCP Service Accounts that can publish data to Mako. Since this is a prod
 # benchmark, only the CI account should be listed here.

--- a/test/performance/benchmarks/channel-imc/dev.config
+++ b/test/performance/benchmarks/channel-imc/dev.config
@@ -15,6 +15,7 @@ owner_list: "xiyue@google.com"
 owner_list: "gracegao@google.com"
 owner_list: "nachocano@google.com"
 owner_list: "cshou@google.com"
+owner_list: "ngiraldo@google.com"
 
 # GCP Service Accounts that can publish data to Mako.
 owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
@@ -23,6 +24,7 @@ owner_list: "mako-upload@xiyue-knative-project.iam.gserviceaccount.com"
 owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
 owner_list: "mako-upload@knative-project-228222.iam.gserviceaccount.com"
 owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
+owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
 
 # Define the name and type for x-axis of run charts
 input_value_info: {

--- a/test/performance/benchmarks/channel-imc/prod.config
+++ b/test/performance/benchmarks/channel-imc/prod.config
@@ -15,6 +15,7 @@ owner_list: "xiyue@google.com"
 owner_list: "gracegao@google.com"
 owner_list: "nachocano@google.com"
 owner_list: "cshou@google.com"
+owner_list: "ngiraldo@google.com"
 
 # GCP Service Accounts that can publish data to Mako. Since this is a prod
 # benchmark, only the CI account should be listed here.

--- a/test/performance/config/config-mako.yaml
+++ b/test/performance/config/config-mako.yaml
@@ -65,6 +65,7 @@ data:
     owner_list: "gracegao@google.com"
     owner_list: "nachocano@google.com"
     owner_list: "cshou@google.com"
+    owner_list: "ngiraldo@google.com"
 
     # Anyone can add their IAM robot here to publish to this benchmark.
     owner_list: "mako-job@knative-performance.iam.gserviceaccount.com"
@@ -74,6 +75,7 @@ data:
     owner_list: "mako-upload@gracegao-knative-gcp-testing.iam.gserviceaccount.com"
     owner_list: "mako-upload@knative-project-228222.iam.gserviceaccount.com"
     owner_list: "mako-upload@cshou-playground.iam.gserviceaccount.com"
+    owner_list: "mako-upload@ngiraldo-knative-dev.iam.gserviceaccount.com"
 
     # Define the name and type for x-axis of run charts
     input_value_info: {


### PR DESCRIPTION
Add myself to mako config owners in order to be able to run performance tests from my dev env.
