### PR TITLE
Remove Subscription's finalizer if the Channel was deleted first

### DIFF
--- a/pkg/apis/messaging/v1alpha1/subscription_lifecycle.go
+++ b/pkg/apis/messaging/v1alpha1/subscription_lifecycle.go
@@ -91,15 +91,15 @@ func (ss *SubscriptionStatus) MarkReferencesResolvedUnknown(reason, messageForma
 
 // MarkChannelFailed sets the ChannelReady condition to False state.
 func (ss *SubscriptionStatus) MarkChannelFailed(reason, messageFormat string, messageA ...interface{}) {
-	SubCondSet.Manage(ss).MarkFalse(SubscriptionConditionChannelReady, reason, messageFormat, messageA)
+	SubCondSet.Manage(ss).MarkFalse(SubscriptionConditionChannelReady, reason, messageFormat, messageA...)
 }
 
 // MarkChannelUnknown sets the ChannelReady condition to Unknown state.
 func (ss *SubscriptionStatus) MarkChannelUnknown(reason, messageFormat string, messageA ...interface{}) {
-	SubCondSet.Manage(ss).MarkUnknown(SubscriptionConditionChannelReady, reason, messageFormat, messageA)
+	SubCondSet.Manage(ss).MarkUnknown(SubscriptionConditionChannelReady, reason, messageFormat, messageA...)
 }
 
 // MarkNotAddedToChannel sets the AddedToChannel condition to False state.
 func (ss *SubscriptionStatus) MarkNotAddedToChannel(reason, messageFormat string, messageA ...interface{}) {
-	SubCondSet.Manage(ss).MarkFalse(SubscriptionConditionAddedToChannel, reason, messageFormat, messageA)
+	SubCondSet.Manage(ss).MarkFalse(SubscriptionConditionAddedToChannel, reason, messageFormat, messageA...)
 }

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1201,7 +1201,7 @@ func TestReconcile(t *testing.T) {
 					// The first reconciliation will initialize the status conditions.
 					WithInitTriggerConditions,
 					WithTriggerBrokerReady(),
-					WithTriggerNotSubscribed("testInducedError", "test induced [error]"),
+					WithTriggerNotSubscribed("testInducedError", "test induced error"),
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDependencyReady(),

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -127,14 +127,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, subscription *v1alpha1.Su
 		// the subscription's finalizer is removed and the object is gc'ed.
 		if apierrors.IsNotFound(err) {
 			return nil
-		} else {
-			return err
 		}
-	} else {
-		// Remove the Subscription from the Channel's subscribers list only if it was actually added in the first place.
-		if subscription.Status.IsAddedToChannel() {
-			return r.syncChannel(ctx, channel, subscription)
-		}
+		return err
+	}
+	// Remove the Subscription from the Channel's subscribers list only if it was actually added in the first place.
+	if subscription.Status.IsAddedToChannel() {
+		return r.syncChannel(ctx, channel, subscription)
 	}
 	return nil
 }
@@ -165,7 +163,7 @@ func (r Reconciler) syncChannel(ctx context.Context, channel *eventingduckv1alph
 	if patched, err := r.syncPhysicalChannel(ctx, sub, channel, false); err != nil {
 		logging.FromContext(ctx).Warn("Failed to sync physical Channel", zap.Error(err))
 		sub.Status.MarkNotAddedToChannel(physicalChannelSyncFailed, "Failed to sync physical Channel: %v", err)
-		return pkgreconciler.NewEvent(corev1.EventTypeWarning, physicalChannelSyncFailed, "Failed to synchronized to channel %q: %v", channel.Name, err)
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, physicalChannelSyncFailed, "Failed to synchronize to channel %q: %v", channel.Name, err)
 	} else if patched {
 		if sub.DeletionTimestamp.IsZero() {
 			sub.Status.MarkAddedToChannel()

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -947,14 +947,12 @@ func TestAllCases(t *testing.T) {
 				patchFinalizers(testNS, "a-"+subscriptionName),
 			},
 		}, {
-			// TODO: this test is wrong.
-			Name: "subscription deleted",
+			Name: "subscription deleted - channel patch succeeded",
 			Objects: []runtime.Object{
 				NewSubscription(subscriptionName, testNS,
 					WithSubscriptionUID(subscriptionUID),
 					WithSubscriptionChannel(testChannelGVK, channelName),
 					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
-					WithSubscriptionReply(testChannelGVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionFinalizers(finalizerName),
@@ -967,10 +965,6 @@ func TestAllCases(t *testing.T) {
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,
 					WithInMemoryChannelAddress(channelDNS),
-				),
-				NewInMemoryChannel(replyName, testNS,
-					WithInitInMemoryChannelConditions,
-					WithInMemoryChannelAddress(replyDNS),
 				),
 			},
 			Key:     testNS + "/" + subscriptionName,
@@ -979,18 +973,15 @@ func TestAllCases(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", subscriptionName),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				//patchSubscribers(testNS, channelName, nil), // the channel does not have subs in this object cache.
 				patchRemoveFinalizers(testNS, subscriptionName),
 			},
 		}, {
-			// TODO: this test is wrong.
-			Name: "subscription deleted - channel patch fails",
+			Name: "subscription not deleted - channel patch fails",
 			Objects: []runtime.Object{
 				NewSubscription(subscriptionName, testNS,
 					WithSubscriptionUID(subscriptionUID),
 					WithSubscriptionChannel(testChannelGVK, channelName),
 					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
-					WithSubscriptionReply(testChannelGVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionFinalizers(finalizerName),
@@ -1003,10 +994,10 @@ func TestAllCases(t *testing.T) {
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,
 					WithInMemoryChannelAddress(channelDNS),
-				),
-				NewInMemoryChannel(replyName, testNS,
-					WithInitInMemoryChannelConditions,
-					WithInMemoryChannelAddress(replyDNS),
+					WithInMemoryChannelSubscribers([]eventingduck.SubscriberSpec{
+						{UID: subscriptionUID, SubscriberURI: subscriberURI},
+					}),
+					WithInMemoryChannelReadySubscriber(subscriptionUID),
 				),
 			},
 			Key: testNS + "/" + subscriptionName,
@@ -1014,12 +1005,23 @@ func TestAllCases(t *testing.T) {
 				InduceFailure("patch", "inmemorychannels"),
 			},
 			WantEvents: []string{
-				//Eventf(corev1.EventTypeWarning, "PhysicalChannelSyncFailed", "Failed to sync physical Channel: inducing failure for patch channels"),
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", subscriptionName),
+				Eventf(corev1.EventTypeWarning, "PhysicalChannelSyncFailed", fmt.Sprintf("Failed to synchronize to channel %q: %s", channelName, "inducing failure for patch inmemorychannels")),
 			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewSubscription(subscriptionName, testNS,
+					WithSubscriptionUID(subscriptionUID),
+					WithSubscriptionChannel(testChannelGVK, channelName),
+					WithInitSubscriptionConditions,
+					MarkSubscriptionReady,
+					MarkNotAddedToChannel("PhysicalChannelSyncFailed", "Failed to sync physical Channel: inducing failure for patch inmemorychannels"),
+					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
+					WithSubscriptionFinalizers(finalizerName),
+					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionDeleted,
+				),
+			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				//patchSubscribers(testNS, channelName, nil), // the channel does not have subs in this object cache.
-				patchRemoveFinalizers(testNS, subscriptionName),
+				patchSubscribers(testNS, channelName, nil), // the channel does not have subs in this object cache.
 			},
 		}, {
 			Name: "subscription deleted - channel does not exists",
@@ -1087,7 +1089,7 @@ func patchSubscribers(namespace, name string, subscribers []eventingduck.Subscri
 		}
 		spec = fmt.Sprintf(`{"subscribable":{"subscribers":%s}}`, subs)
 	} else {
-		spec = `{"subscribable":{}}`
+		spec = `{"subscribable":{"subscribers":null}}`
 	}
 
 	patch := `{"spec":` + spec + `}`

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -1021,6 +1021,31 @@ func TestAllCases(t *testing.T) {
 				//patchSubscribers(testNS, channelName, nil), // the channel does not have subs in this object cache.
 				patchRemoveFinalizers(testNS, subscriptionName),
 			},
+		}, {
+			Name: "subscription deleted - channel does not exists",
+			Objects: []runtime.Object{
+				NewSubscription(subscriptionName, testNS,
+					WithSubscriptionUID(subscriptionUID),
+					WithSubscriptionChannel(testChannelGVK, channelName),
+					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
+					WithSubscriptionReply(testChannelGVK, replyName, testNS),
+					WithInitSubscriptionConditions,
+					MarkSubscriptionReady,
+					WithSubscriptionFinalizers(finalizerName),
+					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionDeleted,
+				),
+				NewUnstructured(subscriberGVK, subscriberName, testNS,
+					WithUnstructuredAddressable(subscriberDNS),
+				),
+			},
+			Key: testNS + "/" + subscriptionName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", subscriptionName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchRemoveFinalizers(testNS, subscriptionName),
+			},
 		},
 	}
 

--- a/pkg/reconciler/testing/subscription.go
+++ b/pkg/reconciler/testing/subscription.go
@@ -197,6 +197,12 @@ func MarkAddedToChannel(s *v1alpha1.Subscription) {
 	s.Status.MarkAddedToChannel()
 }
 
+func MarkNotAddedToChannel(reason, msg string) SubscriptionOption {
+	return func(s *v1alpha1.Subscription) {
+		s.Status.MarkNotAddedToChannel(reason, msg)
+	}
+}
+
 func MarkReferencesResolved(s *v1alpha1.Subscription) {
 	s.Status.MarkReferencesResolved()
 }


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/2633

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🐛 Updated the Subscription's finalizer method. If the channel does not longer exists (i.e., was deleted first), then we remove the Subscription's finalizer and let it be gc'ed. Also, check whether the subscription was actually added to the channel before attempting to remove it from its list. Added UT and fixed wrong ones


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
