### PR TITLE
Allow default broker controller to reconcile unset brokerclass.

### DIFF
--- a/pkg/client/injection/reconciler/eventing/v1alpha1/broker/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1alpha1/broker/controller.go
@@ -47,7 +47,7 @@ const (
 // the queue through an implementation of controller.Reconciler, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // controller.Options to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl {
+func NewImpl(ctx context.Context, r Interface, classFilter func(interface{}) bool, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -77,11 +77,11 @@ func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...
 	}
 
 	rec := &reconcilerImpl{
-		Client:     injectionclient.Get(ctx),
-		Lister:     brokerInformer.Lister(),
-		Recorder:   recorder,
-		reconciler: r,
-		classValue: classValue,
+		Client:      injectionclient.Get(ctx),
+		Lister:      brokerInformer.Lister(),
+		Recorder:    recorder,
+		reconciler:  r,
+		classFilter: classFilter,
 	}
 	impl := controller.NewImpl(rec, logger, defaultQueueName)
 

--- a/pkg/client/injection/reconciler/eventing/v1alpha1/broker/stub/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1alpha1/broker/stub/controller.go
@@ -42,13 +42,14 @@ func NewController(
 	brokerInformer := broker.Get(ctx)
 
 	classValue := "default" // TODO: update this to the appropriate value.
-	classFilter := reconciler.AnnotationFilterFunc(v1alpha1broker.ClassAnnotationKey, classValue, false /*allowUnset*/)
+	allowUnset := false     // TODO: update this to specific matching unset ClassAnnotationKey or not.
+	classFilter := reconciler.AnnotationFilterFunc(v1alpha1broker.ClassAnnotationKey, classValue, allowUnset /*allowUnset*/)
 
 	// TODO: setup additional informers here.
 	// TODO: remember to use the classFilter from above to filter appropriately.
 
 	r := &Reconciler{}
-	impl := v1alpha1broker.NewImpl(ctx, r, classValue)
+	impl := v1alpha1broker.NewImpl(ctx, r, classFilter)
 
 	logger.Info("Setting up event handlers.")
 

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -81,9 +81,6 @@ type Reconciler struct {
 	// Dynamic tracker to track AddressableTypes. In particular, it tracks Trigger subscribers.
 	addressableTracker duck.ListableTracker
 	uriResolver        *resolver.URIResolver
-
-	// If specified, only reconcile brokers with these labels
-	brokerClass string
 }
 
 // Check that our Reconciler implements Interface

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -38,6 +38,7 @@ import (
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelable"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
+	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
@@ -53,6 +54,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
 
@@ -1459,9 +1461,9 @@ func TestReconcile(t *testing.T) {
 			channelableTracker:        duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
 			addressableTracker:        duck.NewListableTracker(ctx, v1a1addr.Get, func(types.NamespacedName) {}, 0),
 			uriResolver:               resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			brokerClass:               eventing.ChannelBrokerClassValue,
 		}
-		return broker.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetBrokerLister(), r.Recorder, r, eventing.ChannelBrokerClassValue)
+		classFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.ChannelBrokerClassValue, true)
+		return broker.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetBrokerLister(), r.Recorder, r, classFilter)
 
 	},
 		false,

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -90,10 +90,11 @@ func NewController(
 		ingressServiceAccountName: env.IngressServiceAccount,
 		filterImage:               env.FilterImage,
 		filterServiceAccountName:  env.FilterServiceAccount,
-		brokerClass:               env.BrokerClass,
 	}
-
-	impl := brokerreconciler.NewImpl(ctx, r, env.BrokerClass)
+	classValue := env.BrokerClass
+	allowUnset := true
+	classFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, classValue, allowUnset /*allowUnset*/)
+	impl := brokerreconciler.NewImpl(ctx, r, classFilter)
 
 	r.Logger.Info("Setting up event handlers")
 
@@ -103,7 +104,7 @@ func NewController(
 	r.uriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, env.BrokerClass, false /*allowUnset*/),
+		FilterFunc: classFilter,
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -164,7 +164,7 @@ const (
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // {{.controllerOptions|raw}} to be used but the internal reconciler.
-func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValue string{{end}}, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
+func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classFilter func(interface{}) bool{{end}}, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -198,7 +198,7 @@ func NewImpl(ctx {{.contextContext|raw}}, r Interface{{if .hasClass}}, classValu
 		Lister:  {{.type|lowercaseSingular}}Informer.Lister(),
 		Recorder: recorder,
 		reconciler:    r,
-		{{if .hasClass}}classValue: classValue,{{end}}
+		{{if .hasClass}}classFilter: classFilter,{{end}}
 	}
 	impl := {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
 

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -120,14 +120,15 @@ func NewController(
 
 	{{if .hasClass}}
 	classValue := "default" // TODO: update this to the appropriate value.
-	classFilter := {{.annotationFilterFunc|raw}}({{.classAnnotationKey|raw}}, classValue, false /*allowUnset*/)
+	allowUnset := false // TODO: update this to specific matching unset ClassAnnotationKey or not.
+	classFilter := {{.annotationFilterFunc|raw}}({{.classAnnotationKey|raw}}, classValue, allowUnset /*allowUnset*/)
 	{{end}}
 
 	// TODO: setup additional informers here.
 	{{if .hasClass}}// TODO: remember to use the classFilter from above to filter appropriately.{{end}}
 
 	r := &Reconciler{}
-	impl := {{.reconcilerNewImpl|raw}}(ctx, r{{if .hasClass}}, classValue{{end}})
+	impl := {{.reconcilerNewImpl|raw}}(ctx, r{{if .hasClass}}, classFilter{{end}})
 
 	logger.Info("Setting up event handlers.")
 


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Allow the default broker controller to reconcile brokers without brokerclass annotation for backwards compatibility.

Depends on https://github.com/knative/pkg/pull/1163.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->


cc @vaikas 