### PR TITLE
avoid leaking ctx 

### DIFF
--- a/test/performance/infra/aggregator/aggregator.go
+++ b/test/performance/infra/aggregator/aggregator.go
@@ -141,7 +141,8 @@ func (ag *Aggregator) Run(ctx context.Context) {
 	if ag.publishResults {
 		log.Printf("Configuring Mako")
 
-		makoClientCtx, _ := context.WithTimeout(ctx, time.Minute*10)
+		makoClientCtx, cancel := context.WithTimeout(ctx, time.Minute*10)
+		defer cancel()
 
 		client, err = mako.Setup(makoClientCtx, ag.makoTags...)
 		if err != nil {


### PR DESCRIPTION
## Proposed Changes

- the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

