### PR TITLE
fixing that triggers can actually have no filters...

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -34,14 +34,19 @@ func (source *Trigger) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
 			sink.Spec.Filter = &v1beta1.TriggerFilter{
-				Attributes: make(v1beta1.TriggerFilterAttributes, 0),
 			}
 			if source.Spec.Filter.Attributes != nil {
+				sink.Spec.Filter = &v1beta1.TriggerFilter{
+					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+				}
 				for k, v := range *source.Spec.Filter.Attributes {
 					sink.Spec.Filter.Attributes[k] = v
 				}
 			}
 			if source.Spec.Filter.DeprecatedSourceAndType != nil {
+				sink.Spec.Filter = &v1beta1.TriggerFilter{
+					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+				}
 				sink.Spec.Filter.Attributes["source"] = source.Spec.Filter.DeprecatedSourceAndType.Source
 				sink.Spec.Filter.Attributes["type"] = source.Spec.Filter.DeprecatedSourceAndType.Type
 			}
@@ -63,7 +68,7 @@ func (sink *Trigger) ConvertFrom(ctx context.Context, obj apis.Convertible) erro
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
-		if source.Spec.Filter != nil {
+		if source.Spec.Filter != nil && source.Spec.Filter.Attributes != nil {
 			attributes := TriggerFilterAttributes{}
 			for k, v := range source.Spec.Filter.Attributes {
 				attributes[k] = v

--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -37,7 +37,7 @@ func (source *Trigger) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 			}
 			if source.Spec.Filter.Attributes != nil {
 				sink.Spec.Filter = &v1beta1.TriggerFilter{
-					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+					Attributes: make(v1beta1.TriggerFilterAttributes, len(*source.Spec.Filter.Attributes)),
 				}
 				for k, v := range *source.Spec.Filter.Attributes {
 					sink.Spec.Filter.Attributes[k] = v

--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -45,7 +45,7 @@ func (source *Trigger) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 			}
 			if source.Spec.Filter.DeprecatedSourceAndType != nil {
 				sink.Spec.Filter = &v1beta1.TriggerFilter{
-					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+					Attributes: make(v1beta1.TriggerFilterAttributes, 2),
 				}
 				sink.Spec.Filter.Attributes["source"] = source.Spec.Filter.DeprecatedSourceAndType.Source
 				sink.Spec.Filter.Attributes["type"] = source.Spec.Filter.DeprecatedSourceAndType.Type

--- a/test/e2e/trigger_dependency_annotation_test.go
+++ b/test/e2e/trigger_dependency_annotation_test.go
@@ -60,9 +60,9 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	client.CreatePodOrFail(pod, lib.WithService(subscriberName))
 
 	// Create triggers.
-	client.CreateTriggerOrFail(triggerName,
-		resources.WithSubscriberServiceRefForTrigger(subscriberName),
-		resources.WithDependencyAnnotaionTrigger(dependencyAnnotation),
+	client.CreateTriggerOrFailV1Beta1(triggerName,
+		resources.WithSubscriberServiceRefForTriggerV1Beta1(subscriberName),
+		resources.WithDependencyAnnotationTriggerV1Beta1(dependencyAnnotation),
 	)
 
 	data := fmt.Sprintf("Test trigger-annotation %s", uuid.NewUUID())

--- a/test/lib/resources/eventing.go
+++ b/test/lib/resources/eventing.go
@@ -294,13 +294,23 @@ func WithAttributesTriggerFilterV1Beta1(eventSource, eventType string, extension
 	}
 }
 
-// WithDependencyAnnotaionTrigger returns an option that adds a dependency annotation to the given Trigger.
-func WithDependencyAnnotaionTrigger(dependencyAnnotation string) TriggerOption {
+// WithDependencyAnnotationTrigger returns an option that adds a dependency annotation to the given Trigger.
+func WithDependencyAnnotationTrigger(dependencyAnnotation string) TriggerOption {
 	return func(t *eventingv1alpha1.Trigger) {
 		if t.Annotations == nil {
 			t.Annotations = make(map[string]string)
 		}
 		t.Annotations[eventingv1alpha1.DependencyAnnotation] = dependencyAnnotation
+	}
+}
+
+// WithDependencyAnnotationTrigger returns an option that adds a dependency annotation to the given Trigger.
+func WithDependencyAnnotationTriggerV1Beta1(dependencyAnnotation string) TriggerOptionV1Beta1 {
+	return func(t *eventingv1beta1.Trigger) {
+		if t.Annotations == nil {
+			t.Annotations = make(map[string]string)
+		}
+		t.Annotations[eventingv1beta1.DependencyAnnotation] = dependencyAnnotation
 	}
 }
 


### PR DESCRIPTION
Fixes #2695 (and is a backport of 2696 to the `knative:release-0.13` branch)

## Proposed Changes

- fixing the conversion to create empty `TriggerFilter{}`, and not requiring actual attributes in there 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug fix broken trigger to NOT require a filter
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
