### PR TITLE
migrate broker config to look like channel config

### DIFF
--- a/config/core/configmaps/default-imc.yaml
+++ b/config/core/configmaps/default-imc.yaml
@@ -18,5 +18,6 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
 data:
-  channelTemplateSpec.apiVersion: messaging.knative.dev/v1alpha1
-  channelTemplateSpec.kind: InMemoryChannel
+  channelTemplateSpec: |
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel

--- a/pkg/apis/eventing/v1alpha1/broker_validation_test.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation_test.go
@@ -110,7 +110,7 @@ func TestValidSpec(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			var errs *apis.FieldError
-			fe := apis.ErrMissingField("channelTemplateSpec.kind")
+			fe := apis.ErrMissingField("kind").ViaField("channelTemplateSpec")
 			errs = errs.Also(fe)
 			return errs
 		}(),
@@ -121,7 +121,7 @@ func TestValidSpec(t *testing.T) {
 		},
 		want: func() *apis.FieldError {
 			var errs *apis.FieldError
-			fe := apis.ErrMissingField("channelTemplateSpec.apiVersion")
+			fe := apis.ErrMissingField("apiVersion").ViaField("channelTemplateSpec")
 			errs = errs.Also(fe)
 			return errs
 		}(),

--- a/pkg/reconciler/broker/config.go
+++ b/pkg/reconciler/broker/config.go
@@ -60,7 +60,6 @@ func NewConfigFromConfigMapFunc(ctx context.Context) func(configMap *corev1.Conf
 		}
 
 		if err := json.Unmarshal(j, &config.DefaultChannelTemplate); err != nil {
-
 			return nil, fmt.Errorf("ConfigMap's value could not be unmarshaled. %w, %s", err, string(j))
 		}
 

--- a/pkg/reconciler/broker/config.go
+++ b/pkg/reconciler/broker/config.go
@@ -18,46 +18,52 @@ package broker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"strings"
+	"fmt"
+	"github.com/ghodss/yaml"
+	"go.uber.org/zap"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing/pkg/logging"
 )
 
 type Config struct {
 	DefaultChannelTemplate messagingv1beta1.ChannelTemplateSpec
 }
 
+const (
+	channelTemplateSpec = "channelTemplateSpec"
+)
+
 func NewConfigFromConfigMapFunc(ctx context.Context) func(configMap *corev1.ConfigMap) (*Config, error) {
 	return func(configMap *corev1.ConfigMap) (*Config, error) {
-
-		apiVersion, ok := configMap.Data["channelTemplateSpec.apiVersion"]
-		if !ok {
-			return nil, errors.New("channelTemplateSpec.apiVersion not found in config")
+		config := &Config{
+			DefaultChannelTemplate: messagingv1beta1.ChannelTemplateSpec{},
 		}
 
-		kind, ok := configMap.Data["channelTemplateSpec.kind"]
-		if !ok {
-			return nil, errors.New("channelTemplateSpec.kind not found in config")
+		temp, present := configMap.Data[channelTemplateSpec]
+		if !present {
+			logging.FromContext(ctx).Info("ConfigMap is missing key", zap.String("key", channelTemplateSpec), zap.Any("configMap", configMap))
+			return nil, errors.New("not found")
 		}
 
-		// Spec is optional.
-		var spec *runtime.RawExtension
-		if rs, ok := configMap.Data["channelTemplateSpec.specJson"]; ok {
-			spec = &runtime.RawExtension{Raw: []byte(strings.TrimSpace(rs))}
+		if temp == "" {
+			logging.FromContext(ctx).Info("ConfigMap's value was the empty string, ignoring it.", zap.Any("configMap", configMap))
+			return nil, errors.New("not found")
 		}
 
-		return &Config{
-			DefaultChannelTemplate: messagingv1beta1.ChannelTemplateSpec{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: apiVersion,
-					Kind:       kind,
-				},
-				Spec: spec,
-			},
-		}, nil
+		j, err := yaml.YAMLToJSON([]byte(temp))
+		if err != nil {
+			return nil, fmt.Errorf("ConfigMap's value could not be converted to JSON. %w, %s", err, temp)
+		}
+
+		if err := json.Unmarshal(j, &config.DefaultChannelTemplate); err != nil {
+
+			return nil, fmt.Errorf("ConfigMap's value could not be unmarshaled. %w, %s", err, string(j))
+		}
+
+		return config, nil
 	}
 }

--- a/pkg/reconciler/broker/config_test.go
+++ b/pkg/reconciler/broker/config_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestOurConfig(t *testing.T) {
 	actual, example := ConfigMapsFromTestFile(t, "config-broker")
-	exampleSpec := runtime.RawExtension{Raw: []byte(`{"customValue": "foo"}`)}
+	exampleSpec := runtime.RawExtension{Raw: []byte(`"customValue: foo\n"`)}
 
 	for _, tt := range []struct {
 		name string
@@ -63,13 +63,14 @@ func TestOurConfig(t *testing.T) {
 					APIVersion: "Foo/v1",
 					Kind:       "Bar",
 				},
-				//Spec: TODO
 			},
 		},
 		data: &corev1.ConfigMap{
 			Data: map[string]string{
-				"channelTemplateSpec.apiVersion": "Foo/v1",
-				"channelTemplateSpec.kind":       "Bar",
+				"channelTemplateSpec": `
+      apiVersion: Foo/v1
+      kind: Bar
+`,
 			},
 		},
 	}} {
@@ -79,7 +80,12 @@ func TestOurConfig(t *testing.T) {
 				t.Fatalf("Unexpected error value: %v", err)
 			}
 
+			t.Log(actual)
+
 			if diff := cmp.Diff(tt.want, testConfig); diff != "" {
+				if testConfig != nil && testConfig.DefaultChannelTemplate.Spec != nil {
+					t.Log(string(testConfig.DefaultChannelTemplate.Spec.Raw))
+				}
 				t.Errorf("Unexpected controller config (-want, +got): %s", diff)
 			}
 		})

--- a/pkg/reconciler/broker/testdata/config-broker.yaml
+++ b/pkg/reconciler/broker/testdata/config-broker.yaml
@@ -35,15 +35,17 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # The api and version of the kind of channel to use inthe broker.
-    # This field required.
-    channelTemplateSpec.apiVersion: messaging.knative.dev/v1alpha1
+    # This defines the default channel template to use for the broker.
+    channelTemplateSpec: |
+      # The api and version of the kind of channel to use inthe broker.
+      # This field required.
+      apiVersion: messaging.knative.dev/v1alpha1
 
-    # The api and version of the kind of channel to use inthe broker.
-    # This field required.
-    channelTemplateSpec.kind: InMemoryChannel
+      # The api and version of the kind of channel to use inthe broker.
+      # This field required.
+      kind: InMemoryChannel
 
-    # A json version of the custom spec that should be used for
-    # channel templates. This field is optional.
-    channelTemplateSpec.specJson: |-
-      {"customValue": "foo"}
+      # The custom spec that should be used for channel templates.
+      #This field is optional.
+      spec: |
+        customValue: foo

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -177,7 +177,7 @@ func (client *Client) CreateBrokerConfigMapOrFail(name string, channel *metav1.T
 			"channelTemplateSpec": fmt.Sprintf(`
       apiVersion: %q
       kind: %q
-`, channel.Kind, channel.APIVersion),
+`, channel.APIVersion, channel.Kind),
 		},
 	}
 	cm, err := client.Kube.Kube.CoreV1().ConfigMaps(client.Namespace).Create(cm)

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -174,8 +174,10 @@ func (client *Client) CreateBrokerConfigMapOrFail(name string, channel *metav1.T
 			Namespace: client.Namespace,
 		},
 		Data: map[string]string{
-			"channelTemplateSpec.kind":       channel.Kind,
-			"channelTemplateSpec.apiVersion": channel.APIVersion,
+			"channelTemplateSpec": fmt.Sprintf(`
+			kind: %s,
+			apiVersion: %s
+`, channel.Kind, channel.APIVersion),
 		},
 	}
 	cm, err := client.Kube.Kube.CoreV1().ConfigMaps(client.Namespace).Create(cm)

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -175,8 +175,8 @@ func (client *Client) CreateBrokerConfigMapOrFail(name string, channel *metav1.T
 		},
 		Data: map[string]string{
 			"channelTemplateSpec": fmt.Sprintf(`
-			kind: %s,
-			apiVersion: %s
+      apiVersion: %q
+      kind: %q
 `, channel.Kind, channel.APIVersion),
 		},
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

An oversight in config map formatting made broker and channel configs have very different format. Moving to yaml strings over json strings.

## Proposed Changes

- Migrate Broker Config to look like Default Channel Config.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**
Already a docs issue for broker config: https://github.com/knative/docs/issues/2227

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
