### PR TITLE
Add webhook and validation config to EventType

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -21,14 +21,6 @@ metadata:
 spec:
   group: eventing.knative.dev
   preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   names:
     kind: EventType
     plural: eventtypes
@@ -98,3 +90,13 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -20,6 +20,15 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # this is a work around so we don't need to flush out the
+      # schema for each version at this time
+      #
+      # see issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   names:
     kind: EventType
     plural: eventtypes


### PR DESCRIPTION
Fixes #2661.

Seems like EventType was just missed when it was upgraded to v1beta1.

Why should this go in before the release: fixes log spamming from the webhook whenever an EventType is reconciled. Could cost money for customers doing log archival.

## Proposed Changes

- Add conversion webhook config to EventType

/cc @dprotaso 