### PR TITLE
E2E event receiver pod with REST endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1593,6 +1593,7 @@
     "knative.dev/pkg/test/helpers",
     "knative.dev/pkg/test/logging",
     "knative.dev/pkg/test/mako",
+    "knative.dev/pkg/test/monitoring",
     "knative.dev/pkg/test/zipkin",
     "knative.dev/pkg/testutils/clustermanager/perf-tests",
     "knative.dev/pkg/tracing",

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -89,7 +89,7 @@ func setupBrokerTracing(
 	client.CreateRBACResourcesForBrokers()
 	broker := client.CreateBrokerOrFail("br", resources.WithChannelTemplateForBroker(channel))
 
-	// Create a logger (EventDetails) Pod and a K8s Service that points to it.
+	// Create a logger (EventRecord) Pod and a K8s Service that points to it.
 	logPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(logPod, lib.WithService(loggerPodName))
 

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -121,15 +121,16 @@ func tracingTest(
 // assertEventMatch verifies that recorder pod contains at least one event that
 // matches mustMatch. It is used to show that the expected event was sent to
 // the logger Pod.  It returns a list of the matching events.
-func assertEventMatch(t *testing.T, client *lib.Client, recorderPodName string, mustMatch lib.EventMatchFunc) []lib.EventInfo {
+func assertEventMatch(t *testing.T, client *lib.Client, recorderPodName string,
+	mustMatch lib.EventMatchFunc) []lib.EventInfo {
 	targetTracker, err := client.NewEventInfoStore(recorderPodName, t.Logf)
 	if err != nil {
-		t.Fatalf("pod tracker failed: %s", err)
+		t.Fatalf("Pod tracker failed: %v", err)
 	}
 	defer targetTracker.Cleanup()
 	matches, err := targetTracker.WaitAtLeastNMatch(lib.ValidEvFunc(mustMatch), 1)
 	if err != nil {
-		t.Fatalf("expected messages not found: %s", err)
+		t.Fatalf("Expected messages not found: %v", err)
 	}
 	return matches
 }
@@ -143,7 +144,8 @@ func getTraceIDHeader(t *testing.T, evInfos []lib.EventInfo) string {
 			traceID, found := evInfos[i].HTTPHeaders["X-B3-Traceid"]
 			if found {
 				if len(traceID) != 1 {
-					t.Fatalf("Unexpected length %d for traceid list: %v", len(traceID), traceID)
+					t.Fatalf("Unexpected length %d for traceid list: %v",
+						len(traceID), traceID)
 				}
 				return strings.TrimSpace(traceID[0])
 			}
@@ -157,8 +159,8 @@ func getTraceIDHeader(t *testing.T, evInfos []lib.EventInfo) string {
 // SendEvents (Pod) -> Channel -> Subscription -> K8s Service -> Mutate (Pod)
 //                                                                   v
 // LogEvents (Pod) <- K8s Service <- Subscription  <- Channel <- (Reply) Subscription
-// It returns the expected trace tree and a string that is expected to be sent by the SendEvents Pod
-// and should be present in the LogEvents Pod logs.
+// It returns the expected trace tree and a match function that is expected to be sent
+// by the SendEvents Pod and should be present in the RecordEvents list of events.
 func setupChannelTracingWithReply(
 	t *testing.T,
 	channel *metav1.TypeMeta,

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -18,7 +18,7 @@ package helpers
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,7 +42,7 @@ type SetupInfrastructureFunc func(
 	client *lib.Client,
 	loggerPodName string,
 	tc TracingTestCase,
-) (tracinghelper.TestSpanTree, string)
+) (tracinghelper.TestSpanTree, lib.EventMatchFunc)
 
 // TracingTestCase is the test case information for tracing tests.
 type TracingTestCase struct {
@@ -103,10 +103,10 @@ func tracingTest(
 	// TestMain.
 	tracinghelper.Setup(t, client)
 
-	expected, mustContain := setupInfrastructure(t, &channel, client, loggerPodName, tc)
-	assertLogContents(t, client, loggerPodName, mustContain)
+	expected, mustMatch := setupInfrastructure(t, &channel, client, loggerPodName, tc)
+	matches := assertEventMatch(t, client, loggerPodName, mustMatch)
 
-	traceID := getTraceID(t, client, loggerPodName)
+	traceID := getTraceIDHeader(t, matches)
 	trace, err := zipkin.JSONTrace(traceID, expected.SpanCount(), 2*time.Minute)
 	if err != nil {
 		t.Fatalf("Unable to get trace %q: %v. Trace so far %+v", traceID, err, tracinghelper.PrettyPrintTrace(trace))
@@ -118,28 +118,39 @@ func tracingTest(
 	}
 }
 
-// assertLogContents verifies that loggerPodName's logs contains mustContain. It is used to show
-// that the expected event was sent to the logger Pod.
-func assertLogContents(t *testing.T, client *lib.Client, loggerPodName string, mustContain string) {
-	if err := client.CheckLog(loggerPodName, lib.CheckerContains(mustContain)); err != nil {
-		t.Fatalf("String %q not found in logs of logger pod %q: %v", mustContain, loggerPodName, err)
+// assertEventMatch verifies that recorder pod contains at least one event that
+// matches mustMatch. It is used to show that the expected event was sent to
+// the logger Pod.  It returns a list of the matching events.
+func assertEventMatch(t *testing.T, client *lib.Client, recorderPodName string, mustMatch lib.EventMatchFunc) []lib.EventInfo {
+	targetTracker, err := client.NewEventInfoStore(recorderPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("pod tracker failed: %s", err)
 	}
+	defer targetTracker.Cleanup()
+	matches, err := targetTracker.WaitAtLeastNMatch(lib.ValidEvFunc(mustMatch), 1)
+	if err != nil {
+		t.Fatalf("expected messages not found: %s", err)
+	}
+	return matches
 }
 
-// getTraceID gets the TraceID from loggerPodName's logs. It will also assert that body is present.
-func getTraceID(t *testing.T, client *lib.Client, loggerPodName string) string {
-	logs, err := client.GetLog(loggerPodName)
-	if err != nil {
-		t.Fatalf("Error getting logs: %v", err)
+// getTraceIDHeader gets the TraceID from the passed in events.  It returns the header from the
+// first matching event, but registers a fatal error if more than one traceid header is seen
+// in that message.
+func getTraceIDHeader(t *testing.T, evInfos []lib.EventInfo) string {
+	for i := range evInfos {
+		if nil != evInfos[i].HTTPHeaders {
+			traceID, found := evInfos[i].HTTPHeaders["X-B3-Traceid"]
+			if found {
+				if len(traceID) != 1 {
+					t.Fatalf("Unexpected length %d for traceid list: %v", len(traceID), traceID)
+				}
+				return strings.TrimSpace(traceID[0])
+			}
+		}
 	}
-	// This is the format that the eventdetails image prints headers.
-	re := regexp.MustCompile("\nGot Header X-B3-Traceid: ([a-zA-Z0-9]{32})\n")
-	matches := re.FindStringSubmatch(logs)
-	if len(matches) != 2 {
-		t.Fatalf("Unable to extract traceID: %q", logs)
-	}
-	traceID := matches[1]
-	return traceID
+	t.Fatalf("FAIL: No traceid in %d messages: (%s)", len(evInfos), evInfos)
+	return ""
 }
 
 // setupChannelTracing is the general setup for TestChannelTracing. It creates the following:
@@ -154,7 +165,7 @@ func setupChannelTracingWithReply(
 	client *lib.Client,
 	loggerPodName string,
 	tc TracingTestCase,
-) (tracinghelper.TestSpanTree, string) {
+) (tracinghelper.TestSpanTree, lib.EventMatchFunc) {
 	// Create the Channels.
 	channelName := "ch"
 	client.CreateChannelOrFail(channelName, channel)
@@ -163,7 +174,7 @@ func setupChannelTracingWithReply(
 	client.CreateChannelOrFail(replyChannelName, channel)
 
 	// Create the 'sink', a LogEvents Pod and a K8s Service that points to it.
-	loggerPod := resources.EventDetailsPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
 
 	// Create the subscriber, a Pod that mutates the event.
@@ -322,5 +333,17 @@ func setupChannelTracingWithReply(
 			},
 		}
 	}
-	return expected, body
+
+	matchFunc := func(ev ce.Event) bool {
+		if ev.Source() != senderName {
+			return false
+		}
+		if ev.ID() != eventID {
+			return false
+		}
+		db, _ := ev.DataBytes()
+		return strings.Contains(string(db), body)
+	}
+
+	return expected, matchFunc
 }

--- a/test/lib/checkevents.go
+++ b/test/lib/checkevents.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"knative.dev/pkg/test/logging"
+)
+
+const (
+	// The interval and timeout used for checking events
+	minEvRetryInterval = 4 * time.Second
+	timeoutEvRetry     = 4 * time.Minute
+)
+
+// Stateful store of events received by the recordevents pod it is pointed at.
+// This pulls events from the pod during any Find or Wait call, storing them
+// locally and triming them from the remote pod store.
+type EventInfoStore struct {
+	getter eventGetterInterface
+
+	lock          sync.Mutex
+	allEvents     []EventInfo
+	firstID       int
+	closeCh       chan struct{}
+	doRefresh     chan chan error
+	timeout       time.Duration
+	retryInterval time.Duration
+}
+
+// Functions used for getting data from the REST api of the recordevents pod.
+// The interface exists for use with unit tests of this module.
+type eventGetterInterface interface {
+	getMinMax() (minRet int, maxRet int, errRet error)
+	getEntry(seqno int) (EventInfo, error)
+	trimThrough(seqno int) error
+	cleanup()
+}
+
+// Internal function to create an event store.  This is called directly by unit tests of
+// this module.
+func newTestableEventInfoStore(egi eventGetterInterface, retryInterval time.Duration, timeout time.Duration) *EventInfoStore {
+	if timeout == -1 {
+		timeout = timeoutEvRetry
+	}
+	if retryInterval == -1 {
+		retryInterval = minEvRetryInterval
+	}
+	ei := &EventInfoStore{getter: egi, firstID: 1, timeout: timeout, retryInterval: retryInterval}
+	ei.start()
+	return ei
+}
+
+// Creates an EventInfoStore that is used to iteratively download events recorded by the
+// recordevents pod.  Calling this forwards the recordevents port to the local machine
+// and blocks waiting to connect to that pod.  Fails if it cannot connect within
+// the expected timeout (4 minutes currently)
+func (client *Client) NewEventInfoStore(podName string, logf logging.FormatLogger) (*EventInfoStore, error) {
+	egi, err := newEventGetter(podName, client, logf)
+	if err != nil {
+		return nil, err
+	}
+	ei := newTestableEventInfoStore(egi, -1, -1)
+	return ei, nil
+}
+
+// Starts the single threaded background goroutine used to update local state
+// from the remote REST API.
+func (ei *EventInfoStore) start() {
+	ei.closeCh = make(chan struct{})
+	ei.doRefresh = make(chan chan error)
+	go func() {
+		for {
+			select {
+			case <-ei.closeCh:
+				ei.getter.cleanup()
+				return
+			case replyCh := <-ei.doRefresh:
+				err := ei.doRetrieveData()
+				replyCh <- err
+			}
+		}
+	}()
+}
+
+// The data update thread used by the single threaded background goroutine
+// for updating data from the REST api.
+func (ei *EventInfoStore) doRetrieveData() error {
+	min, max, err := ei.getter.getMinMax()
+	if err != nil {
+		return fmt.Errorf("error getting MinMax %s", err)
+	}
+	ei.lock.Lock()
+	curMin := ei.firstID
+	curMax := curMin + len(ei.allEvents) - 1
+	ei.lock.Unlock()
+	if min == max+1 {
+		// Nothing to read or trim
+		return nil
+	} else {
+		if min > curMax+1 {
+			return fmt.Errorf("mismatched stored max/available min: %d, %d", curMax, min)
+		}
+		min = curMax + 1
+		// We may have data to read, definitely have data to trim.
+	}
+	var newEvents []EventInfo
+	for i := min; i <= max; i++ {
+		e, err := ei.getter.getEntry(i)
+		if err != nil {
+			return fmt.Errorf("error alling GetEntry of %d %s", i, err)
+		}
+
+		newEvents = append(newEvents, e)
+	}
+	ei.lock.Lock()
+	ei.allEvents = append(ei.allEvents, newEvents...)
+	ei.lock.Unlock()
+	err = ei.getter.trimThrough(max)
+	return err
+
+}
+
+// Clean up any background resources used by the store.  Must be called exactly once after
+// the last use.
+func (ei *EventInfoStore) Cleanup() error {
+	close(ei.closeCh)
+	return nil
+}
+
+// Called internally by functions wanting the current list of all
+// known events.  This calls for an update from the REST server and
+// returns the summary of all locally and remotely known events.
+// Returns an error in case of a connection or protocol error.
+func (ei *EventInfoStore) refreshData() ([]EventInfo, error) {
+	var allEvents []EventInfo
+	replyCh := make(chan error)
+	ei.doRefresh <- replyCh
+	err := <-replyCh
+	if err != nil {
+		return nil, err
+	}
+	ei.lock.Lock()
+	allEvents = append(allEvents, ei.allEvents...)
+	ei.lock.Unlock()
+	return allEvents, nil
+}
+
+// Find all events received by the recordevents pod that match the provided function,
+// returning all matching events as well as a SearchedInfo structure including the
+// last 5 events seen and the total events matched.  This SearchedInfo structure
+// is primarily to ease debugging in failure printouts.  The provided function is
+// guaranteed to be called exactly once on each EventInfo from the pod.
+func (ei *EventInfoStore) Find(f EventInfoMatchFunc) ([]EventInfo, SearchedInfo, error) {
+	maxLastEvents := 5
+	allMatch := []EventInfo{}
+	sInfo := SearchedInfo{}
+	lastEvents := []EventInfo{}
+
+	allEvents, err := ei.refreshData()
+	if err != nil {
+		return nil, sInfo, fmt.Errorf("error getting events %s", err)
+	}
+	for i := range allEvents {
+		if f(allEvents[i]) {
+			allMatch = append(allMatch, allEvents[i])
+		}
+		lastEvents = append(lastEvents, allEvents[i])
+		if len(lastEvents) > maxLastEvents {
+			copy(lastEvents, lastEvents[1:])
+			lastEvents = lastEvents[:maxLastEvents]
+		}
+	}
+	sInfo.LastNEvent = lastEvents
+	sInfo.TotalEvent = len(allEvents)
+
+	return allMatch, sInfo, nil
+}
+
+// Convert a boolean check function that checks valid messages to a function
+// that checks EventInfo structures, returning false for any that don't
+// contain valid events.
+func ValidEvFunc(evf EventMatchFunc) EventInfoMatchFunc {
+	return func(ei EventInfo) bool {
+		if ei.Event == nil {
+			return false
+		} else {
+			return evf(*ei.Event)
+		}
+	}
+
+}
+
+// Wait a long time (currently 4 minutes) until the provided function matches at least
+// five events.  The matching events are returned if we find at least n.  If the
+// function times out, an error is returned.
+func (ei *EventInfoStore) WaitAtLeastNMatch(f EventInfoMatchFunc, n int) ([]EventInfo, error) {
+	var matchRet []EventInfo
+	var internalErr error
+
+	wait.PollImmediate(ei.retryInterval, ei.timeout, func() (bool, error) {
+		allMatch, sInfo, err := ei.Find(f)
+		if err != nil {
+			internalErr = fmt.Errorf("FAIL MATCHING: unexpected error during find: %s", err)
+			return false, nil
+		}
+		count := len(allMatch)
+		if count < n {
+			internalErr = fmt.Errorf("FAIL MATCHING: saw %d/%d matching events. recent events: (%s)", count, n, &sInfo)
+			return false, nil
+		}
+		matchRet = allMatch
+		internalErr = nil
+		return true, nil
+	})
+	return matchRet, internalErr
+}
+
+// Does the provideded EventInfo match some criteria
+type EventInfoMatchFunc func(EventInfo) bool
+
+// Does the provided event match some criteria
+type EventMatchFunc func(cloudevents.Event) bool

--- a/test/lib/checkevents.go
+++ b/test/lib/checkevents.go
@@ -143,9 +143,8 @@ func (ei *EventInfoStore) doRetrieveData() error {
 
 // Clean up any background resources used by the store.  Must be called exactly once after
 // the last use.
-func (ei *EventInfoStore) Cleanup() error {
+func (ei *EventInfoStore) Cleanup() {
 	close(ei.closeCh)
-	return nil
 }
 
 // Called internally by functions wanting the current list of all
@@ -236,7 +235,7 @@ func (ei *EventInfoStore) WaitAtLeastNMatch(f EventInfoMatchFunc, n int) ([]Even
 	return matchRet, internalErr
 }
 
-// Does the provideded EventInfo match some criteria
+// Does the provided EventInfo match some criteria
 type EventInfoMatchFunc func(EventInfo) bool
 
 // Does the provided event match some criteria

--- a/test/lib/checkevents_test.go
+++ b/test/lib/checkevents_test.go
@@ -130,6 +130,8 @@ func (deg *dummyEventGet) setEv(firstID int, allEv []EventInfo) {
 	deg.allEv = allEv
 }
 
+// Test that Finds where the server gives sequential updates that
+// don't overlap see the expected events.
 func TestSequentialAndTrim(t *testing.T) {
 	totalEv := makeEvents()
 	expectedFull := makeEvents()
@@ -158,6 +160,8 @@ func TestSequentialAndTrim(t *testing.T) {
 	ei.Cleanup()
 }
 
+// Test that Finds where the server gives overlapping updates
+// see the expected events (no double events)
 func TestOverlap(t *testing.T) {
 	totalEv := makeEvents()
 	expectedFull := makeEvents()
@@ -180,6 +184,8 @@ func TestOverlap(t *testing.T) {
 	ei.Cleanup()
 }
 
+// Test that we see an error if repeated Finds see a gap in the sequence
+// space
 func TestGap(t *testing.T) {
 	totalEv := makeEvents()
 	expectedFull := makeEvents()
@@ -201,6 +207,8 @@ func TestGap(t *testing.T) {
 	ei.Cleanup()
 }
 
+// Test that two finds, with the second one having
+// no new events, returns the right events.
 func TestSequentialNoOp(t *testing.T) {
 	totalEv := makeEvents()
 	expectedFull := makeEvents()
@@ -223,6 +231,7 @@ func TestSequentialNoOp(t *testing.T) {
 	ei.Cleanup()
 }
 
+// Test that wait for N Works
 func TestWaitForN(t *testing.T) {
 	deg := newDummyEventGet()
 	subEv := makeEvents()[:10]

--- a/test/lib/checkevents_test.go
+++ b/test/lib/checkevents_test.go
@@ -112,12 +112,13 @@ func makeEvents() []EventInfo {
 
 func checkEvIDEqual(t *testing.T, seen []EventInfo, expected []EventInfo) {
 	if len(seen) != len(expected) {
-		t.Fatalf("seen ev list length %d does not match expected %d", len(seen), len(expected))
+		t.Fatalf("Seen ev list length %d does not match expected %d", len(seen), len(expected))
 
 	}
 	for i := range seen {
 		if seen[i].Event.ID() != expected[i].Event.ID() {
-			t.Fatalf("Id entry %d mismatch: seen %s != expected %s", i, seen[i].Event.ID(), expected[i].Event.ID())
+			t.Fatalf("Id entry %d mismatch: seen %s != expected %s",
+				i, seen[i].Event.ID(), expected[i].Event.ID())
 		}
 	}
 }
@@ -138,7 +139,7 @@ func TestSequentialAndTrim(t *testing.T) {
 	ei := newTestableEventInfoStore(deg, -1, -1)
 	allData, _, err := ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	min, _, _ := deg.getMinMax()
@@ -151,7 +152,7 @@ func TestSequentialAndTrim(t *testing.T) {
 
 	allData, _, err = ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:19])
 	ei.Cleanup()
@@ -166,14 +167,14 @@ func TestOverlap(t *testing.T) {
 	ei := newTestableEventInfoStore(deg, -1, -1)
 	allData, _, err := ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = totalEv[6:19]
 	deg.setEv(7, subEv)
 	allData, _, err = ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:19])
 	ei.Cleanup()
@@ -188,7 +189,7 @@ func TestGap(t *testing.T) {
 	ei := newTestableEventInfoStore(deg, -1, -1)
 	allData, _, err := ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = totalEv[11:19]
@@ -209,14 +210,14 @@ func TestSequentialNoOp(t *testing.T) {
 	ei := newTestableEventInfoStore(deg, -1, -1)
 	allData, _, err := ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = []EventInfo{}
 	deg.setEv(11, subEv)
 	allData, _, err = ei.Find(func(EventInfo) bool { return true })
 	if err != nil {
-		t.Fatalf("Unexpected error from find: %s", err)
+		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	ei.Cleanup()
@@ -245,7 +246,7 @@ func TestWaitForN(t *testing.T) {
 
 	wg.Wait()
 	if waitErr != nil {
-		t.Fatalf("Unexpected error from find: %s", waitErr)
+		t.Fatalf("Unexpected error from find: %v", waitErr)
 	}
 	if len(allMatch) != 2 {
 		t.Fatalf("Unexpected match length: %d != %d", len(allMatch), 2)

--- a/test/lib/checkevents_test.go
+++ b/test/lib/checkevents_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+)
+
+type dummyEventGet struct {
+	lock sync.Mutex
+
+	minSeq int
+	allEv  []EventInfo
+	clean  bool
+	tCalls int
+}
+
+func newDummyEventGet() *dummyEventGet {
+	return &dummyEventGet{minSeq: 1}
+}
+
+func (deg *dummyEventGet) getMinMax() (minRet int, maxRet int, errRet error) {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	if deg.clean {
+		panic("getminmax called on cleaned event getter")
+	}
+	min := deg.minSeq
+	max := min + len(deg.allEv) - 1
+	return min, max, nil
+}
+func (deg *dummyEventGet) getEntry(seqno int) (EventInfo, error) {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	if deg.clean {
+		panic("getentry called on cleaned event getter")
+	}
+	min := deg.minSeq
+	max := min + len(deg.allEv) - 1
+	if seqno >= min && seqno <= max {
+		return deg.allEv[seqno-deg.minSeq], nil
+	} else {
+		return EventInfo{}, fmt.Errorf("illegal get seqno: %d, range min = %d, max = %d", seqno, min, max)
+	}
+}
+func (deg *dummyEventGet) trimThrough(seqno int) error {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	deg.tCalls++
+	if deg.clean {
+		panic("trim called on cleaned event getter")
+	}
+	min := deg.minSeq
+	max := min + len(deg.allEv) - 1
+	if seqno < 0 {
+		return fmt.Errorf("Illegal negative seqno %d", seqno)
+	} else if seqno > max {
+		return fmt.Errorf("Illegal negative seqno %d > %d", seqno, max)
+	} else if seqno < min {
+		return nil
+	}
+	deg.allEv = deg.allEv[seqno-min+1:]
+	deg.minSeq = seqno + 1
+	return nil
+}
+func (deg *dummyEventGet) trimCalls() int {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	return deg.tCalls
+}
+func (deg *dummyEventGet) cleanup() {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	if deg.clean {
+		panic("Unexpected clean")
+	} else {
+		deg.clean = true
+	}
+}
+
+func makeEvents() []EventInfo {
+	var allEv []EventInfo
+	for i := 0; i < 30; i++ {
+		ce := cloudevents.NewEvent(cloudevents.VersionV1)
+		ce.SetType("knative.dev.test.event.a")
+		ce.SetSource("https://source.test.event.knative.dev/foo")
+		ce.SetID(strconv.FormatInt(int64(i), 10))
+		allEv = append(allEv, EventInfo{Event: &ce})
+	}
+	return allEv
+}
+
+func checkEvIDEqual(t *testing.T, seen []EventInfo, expected []EventInfo) {
+	if len(seen) != len(expected) {
+		t.Fatalf("seen ev list length %d does not match expected %d", len(seen), len(expected))
+
+	}
+	for i := range seen {
+		if seen[i].Event.ID() != expected[i].Event.ID() {
+			t.Fatalf("Id entry %d mismatch: seen %s != expected %s", i, seen[i].Event.ID(), expected[i].Event.ID())
+		}
+	}
+}
+
+func (deg *dummyEventGet) setEv(firstID int, allEv []EventInfo) {
+	deg.lock.Lock()
+	defer deg.lock.Unlock()
+	deg.minSeq = firstID
+	deg.allEv = allEv
+}
+
+func TestSequentialAndTrim(t *testing.T) {
+	totalEv := makeEvents()
+	expectedFull := makeEvents()
+	deg := newDummyEventGet()
+	subEv := totalEv[:10]
+	deg.setEv(1, subEv)
+	ei := newTestableEventInfoStore(deg, -1, -1)
+	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:10])
+	min, _, _ := deg.getMinMax()
+	if min != 11 {
+		t.Fatalf("Expected trim to have moved min to %d, saw %d", 11, min)
+	}
+
+	subEv = totalEv[10:19]
+	deg.setEv(11, subEv)
+
+	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:19])
+	ei.Cleanup()
+}
+
+func TestOverlap(t *testing.T) {
+	totalEv := makeEvents()
+	expectedFull := makeEvents()
+	deg := newDummyEventGet()
+	subEv := totalEv[:10]
+	deg.setEv(1, subEv)
+	ei := newTestableEventInfoStore(deg, -1, -1)
+	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:10])
+	subEv = totalEv[6:19]
+	deg.setEv(7, subEv)
+	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:19])
+	ei.Cleanup()
+}
+
+func TestGap(t *testing.T) {
+	totalEv := makeEvents()
+	expectedFull := makeEvents()
+	deg := newDummyEventGet()
+	subEv := totalEv[:10]
+	deg.setEv(1, subEv)
+	ei := newTestableEventInfoStore(deg, -1, -1)
+	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:10])
+	subEv = totalEv[11:19]
+	deg.setEv(12, subEv)
+	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	if err == nil {
+		t.Fatalf("Unexpected success from find")
+	}
+	ei.Cleanup()
+}
+
+func TestSequentialNoOp(t *testing.T) {
+	totalEv := makeEvents()
+	expectedFull := makeEvents()
+	deg := newDummyEventGet()
+	subEv := totalEv[:10]
+	deg.setEv(1, subEv)
+	ei := newTestableEventInfoStore(deg, -1, -1)
+	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:10])
+	subEv = []EventInfo{}
+	deg.setEv(11, subEv)
+	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	if err != nil {
+		t.Fatalf("Unexpected error from find: %s", err)
+	}
+	checkEvIDEqual(t, allData, expectedFull[:10])
+	ei.Cleanup()
+}
+
+func TestWaitForN(t *testing.T) {
+	deg := newDummyEventGet()
+	subEv := makeEvents()[:10]
+	deg.setEv(1, subEv)
+	ei := newTestableEventInfoStore(deg, time.Second/8, -1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var waitErr error
+	var allMatch []EventInfo
+	go func() {
+		allMatch, waitErr = ei.WaitAtLeastNMatch(ValidEvFunc(func(ev cloudevents.Event) bool { return ev.ID() == "3" }), 2)
+		wg.Done()
+	}()
+	var tCalls int
+	for tCalls == 0 {
+		time.Sleep(time.Second / 100)
+		tCalls = deg.trimCalls()
+	}
+	subEv = makeEvents()[:10]
+	deg.setEv(11, subEv)
+
+	wg.Wait()
+	if waitErr != nil {
+		t.Fatalf("Unexpected error from find: %s", waitErr)
+	}
+	if len(allMatch) != 2 {
+		t.Fatalf("Unexpected match length: %d != %d", len(allMatch), 2)
+	}
+	if allMatch[0].Event.ID() != "3" || allMatch[1].Event.ID() != "3" {
+		t.Fatalf("Unexpected IDs %s, %s, expected both %s", allMatch[0].Event.ID(), allMatch[1].Event.ID(), "3")
+	}
+	tCalls = deg.trimCalls()
+	if tCalls < 2 {
+		t.Fatalf("Expected at least %d trim calls, saw %d", 2, tCalls)
+	}
+	ei.Cleanup()
+}

--- a/test/lib/requests.go
+++ b/test/lib/requests.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/test/monitoring"
+
+	"knative.dev/pkg/test/logging"
+)
+
+// Port for the recordevents pod REST listener
+const RecordEventsPort = 8392
+
+// HTTP path for the GetMinMax REST call
+const GetMinMaxPath = "/minmax"
+
+// HTTP path for the GetEntry REST call
+const GetEntryPath = "/entry/"
+
+// HTTP path for the TrimThrough REST call
+const TrimThroughPath = "/trimthrough/"
+
+// On-wire json rest api format for recordevents GetMinMax calls
+// sennt to the recordevents pod.
+type MinMaxResponse struct {
+	MinAvail int
+	MaxSeen  int
+}
+
+// Structure to hold information about an event seen by recordevents pod.
+type EventInfo struct {
+	// Set if the cloudevent received by the pod didn't pass validation
+	ValidationError string
+	// Event received if the cloudevent received by the pod passed validation
+	Event *cloudevents.Event
+	// HTTPHeaders of the connection that delivered the event
+	HTTPHeaders map[string][]string
+}
+
+// Pretty print the event. Meant for debugging.  This formats the validation error
+// or the full event as appropriate.  This does NOT format the headers.
+func (ei *EventInfo) String() string {
+	if ei.Event != nil {
+		return ei.Event.String()
+	} else {
+		return fmt.Sprintf("invalid event \"%s\"", ei.ValidationError)
+	}
+}
+
+// This is mainly used for providing better failure messages
+type SearchedInfo struct {
+	TotalEvent int
+	LastNEvent []EventInfo
+}
+
+// Pretty print the SearchedInfor for error messages
+func (s *SearchedInfo) String() string {
+	return fmt.Sprintf("%d events seen, last N = %s", s.TotalEvent, s.LastNEvent)
+}
+
+// Connection state for a REST connection to a pod
+type eventGetter struct {
+	podName       string
+	podNamespace  string
+	podPort       int
+	kubeClientset *kubernetes.Clientset
+	logf          logging.FormatLogger
+
+	host       string
+	port       int
+	forwardPID int
+}
+
+// Creates a forwarded port to the specified recordevetns pod and waits until
+// it can successfully talk to the REST API.  Times out after 4 minutes
+func newEventGetter(podName string, client *Client, logf logging.FormatLogger) (eventGetterInterface, error) {
+	egi := &eventGetter{podName: podName, podNamespace: client.Namespace, kubeClientset: client.Kube.Kube, podPort: RecordEventsPort, logf: logf}
+	err := egi.forwardPort()
+	if err != nil {
+		return nil, err
+	}
+
+	err = egi.waitTillUp()
+	if err != nil {
+		return nil, err
+	}
+	return egi, nil
+}
+
+// Get information about the provided podName.  Uses list (rather than get) and
+// returns a pod list for compatibility with the monitoring.PortForward
+// interface
+func (eg *eventGetter) getRunningPodInfo(podName, namespace string) (*v1.PodList, error) {
+	pods, err := eg.kubeClientset.CoreV1().Pods(namespace).List(metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", podName)})
+	if err == nil && len(pods.Items) != 1 {
+		err = fmt.Errorf("no %s Pod found on the cluster", podName)
+	} else if pods.Items[0].Status.Phase != corev1.PodRunning {
+		err = fmt.Errorf("pod %s in state %s, wanted Running", podName, pods.Items[0].Status.Phase)
+	}
+
+	return pods, err
+}
+
+// Try to forward the pod port to a local port somewhere in the range 30000-60000.
+// keeps retrying with random ports in that range for 4 minutes.
+func (eg *eventGetter) forwardPort() error {
+	portRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	portMin := 30000
+	portMax := 60000
+	var internalErr error
+
+	wait.PollImmediate(minEvRetryInterval, timeoutEvRetry, func() (bool, error) {
+		localPort := portMin + portRand.Intn(portMax-portMin)
+		if err := monitoring.CheckPortAvailability(localPort); err != nil {
+			internalErr = err
+			return false, nil
+		}
+		pods, err := eg.getRunningPodInfo(eg.podName, eg.podNamespace)
+		if err != nil {
+			internalErr = err
+			return false, nil
+		}
+
+		pid, err := monitoring.PortForward(eg.logf, pods, localPort, eg.podPort, eg.podNamespace)
+		if err != nil {
+			internalErr = err
+			return false, nil
+		}
+		internalErr = nil
+
+		eg.forwardPID = pid
+		eg.port = localPort
+		eg.host = "localhost"
+		return true, nil
+	})
+	if internalErr != nil {
+		return fmt.Errorf("timeout forwarding port: %s", internalErr)
+	}
+	return nil
+}
+
+// Return the min available, max seen by the recordevents pod.
+// maxRet is the largest event that has ever been seen (whether it's been trimmed
+// or not).  minRet is the smallest event still available via Get, or 1+maxRet if
+// no events are available.  maxRet starts at 0 when no events have been seen.
+func (eg *eventGetter) getMinMax() (minRet int, maxRet int, errRet error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s:%d%s", eg.host, eg.port, GetMinMaxPath))
+	if err != nil {
+		return -1, -1, fmt.Errorf("http get error: %s", err)
+	}
+	defer resp.Body.Close()
+	bodyContents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return -1, -1, fmt.Errorf("Error reading response body %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return -1, -1, fmt.Errorf("Error %d reading GetMinMax response", resp.StatusCode)
+	}
+	minMaxResponse := MinMaxResponse{}
+	err = json.Unmarshal(bodyContents, &minMaxResponse)
+	if err != nil {
+		return -1, -1, fmt.Errorf("Error unmarshalling response %w", err)
+	}
+	if minMaxResponse.MinAvail == 0 || minMaxResponse.MaxSeen == 0 {
+		return -1, -1, fmt.Errorf("Invalid decoded json: %+v", minMaxResponse)
+	}
+
+	return minMaxResponse.MinAvail, minMaxResponse.MaxSeen, nil
+}
+
+// Return the event with the provided sequence number.  Returns the appropriate
+// EventInfo or an error if no such event is known, or the event has already
+// been trimmed.
+func (eg *eventGetter) getEntry(seqno int) (EventInfo, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s:%d%s/%d", eg.host, eg.port, GetEntryPath, seqno))
+	if err != nil {
+		return EventInfo{}, fmt.Errorf("http get err %s", err)
+	}
+	defer resp.Body.Close()
+	bodyContents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return EventInfo{}, fmt.Errorf("Error reading response body %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return EventInfo{}, fmt.Errorf("Error %d reading GetEntry response", resp.StatusCode)
+	}
+	entryResponse := EventInfo{}
+	err = json.Unmarshal(bodyContents, &entryResponse)
+	if err != nil {
+		return EventInfo{}, fmt.Errorf("Error unmarshalling response %w", err)
+	}
+	if len(entryResponse.ValidationError) == 0 && entryResponse.Event == nil {
+		return EventInfo{}, fmt.Errorf("Invalid decoded json: %+v", entryResponse)
+	}
+
+	return entryResponse, nil
+}
+
+// Trim the events up to and including seqno from the recordevents pod.
+// Returns an error if a nonsensical seqno is passed in, but does not return
+// error for trimming already trimmed regions.
+func (eg *eventGetter) trimThrough(seqno int) error {
+	resp, err := http.Post(fmt.Sprintf("http://%s:%d%s/%d", eg.host, eg.port, TrimThroughPath, seqno), "", nil)
+	if err != nil {
+		return fmt.Errorf("http post err %s", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading response body %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Error %d reading TrimThrough response: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// Clean up the getter by tearing down the port forward.
+func (eg *eventGetter) cleanup() {
+	pid := eg.forwardPID
+	eg.forwardPID = 0
+	if pid != 0 {
+		monitoring.Cleanup(pid)
+	}
+}
+
+// Wait (up to 4 minutes) for the pod to RestAPI to answer request.
+func (eg *eventGetter) waitTillUp() error {
+	var internalErr error
+	wait.PollImmediate(minEvRetryInterval, timeoutEvRetry, func() (bool, error) {
+		_, _, internalErr = eg.getMinMax()
+		if internalErr != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	if internalErr != nil {
+		return fmt.Errorf("timeout waiting for recordevents pod to come up: %s", internalErr)
+	}
+	return nil
+}

--- a/test/lib/resources/kube.go
+++ b/test/lib/resources/kube.go
@@ -104,6 +104,11 @@ func EventDetailsPod(name string) *corev1.Pod {
 	return eventLoggerPod("eventdetails", name)
 }
 
+// EventDetailsPod creates a Pod that validates events received and log details about events.
+func EventRecordPod(name string) *corev1.Pod {
+	return eventLoggerPod("recordevents", name)
+}
+
 func eventLoggerPod(imageName string, name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/lib/resources/kube.go
+++ b/test/lib/resources/kube.go
@@ -104,7 +104,7 @@ func EventDetailsPod(name string) *corev1.Pod {
 	return eventLoggerPod("eventdetails", name)
 }
 
-// EventDetailsPod creates a Pod that validates events received and log details about events.
+// EventRecordPod creates a Pod that stores received events for test retrieval.
 func EventRecordPod(name string) *corev1.Pod {
 	return eventLoggerPod("recordevents", name)
 }

--- a/test/lib/validation.go
+++ b/test/lib/validation.go
@@ -36,6 +36,11 @@ const (
 	timeout  = 4 * time.Minute
 )
 
+// Used by logging pods to decide interesting HTTP headers to log
+func InterestingHeaders() []string {
+	return []string{"X-B3-Sampled", "X-B3-Traceid", "X-B3-Spanid", "X-B3-ParentSpanId", "X-Custom-Header"}
+}
+
 // GetLog gets the logs from the given Pod in the namespace of this client. It will get the logs
 // from the first container, whichever it is.
 func (client *Client) GetLog(podName string) (string, error) {

--- a/test/test_images/eventdetails/main.go
+++ b/test/test_images/eventdetails/main.go
@@ -26,6 +26,7 @@ import (
 
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/tracing"
+	"knative.dev/eventing/test/lib"
 )
 
 func handler(ctx context.Context, event cloudevents.Event) {
@@ -34,7 +35,7 @@ func handler(ctx context.Context, event cloudevents.Event) {
 	fmt.Printf("Got Transport Context: %+v\n", tx)
 	fmt.Printf("----------------------------\n")
 	header := tx.Header
-	headerNameList := []string{"X-B3-Sampled", "X-B3-Traceid", "X-B3-Spanid", "X-B3-ParentSpanId", "X-Custom-Header"}
+	headerNameList := lib.InterestingHeaders()
 	for _, headerName := range headerNameList {
 		if headerValue := header.Get(headerName); headerValue != "" {
 			fmt.Printf("Got Header %s: %s\n", headerName, headerValue)

--- a/test/test_images/recordevents/README.md
+++ b/test/test_images/recordevents/README.md
@@ -1,10 +1,8 @@
 # Record Events Image
 
 This stores received events along with their HTTP headers and any validation
-errors, exposing a REST API on port 8392.  This REST API is designed to be used
+errors, exposing a REST API on port 8392. This REST API is designed to be used
 in combination with knative.dev/test/lib/EventInfoStore which allows e2e test
 libraries to query the set of received events.
 
-
 Also logs received events and http headers to aid debugging.
-

--- a/test/test_images/recordevents/README.md
+++ b/test/test_images/recordevents/README.md
@@ -1,0 +1,10 @@
+# Record Events Image
+
+This stores received events along with their HTTP headers and any validation
+errors, exposing a REST API on port 8392.  This REST API is designed to be used
+in combination with knative.dev/test/lib/EventInfoStore which allows e2e test
+libraries to query the set of received events.
+
+
+Also logs received events and http headers to aid debugging.
+

--- a/test/test_images/recordevents/eventstore.go
+++ b/test/test_images/recordevents/eventstore.go
@@ -86,20 +86,19 @@ func (es *eventStore) StoreEvent(event cloudevents.Event, httpHeaders map[string
 		}
 		evInfoBytes, err = json.Marshal(&evInfo)
 		if err != nil {
-			panic(fmt.Errorf("Unexpected marshal error (%s) (%+v)", err, evInfo))
+			panic(fmt.Errorf("Unexpected marshal error (%v) (%+v)", err, evInfo))
 		}
 	}
 
 	es.evBlocksLock.Lock()
+	// Add a new block if we're out of space
+	es.checkAppendBlock()
 
 	evBlock := es.evBlocks[len(es.evBlocks)-1]
 	if evBlock.firstOffsetFree < evBlockSize {
 		evBlock.evInfoBytes[evBlock.firstOffsetFree] = evInfoBytes
 		evBlock.firstOffsetFree++
 	}
-
-	// We always keep at least one free entry
-	es.checkAppendBlock()
 
 	es.evBlocksLock.Unlock()
 }

--- a/test/test_images/recordevents/eventstore.go
+++ b/test/test_images/recordevents/eventstore.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+
+	"knative.dev/eventing/test/lib"
+)
+
+// Number of EventInfo per block
+const evBlockSize = 100
+
+// Block of stored EventInfo
+type eventBlock struct {
+	// seqno of [0] evInfoBytes entry
+	firstIndex int
+	// offset inside block for newly appended event
+	firstOffsetFree int
+	// offset inside block of first non-trimmed event
+	firstValid int
+	// serialized EventInfo structures for each seqno.  We enforce
+	// that there is always at least one block.
+	evInfoBytes [evBlockSize][]byte
+}
+
+// All events currently seen
+type eventStore struct {
+	// Blocks of events in increasing sequency number order
+	evBlocks     []*eventBlock
+	evBlocksLock sync.Mutex
+}
+
+// Create a new event store.
+func newEventStore() *eventStore {
+	es := &eventStore{}
+	es.evBlocks = []*eventBlock{&eventBlock{}}
+
+	// One block with no entries starting at sequence number 1
+	es.evBlocks[0].firstIndex = 1
+	es.evBlocks[0].firstOffsetFree = 0
+	es.evBlocks[0].firstValid = 0
+	return es
+}
+
+// See if there's enough room to append to the current last block.  If not,
+// append an extra block.
+func (es *eventStore) checkAppendBlock() {
+	if es.evBlocks[len(es.evBlocks)-1].firstOffsetFree == evBlockSize {
+		newEVBlock := &eventBlock{
+			firstIndex: es.evBlocks[len(es.evBlocks)-1].firstIndex + evBlockSize,
+		}
+		es.evBlocks = append(es.evBlocks, newEVBlock)
+	}
+}
+
+// Store the specified event.
+func (es *eventStore) StoreEvent(event cloudevents.Event, httpHeaders map[string][]string) {
+	var evInfo lib.EventInfo
+	evInfo.Event = &event
+	evInfo.HTTPHeaders = httpHeaders
+	evInfoBytes, err := json.Marshal(&evInfo)
+	if err != nil {
+		evInfo.Event = nil
+		evInfo.ValidationError = err.Error()
+		if evInfo.ValidationError == "" {
+			evInfo.ValidationError = "Unknown Error"
+		}
+		evInfoBytes, err = json.Marshal(&evInfo)
+		if err != nil {
+			panic(fmt.Errorf("Unexpected marshal error (%s) (%+v)", err, evInfo))
+		}
+	}
+
+	es.evBlocksLock.Lock()
+
+	evBlock := es.evBlocks[len(es.evBlocks)-1]
+	if evBlock.firstOffsetFree < evBlockSize {
+		evBlock.evInfoBytes[evBlock.firstOffsetFree] = evInfoBytes
+		evBlock.firstOffsetFree++
+	}
+
+	// We always keep at least one free entry
+	es.checkAppendBlock()
+
+	es.evBlocksLock.Unlock()
+}
+
+// Logically trim all events up to and include the provided
+// sequence number.  Returns error for patently incorrect
+// values (negative sequence number or sequence number larger
+// than the largest event seen).  Trimming already trimmed
+// regions is legal.
+func (es *eventStore) TrimThrough(through int) error {
+	es.evBlocksLock.Lock()
+	defer es.evBlocksLock.Unlock()
+	minAvail, maxSeen := es.minMaxUnlocked()
+	if through > maxSeen {
+		return fmt.Errorf("invalid trim through %d, maxSeen %d", through, maxSeen)
+	} else if through < 0 {
+		return fmt.Errorf("invalid trim less than zero %d", through)
+	} else if through < minAvail {
+		return nil
+	}
+	// Completely remove blocks if they are full and all events in them are less than
+	// the specified value.
+	for len(es.evBlocks) > 1 && (es.evBlocks[0].firstIndex+evBlockSize-1) <= through {
+		es.evBlocks = es.evBlocks[1:]
+	}
+	// Logically trim the block split by through.
+	es.evBlocks[0].firstValid = through - es.evBlocks[0].firstIndex + 1
+	return nil
+}
+
+// return min/max untrimmed value when already holding the lock
+func (es *eventStore) minMaxUnlocked() (minAvail int, maxSeen int) {
+	minBlock := es.evBlocks[0]
+	minAvail = minBlock.firstIndex + (minBlock.firstValid)
+
+	maxBlock := es.evBlocks[len(es.evBlocks)-1]
+	maxSeen = maxBlock.firstIndex + maxBlock.firstOffsetFree - 1
+	return minAvail, maxSeen
+}
+
+// Returns min available value and max seen value for the store.
+// min is the minimum value that can be retrieved via GetEntry, or
+// if no values can be retrieved, min == max+1.  Max starts at 0
+// when no events have been seen.
+func (es *eventStore) MinMax() (minAvail int, maxSeen int) {
+	es.evBlocksLock.Lock()
+	minAvail, maxSeen = es.minMaxUnlocked()
+
+	es.evBlocksLock.Unlock()
+	return minAvail, maxSeen
+}
+
+// Get the already serialized EventInfo structure for the provided sequence
+// number.
+func (es *eventStore) GetEventInfoBytes(seq int) ([]byte, error) {
+	var evInfoBytes []byte
+	found := false
+
+	es.evBlocksLock.Lock()
+	for _, block := range es.evBlocks {
+		if seq < block.firstIndex+block.firstValid {
+			break
+		}
+		if seq < block.firstIndex+block.firstOffsetFree {
+			found = true
+			evInfoBytes = block.evInfoBytes[seq-block.firstIndex]
+			break
+		}
+	}
+	es.evBlocksLock.Unlock()
+	if !found {
+		return evInfoBytes, fmt.Errorf("Invalid sequence number %d", seq)
+	}
+	return evInfoBytes, nil
+}

--- a/test/test_images/recordevents/eventstore.go
+++ b/test/test_images/recordevents/eventstore.go
@@ -52,7 +52,7 @@ type eventStore struct {
 // Create a new event store.
 func newEventStore() *eventStore {
 	es := &eventStore{}
-	es.evBlocks = []*eventBlock{&eventBlock{}}
+	es.evBlocks = []*eventBlock{{}}
 
 	// One block with no entries starting at sequence number 1
 	es.evBlocks[0].firstIndex = 1

--- a/test/test_images/recordevents/eventstore_test.go
+++ b/test/test_images/recordevents/eventstore_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+
+	"knative.dev/eventing/test/lib"
+)
+
+func helperGetEvInfo(es *eventStore, entry int) (*lib.EventInfo, error) {
+	evInfoBytes, err := es.GetEventInfoBytes(entry)
+	if err != nil {
+		return nil, fmt.Errorf("error calling get on item %d: %s", entry, err)
+	}
+	if len(evInfoBytes) == 0 {
+		return nil, fmt.Errorf("empty info bytes")
+	}
+
+	var evInfo lib.EventInfo
+	err = json.Unmarshal(evInfoBytes, &evInfo)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling stored JSON: %s", err)
+	}
+	return &evInfo, nil
+}
+
+// Test that adding and getting a bunch of events stores them all
+// and that retrieving the events retrieves the correct events.
+func TestAddGetMany(t *testing.T) {
+	es := newEventStore()
+
+	count := 10009
+	for i := 0; i < count; i++ {
+		ce := cloudevents.NewEvent(cloudevents.VersionV1)
+		ce.SetType("knative.dev.test.event.a")
+		ce.SetSource("https://source.test.event.knative.dev/foo")
+		ce.SetID(strconv.FormatInt(int64(i), 10))
+		es.StoreEvent(ce, nil)
+		minAvail, maxSeen := es.MinMax()
+		if minAvail != 1 {
+			t.Fatalf("Pass %d Bad min: %d, expected %d", i, minAvail, 1)
+		}
+		if maxSeen != i+1 {
+			t.Fatalf("Pass %d Bad max: %d, expected %d", i, maxSeen, i+1)
+		}
+
+	}
+	for i := 1; i <= count; i++ {
+		evInfo, err := helperGetEvInfo(es, i)
+		if err != nil {
+			t.Fatalf("count %d error: %s", count, err)
+		}
+
+		if evInfo.Event == nil {
+			t.Fatalf("Unexpected empty event info event %d: %+v", i, evInfo)
+		}
+		if len(evInfo.ValidationError) != 0 {
+			t.Fatalf("Unexpected error for stored event %d: %s", i, evInfo.ValidationError)
+		}
+
+		// Make sure it's the expected event
+		seenID := evInfo.Event.ID()
+		expectedID := strconv.FormatInt(int64(i-1), 10)
+		if seenID != expectedID {
+			t.Errorf("Incorrect id on retrieval: %s, expected %s", seenID, expectedID)
+		}
+	}
+	_, err := es.GetEventInfoBytes(count + 1)
+	if err == nil {
+		t.Errorf("Unexpected non-error return for getinfo of %d", count+1)
+	}
+
+	_, err = es.GetEventInfoBytes(0)
+	if err == nil {
+		t.Errorf("Unexpected non-error return for getinfo of %d", 0)
+	}
+
+}
+
+func TestEmpty(t *testing.T) {
+	es := newEventStore()
+	min, max := es.MinMax()
+	if min != 1 {
+		t.Errorf("Invalid min: %d, expected %d", min, 1)
+	}
+	if max != 0 {
+		t.Errorf("Invalid max: %d, expected %d", max, 0)
+	}
+
+	for i := -2; i < 2; i++ {
+		_, err := es.GetEventInfoBytes(0)
+		if err == nil {
+			t.Errorf("Unexpected non-error return for getinfo of %d", i)
+		}
+	}
+
+}
+
+func TestAddGetSingleValid(t *testing.T) {
+	expectedType := "knative.dev.test.event.a"
+	expectedSource := "https://source.test.event.knative.dev/foo"
+	expectedID := "111"
+	es := newEventStore()
+
+	headers := make(map[string][]string)
+	headers["foo"] = []string{"bar", "baz"}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetType(expectedType)
+	ce.SetSource(expectedSource)
+	ce.SetID(expectedID)
+	es.StoreEvent(ce, headers)
+	minAvail, maxSeen := es.MinMax()
+	if minAvail != maxSeen {
+		t.Fatalf("Expected match, saw %d, %d", minAvail, maxSeen)
+	}
+
+	evInfoBytes, err := es.GetEventInfoBytes(minAvail)
+	if err != nil {
+		t.Fatalf("Error calling get: %s", err)
+	}
+	var evInfo lib.EventInfo
+	err = json.Unmarshal(evInfoBytes, &evInfo)
+	if err != nil {
+		t.Fatalf("Error unmarshalling stored JSON: %s", err)
+	}
+
+	if evInfo.Event == nil {
+		t.Fatalf("Unexpected empty event info event: %+v", evInfo)
+	}
+	if len(evInfo.ValidationError) != 0 {
+		t.Fatalf("Unexpected error for stored event: %s", evInfo.ValidationError)
+	}
+	if len(evInfo.HTTPHeaders) != 1 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if len(evInfo.HTTPHeaders["foo"]) != 2 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if evInfo.HTTPHeaders["foo"][0] != "bar" || evInfo.HTTPHeaders["foo"][1] != "baz" {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	seenID := evInfo.Event.ID()
+	if seenID != expectedID {
+		t.Errorf("Incorrect id on retrieval: %s, expected %s", seenID, expectedID)
+	}
+	seenSource := evInfo.Event.Source()
+	if seenSource != expectedSource {
+		t.Errorf("Incorrect source on retrieval: %s, expected %s", seenSource, expectedSource)
+	}
+	seenType := evInfo.Event.Type()
+	if seenType != expectedType {
+		t.Errorf("Incorrect type on retrieval: %s, expected %s", seenType, expectedType)
+	}
+}
+
+func TestAddGetSingleInvalid(t *testing.T) {
+	es := newEventStore()
+
+	headers := make(map[string][]string)
+	headers["foo"] = []string{"bar", "baz"}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetType("knative.dev.test.event.a")
+	// No source
+	ce.SetID("111")
+	es.StoreEvent(ce, headers)
+	minAvail, maxSeen := es.MinMax()
+	if minAvail != maxSeen {
+		t.Fatalf("Expected match, saw %d, %d", minAvail, maxSeen)
+	}
+
+	evInfoBytes, err := es.GetEventInfoBytes(minAvail)
+	if err != nil {
+		t.Fatalf("Error calling get: %s", err)
+	}
+	var evInfo lib.EventInfo
+	err = json.Unmarshal(evInfoBytes, &evInfo)
+	if err != nil {
+		t.Fatalf("Error unmarshalling stored JSON: %s", err)
+	}
+	if evInfo.Event != nil {
+		t.Fatalf("Unexpected event info: %+v", evInfo)
+	}
+	if len(evInfo.ValidationError) == 0 {
+		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.ValidationError)
+	}
+	if len(evInfo.HTTPHeaders) != 1 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if len(evInfo.HTTPHeaders["foo"]) != 2 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if evInfo.HTTPHeaders["foo"][0] != "bar" || evInfo.HTTPHeaders["foo"][1] != "baz" {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+}
+
+func helperFillCount(es *eventStore, count int) {
+	for i := 0; i < count; i++ {
+		ce := cloudevents.NewEvent(cloudevents.VersionV1)
+		ce.SetType("knative.dev.test.event.a")
+		ce.SetSource("https://source.test.event.knative.dev/foo")
+		ce.SetID(strconv.FormatInt(int64(i), 10))
+		es.StoreEvent(ce, nil)
+	}
+}
+
+// Test that adding and getting a bunch of events stores them all
+// and that retrieving the events retrieves the correct events.
+func TestTrim(t *testing.T) {
+	count := evBlockSize + 10
+
+	validTrimPoints := []int{0, 1, 2, evBlockSize - 1, evBlockSize, evBlockSize + 1, evBlockSize + 2, count - 1, count}
+	invalidTrimPoints := []int{-2, -1, count + 1, count + evBlockSize}
+
+	for _, testVal := range validTrimPoints {
+		es := newEventStore()
+		helperFillCount(es, count)
+		err := es.TrimThrough(testVal)
+		if err != nil {
+			t.Fatalf("Unexpected error trimming to %d: %s", testVal, err)
+		}
+		minAvail, maxSeen := es.MinMax()
+		if testVal == count {
+			if minAvail != maxSeen+1 {
+				t.Errorf("Incorrect minAvail (%d != %d+1) trimming to %d", minAvail, maxSeen, testVal)
+			}
+		} else if minAvail != testVal+1 {
+			t.Errorf("Incorrect minAvail %d trimming to %d", minAvail, testVal)
+		}
+		if maxSeen != count {
+			t.Errorf("Incorrect maxSeen %d trimming to %d", maxSeen, testVal)
+		}
+		if minAvail <= maxSeen {
+			evInfo, err := helperGetEvInfo(es, minAvail)
+			if err != nil {
+				t.Fatalf("Couldn't get min avail %d, trim %d error: %s", minAvail, testVal, err)
+			}
+			seenID := evInfo.Event.ID()
+			expectedID := strconv.FormatInt(int64(minAvail-1), 10)
+			if seenID != expectedID {
+				t.Fatalf("Expected ID %s, saw %s for ev %d, trim %d", expectedID, seenID, minAvail, testVal)
+			}
+		}
+		ce := cloudevents.NewEvent(cloudevents.VersionV1)
+		ce.SetType("knative.dev.test.event.a")
+		ce.SetSource("https://source.test.event.knative.dev/foo")
+		ce.SetID(strconv.FormatInt(int64(count), 10))
+		es.StoreEvent(ce, nil)
+		addedMinAvail, addedMaxSeen := es.MinMax()
+		if addedMaxSeen != maxSeen+1 {
+			t.Fatalf("Add after trim resulted in bad maxSeen: expected %d, saw %d for trim %d", maxSeen, addedMaxSeen, testVal)
+		}
+		if minAvail == -1 && addedMinAvail != addedMaxSeen {
+			t.Errorf("Add after full trim resulted in bad minAvail: expected %d, saw %d for trim %d", addedMaxSeen, addedMinAvail, testVal)
+		} else if minAvail != -1 && minAvail != addedMinAvail {
+			t.Errorf("Add after partial trim resulted in bad minAvail: expected %d, saw %d for trim %d", minAvail, addedMinAvail, testVal)
+
+		}
+
+	}
+	for _, testVal := range invalidTrimPoints {
+		es := newEventStore()
+		helperFillCount(es, count)
+		err := es.TrimThrough(testVal)
+		if err == nil {
+			t.Fatalf("Incorrect missing error trimming to %d", testVal)
+		}
+		minAvail, maxSeen := es.MinMax()
+		if minAvail != 1 {
+			t.Errorf("Incorrect minAvail %d trimming to %d", minAvail, testVal)
+		}
+		if maxSeen != count {
+			t.Errorf("Incorrect maxSeen %d trimming to %d", maxSeen, testVal)
+		}
+	}
+}

--- a/test/test_images/recordevents/eventstore_test.go
+++ b/test/test_images/recordevents/eventstore_test.go
@@ -29,7 +29,7 @@ import (
 func helperGetEvInfo(es *eventStore, entry int) (*lib.EventInfo, error) {
 	evInfoBytes, err := es.GetEventInfoBytes(entry)
 	if err != nil {
-		return nil, fmt.Errorf("error calling get on item %d: %s", entry, err)
+		return nil, fmt.Errorf("error calling get on item %d: %v", entry, err)
 	}
 	if len(evInfoBytes) == 0 {
 		return nil, fmt.Errorf("empty info bytes")
@@ -38,7 +38,7 @@ func helperGetEvInfo(es *eventStore, entry int) (*lib.EventInfo, error) {
 	var evInfo lib.EventInfo
 	err = json.Unmarshal(evInfoBytes, &evInfo)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling stored JSON: %s", err)
+		return nil, fmt.Errorf("error unmarshalling stored JSON: %v", err)
 	}
 	return &evInfo, nil
 }
@@ -67,7 +67,7 @@ func TestAddGetMany(t *testing.T) {
 	for i := 1; i <= count; i++ {
 		evInfo, err := helperGetEvInfo(es, i)
 		if err != nil {
-			t.Fatalf("count %d error: %s", count, err)
+			t.Fatalf("Count %d error: %v", count, err)
 		}
 
 		if evInfo.Event == nil {
@@ -135,12 +135,12 @@ func TestAddGetSingleValid(t *testing.T) {
 
 	evInfoBytes, err := es.GetEventInfoBytes(minAvail)
 	if err != nil {
-		t.Fatalf("Error calling get: %s", err)
+		t.Fatalf("Error calling get: %v", err)
 	}
 	var evInfo lib.EventInfo
 	err = json.Unmarshal(evInfoBytes, &evInfo)
 	if err != nil {
-		t.Fatalf("Error unmarshalling stored JSON: %s", err)
+		t.Fatalf("Error unmarshalling stored JSON: %v", err)
 	}
 
 	if evInfo.Event == nil {
@@ -189,12 +189,12 @@ func TestAddGetSingleInvalid(t *testing.T) {
 
 	evInfoBytes, err := es.GetEventInfoBytes(minAvail)
 	if err != nil {
-		t.Fatalf("Error calling get: %s", err)
+		t.Fatalf("Error calling get: %v", err)
 	}
 	var evInfo lib.EventInfo
 	err = json.Unmarshal(evInfoBytes, &evInfo)
 	if err != nil {
-		t.Fatalf("Error unmarshalling stored JSON: %s", err)
+		t.Fatalf("Error unmarshalling stored JSON: %v", err)
 	}
 	if evInfo.Event != nil {
 		t.Fatalf("Unexpected event info: %+v", evInfo)
@@ -236,7 +236,7 @@ func TestTrim(t *testing.T) {
 		helperFillCount(es, count)
 		err := es.TrimThrough(testVal)
 		if err != nil {
-			t.Fatalf("Unexpected error trimming to %d: %s", testVal, err)
+			t.Fatalf("Unexpected error trimming to %d: %v", testVal, err)
 		}
 		minAvail, maxSeen := es.MinMax()
 		if testVal == count {
@@ -252,7 +252,7 @@ func TestTrim(t *testing.T) {
 		if minAvail <= maxSeen {
 			evInfo, err := helperGetEvInfo(es, minAvail)
 			if err != nil {
-				t.Fatalf("Couldn't get min avail %d, trim %d error: %s", minAvail, testVal, err)
+				t.Fatalf("Couldn't get min avail %d, trim %d error: %v", minAvail, testVal, err)
 			}
 			seenID := evInfo.Event.ID()
 			expectedID := strconv.FormatInt(int64(minAvail-1), 10)
@@ -267,12 +267,15 @@ func TestTrim(t *testing.T) {
 		es.StoreEvent(ce, nil)
 		addedMinAvail, addedMaxSeen := es.MinMax()
 		if addedMaxSeen != maxSeen+1 {
-			t.Fatalf("Add after trim resulted in bad maxSeen: expected %d, saw %d for trim %d", maxSeen, addedMaxSeen, testVal)
+			t.Fatalf("Add after trim resulted in bad maxSeen: expected %d, saw %d for trim %d",
+				maxSeen, addedMaxSeen, testVal)
 		}
 		if minAvail == -1 && addedMinAvail != addedMaxSeen {
-			t.Errorf("Add after full trim resulted in bad minAvail: expected %d, saw %d for trim %d", addedMaxSeen, addedMinAvail, testVal)
+			t.Errorf("Add after full trim resulted in bad minAvail: expected %d, saw %d for trim %d",
+				addedMaxSeen, addedMinAvail, testVal)
 		} else if minAvail != -1 && minAvail != addedMinAvail {
-			t.Errorf("Add after partial trim resulted in bad minAvail: expected %d, saw %d for trim %d", minAvail, addedMinAvail, testVal)
+			t.Errorf("Add after partial trim resulted in bad minAvail: expected %d, saw %d for trim %d",
+				minAvail, addedMinAvail, testVal)
 
 		}
 

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -58,7 +58,7 @@ func (er *eventRecorder) handleMinMax(w http.ResponseWriter, r *http.Request) {
 	}
 	respBytes, err := json.Marshal(minMax)
 	if err != nil {
-		panic(fmt.Errorf("Internal error: json marshal shouldn't fail: (%s) (%+v)", err, minMax))
+		log.Panicf("Internal error: json marshal shouldn't fail: (%v) (%+v)", err, minMax)
 	}
 
 	w.Header().Set("Content-Type", "text/json")
@@ -124,16 +124,16 @@ func (er *eventRecorder) handler(ctx context.Context, event cloudevents.Event) {
 
 	// Print interesting headers and full events for debugging
 	header := tx.Header
-	headerNameList := []string{"X-B3-Sampled", "X-B3-Traceid", "X-B3-Spanid", "X-B3-ParentSpanId", "X-Custom-Header"}
+	headerNameList := lib.InterestingHeaders()
 	for _, headerName := range headerNameList {
 		if headerValue := header.Get(headerName); headerValue != "" {
-			fmt.Printf("Header %s: %s\n", headerName, headerValue)
+			log.Printf("Header %s: %s\n", headerName, headerValue)
 		}
 	}
 	if err := event.Validate(); err == nil {
-		fmt.Printf("eventdetails:\n%s", event.String())
+		log.Printf("eventdetails:\n%s", event.String())
 	} else {
-		fmt.Printf("error validating the event: %v", err)
+		log.Printf("error validating the event: %v", err)
 	}
 }
 
@@ -147,8 +147,8 @@ func main() {
 	}
 	c, err := kncloudevents.NewDefaultClient()
 	if err != nil {
-		log.Fatalf("failed to create client, %v", err)
+		log.Fatalf("Failed to create client, %v", err)
 	}
 
-	log.Fatalf("failed to start receiver: %s", c.StartReceiver(context.Background(), er.handler))
+	log.Fatalf("Failed to start receiver: %s", c.StartReceiver(context.Background(), er.handler))
 }

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"go.uber.org/zap"
+
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/eventing/pkg/tracing"
+	"knative.dev/eventing/test/lib"
+)
+
+type eventRecorder struct {
+	es *eventStore
+}
+
+func newEventRecorder() *eventRecorder {
+	return &eventRecorder{es: newEventStore()}
+}
+
+// Start the recordevents REST api server
+func (er *eventRecorder) StartServer(port int) {
+	http.HandleFunc(lib.GetMinMaxPath, er.handleMinMax)
+	http.HandleFunc(lib.GetEntryPath, er.handleGetEntry)
+	http.HandleFunc(lib.TrimThroughPath, er.handleTrim)
+	go http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+}
+
+// HTTP handler for GetMinMax requests
+func (er *eventRecorder) handleMinMax(w http.ResponseWriter, r *http.Request) {
+	minAvail, maxSeen := er.es.MinMax()
+	minMax := lib.MinMaxResponse{
+		MinAvail: minAvail,
+		MaxSeen:  maxSeen,
+	}
+	respBytes, err := json.Marshal(minMax)
+	if err != nil {
+		panic(fmt.Errorf("Internal error: json marshal shouldn't fail: (%s) (%+v)", err, minMax))
+	}
+
+	w.Header().Set("Content-Type", "text/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBytes)
+}
+
+// HTTP handler for TrimThrough requests
+func (er *eventRecorder) handleTrim(w http.ResponseWriter, r *http.Request) {
+	// If we extend this much at all we should vendor a better mux(gorilla, etc)
+	path := strings.TrimLeft(r.URL.Path, "/")
+	getPrefix := strings.TrimLeft(lib.TrimThroughPath, "/")
+	suffix := strings.TrimLeft(strings.TrimPrefix(path, getPrefix), "/")
+
+	seqNum, err := strconv.ParseInt(suffix, 10, 32)
+	if err != nil {
+		http.Error(w, "Can't parse event sequence number in request", http.StatusBadRequest)
+		return
+	}
+
+	err = er.es.TrimThrough(int(seqNum))
+	if err != nil {
+		http.Error(w, "Invalid sequence number in request to trim", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/json")
+	w.WriteHeader(http.StatusOK)
+}
+
+// HTTP handler for GetEntry requests
+func (er *eventRecorder) handleGetEntry(w http.ResponseWriter, r *http.Request) {
+	// If we extend this much at all we should vendor a better mux(gorilla, etc)
+	path := strings.TrimLeft(r.URL.Path, "/")
+	getPrefix := strings.TrimLeft(lib.GetEntryPath, "/")
+	suffix := strings.TrimLeft(strings.TrimPrefix(path, getPrefix), "/")
+
+	seqNum, err := strconv.ParseInt(suffix, 10, 32)
+	if err != nil {
+		http.Error(w, "Can't parse event sequence number in request", http.StatusBadRequest)
+		return
+	}
+
+	entryBytes, err := er.es.GetEventInfoBytes(int(seqNum))
+	if err != nil {
+		http.Error(w, "Couldn't find requested event", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(entryBytes)
+}
+
+// handler for cloudevents
+func (er *eventRecorder) handler(ctx context.Context, event cloudevents.Event) {
+	cloudevents.HTTPTransportContextFrom(ctx)
+
+	tx := cloudevents.HTTPTransportContextFrom(ctx)
+
+	// Store the event
+	er.es.StoreEvent(event, map[string][]string(tx.Header))
+
+	// Print interesting headers and full events for debugging
+	header := tx.Header
+	headerNameList := []string{"X-B3-Sampled", "X-B3-Traceid", "X-B3-Spanid", "X-B3-ParentSpanId", "X-Custom-Header"}
+	for _, headerName := range headerNameList {
+		if headerValue := header.Get(headerName); headerValue != "" {
+			fmt.Printf("Header %s: %s\n", headerName, headerValue)
+		}
+	}
+	if err := event.Validate(); err == nil {
+		fmt.Printf("eventdetails:\n%s", event.String())
+	} else {
+		fmt.Printf("error validating the event: %v", err)
+	}
+}
+
+func main() {
+	er := newEventRecorder()
+	er.StartServer(lib.RecordEventsPort)
+
+	logger, _ := zap.NewDevelopment()
+	if err := tracing.SetupStaticPublishing(logger.Sugar(), "", tracing.AlwaysSample); err != nil {
+		log.Fatalf("Unable to setup trace publishing: %v", err)
+	}
+	c, err := kncloudevents.NewDefaultClient()
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	log.Fatalf("failed to start receiver: %s", c.StartReceiver(context.Background(), er.handler))
+}

--- a/test/test_images/recordevents/pod.yaml
+++ b/test/test_images/recordevents/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: recordevents
+spec:
+  containers:
+    - name: recordevents
+      image: knative.dev/eventing/test/test_images/recordevents
+

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -7957,6 +7957,214 @@ Import: knative.dev/eventing/vendor/k8s.io/apimachinery
 
 
 ===========================================================
+Import: knative.dev/eventing/vendor/k8s.io/apiserver
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+===========================================================
 Import: knative.dev/eventing/vendor/k8s.io/client-go
 
 


### PR DESCRIPTION
Fixes #2390

## Proposed Changes
- Add a recordevents event consumer pod with a REST API to retrieve events it has seen
- Add e2e test support for accessing this API via kubectl portforward
- Add Find and WaitAtLeastNMatch functions that take a function that looks at event contents and http headers to check results
- Convert a first few e2e users of eventlogging and eventdetails pods to the new model

