### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/messaging/config/channel_defaults_test.go
+++ b/pkg/apis/messaging/config/channel_defaults_test.go
@@ -86,7 +86,7 @@ func TestChannelDefaultsConfiguration(t *testing.T) {
 		wantErr: false,
 		wantChannelDefaults: &ChannelDefaults{
 			NamespaceDefaults: map[string]*ChannelTemplateSpec{
-				"some-namespace": &ChannelTemplateSpec{
+				"some-namespace": {
 					TypeMeta: v1.TypeMeta{
 						APIVersion: "messaging.knative.dev/v1alpha1",
 						Kind:       "KafkaChannel",
@@ -146,7 +146,7 @@ func TestChannelDefaultsConfiguration(t *testing.T) {
 		wantErr: false,
 		wantChannelDefaults: &ChannelDefaults{
 			NamespaceDefaults: map[string]*ChannelTemplateSpec{
-				"some-namespace": &ChannelTemplateSpec{
+				"some-namespace": {
 					TypeMeta: v1.TypeMeta{
 						APIVersion: "messaging.knative.dev/v1beta1",
 						Kind:       "InMemoryChannel",

--- a/pkg/apis/sources/v1alpha1/apiserver_conversion.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_conversion.go
@@ -19,13 +19,14 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
-	"reflect"
 )
 
 // ConvertTo implements apis.Convertible.

--- a/pkg/apis/sources/v1alpha1/apiserver_conversion_test.go
+++ b/pkg/apis/sources/v1alpha1/apiserver_conversion_test.go
@@ -18,10 +18,11 @@ package v1alpha1
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 
 	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
 
@@ -300,7 +301,7 @@ func TestApiServerSourceConversionRoundTripDown(t *testing.T) {
 
 // Since v1alpha1 to v1alpha2 is lossy.
 func fixApiServerSourceDeprecated(in *ApiServerSource) *ApiServerSource {
-	for i, _ := range in.Spec.Resources {
+	for i := range in.Spec.Resources {
 		in.Spec.Resources[i].Controller = false
 		in.Spec.Resources[i].LabelSelector = metav1.LabelSelector{}
 		in.Spec.Resources[i].ControllerSelector = metav1.OwnerReference{}

--- a/pkg/apis/sources/v1alpha2/apiserver_validation.go
+++ b/pkg/apis/sources/v1alpha2/apiserver_validation.go
@@ -18,6 +18,7 @@ package v1alpha2
 
 import (
 	"context"
+
 	"knative.dev/pkg/apis"
 )
 

--- a/pkg/apis/sources/v1alpha2/apiserver_validation_test.go
+++ b/pkg/apis/sources/v1alpha2/apiserver_validation_test.go
@@ -18,8 +18,9 @@ package v1alpha2
 
 import (
 	"context"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"testing"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"

--- a/pkg/reconciler/broker/config.go
+++ b/pkg/reconciler/broker/config.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	"go.uber.org/zap"
 


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign n3wscott
/cc n3wscott
