### PR TITLE
Rename leader election config package/methods

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
-	"knative.dev/pkg/leaderelection"
+	kle "knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 	tracingconfig "knative.dev/pkg/tracing/config"
@@ -45,7 +45,6 @@ import (
 
 	defaultconfig "knative.dev/eventing/pkg/apis/config"
 	configsv1alpha1 "knative.dev/eventing/pkg/apis/configs/v1alpha1"
-	configvalidation "knative.dev/eventing/pkg/apis/configs/validation"
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
@@ -59,6 +58,7 @@ import (
 	"knative.dev/eventing/pkg/apis/sources"
 	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
+	"knative.dev/eventing/pkg/leaderelection"
 	"knative.dev/eventing/pkg/reconciler/sinkbinding"
 )
 
@@ -193,8 +193,8 @@ func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 		configmap.Constructors{
 			tracingconfig.ConfigName: tracingconfig.NewTracingConfigFromConfigMap,
 			// metrics.ConfigMapName():   metricsconfig.NewObservabilityConfigFromConfigMap,
-			logging.ConfigMapName():        logging.NewConfigFromConfigMap,
-			leaderelection.ConfigMapName(): configvalidation.ValidateLeaderElectionConfig,
+			logging.ConfigMapName(): logging.NewConfigFromConfigMap,
+			kle.ConfigMapName():     leaderelection.ValidateConfig,
 		},
 	)
 }

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validation
+package leaderelection
 
 import (
 	"fmt"
@@ -33,7 +33,7 @@ var (
 	)
 )
 
-func ValidateLeaderElectionConfig(configMap *corev1.ConfigMap) (*kle.Config, error) {
+func ValidateConfig(configMap *corev1.ConfigMap) (*kle.Config, error) {
 	config, err := kle.NewConfigFromMap(configMap.Data)
 	if err != nil {
 		return nil, err

--- a/pkg/leaderelection/leader_election_test.go
+++ b/pkg/leaderelection/leader_election_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validation
+package leaderelection
 
 import (
 	"errors"
@@ -50,7 +50,7 @@ func okData() map[string]string {
 	}
 }
 
-func TestValidateLeaderElectionConfig(t *testing.T) {
+func TestValidateConfig(t *testing.T) {
 	cases := []struct {
 		name     string
 		data     map[string]string
@@ -75,7 +75,7 @@ func TestValidateLeaderElectionConfig(t *testing.T) {
 
 	for i := range cases {
 		tc := cases[i]
-		actualConfig, actualErr := ValidateLeaderElectionConfig(&corev1.ConfigMap{Data: tc.data})
+		actualConfig, actualErr := ValidateConfig(&corev1.ConfigMap{Data: tc.data})
 		if !reflect.DeepEqual(tc.err, actualErr) {
 			t.Errorf("%v: expected error\n%v\ngot:\n%v", tc.name, tc.err, actualErr)
 			continue


### PR DESCRIPTION
Renames the former weirdly named packages to `pkg/leaderelection`, to have parity with what I was asked to do in serving.

```release-note
None
```
