### PR TITLE
remove 0.2 from the sources spec

### DIFF
--- a/docs/spec/sources.md
+++ b/docs/spec/sources.md
@@ -351,7 +351,6 @@ documentation.
 Sources SHOULD produce CloudEvents. The output SHOULD be via the HTTP binding
 specified in one of the following versions of the specification:
 
-- [CloudEvents 0.2 specification](https://github.com/cloudevents/spec/blob/v0.2/http-transport-binding.md)
 - [CloudEvents 0.3 specification](https://github.com/cloudevents/spec/blob/v0.3/http-transport-binding.md)
 - [CloudEvents 1.0 specification](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md)
 


### PR DESCRIPTION
Fixes #2706

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove 0.2 as supported Cloud Event version.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior : Cloud Events 0.2 is not supported by sources.

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
