### PR TITLE
Port channel fanout code to bindings

### DIFF
--- a/pkg/channel/fanout/fanout_handler_binding.go
+++ b/pkg/channel/fanout/fanout_handler_binding.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fanout provides an http.Handler that takes in one request and fans it out to N other
+// requests, based on a list of Subscriptions. Logically, it represents all the Subscriptions to a
+// single Knative Channel.
+// It will normally be used in conjunction with multichannelfanout.Handler, which contains multiple
+// fanout.Handlers, each corresponding to a single Knative Channel.
+package fanout
+
+import (
+	"context"
+	"errors"
+	nethttp "net/http"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/buffering"
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	"knative.dev/eventing/pkg/channel"
+)
+
+// Handler is a http.Handler that takes a single request in and fans it out to N other servers.
+type MessageHandler struct {
+	config Config
+
+	receiver   *channel.MessageReceiver
+	dispatcher *channel.MessageDispatcherImpl
+
+	// TODO: Plumb context through the receiver and dispatcher and use that to store the timeout,
+	// rather than a member variable.
+	timeout time.Duration
+
+	logger *zap.Logger
+}
+
+// NewHandler creates a new fanout.Handler.
+func NewMessageHandler(ctx context.Context, logger *zap.Logger, config Config) (*MessageHandler, error) {
+	handler := &MessageHandler{
+		logger:     logger,
+		config:     config,
+		dispatcher: channel.NewMessageDispatcherFromConfig(logger, config.DispatcherConfig),
+		timeout:    defaultTimeout,
+	}
+	// The receiver function needs to point back at the handler itself, so set it up after
+	// initialization.
+	receiver, err := channel.NewMessageReceiver(ctx, createReceiverFunctionBinding(handler), logger)
+	if err != nil {
+		return nil, err
+	}
+	handler.receiver = receiver
+	return handler, nil
+}
+
+func createReceiverFunctionBinding(f *MessageHandler) func(context.Context, channel.ChannelReference, binding.Message, nethttp.Header) error {
+	if f.config.AsyncHandler {
+		return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, additionalHeaders nethttp.Header) error {
+			parentSpan := trace.FromContext(ctx)
+			go func() {
+				// Run async dispatch with background context.
+				ctx = trace.NewContext(context.Background(), parentSpan)
+				// Any returned error is already logged in f.dispatch().
+				_ = f.dispatch(ctx, message, additionalHeaders)
+			}()
+			return nil
+		}
+	}
+	return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, additionalHeaders nethttp.Header) error {
+		return f.dispatch(ctx, message, additionalHeaders)
+	}
+}
+
+func (f *MessageHandler) ServeHTTP(response nethttp.ResponseWriter, request *nethttp.Request) {
+	f.receiver.ServeHTTP(response, request)
+}
+
+// dispatch takes the event, fans it out to each subscription in f.config. If all the fanned out
+// events return successfully, then return nil. Else, return an error.
+func (f *MessageHandler) dispatch(ctx context.Context, message binding.Message, additionalHeaders nethttp.Header) error {
+	//TODO what if this method handles the lifecycle of the final message, more than EventDispatcher?
+	message = buffering.WithAcksBeforeFinish(message, len(f.config.Subscriptions))
+	errorCh := make(chan error, len(f.config.Subscriptions))
+	for _, sub := range f.config.Subscriptions {
+		go func(s eventingduck.SubscriberSpec) {
+			errorCh <- f.makeFanoutRequest(ctx, message, additionalHeaders, s)
+		}(sub)
+	}
+
+	for range f.config.Subscriptions {
+		select {
+		case err := <-errorCh:
+			if err != nil {
+				f.logger.Error("Fanout had an error", zap.Error(err))
+				return err
+			}
+		case <-time.After(f.timeout):
+			f.logger.Error("Fanout timed out")
+			return errors.New("fanout timed out")
+		}
+	}
+	// All Subscriptions returned err = nil.
+	return nil
+}
+
+// makeFanoutRequest sends the request to exactly one subscription. It handles both the `call` and
+// the `sink` portions of the subscription.
+func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.Message, additionalHeaders nethttp.Header, sub eventingduck.SubscriberSpec) error {
+	return f.dispatcher.DispatchMessageWithDelivery(ctx, message, additionalHeaders, sub.SubscriberURI.String(), sub.ReplyURI.String(), &channel.DeliveryOptions{DeadLetterSink: sub.DeadLetterSinkURI.String()})
+}

--- a/pkg/channel/fanout/fanout_handler_binding_test.go
+++ b/pkg/channel/fanout/fanout_handler_binding_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fanout
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	bindingshttp "github.com/cloudevents/sdk-go/pkg/protocol/http"
+	"go.uber.org/zap"
+	"knative.dev/pkg/apis"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	"knative.dev/eventing/pkg/channel"
+)
+
+func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
+	testCases := map[string]struct {
+		receiverFunc   channel.MessageReceiverFunc
+		timeout        time.Duration
+		subs           []eventingduck.SubscriberSpec
+		subscriber     func(http.ResponseWriter, *http.Request)
+		channel        func(http.ResponseWriter, *http.Request)
+		expectedStatus int
+		asyncHandler   bool
+		skip           string
+	}{
+		"rejected by receiver": {
+			receiverFunc: func(context.Context, channel.ChannelReference, binding.Message, http.Header) error {
+				return errors.New("rejected by test-receiver")
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"fanout times out": {
+			timeout: time.Millisecond,
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+				},
+			},
+			subscriber: func(writer http.ResponseWriter, _ *http.Request) {
+				time.Sleep(time.Second)
+				writer.WriteHeader(http.StatusAccepted)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"zero subs succeed": {
+			subs:           []eventingduck.SubscriberSpec{},
+			expectedStatus: http.StatusAccepted,
+		},
+		"empty sub succeeds": {
+			subs: []eventingduck.SubscriberSpec{
+				{},
+			},
+			expectedStatus: http.StatusAccepted,
+		},
+		"reply fails": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					ReplyURI: replaceChannel,
+				},
+			},
+			channel: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusNotFound)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"subscriber fails": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+				},
+			},
+			subscriber: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusNotFound)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"subscriber succeeds, result fails": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+			},
+			subscriber: callableSucceed,
+			channel: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusForbidden)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"one sub succeeds": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+			},
+			subscriber: callableSucceed,
+			channel: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusAccepted)
+			},
+			expectedStatus: http.StatusAccepted,
+		},
+		"one sub succeeds, one sub fails": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+			},
+			subscriber:     callableSucceed,
+			channel:        (&succeedOnce{}).handler,
+			expectedStatus: http.StatusInternalServerError,
+		},
+		"all subs succeed": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+			},
+			subscriber: callableSucceed,
+			channel: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusAccepted)
+			},
+			expectedStatus: http.StatusAccepted,
+		},
+		"all subs succeed with async handler": {
+			subs: []eventingduck.SubscriberSpec{
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+				{
+					SubscriberURI: replaceSubscriber,
+					ReplyURI:      replaceChannel,
+				},
+			},
+			subscriber: callableSucceed,
+			channel: func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusAccepted)
+			},
+			expectedStatus: http.StatusAccepted,
+			asyncHandler:   true,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+			callableServer := httptest.NewServer(&fakeHandler{
+				handler: tc.subscriber,
+			})
+			defer callableServer.Close()
+			channelServer := httptest.NewServer(&fakeHandler{
+				handler: tc.channel,
+			})
+			defer channelServer.Close()
+
+			// Rewrite the subs to use the servers we just started.
+			subs := make([]eventingduck.SubscriberSpec, 0)
+			for _, sub := range tc.subs {
+				if sub.SubscriberURI == replaceSubscriber {
+					sub.SubscriberURI = apis.HTTP(callableServer.URL[7:]) // strip the leading 'http://'
+				}
+				if sub.ReplyURI == replaceChannel {
+					sub.ReplyURI = apis.HTTP(channelServer.URL[7:]) // strip the leading 'http://'
+				}
+				subs = append(subs, sub)
+			}
+
+			h, err := NewMessageHandler(context.TODO(), zap.NewNop(), Config{Subscriptions: subs})
+			if err != nil {
+				t.Fatalf("NewHandler failed. Error:%s", err)
+			}
+			if tc.asyncHandler {
+				h.config.AsyncHandler = true
+			}
+			if tc.receiverFunc != nil {
+				receiver, err := channel.NewMessageReceiver(context.TODO(), tc.receiverFunc, zap.NewNop())
+				if err != nil {
+					t.Fatalf("NewEventReceiver failed. Error:%s", err)
+				}
+				h.receiver = receiver
+			}
+			if tc.timeout != 0 {
+				h.timeout = tc.timeout
+			} else {
+				// Reasonable timeout for the tests.
+				h.timeout = 100 * time.Millisecond
+			}
+
+			event := makeCloudEventNew()
+			req := httptest.NewRequest(http.MethodPost, "http://channelname.channelnamespace/", nil)
+
+			ctx := context.Background()
+			err = bindingshttp.WriteRequest(ctx, binding.ToMessage(&event), req, binding.TransformerFactories{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp := httptest.ResponseRecorder{}
+
+			h.ServeHTTP(&resp, req)
+			if resp.Code != tc.expectedStatus {
+				t.Errorf("Unexpected status code. Expected %v, Actual %v", tc.expectedStatus, resp.Code)
+			}
+		})
+	}
+}
+
+func makeCloudEventNew() cloudevents.Event {
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetType("com.example.someevent")
+	event.SetSource("/mycontext")
+	event.SetID("A234-1234-1234")
+	event.SetExtension("comexampleextension", "value")
+	event.SetData(cloudevents.ApplicationXML, "<much wow=\"xml\"/>")
+	return event
+}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_handler_binding.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_handler_binding.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package multichannelfanout provides an http.Handler that takes in one request to a Knative
+// Channel and fans it out to N other requests. Logically, it represents multiple Knative Channels.
+// It is made up of a map, map[channel]fanout.Handler and each incoming request is inspected to
+// determine which Channel it is on. This Handler delegates the HTTP handling to the fanout.Handler
+// corresponding to the incoming request's Channel.
+// It is often used in conjunction with a swappable.Handler. The swappable.Handler delegates all its
+// requests to the multichannelfanout.Handler. When a new configuration is available, a new
+// multichannelfanout.Handler is created and swapped in for all subsequent requests. The old
+// multichannelfanout.Handler is discarded.
+package multichannelfanout
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+
+	"knative.dev/eventing/pkg/channel/fanout"
+)
+
+// Handler is an http.Handler that introspects the incoming request to determine what Channel it is
+// on, and then delegates handling of that request to the single fanout.Handler corresponding to
+// that Channel.
+type MessageHandler struct {
+	logger   *zap.Logger
+	handlers map[string]*fanout.MessageHandler
+	config   Config
+}
+
+// NewHandler creates a new Handler.
+func NewMessageHandler(ctx context.Context, logger *zap.Logger, conf Config) (*MessageHandler, error) {
+	handlers := make(map[string]*fanout.MessageHandler, len(conf.ChannelConfigs))
+
+	for _, cc := range conf.ChannelConfigs {
+		key := makeChannelKeyFromConfig(cc)
+		handler, err := fanout.NewMessageHandler(ctx, logger, cc.FanoutConfig)
+		if err != nil {
+			logger.Error("Failed creating new fanout handler.", zap.Error(err))
+			return nil, err
+		}
+		if _, present := handlers[key]; present {
+			logger.Error("Duplicate channel key", zap.String("channelKey", key))
+			return nil, fmt.Errorf("duplicate channel key: %v", key)
+		}
+		handlers[key] = handler
+	}
+
+	return &MessageHandler{
+		logger:   logger,
+		config:   conf,
+		handlers: handlers,
+	}, nil
+}
+
+// ConfigDiffs diffs the new config with the existing config. If there are no differences, then the
+// empty string is returned. If there are differences, then a non-empty string is returned
+// describing the differences.
+func (h *MessageHandler) ConfigDiff(updated Config) string {
+	return cmp.Diff(h.config, updated)
+}
+
+// CopyWithNewConfig creates a new copy of this Handler with all the fields identical, except the
+// new Handler uses conf, rather than copying the existing Handler's config.
+func (h *MessageHandler) CopyWithNewConfig(ctx context.Context, conf Config) (*MessageHandler, error) {
+	return NewMessageHandler(ctx, h.logger, conf)
+}
+
+// ServeHTTP delegates the actual handling of the request to a fanout.Handler, based on the
+// request's channel key.
+func (h *MessageHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	channelKey := request.Host
+	fh, ok := h.handlers[channelKey]
+	if !ok {
+		h.logger.Info("Unable to find a handler for request", zap.String("channelKey", channelKey))
+		response.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	fh.ServeHTTP(response, request)
+}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_handler_binding_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_handler_binding_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multichannelfanout
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	bindingshttp "github.com/cloudevents/sdk-go/pkg/protocol/http"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
+	"knative.dev/pkg/apis"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	"knative.dev/eventing/pkg/channel/fanout"
+)
+
+func TestNewMessageHandler(t *testing.T) {
+	testCases := []struct {
+		name      string
+		config    Config
+		createErr string
+	}{
+		{
+			name: "duplicate channel key",
+			config: Config{
+				ChannelConfigs: []ChannelConfig{
+					{
+						HostName: "duplicatekey",
+					},
+					{
+						HostName: "duplicatekey",
+					},
+				},
+			},
+			createErr: "duplicate channel key: duplicatekey",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.config)
+			if tc.createErr != "" {
+				if err == nil {
+					t.Errorf("Expected NewHandler error: '%v'. Actual nil", tc.createErr)
+				} else if err.Error() != tc.createErr {
+					t.Errorf("Unexpected NewHandler error. Expected '%v'. Actual '%v'", tc.createErr, err)
+				}
+				return
+			} else if err != nil {
+				t.Errorf("Unexpected NewHandler error. Expected nil. Actual '%v'", err)
+			}
+		})
+	}
+}
+
+func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
+	orig := Config{
+		ChannelConfigs: []ChannelConfig{
+			{
+				Namespace: "default",
+				Name:      "c1",
+				FanoutConfig: fanout.Config{
+					Subscriptions: []eventingduck.SubscriberSpec{
+						{
+							SubscriberURI: apis.HTTP("subscriberdomain"),
+						},
+					},
+				},
+			},
+		},
+	}
+	updated := Config{
+		ChannelConfigs: []ChannelConfig{
+			{
+				Namespace: "default",
+				Name:      "somethingdifferent",
+				FanoutConfig: fanout.Config{
+					Subscriptions: []eventingduck.SubscriberSpec{
+						{
+							ReplyURI: apis.HTTP("replydomain"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if cmp.Equal(orig, updated) {
+		t.Errorf("Orig and updated must be different")
+	}
+	h, err := NewMessageHandler(context.TODO(), zap.NewNop(), orig)
+	if err != nil {
+		t.Errorf("Unable to create handler, %v", err)
+	}
+	if !cmp.Equal(h.config, orig) {
+		t.Errorf("Incorrect config. Expected '%v'. Actual '%v'", orig, h.config)
+	}
+	newH, err := h.CopyWithNewConfig(context.TODO(), updated)
+	if err != nil {
+		t.Errorf("Unable to copy handler: %v", err)
+	}
+	if h.logger != newH.logger {
+		t.Errorf("Did not copy logger")
+	}
+	if !cmp.Equal(newH.config, updated) {
+		t.Errorf("Incorrect copied config. Expected '%v'. Actual '%v'", updated, newH.config)
+	}
+}
+
+func TestConfigDiffMessageHandler(t *testing.T) {
+	config := Config{
+		ChannelConfigs: []ChannelConfig{
+			{
+				Namespace: "default",
+				Name:      "c1",
+				FanoutConfig: fanout.Config{
+					Subscriptions: []eventingduck.SubscriberSpec{
+						{
+							SubscriberURI: apis.HTTP("subscriberdomain"),
+						},
+					},
+				},
+			},
+		},
+	}
+	testCases := []struct {
+		name         string
+		orig         Config
+		updated      Config
+		expectedDiff bool
+	}{
+		{
+			name:         "same",
+			orig:         config,
+			updated:      config,
+			expectedDiff: false,
+		},
+		{
+			name: "different",
+			orig: config,
+			updated: Config{
+				ChannelConfigs: []ChannelConfig{
+					{
+						Namespace: "default",
+						Name:      "c1",
+						FanoutConfig: fanout.Config{
+							Subscriptions: []eventingduck.SubscriberSpec{
+								{
+									SubscriberURI: apis.HTTP("different"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDiff: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.orig)
+			if err != nil {
+				t.Errorf("Unable to create handler: %v", err)
+			}
+			diff := h.ConfigDiff(tc.updated)
+
+			if hasDiff := diff != ""; hasDiff != tc.expectedDiff {
+				t.Errorf("Unexpected diff result. Expected %v. Actual %v", tc.expectedDiff, hasDiff)
+			}
+		})
+	}
+}
+
+func TestServeHTTPMessageHandler(t *testing.T) {
+	testCases := map[string]struct {
+		name               string
+		config             Config
+		respStatusCode     int
+		key                string
+		expectedStatusCode int
+	}{
+		"non-existent channel": {
+			config:             Config{},
+			key:                "default.does-not-exist",
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		"bad host": {
+			config:             Config{},
+			key:                "no-dot",
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		"pass through failure": {
+			config: Config{
+				ChannelConfigs: []ChannelConfig{
+					{
+						Namespace: "ns",
+						Name:      "name",
+						HostName:  "first-channel.default",
+						FanoutConfig: fanout.Config{
+							Subscriptions: []eventingduck.SubscriberSpec{
+								{
+									ReplyURI: replaceDomain,
+								},
+							},
+						},
+					},
+				},
+			},
+			respStatusCode:     http.StatusInternalServerError,
+			key:                "first-channel.default",
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		"choose channel": {
+			config: Config{
+				ChannelConfigs: []ChannelConfig{
+					{
+
+						Namespace: "ns",
+						Name:      "name",
+						HostName:  "first-channel.default",
+						FanoutConfig: fanout.Config{
+							Subscriptions: []eventingduck.SubscriberSpec{
+								{
+									ReplyURI: apis.HTTP("first-to-domain"),
+								},
+							},
+						},
+					},
+					{
+						Namespace: "default",
+						Name:      "second-channel",
+						HostName:  "second-channel.default",
+						FanoutConfig: fanout.Config{
+							Subscriptions: []eventingduck.SubscriberSpec{
+								{
+									SubscriberURI: replaceDomain,
+								},
+							},
+						},
+					},
+				},
+			},
+			respStatusCode:     http.StatusOK,
+			key:                "second-channel.default",
+			expectedStatusCode: http.StatusAccepted,
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			server := httptest.NewServer(&fakeHandler{statusCode: tc.respStatusCode})
+			defer server.Close()
+
+			// Rewrite the replaceDomains to call the server we just created.
+			replaceDomains(tc.config, server.URL[7:])
+
+			h, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.config)
+			if err != nil {
+				t.Fatalf("Unexpected NewHandler error: '%v'", err)
+			}
+
+			ctx := context.Background()
+
+			event := cloudevents.NewEvent(cloudevents.VersionV1)
+			event.SetType("testtype")
+			event.SetSource("testsource")
+			event.SetData(cloudevents.ApplicationJSON, "{}")
+
+			req := httptest.NewRequest(http.MethodPost, "http://"+tc.key+"/", nil)
+			err = bindingshttp.WriteRequest(ctx, binding.ToMessage(&event), req, binding.TransformerFactories{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			res := httptest.ResponseRecorder{}
+
+			h.ServeHTTP(&res, req)
+			if res.Code != tc.expectedStatusCode {
+				t.Errorf("Unexpected status code. Expected %v, actual %v", tc.expectedStatusCode, res.Code)
+			}
+
+			var message binding.Message
+			if res.Body != nil {
+				message = bindingshttp.NewMessage(res.Header(), ioutil.NopCloser(bytes.NewReader(res.Body.Bytes())))
+			} else {
+				message = bindingshttp.NewMessage(res.Header(), nil)
+			}
+			if message.ReadEncoding() != binding.EncodingUnknown {
+				t.Errorf("Expected EncodingUnkwnown. Actual: %v", message.ReadEncoding())
+			}
+		})
+	}
+}

--- a/pkg/channel/swappable/swappable_binding.go
+++ b/pkg/channel/swappable/swappable_binding.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package swappable provides an http.Handler that delegates all HTTP requests to an underlying
+// multichannelfanout.Handler. When a new configuration is available, a new
+// multichannelfanout.Handler is created and swapped in. All subsequent requests go to the new
+// handler.
+// It is often used in conjunction with something that notices changes to ConfigMaps, such as
+// configmap.watcher or configmap.filesystem.
+package swappable
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+
+	"knative.dev/eventing/pkg/channel/multichannelfanout"
+)
+
+// Handler is an http.Handler that atomically swaps between underlying handlers.
+type MessageHandler struct {
+	// The current multichannelfanout.Handler to delegate HTTP requests to. Never use this directly,
+	// instead use {get,set}MultiChannelFanoutHandler, which enforces the type we expect.
+	fanout     atomic.Value
+	updateLock sync.Mutex
+	logger     *zap.Logger
+}
+
+// NewMessageHandler creates a new swappable.Handler.
+func NewMessageHandler(handler *multichannelfanout.MessageHandler, logger *zap.Logger) *MessageHandler {
+	h := &MessageHandler{
+		logger: logger.With(zap.String("httpHandler", "swappable")),
+	}
+	h.setMultiChannelFanoutHandler(handler)
+	return h
+}
+
+// NewEmptyMessageHandler creates a new swappable.Handler with an empty configuration.
+func NewEmptyMessageHandler(context context.Context, logger *zap.Logger) (*MessageHandler, error) {
+	h, err := multichannelfanout.NewMessageHandler(context, logger, multichannelfanout.Config{})
+	if err != nil {
+		return nil, err
+	}
+	return NewMessageHandler(h, logger), nil
+}
+
+// getMultiChannelFanoutHandler gets the current multichannelfanout.Handler to delegate all HTTP
+// requests to.
+func (h *MessageHandler) getMultiChannelFanoutHandler() *multichannelfanout.MessageHandler {
+	return h.fanout.Load().(*multichannelfanout.MessageHandler)
+}
+
+// setMultiChannelFanoutHandler sets a new multichannelfanout.Handler to delegate all subsequent
+// HTTP requests to.
+func (h *MessageHandler) setMultiChannelFanoutHandler(nh *multichannelfanout.MessageHandler) {
+	h.fanout.Store(nh)
+}
+
+// UpdateConfig copies the current inner multichannelfanout.Handler with the new configuration. If
+// the new configuration is valid, then the new inner handler is swapped in and will start serving
+// HTTP traffic.
+func (h *MessageHandler) UpdateConfig(context context.Context, config *multichannelfanout.Config) error {
+	if config == nil {
+		return errors.New("nil config")
+	}
+
+	h.updateLock.Lock()
+	defer h.updateLock.Unlock()
+
+	ih := h.getMultiChannelFanoutHandler()
+	if diff := ih.ConfigDiff(*config); diff != "" {
+		h.logger.Info("Updating config (-old +new)", zap.String("diff", diff))
+		newIh, err := ih.CopyWithNewConfig(context, *config)
+		if err != nil {
+			h.logger.Info("Unable to update config", zap.Error(err), zap.Any("config", config))
+			return err
+		}
+		h.setMultiChannelFanoutHandler(newIh)
+	}
+	return nil
+}
+
+// ServeHTTP delegates all HTTP requests to the current multichannelfanout.Handler.
+func (h *MessageHandler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	// Hand work off to the current multi channel fanout handler.
+	h.logger.Debug("ServeHTTP request received")
+	h.getMultiChannelFanoutHandler().ServeHTTP(response, request)
+}

--- a/pkg/channel/swappable/swappable_binding_test.go
+++ b/pkg/channel/swappable/swappable_binding_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swappable
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	bindingshttp "github.com/cloudevents/sdk-go/pkg/protocol/http"
+	"go.uber.org/zap"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	"knative.dev/eventing/pkg/channel/fanout"
+	"knative.dev/eventing/pkg/channel/multichannelfanout"
+)
+
+func TestMessageHandler(t *testing.T) {
+	testCases := map[string]struct {
+		configs []multichannelfanout.Config
+	}{
+		"config change": {
+			configs: []multichannelfanout.Config{
+				{
+					ChannelConfigs: []multichannelfanout.ChannelConfig{
+						{
+							HostName: hostName,
+							FanoutConfig: fanout.Config{
+								Subscriptions: []eventingduck.SubscriberSpec{
+									{
+										SubscriberURI: replaceDomain,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ChannelConfigs: []multichannelfanout.ChannelConfig{
+						{
+							HostName: hostName,
+							FanoutConfig: fanout.Config{
+								Subscriptions: []eventingduck.SubscriberSpec{
+									{
+										ReplyURI: replaceDomain,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			h, err := NewEmptyMessageHandler(context.TODO(), zap.NewNop())
+			if err != nil {
+				t.Errorf("Unexpected error creating handler: %v", err)
+			}
+			for _, c := range tc.configs {
+				updateConfigAndTestBinding(t, h, c)
+			}
+		})
+	}
+}
+
+func TestMessageHandler_InvalidConfigChange(t *testing.T) {
+	testCases := map[string]struct {
+		initialConfig   multichannelfanout.Config
+		badUpdateConfig multichannelfanout.Config
+	}{
+		"invalid config change": {
+			initialConfig: multichannelfanout.Config{
+				ChannelConfigs: []multichannelfanout.ChannelConfig{
+					{
+						HostName: hostName,
+						FanoutConfig: fanout.Config{
+							Subscriptions: []eventingduck.SubscriberSpec{
+								{
+									SubscriberURI: replaceDomain,
+								},
+							},
+						},
+					},
+				},
+			},
+			badUpdateConfig: multichannelfanout.Config{
+				// Duplicate (namespace, name).
+				ChannelConfigs: []multichannelfanout.ChannelConfig{
+					{
+						HostName: hostName,
+					},
+					{
+						HostName: hostName,
+					},
+				},
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			h, err := NewEmptyHandler(zap.NewNop())
+			if err != nil {
+				t.Errorf("Unexpected error creating handler: %v", err)
+			}
+
+			server := httptest.NewServer(&successHandler{})
+			defer server.Close()
+
+			rc := replaceDomains(tc.initialConfig, server.URL[7:])
+			err = h.UpdateConfig(&rc)
+			if err != nil {
+				t.Errorf("Unexpected error updating to initial config: %v", tc.initialConfig)
+			}
+			assertRequestAccepted(t, h)
+
+			// Try to update to the new config, it will fail. But we should still be able to hit the
+			// original server.
+			ruc := replaceDomains(tc.badUpdateConfig, server.URL[7:])
+			err = h.UpdateConfig(&ruc)
+			if err == nil {
+				t.Errorf("Expected an error when updating to a bad config.")
+			}
+			assertRequestAccepted(t, h)
+		})
+	}
+}
+
+func TestMessageHandler_NilConfigChange(t *testing.T) {
+	h, err := NewEmptyMessageHandler(context.TODO(), zap.NewNop())
+	if err != nil {
+		t.Errorf("Unexpected error creating handler: %v", err)
+	}
+
+	err = h.UpdateConfig(context.TODO(), nil)
+	if err == nil {
+		t.Errorf("Expected an error when updating to a nil config.")
+	}
+}
+
+func updateConfigAndTestBinding(t *testing.T, h *MessageHandler, config multichannelfanout.Config) {
+	server := httptest.NewServer(&successHandler{})
+	defer server.Close()
+
+	rc := replaceDomains(config, server.URL[7:])
+	orig := h.fanout.Load()
+	err := h.UpdateConfig(context.TODO(), &rc)
+	if err != nil {
+		t.Errorf("Unexpected error updating config: %+v", err)
+	}
+	if orig == h.fanout.Load() {
+		t.Errorf("Expected the inner multiChannelFanoutHandler to change, it didn't: %v", orig)
+	}
+
+	assertRequestBindingAccepted(t, h)
+}
+
+func assertRequestBindingAccepted(t *testing.T, h *MessageHandler) {
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetType("testtype")
+	event.SetSource("testsource")
+	event.SetData("text/plain", "")
+
+	req := httptest.NewRequest(http.MethodPost, "http://"+hostName+"/", nil)
+	err := bindingshttp.WriteRequest(context.Background(), binding.ToMessage(&event), req, binding.TransformerFactories{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.ResponseRecorder{}
+
+	h.ServeHTTP(&resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Errorf("Unexpected response code. Expected 202. Actual %v", resp.Code)
+	}
+}


### PR DESCRIPTION
Fixes #2671, makes obsolete the #2680

Ported:

* `knative.dev/eventing/pkg/channel/fanout`: `Handler` -> `MessageHandler`
* `knative.dev/eventing/pkg/channel/multichannelfanout`: `Handler` -> `MessageHandler`
* `knative.dev/eventing/pkg/channel/swappable`: `Handler` -> `MessageHandler`