### PR TITLE
Similar to PR2700: make trigger conversion attribute length variable

### DIFF
--- a/pkg/apis/eventing/v1alpha1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1alpha1/trigger_conversion.go
@@ -33,11 +33,10 @@ func (source *Trigger) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
-			sink.Spec.Filter = &v1beta1.TriggerFilter{
-			}
+			sink.Spec.Filter = &v1beta1.TriggerFilter{}
 			if source.Spec.Filter.Attributes != nil {
 				sink.Spec.Filter = &v1beta1.TriggerFilter{
-					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+					Attributes: make(v1beta1.TriggerFilterAttributes, len(*source.Spec.Filter.Attributes)),
 				}
 				for k, v := range *source.Spec.Filter.Attributes {
 					sink.Spec.Filter.Attributes[k] = v
@@ -45,7 +44,7 @@ func (source *Trigger) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 			}
 			if source.Spec.Filter.DeprecatedSourceAndType != nil {
 				sink.Spec.Filter = &v1beta1.TriggerFilter{
-					Attributes: make(v1beta1.TriggerFilterAttributes, 0),
+					Attributes: make(v1beta1.TriggerFilterAttributes, 2),
 				}
 				sink.Spec.Filter.Attributes["source"] = source.Spec.Filter.DeprecatedSourceAndType.Source
 				sink.Spec.Filter.Attributes["type"] = source.Spec.Filter.DeprecatedSourceAndType.Type


### PR DESCRIPTION
Previously we made the map size zero by default, lets make it match
the existing length of attributes by default.


----

#