### PR TITLE
Migrate source duck and crd controller off reconciler.Base

### DIFF
--- a/pkg/reconciler/source/crd/controller.go
+++ b/pkg/reconciler/source/crd/controller.go
@@ -19,14 +19,21 @@ package crd
 import (
 	"context"
 
-	"knative.dev/eventing/pkg/apis/sources"
-	"knative.dev/eventing/pkg/reconciler"
-	"knative.dev/pkg/configmap"
-	"knative.dev/pkg/controller"
-	pkgreconciler "knative.dev/pkg/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/eventing/pkg/apis/sources"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+
 	crdinfomer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition"
+	client "knative.dev/pkg/client/injection/kube/client"
 )
 
 const (
@@ -42,18 +49,37 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-
+	logger := logging.FromContext(ctx)
 	crdInformer := crdinfomer.Get(ctx)
 
+	recorder := controller.GetEventRecorder(ctx)
+	if recorder == nil {
+		// Create event broadcaster
+		logger.Debug("Creating event broadcaster")
+		eventBroadcaster := record.NewBroadcaster()
+		watches := []watch.Interface{
+			eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof),
+			eventBroadcaster.StartRecordingToSink(
+				&v1.EventSinkImpl{Interface: client.Get(ctx).CoreV1().Events("")}),
+		}
+		recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+		go func() {
+			<-ctx.Done()
+			for _, w := range watches {
+				w.Stop()
+			}
+		}()
+	}
+
 	r := &Reconciler{
-		Base:      reconciler.NewBase(ctx, controllerAgentName, cmw),
 		crdLister: crdInformer.Lister(),
 		ogctx:     ctx,
 		ogcmw:     cmw,
+		recorder:  recorder,
 	}
-	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
+	impl := controller.NewImpl(r, logger, ReconcilerName)
 
-	r.Logger.Info("Setting up event handlers")
+	logging.FromContext(ctx).Info("Setting up event handlers")
 	crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.LabelFilterFunc(sources.SourceDuckAnnotationKey, sources.SourceDuckAnnotationValue, false),
 		Handler:    controller.HandleAll(impl.Enqueue),

--- a/pkg/reconciler/source/crd/controller.go
+++ b/pkg/reconciler/source/crd/controller.go
@@ -78,7 +78,7 @@ func NewController(
 	}
 	impl := controller.NewImpl(r, logger, ReconcilerName)
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
+	logger.Info("Setting up event handlers")
 	crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.LabelFilterFunc(sources.SourceDuckAnnotationKey, sources.SourceDuckAnnotationValue, false),
 		Handler:    controller.HandleAll(impl.Enqueue),

--- a/pkg/reconciler/source/crd/controller.go
+++ b/pkg/reconciler/source/crd/controller.go
@@ -23,9 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
-
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"knative.dev/eventing/pkg/apis/sources"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"

--- a/pkg/reconciler/source/crd/crd.go
+++ b/pkg/reconciler/source/crd/crd.go
@@ -19,18 +19,17 @@ package crd
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/tools/record"
 	"sync"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler/source/duck"
 	"knative.dev/pkg/configmap"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/controller"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/pkg/reconciler/source/duck/controller.go
+++ b/pkg/reconciler/source/duck/controller.go
@@ -20,10 +20,9 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -31,6 +30,7 @@ import (
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventtype"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	crdinfomer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1beta1/customresourcedefinition"
@@ -39,9 +39,6 @@ import (
 const (
 	// ReconcilerName is the name of the reconciler.
 	ReconcilerName = "SourceDucks"
-	// controllerAgentName is the string used by this controller to identify
-	// itself when creating events.
-	controllerAgentName = "source-duck-controller"
 )
 
 // NewController returns a function that initializes the controller and
@@ -69,16 +66,16 @@ func NewController(crd string, gvr schema.GroupVersionResource, gvk schema.Group
 		}
 
 		r := &Reconciler{
-			Base:            reconciler.NewBase(ctx, controllerAgentName, cmw),
-			eventTypeLister: eventTypeInformer.Lister(),
-			crdLister:       crdInformer.Lister(),
-			sourceLister:    sourceLister,
-			gvr:             gvr,
-			crdName:         crd,
+			eventTypeLister:   eventTypeInformer.Lister(),
+			crdLister:         crdInformer.Lister(),
+			sourceLister:      sourceLister,
+			gvr:               gvr,
+			crdName:           crd,
+			eventingClientSet: eventingclient.Get(ctx),
 		}
-		impl := controller.NewImpl(r, r.Logger, ReconcilerName)
+		impl := controller.NewImpl(r, logging.FromContext(ctx), ReconcilerName)
 
-		r.Logger.Info("Setting up event handlers")
+		logging.FromContext(ctx).Info("Setting up event handlers")
 		sourceInformer.AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		eventTypeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/source/duck/controller.go
+++ b/pkg/reconciler/source/duck/controller.go
@@ -47,7 +47,7 @@ func NewController(crd string, gvr schema.GroupVersionResource, gvk schema.Group
 	return func(ctx context.Context,
 		cmw configmap.Watcher,
 	) *controller.Impl {
-
+		logger := logging.FromContext(ctx)
 		eventTypeInformer := eventtypeinformer.Get(ctx)
 		crdInformer := crdinfomer.Get(ctx)
 
@@ -61,7 +61,7 @@ func NewController(crd string, gvr schema.GroupVersionResource, gvk schema.Group
 
 		sourceInformer, sourceLister, err := sourceinformer.Get(gvr)
 		if err != nil {
-			logging.FromContext(ctx).Desugar().Error("Error getting source informer", zap.String("GVR", gvr.String()), zap.Error(err))
+			logger.Errorw("Error getting source informer", zap.String("GVR", gvr.String()), zap.Error(err))
 			return nil
 		}
 
@@ -73,9 +73,9 @@ func NewController(crd string, gvr schema.GroupVersionResource, gvk schema.Group
 			crdName:           crd,
 			eventingClientSet: eventingclient.Get(ctx),
 		}
-		impl := controller.NewImpl(r, logging.FromContext(ctx), ReconcilerName)
+		impl := controller.NewImpl(r, logger, ReconcilerName)
 
-		logging.FromContext(ctx).Info("Setting up event handlers")
+		logger.Info("Setting up event handlers")
 		sourceInformer.AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		eventTypeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{


### PR DESCRIPTION
## Proposed Changes

- Migrate source duck and crd controller off reconciler.Base

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
