### PR TITLE
Wait for dependency annotation test subscriber to become ready

### DIFF
--- a/test/e2e/trigger_dependency_annotation_test.go
+++ b/test/e2e/trigger_dependency_annotation_test.go
@@ -59,6 +59,9 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	pod := resources.EventLoggerPod(subscriberName)
 	client.CreatePodOrFail(pod, lib.WithService(subscriberName))
 
+	// Wait for subscriber to become ready
+	client.WaitForAllTestResourcesReadyOrFail()
+
 	// Create triggers.
 	client.CreateTriggerOrFailV1Beta1(triggerName,
 		resources.WithSubscriberServiceRefForTriggerV1Beta1(subscriberName),


### PR DESCRIPTION
This test was failing consistently, apparently because it wasn't waiting for the subscriber pod to become ready.

/cc @vaikas