### PR TITLE
fix: composite literal uses unkeyed fields, defaults

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/broker_defaults.go
@@ -39,8 +39,8 @@ func (bs *BrokerSpec) SetDefaults(ctx context.Context) {
 
 			if err == nil {
 				bs.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{
-					c.TypeMeta,
-					c.Spec,
+					TypeMeta: c.TypeMeta,
+					Spec:     c.Spec,
 				}
 			}
 		}

--- a/pkg/apis/flows/v1alpha1/parallel_defaults.go
+++ b/pkg/apis/flows/v1alpha1/parallel_defaults.go
@@ -32,8 +32,8 @@ func (p *Parallel) SetDefaults(ctx context.Context) {
 
 		if err == nil {
 			p.Spec.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{
-				c.TypeMeta,
-				c.Spec,
+				TypeMeta: c.TypeMeta,
+				Spec:     c.Spec,
 			}
 		}
 	}

--- a/pkg/apis/flows/v1alpha1/sequence_defaults.go
+++ b/pkg/apis/flows/v1alpha1/sequence_defaults.go
@@ -32,8 +32,8 @@ func (s *Sequence) SetDefaults(ctx context.Context) {
 
 		if err == nil {
 			s.Spec.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{
-				c.TypeMeta,
-				c.Spec,
+				TypeMeta: c.TypeMeta,
+				Spec:     c.Spec,
 			}
 		}
 	}

--- a/pkg/apis/flows/v1beta1/parallel_defaults.go
+++ b/pkg/apis/flows/v1beta1/parallel_defaults.go
@@ -32,8 +32,8 @@ func (p *Parallel) SetDefaults(ctx context.Context) {
 
 		if err == nil {
 			p.Spec.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{
-				c.TypeMeta,
-				c.Spec,
+				TypeMeta: c.TypeMeta,
+				Spec:     c.Spec,
 			}
 		}
 	}

--- a/pkg/apis/flows/v1beta1/sequence_defaults.go
+++ b/pkg/apis/flows/v1beta1/sequence_defaults.go
@@ -32,8 +32,8 @@ func (s *Sequence) SetDefaults(ctx context.Context) {
 
 		if err == nil {
 			s.Spec.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{
-				c.TypeMeta,
-				c.Spec,
+				TypeMeta: c.TypeMeta,
+				Spec:     c.Spec,
 			}
 		}
 	}

--- a/pkg/apis/messaging/v1alpha1/channel_defaults.go
+++ b/pkg/apis/messaging/v1alpha1/channel_defaults.go
@@ -30,8 +30,8 @@ func (c *Channel) SetDefaults(ctx context.Context) {
 		defaultChannel, err := cfg.ChannelDefaults.GetChannelConfig(apis.ParentMeta(ctx).Namespace)
 		if err == nil {
 			c.Spec.ChannelTemplate = &v1beta1.ChannelTemplateSpec{
-				defaultChannel.TypeMeta,
-				defaultChannel.Spec,
+				TypeMeta: defaultChannel.TypeMeta,
+				Spec:     defaultChannel.Spec,
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

- fix: composite literal uses unkeyed fields, for seq, parallel defaults 
- same for broker, channel

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
