### PR TITLE
Pick a better name for the sinkbinding selector env var.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -336,7 +336,7 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 
 func main() {
 	sbSelector := psbinding.WithSelector(psbinding.ExclusionSelector)
-	if os.Getenv("SINK_BINDING_OPT_OUT_SELECTOR") == "true" {
+	if os.Getenv("SINK_BINDING_SELECTION_MODE") == "inclusion" {
 		sbSelector = psbinding.WithSelector(psbinding.InclusionSelector)
 	}
 	// Set up a signal context with our webhook options

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -60,8 +60,15 @@ spec:
           value: knative.dev/eventing
         - name: WEBHOOK_NAME
           value: eventing-webhook
-        - name: SINK_BINDING_OPT_OUT_SELECTOR
-          value: "false"
+          # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
+          # for the sinkbinding webhook.
+          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # will be considered by the sinkbinding webhook;
+          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # will NOT be considered by the sinkbinding webhook.
+          # The default is `exclusion`.
+        - name: SINK_BINDING_SELECTION_MODE
+          value: "exclusion"
 
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/pull/2634#discussion_r384777104

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- `SINK_BINDING_OPT_OUT_SELECTOR` -> `SINK_BINDING_SELECTION_MODE`
- Instead of specifying `true` or `false`, just pick the selector type `inclusion` or `exclusion`
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Specify sinkbinding webhook selector by `SINK_BINDING_SELECTION_MODE` environment variable.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/assign @n3wscott @matzew 
cc @vaikas 