### PR TITLE
fix: composite literal uses unkeyed fields

### DIFF
--- a/pkg/apis/flows/v1alpha1/sequence_lifecycle_test.go
+++ b/pkg/apis/flows/v1alpha1/sequence_lifecycle_test.go
@@ -38,16 +38,6 @@ var sequenceConditionReady = apis.Condition{
 	Status: corev1.ConditionTrue,
 }
 
-var sequenceConditionChannelsReady = apis.Condition{
-	Type:   SequenceConditionChannelsReady,
-	Status: corev1.ConditionTrue,
-}
-
-var sequenceConditionSubscriptionsReady = apis.Condition{
-	Type:   SequenceConditionSubscriptionsReady,
-	Status: corev1.ConditionTrue,
-}
-
 func getSubscription(name string, ready bool) *messagingv1alpha1.Subscription {
 	s := messagingv1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
@@ -84,7 +74,7 @@ func getChannelable(ready bool) *duckv1alpha1.Channelable {
 	}
 
 	if ready {
-		c.Status.Address = &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{URL}, ""}
+		c.Status.Address = &pkgduckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{URL: URL}, Hostname: ""}
 	}
 
 	return &c
@@ -382,17 +372,17 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 		wantStatus: corev1.ConditionFalse,
 	}, {
 		name:       "URL",
-		address:    &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{URL}, ""},
-		want:       &pkgduckv1.Addressable{URL},
+		address:    &pkgduckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{URL: URL}, Hostname: ""},
+		want:       &pkgduckv1.Addressable{URL: URL},
 		wantStatus: corev1.ConditionTrue,
 	}, {
 		name:       "hostname",
-		address:    &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{}, "myhostname"},
-		want:       &pkgduckv1.Addressable{hostnameURL},
+		address:    &pkgduckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{}, Hostname: "myhostname"},
+		want:       &pkgduckv1.Addressable{URL: hostnameURL},
 		wantStatus: corev1.ConditionTrue,
 	}, {
 		name:       "nil",
-		address:    &pkgduckv1alpha1.Addressable{duckv1beta1.Addressable{nil}, ""},
+		address:    &pkgduckv1alpha1.Addressable{Addressable: duckv1beta1.Addressable{URL: nil}, Hostname: ""},
 		want:       nil,
 		wantStatus: corev1.ConditionFalse,
 	}}


### PR DESCRIPTION
## Proposed Changes

- fix vet warning `composite literal uses unkeyed fields` on sequence tests.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
