### PR TITLE
Apply defaults to BrokerClass and only filter brokers that match BrokerClass.

### DIFF
--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -21,6 +21,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |
     clusterDefault:
+      brokerClass: ChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: config-br-default-channel

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -25,8 +25,6 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/system"
 
-	"knative.dev/eventing/pkg/apis/eventing"
-
 	. "knative.dev/pkg/configmap/testing"
 	_ "knative.dev/pkg/system/testing"
 )
@@ -88,8 +86,8 @@ func TestGetBrokerClass(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetBrokerClass Failed = %v", err)
 	}
-	if c != eventing.ChannelBrokerClassValue {
-		t.Errorf("GetBrokerClass Failed, wanted somename, got: %s", c)
+	if c != "ChannelBasedBroker" {
+		t.Errorf("GetBrokerClass Failed, wanted ChannelBasedBroker, got: %s", c)
 	}
 	c, err = defaults.GetBrokerClass("some-namespace")
 	if err != nil {

--- a/pkg/apis/eventing/v1alpha1/broker_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/broker_defaults.go
@@ -19,7 +19,8 @@ package v1alpha1
 import (
 	"context"
 
-	"knative.dev/eventing/pkg/apis/messaging/config"
+	"knative.dev/eventing/pkg/apis/eventing"
+	messagingconfig "knative.dev/eventing/pkg/apis/messaging/config"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	"knative.dev/pkg/apis"
 )
@@ -27,6 +28,7 @@ import (
 func (b *Broker) SetDefaults(ctx context.Context) {
 	withNS := apis.WithinParent(ctx, b.ObjectMeta)
 	b.Spec.SetDefaults(withNS)
+	eventing.DefaultBrokerClassIfUnset(withNS, &b.ObjectMeta)
 }
 
 func (bs *BrokerSpec) SetDefaults(ctx context.Context) {
@@ -34,8 +36,8 @@ func (bs *BrokerSpec) SetDefaults(ctx context.Context) {
 		// If we haven't configured the new channelTemplate,
 		// then set the default channel to the new channelTemplate.
 		if bs.ChannelTemplate == nil {
-			cfg := config.FromContextOrDefaults(ctx)
-			c, err := cfg.ChannelDefaults.GetChannelConfig(apis.ParentMeta(ctx).Namespace)
+			channelCfg := messagingconfig.FromContextOrDefaults(ctx)
+			c, err := channelCfg.ChannelDefaults.GetChannelConfig(apis.ParentMeta(ctx).Namespace)
 
 			if err == nil {
 				bs.ChannelTemplate = &messagingv1beta1.ChannelTemplateSpec{

--- a/pkg/apis/eventing/v1alpha1/broker_types.go
+++ b/pkg/apis/eventing/v1alpha1/broker_types.go
@@ -30,7 +30,7 @@ import (
 )
 
 // +genclient
-// +genreconciler
+// +genreconciler:class=eventing.knative.dev/broker.class
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Broker collects a pool of events that are consumable using Triggers. Brokers

--- a/pkg/client/injection/reconciler/eventing/v1alpha1/broker/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1alpha1/broker/controller.go
@@ -38,13 +38,16 @@ const (
 	defaultControllerAgentName = "broker-controller"
 	defaultFinalizerName       = "brokers.eventing.knative.dev"
 	defaultQueueName           = "brokers"
+
+	// ClassAnnotationKey points to the annotation for the class of this resource.
+	ClassAnnotationKey = "eventing.knative.dev/broker.class"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // controller.Options to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
+func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -78,6 +81,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		Lister:     brokerInformer.Lister(),
 		Recorder:   recorder,
 		reconciler: r,
+		classValue: classValue,
 	}
 	impl := controller.NewImpl(rec, logger, defaultQueueName)
 

--- a/pkg/client/injection/reconciler/eventing/v1alpha1/broker/reconciler.go
+++ b/pkg/client/injection/reconciler/eventing/v1alpha1/broker/reconciler.go
@@ -81,12 +81,15 @@ type reconcilerImpl struct {
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
+
+	// classValue is the resource annotation[eventing.knative.dev/broker.class] instance value this reconciler instance filters on.
+	classValue string
 }
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister eventingv1alpha1.BrokerLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister eventingv1alpha1.BrokerLister, recorder record.EventRecorder, r Interface, classValue string, options ...controller.Options) controller.Reconciler {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
@@ -97,6 +100,7 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
+		classValue: classValue,
 	}
 
 	for _, opts := range options {
@@ -135,6 +139,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		return nil
 	} else if err != nil {
 		return err
+	}
+
+	if classValue, found := original.GetAnnotations()[ClassAnnotationKey]; !found || classValue != r.classValue {
+		logger.Debugw("Skip reconciling resource, class annotation value does not match reconciler instance value.",
+			zap.String("classKey", ClassAnnotationKey),
+			zap.String("issue", classValue+"!="+r.classValue))
+		return nil
 	}
 
 	// Don't modify the informers copy.

--- a/pkg/client/injection/reconciler/eventing/v1alpha1/broker/stub/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1alpha1/broker/stub/controller.go
@@ -21,11 +21,13 @@ package broker
 import (
 	context "context"
 
+	cache "k8s.io/client-go/tools/cache"
 	broker "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/broker"
 	v1alpha1broker "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
+	reconciler "knative.dev/pkg/reconciler"
 )
 
 // TODO: PLEASE COPY AND MODIFY THIS FILE AS A STARTING POINT
@@ -39,14 +41,21 @@ func NewController(
 
 	brokerInformer := broker.Get(ctx)
 
+	classValue := "default" // TODO: update this to the appropriate value.
+	classFilter := reconciler.AnnotationFilterFunc(v1alpha1broker.ClassAnnotationKey, classValue, false /*allowUnset*/)
+
 	// TODO: setup additional informers here.
+	// TODO: remember to use the classFilter from above to filter appropriately.
 
 	r := &Reconciler{}
-	impl := v1alpha1broker.NewImpl(ctx, r)
+	impl := v1alpha1broker.NewImpl(ctx, r, classValue)
 
 	logger.Info("Setting up event handlers.")
 
-	brokerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: classFilter,
+		Handler:    controller.HandleAll(impl.Enqueue),
+	})
 
 	// TODO: add additional informer event handlers here.
 

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -105,11 +105,6 @@ func newReconciledNormal(namespace, name string) pkgreconciler.Event {
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, b *v1alpha1.Broker) pkgreconciler.Event {
-	filterFunc := pkgreconciler.AnnotationFilterFunc(eventing.BrokerClassKey, r.brokerClass, true)
-	if !filterFunc(b) {
-		logging.FromContext(ctx).Info("Not reconciling broker, cause it's not mine", zap.String("broker", b.Name))
-		return nil
-	}
 	filterSvc, err := r.reconcileKind(ctx, b)
 
 	if b.Status.IsReady() {

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -105,9 +105,8 @@ func newReconciledNormal(namespace, name string) pkgreconciler.Event {
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, b *v1alpha1.Broker) pkgreconciler.Event {
-	// TODO(vaikas): Can we just add this into the controller as part of the filtering
-	// so they won't even get queued into my queue???
-	if b.GetAnnotations()[eventing.BrokerClassKey] != r.brokerClass {
+	filterFunc := pkgreconciler.AnnotationFilterFunc(eventing.BrokerClassKey, r.brokerClass, true)
+	if !filterFunc(b) {
 		logging.FromContext(ctx).Info("Not reconciling broker, cause it's not mine", zap.String("broker", b.Name))
 		return nil
 	}

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -107,11 +107,9 @@ func newReconciledNormal(namespace, name string) pkgreconciler.Event {
 func (r *Reconciler) ReconcileKind(ctx context.Context, b *v1alpha1.Broker) pkgreconciler.Event {
 	// TODO(vaikas): Can we just add this into the controller as part of the filtering
 	// so they won't even get queued into my queue???
-	if r.brokerClass != "" {
-		if b.GetAnnotations()[eventing.BrokerClassKey] != r.brokerClass {
-			logging.FromContext(ctx).Info("Not reconciling broker, cause it's not mine", zap.String("broker", b.Name))
-			return nil
-		}
+	if b.GetAnnotations()[eventing.BrokerClassKey] != r.brokerClass {
+		logging.FromContext(ctx).Info("Not reconciling broker, cause it's not mine", zap.String("broker", b.Name))
+		return nil
 	}
 	filterSvc, err := r.reconcileKind(ctx, b)
 

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -191,6 +191,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithBrokerDeletionTimestamp),
@@ -203,6 +204,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions),
 			},
 			WantEvents: []string{
@@ -214,6 +216,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions,
 					WithTriggerChannelFailed("ChannelTemplateFailed", "Error on setting up the ChannelTemplate: Broker.Spec.ChannelTemplate is nil")),
 			}},
@@ -224,6 +227,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 			},
@@ -232,6 +236,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions,
 					WithBrokerChannel(channel()),
 					WithTriggerChannelFailed("ChannelFailure", "inducing failure for create inmemorychannels")),
@@ -252,6 +257,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 			},
@@ -260,6 +266,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions,
 					WithBrokerChannel(channel()),
 					WithTriggerChannelFailed("NoAddress", "Channel does not have an address.")),
@@ -275,12 +282,14 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, false),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelFailed("NoAddress", "Channel does not have an address.")),
@@ -296,6 +305,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -312,6 +322,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -331,6 +342,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -345,6 +357,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -371,6 +384,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -391,6 +405,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -410,6 +425,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -434,6 +450,7 @@ func TestReconcile(t *testing.T) {
 			}},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -453,6 +470,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -479,6 +497,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -499,6 +518,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithBrokerGeneration(brokerGeneration),
@@ -531,6 +551,7 @@ func TestReconcile(t *testing.T) {
 			}},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithBrokerGeneration(brokerGeneration),
@@ -553,6 +574,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -582,6 +604,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -602,6 +625,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -635,6 +659,7 @@ func TestReconcile(t *testing.T) {
 			}},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithTriggerChannelReady(),
@@ -655,6 +680,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -679,54 +705,11 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
-					WithBrokerChannel(channel()),
-					WithBrokerReady,
-					WithBrokerTriggerChannel(createTriggerChannelRef()),
-					WithBrokerAddress(fmt.Sprintf("%s.%s.svc.%s", ingressServiceName, testNS, utils.GetClusterDomainName())),
-				),
-			}},
-			WantEvents: []string{
-				finalizerUpdatedEvent,
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, brokerName),
-			},
-		},
-		{
-			Name: "Successful Reconciliation, matching BrokerClass",
-			Key:  testKey,
-			Objects: []runtime.Object{
-				NewBroker(brokerName, testNS,
-					WithBrokerChannel(channel()),
-					WithInitBrokerConditions,
-					WithBrokerClass(eventing.ChannelBrokerClassValue)),
-				createChannel(testNS, triggerChannel, true),
-				NewDeployment(filterDeploymentName, testNS,
-					WithDeploymentOwnerReferences(ownerReferences()),
-					WithDeploymentLabels(resources.FilterLabels(brokerName)),
-					WithDeploymentServiceAccount(filterSA),
-					WithDeploymentContainer(filterContainerName, filterImage, livenessProbe(), readinessProbe(), envVars(filterContainerName), containerPorts(8080))),
-				NewService(filterServiceName, testNS,
-					WithServiceOwnerReferences(ownerReferences()),
-					WithServiceLabels(resources.FilterLabels(brokerName)),
-					WithServicePorts(servicePorts(8080))),
-				NewDeployment(ingressDeploymentName, testNS,
-					WithDeploymentOwnerReferences(ownerReferences()),
-					WithDeploymentLabels(resources.IngressLabels(brokerName)),
-					WithDeploymentServiceAccount(ingressSA),
-					WithDeploymentContainer(ingressContainerName, ingressImage, livenessProbe(), nil, envVars(ingressContainerName), containerPorts(8080))),
-				NewService(ingressServiceName, testNS,
-					WithServiceOwnerReferences(ownerReferences()),
-					WithServiceLabels(resources.IngressLabels(brokerName)),
-					WithServicePorts(servicePorts(8080))),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewBroker(brokerName, testNS,
-					WithBrokerChannel(channel()),
-					WithBrokerReady,
-					WithBrokerTriggerChannel(createTriggerChannelRef()),
-					WithBrokerAddress(fmt.Sprintf("%s.%s.svc.%s", ingressServiceName, testNS, utils.GetClusterDomainName())),
 					WithBrokerClass(eventing.ChannelBrokerClassValue),
+					WithBrokerChannel(channel()),
+					WithBrokerReady,
+					WithBrokerTriggerChannel(createTriggerChannelRef()),
+					WithBrokerAddress(fmt.Sprintf("%s.%s.svc.%s", ingressServiceName, testNS, utils.GetClusterDomainName())),
 				),
 			}},
 			WantEvents: []string{
@@ -745,18 +728,13 @@ func TestReconcile(t *testing.T) {
 					WithInitBrokerConditions,
 					WithBrokerClass("broker-class-mismatch")),
 			},
-			WantEvents: []string{
-				finalizerUpdatedEvent,
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, brokerName),
-			},
 		},
 		{
 			Name: "Successful Reconciliation, status update fails",
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -784,6 +762,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithBrokerReady,
 					WithBrokerTriggerChannel(createTriggerChannelRef()),
@@ -803,6 +782,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions),
 				createChannel(testNS, triggerChannel, true),
@@ -842,6 +822,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI)),
 			}, {
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithBrokerReady,
 					WithBrokerTriggerChannel(createTriggerChannelRef()),
@@ -859,6 +840,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions),
 				NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -882,6 +864,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI)),
 			}, {
 				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithInitBrokerConditions,
 					WithTriggerChannelFailed("ChannelTemplateFailed", "Error on setting up the ChannelTemplate: Broker.Spec.ChannelTemplate is nil")),
 			}},
@@ -898,6 +881,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithBrokerFinalizers("brokers.eventing.knative.dev"),
@@ -926,6 +910,7 @@ func TestReconcile(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.ChannelBrokerClassValue),
 					WithBrokerChannel(channel()),
 					WithInitBrokerConditions,
 					WithBrokerFinalizers("brokers.eventing.knative.dev"),
@@ -1476,7 +1461,7 @@ func TestReconcile(t *testing.T) {
 			uriResolver:               resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			brokerClass:               eventing.ChannelBrokerClassValue,
 		}
-		return broker.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetBrokerLister(), r.Recorder, r)
+		return broker.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetBrokerLister(), r.Recorder, r, eventing.ChannelBrokerClassValue)
 
 	},
 		false,
@@ -1790,6 +1775,7 @@ func makeBroker() *v1alpha1.Broker {
 func allBrokerObjectsReadyPlus(objs ...runtime.Object) []runtime.Object {
 	brokerObjs := []runtime.Object{
 		NewBroker(brokerName, testNS,
+			WithBrokerClass(eventing.ChannelBrokerClassValue),
 			WithBrokerChannel(channel()),
 			WithInitBrokerConditions,
 			WithBrokerReady,

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -58,7 +58,7 @@ type envConfig struct {
 	FilterImage           string `envconfig:"BROKER_FILTER_IMAGE" required:"true"`
 	FilterServiceAccount  string `envconfig:"BROKER_FILTER_SERVICE_ACCOUNT" required:"true"`
 	// The default value should match the cluster default in config/core/configmaps/default-broker.yaml
-	BrokerClass           string `envconfig:"BROKER_CLASS" default:"ChannelBasedBroker"`
+	BrokerClass string `envconfig:"BROKER_CLASS" default:"ChannelBasedBroker"`
 }
 
 // NewController initializes the controller and is called by the generated code

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -57,7 +57,8 @@ type envConfig struct {
 	IngressServiceAccount string `envconfig:"BROKER_INGRESS_SERVICE_ACCOUNT" required:"true"`
 	FilterImage           string `envconfig:"BROKER_FILTER_IMAGE" required:"true"`
 	FilterServiceAccount  string `envconfig:"BROKER_FILTER_SERVICE_ACCOUNT" required:"true"`
-	BrokerClass           string `envconfig:"BROKER_CLASS"`
+	// The default value should match the cluster default in config/core/configmaps/default-broker.yaml
+	BrokerClass           string `envconfig:"BROKER_CLASS" default:"ChannelBasedBroker"`
 }
 
 // NewController initializes the controller and is called by the generated code

--- a/pkg/reconciler/testing/broker.go
+++ b/pkg/reconciler/testing/broker.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	"knative.dev/pkg/apis"
@@ -146,5 +147,14 @@ func WithIngressDeploymentAvailable() BrokerOption {
 func WithBrokerTriggerChannel(c *corev1.ObjectReference) BrokerOption {
 	return func(b *v1alpha1.Broker) {
 		b.Status.TriggerChannel = c
+	}
+}
+
+func WithBrokerClass(bc string) BrokerOption {
+	return func(b *v1alpha1.Broker) {
+		if b.GetAnnotations() == nil {
+			b.SetAnnotations(map[string]string{})
+		}
+		b.GetAnnotations()[eventing.BrokerClassKey] = bc
 	}
 }

--- a/pkg/reconciler/testing/broker.go
+++ b/pkg/reconciler/testing/broker.go
@@ -22,9 +22,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	"knative.dev/pkg/apis"
 )
 
@@ -152,9 +152,11 @@ func WithBrokerTriggerChannel(c *corev1.ObjectReference) BrokerOption {
 
 func WithBrokerClass(bc string) BrokerOption {
 	return func(b *v1alpha1.Broker) {
-		if b.GetAnnotations() == nil {
-			b.SetAnnotations(map[string]string{})
+		annotations := b.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
 		}
-		b.GetAnnotations()[eventing.BrokerClassKey] = bc
+		annotations[broker.ClassAnnotationKey] = bc
+		b.SetAnnotations(annotations)
 	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
The existing filter function only applies when the default controller has a non-empty BrokerClass. This has an issue: If the incoming broker is specified with `BrokerClass: Foo-Class`, the default controller with `BrokerClass:""` will happily pick it up even thought the broker doesn't belong to it. 

This change ensures that any broker object, as well as the default broker controller,  will have a non-empty BrokerClass to match against.

- Add default BrokerClass in cluster default. This allows the broker Defaulter to apply the default BrokerClass annotation if not set.
- Add default BrokerClass in broker controller env var.
- Modify the filter func to do exact match of given broker and the controller based on broker class.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

## Testing
* Tested new brokers will be added with the default BrokerClass.
* Tested that existing brokers without BrokerClass annotation will be configured with the default BrokerClass by the conversion controller. 

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/assign @vaikas 