### PR TITLE
Use Listers in Namespace Reconciler

### DIFF
--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler"
 
 	"knative.dev/eventing/pkg/client/injection/informers/configs/v1alpha1/configmappropagation"
-	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/broker"
+	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	"knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
@@ -63,6 +63,10 @@ func NewController(
 	r := &Reconciler{
 		Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
 		namespaceLister: namespaceInformer.Lister(),
+		serviceAccountLister: serviceAccountInformer.Lister(),
+		roleBindingLister: roleBindingInformer.Lister(),
+		brokerLister: brokerInformer.Lister(),
+		configMapPropagationLister: configMapPropagationInformer.Lister(),
 	}
 
 	var env envConfig

--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -61,11 +61,11 @@ func NewController(
 	configMapPropagationInformer := configmappropagation.Get(ctx)
 
 	r := &Reconciler{
-		Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
-		namespaceLister: namespaceInformer.Lister(),
-		serviceAccountLister: serviceAccountInformer.Lister(),
-		roleBindingLister: roleBindingInformer.Lister(),
-		brokerLister: brokerInformer.Lister(),
+		Base:                       reconciler.NewBase(ctx, controllerAgentName, cmw),
+		namespaceLister:            namespaceInformer.Lister(),
+		serviceAccountLister:       serviceAccountInformer.Lister(),
+		roleBindingLister:          roleBindingInformer.Lister(),
+		brokerLister:               brokerInformer.Lister(),
 		configMapPropagationLister: configMapPropagationInformer.Lister(),
 	}
 

--- a/pkg/reconciler/namespace/controller_test.go
+++ b/pkg/reconciler/namespace/controller_test.go
@@ -24,7 +24,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/configs/v1alpha1/configmappropagation/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/broker/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -28,14 +28,13 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 	configslisters "knative.dev/eventing/pkg/client/listers/configs/v1alpha1"
-	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
+	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	configsv1alpha1 "knative.dev/eventing/pkg/apis/configs/v1alpha1"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
@@ -147,7 +146,7 @@ func (r *Reconciler) reconcile(ctx context.Context, ns *corev1.Namespace) error 
 
 // reconcileConfigMapPropagation reconciles the default ConfigMapPropagation for the Namespace 'ns'.
 func (r *Reconciler) reconcileConfigMapPropagation(ctx context.Context, ns *corev1.Namespace) (*configsv1alpha1.ConfigMapPropagation, error) {
-	current, err := r.EventingClientSet.ConfigsV1alpha1().ConfigMapPropagations(ns.Name).Get(resources.DefaultConfigMapPropagationName, metav1.GetOptions{})
+	current, err := r.configMapPropagationLister.ConfigMapPropagations(ns.Name).Get(resources.DefaultConfigMapPropagationName)
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {
@@ -207,7 +206,7 @@ func (r *Reconciler) reconcileServiceAccountAndRoleBindings(ctx context.Context,
 
 // reconcileBrokerServiceAccount reconciles the Broker's service account for Namespace 'ns'.
 func (r *Reconciler) reconcileBrokerServiceAccount(ctx context.Context, ns *corev1.Namespace, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-	current, err := r.KubeClientSet.CoreV1().ServiceAccounts(ns.Name).Get(sa.Name, metav1.GetOptions{})
+	current, err := r.serviceAccountLister.ServiceAccounts(ns.Name).Get(sa.Name)
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {
@@ -227,7 +226,7 @@ func (r *Reconciler) reconcileBrokerServiceAccount(ctx context.Context, ns *core
 
 // reconcileBrokerRBAC reconciles the Broker's service account RBAC for the Namespace 'ns'.
 func (r *Reconciler) reconcileBrokerRBAC(ctx context.Context, ns *corev1.Namespace, sa *corev1.ServiceAccount, rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
-	current, err := r.KubeClientSet.RbacV1().RoleBindings(rb.Namespace).Get(rb.Name, metav1.GetOptions{})
+	current, err := r.roleBindingLister.RoleBindings(rb.Namespace).Get(rb.Name)
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {
@@ -247,7 +246,7 @@ func (r *Reconciler) reconcileBrokerRBAC(ctx context.Context, ns *corev1.Namespa
 
 // reconcileBroker reconciles the default Broker for the Namespace 'ns'.
 func (r *Reconciler) reconcileBroker(ctx context.Context, ns *corev1.Namespace) (*v1beta1.Broker, error) {
-	current, err := r.EventingClientSet.EventingV1beta1().Brokers(ns.Name).Get(resources.DefaultBrokerName, metav1.GetOptions{})
+	current, err := r.brokerLister.Brokers(ns.Name).Get(resources.DefaultBrokerName)
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -418,7 +418,7 @@ func TestAllCases(t *testing.T) {
 		r := &Reconciler{
 			Base:                       reconciler.NewBase(ctx, controllerAgentName, cmw),
 			namespaceLister:            listers.GetNamespaceLister(),
-			brokerLister:               listers.GetBrokerLister(),
+			brokerLister:               listers.GetV1Beta1BrokerLister(),
 			serviceAccountLister:       listers.GetServiceAccountLister(),
 			roleBindingLister:          listers.GetRoleBindingLister(),
 			configMapPropagationLister: listers.GetConfigMapPropagationLister(),

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	configsv1alpha1 "knative.dev/eventing/pkg/apis/configs/v1alpha1"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	flowsv1alpha1 "knative.dev/eventing/pkg/apis/flows/v1alpha1"
 	legacysourcesv1alpha1 "knative.dev/eventing/pkg/apis/legacysources/v1alpha1"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
@@ -40,6 +41,7 @@ import (
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
 	configslisters "knative.dev/eventing/pkg/client/listers/configs/v1alpha1"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
+	eventingv1beta1listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
 	flowslisters "knative.dev/eventing/pkg/client/listers/flows/v1alpha1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1alpha1"
 	sourcelisters "knative.dev/eventing/pkg/client/listers/sources/v1alpha1"
@@ -132,6 +134,10 @@ func (l *Listers) GetTriggerLister() eventinglisters.TriggerLister {
 
 func (l *Listers) GetBrokerLister() eventinglisters.BrokerLister {
 	return eventinglisters.NewBrokerLister(l.indexerFor(&eventingv1alpha1.Broker{}))
+}
+
+func (l *Listers) GetV1Beta1BrokerLister() eventingv1beta1listers.BrokerLister {
+	return eventingv1beta1listers.NewBrokerLister(l.indexerFor(&eventingv1beta1.Broker{}))
 }
 
 func (l *Listers) GetEventTypeLister() eventinglisters.EventTypeLister {


### PR DESCRIPTION
Fixes #2396

Uses the shared informer cache instead of the API server to list resources that should be inspected in the Namespace Reconciler.

