### PR TITLE
GeneratedNames: fix generated names not being RFC 1123 compliant

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -116,15 +116,20 @@ func ToDNS1123Subdomain(name string) string {
 // The name's length will be short enough to be valid for K8s Services.
 func GenerateFixedName(owner metav1.Object, prefix string) string {
 	uid := string(owner.GetUID())
-	// Make sure the UID is separated from the prefix by a leading dash.
-	if !strings.HasPrefix(uid, "-") {
-		uid = "-" + uid
-	}
-	// Trim any trailing dash from the prefix as the UID is now prepended with the dash.
-	prefix = strings.TrimSuffix(prefix, "-")
+
 	pl := validation.DNS1123LabelMaxLength - len(uid)
-	if pl > len(prefix) {
-		pl = len(prefix)
+	if pl < len(prefix) {
+		prefix = prefix[:pl]
 	}
-	return prefix[:pl] + uid
+
+	// Make sure the UID is separated from the prefix by a leading dash.
+	if !strings.HasSuffix(prefix, "-") && !strings.HasPrefix(uid, "-") {
+		uid = "-" + uid
+		if len(prefix) == pl {
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+
+	// A dot must be followed by [a-z0-9] to be DNS1123 compliant. Make sure we are not joining a dot and a dash.
+	return strings.TrimSuffix(prefix, ".") + uid
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -93,6 +93,16 @@ func TestGenerateFixedName(t *testing.T) {
 			prefix:   "default-text-extractor-",
 			expected: "default-text-extractor-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
 		},
+		"dot in prefix": {
+			uid:      "2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+			prefix:   "default-text-extractor.",
+			expected: "default-text-extractor-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+		},
+		"too long and dot in prefix": {
+			uid:      "2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+			prefix:   "this-is-an-extremely-long.prefix-and-it-will-be-cut-at-the-dot",
+			expected: "this-is-an-extremely-long-2d6c09e1-aa54-11e9-9d6a-42010a8a0062",
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
Fixes #2753

Regarding the original issue kubernetes names are DNS-1123 compliant so are Trigger names, no need to add extra validation.
This PR removes any dot that will be prefixing to the `dash + UID` string to avoid the issue.

Although double dashes are DNS-1123 compliant they do not look pretty; the PR also avoids adding a dash to the concatenation when the prefix already begins with one.

**Release Note**

```release-note
- Fix generated names not being DNS1123 compliant when based on strings that contain dots.
```

