### PR TITLE
migrate imc dispatcher to recgen, move imc off reconciler.Base

### DIFF
--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -18,10 +18,11 @@ package controller
 
 import (
 	"context"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
 
 	"github.com/kelseyhightower/envconfig"
 	"k8s.io/client-go/tools/cache"
-	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/system"
@@ -57,7 +58,7 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-
+	logger := logging.FromContext(ctx)
 	inmemorychannelInformer := inmemorychannel.Get(ctx)
 	deploymentInformer := deployment.Get(ctx)
 	serviceInformer := service.Get(ctx)
@@ -66,8 +67,7 @@ func NewController(
 	roleBindingInformer := rolebinding.Get(ctx)
 
 	r := &Reconciler{
-		Base: reconciler.NewBase(ctx, controllerAgentName, cmw),
-
+		kubeClientSet:           kubeclient.Get(ctx),
 		systemNamespace:         system.Namespace(),
 		inmemorychannelLister:   inmemorychannelInformer.Lister(),
 		inmemorychannelInformer: inmemorychannelInformer.Informer(),
@@ -80,18 +80,18 @@ func NewController(
 
 	env := &envConfig{}
 	if err := envconfig.Process("", env); err != nil {
-		r.Logger.Panicf("unable to process in-memory channel's required environment variables: %v", err)
+		logger.Panicf("unable to process in-memory channel's required environment variables: %v", err)
 	}
 
 	if env.Image == "" {
-		r.Logger.Panic("unable to process in-memory channel's required environment variables (missing DISPATCHER_IMAGE)")
+		logger.Panic("unable to process in-memory channel's required environment variables (missing DISPATCHER_IMAGE)")
 	}
 
 	r.dispatcherImage = env.Image
 
 	impl := inmemorychannelreconciler.NewImpl(ctx, r)
 
-	r.Logger.Info("Setting up event handlers")
+	logger.Info("Setting up event handlers")
 	inmemorychannelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Set up watches for dispatcher resources we care about, since any changes to these

--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/controller"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,7 +43,6 @@ import (
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
 	listers "knative.dev/eventing/pkg/client/listers/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/logging"
-	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 	"knative.dev/eventing/pkg/utils"
 )
@@ -77,7 +78,7 @@ func newRoleBindingWarn(err error) pkgreconciler.Event {
 }
 
 type Reconciler struct {
-	*reconciler.Base
+	kubeClientSet kubernetes.Interface
 
 	systemNamespace         string
 	dispatcherImage         string
@@ -210,11 +211,11 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope, dispatcherN
 					Image:               r.dispatcherImage,
 				}
 				expected := resources.MakeDispatcher(args)
-				d, err := r.KubeClientSet.AppsV1().Deployments(dispatcherNamespace).Create(expected)
+				d, err := r.kubeClientSet.AppsV1().Deployments(dispatcherNamespace).Create(expected)
 				if err != nil {
 					return d, newDeploymentWarn(err)
 				}
-				r.Recorder.Eventf(imc, corev1.EventTypeNormal, dispatcherDeploymentCreated, "Dispatcher Deployment created")
+				controller.GetEventRecorder(ctx).Eventf(imc, corev1.EventTypeNormal, dispatcherDeploymentCreated, "Dispatcher Deployment created")
 				return d, nil
 			}
 
@@ -233,11 +234,11 @@ func (r *Reconciler) reconcileServiceAccount(ctx context.Context, dispatcherName
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			expected := resources.MakeServiceAccount(dispatcherNamespace, dispatcherName)
-			sa, err := r.KubeClientSet.CoreV1().ServiceAccounts(dispatcherNamespace).Create(expected)
+			sa, err := r.kubeClientSet.CoreV1().ServiceAccounts(dispatcherNamespace).Create(expected)
 			if err != nil {
 				return sa, newServiceAccountWarn(err)
 			}
-			r.Recorder.Eventf(imc, corev1.EventTypeNormal, dispatcherServiceAccountCreated, "Dispatcher ServiceAccount created")
+			controller.GetEventRecorder(ctx).Eventf(imc, corev1.EventTypeNormal, dispatcherServiceAccountCreated, "Dispatcher ServiceAccount created")
 			return sa, nil
 		}
 
@@ -253,11 +254,11 @@ func (r *Reconciler) reconcileRoleBinding(ctx context.Context, name string, ns s
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			expected := resources.MakeRoleBinding(ns, name, sa, clusterRoleName)
-			rb, err := r.KubeClientSet.RbacV1().RoleBindings(ns).Create(expected)
+			rb, err := r.kubeClientSet.RbacV1().RoleBindings(ns).Create(expected)
 			if err != nil {
 				return rb, newRoleBindingWarn(err)
 			}
-			r.Recorder.Eventf(imc, corev1.EventTypeNormal, dispatcherRoleBindingCreated, "Dispatcher RoleBinding created")
+			controller.GetEventRecorder(ctx).Eventf(imc, corev1.EventTypeNormal, dispatcherRoleBindingCreated, "Dispatcher RoleBinding created")
 			return rb, nil
 		}
 		logging.FromContext(ctx).Error("Unable to get the dispatcher RoleBinding", zap.Error(err))
@@ -273,11 +274,11 @@ func (r *Reconciler) reconcileDispatcherService(ctx context.Context, scope, disp
 		if apierrs.IsNotFound(err) {
 			if scope == eventing.ScopeNamespace {
 				expected := resources.MakeDispatcherService(dispatcherName, dispatcherNamespace)
-				svc, err := r.KubeClientSet.CoreV1().Services(dispatcherNamespace).Create(expected)
+				svc, err := r.kubeClientSet.CoreV1().Services(dispatcherNamespace).Create(expected)
 				if err != nil {
 					return svc, newServiceWarn(err)
 				}
-				r.Recorder.Eventf(imc, corev1.EventTypeNormal, dispatcherServiceCreated, "Dispatcher Service created")
+				controller.GetEventRecorder(ctx).Eventf(imc, corev1.EventTypeNormal, dispatcherServiceCreated, "Dispatcher Service created")
 				return svc, nil
 			}
 
@@ -308,7 +309,7 @@ func (r *Reconciler) reconcileChannelService(ctx context.Context, dispatcherName
 	svc, err := r.serviceLister.Services(imc.Namespace).Get(channelSvcName)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
-			svc, err = r.KubeClientSet.CoreV1().Services(imc.Namespace).Create(expected)
+			svc, err = r.kubeClientSet.CoreV1().Services(imc.Namespace).Create(expected)
 			if err != nil {
 				logging.FromContext(ctx).Error("failed to create the channel service", zap.Error(err))
 				imc.Status.MarkChannelServiceFailed("ChannelServiceFailed", fmt.Sprintf("Channel Service failed: %s", err))
@@ -323,7 +324,7 @@ func (r *Reconciler) reconcileChannelService(ctx context.Context, dispatcherName
 		svc = svc.DeepCopy()
 		svc.Spec = expected.Spec
 
-		svc, err = r.KubeClientSet.CoreV1().Services(imc.Namespace).Update(svc)
+		svc, err = r.kubeClientSet.CoreV1().Services(imc.Namespace).Update(svc)
 		if err != nil {
 			logging.FromContext(ctx).Error("failed to update the channel service", zap.Error(err))
 			imc.Status.MarkChannelServiceFailed("ChannelServiceFailed", fmt.Sprintf("Channel Service failed: %s", err))

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/controller"
 

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"testing"
 
 	"knative.dev/eventing/pkg/apis/eventing"
@@ -34,7 +36,6 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/messaging/v1alpha1"
-	"knative.dev/eventing/pkg/reconciler"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 	. "knative.dev/eventing/pkg/reconciler/testing"
 	reconciletesting "knative.dev/eventing/pkg/reconciler/testing"
@@ -56,13 +57,6 @@ const (
 	imageName             = "test-image"
 
 	imcGeneration = 7
-)
-
-var (
-	trueVal = true
-	// deletionTime is used when objects are marked as deleted. Rfc3339Copy()
-	// truncates to seconds to match the loss of precision during serialization.
-	deletionTime = metav1.Now().Rfc3339Copy()
 )
 
 func init() {
@@ -371,7 +365,7 @@ func TestAllCases(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
-			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
+			kubeClientSet:         fakekubeclient.Get(ctx),
 			systemNamespace:       testNS,
 			inmemorychannelLister: listers.GetInMemoryChannelLister(),
 			// TODO: FIx
@@ -380,7 +374,9 @@ func TestAllCases(t *testing.T) {
 			serviceLister:           listers.GetServiceLister(),
 			endpointsLister:         listers.GetEndpointsLister(),
 		}
-		return inmemorychannel.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetInMemoryChannelLister(), r.Recorder, r)
+		return inmemorychannel.NewReconciler(ctx, logger,
+			fakeeventingclient.Get(ctx), listers.GetInMemoryChannelLister(),
+			controller.GetEventRecorder(ctx), r)
 	},
 		false,
 		logger,
@@ -459,7 +455,7 @@ func TestInNamespace(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
-			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
+			kubeClientSet:         fakekubeclient.Get(ctx),
 			dispatcherImage:       imageName,
 			systemNamespace:       systemNS,
 			inmemorychannelLister: listers.GetInMemoryChannelLister(),
@@ -471,7 +467,9 @@ func TestInNamespace(t *testing.T) {
 			serviceAccountLister:    listers.GetServiceAccountLister(),
 			roleBindingLister:       listers.GetRoleBindingLister(),
 		}
-		return inmemorychannel.NewReconciler(ctx, r.Logger, r.EventingClientSet, listers.GetInMemoryChannelLister(), r.Recorder, r)
+		return inmemorychannel.NewReconciler(ctx, logger,
+			fakeeventingclient.Get(ctx), listers.GetInMemoryChannelLister(),
+			controller.GetEventRecorder(ctx), r)
 	},
 		false,
 		logger,

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -19,9 +19,10 @@ package controller
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"testing"
 
 	"knative.dev/eventing/pkg/apis/eventing"
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -18,9 +18,10 @@ package dispatcher
 
 import (
 	"context"
+	"time"
+
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
 	"knative.dev/pkg/logging"
-	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -18,10 +18,8 @@ package dispatcher
 
 import (
 	"context"
-	"fmt"
+	"knative.dev/pkg/reconciler"
 
-	"go.uber.org/zap"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/apis/messaging/v1alpha1"
@@ -31,56 +29,17 @@ import (
 	listers "knative.dev/eventing/pkg/client/listers/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/inmemorychannel"
 	"knative.dev/eventing/pkg/logging"
-	"knative.dev/eventing/pkg/reconciler"
-	"knative.dev/pkg/controller"
 )
 
 // Reconciler reconciles InMemory Channels.
 type Reconciler struct {
-	*reconciler.Base
-
 	configStore             *channel.EventDispatcherConfigStore
 	dispatcher              inmemorychannel.Dispatcher
 	inmemorychannelLister   listers.InMemoryChannelLister
 	inmemorychannelInformer cache.SharedIndexInformer
 }
 
-// Check that our Reconciler implements controller.Reconciler.
-var _ controller.Reconciler = (*Reconciler)(nil)
-
-func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
-	// Convert the namespace/name string into a distinct namespace and name.
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		logging.FromContext(ctx).Error("invalid resource key")
-		return nil
-	}
-
-	// Get the IMC resource with this namespace/name.
-	channel, err := r.inmemorychannelLister.InMemoryChannels(namespace).Get(name)
-	if apierrs.IsNotFound(err) {
-		// The resource may no longer exist, in which case we stop processing.
-		logging.FromContext(ctx).Error("InMemoryChannel key in work queue no longer exists")
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	if !channel.Status.IsReady() {
-		return fmt.Errorf("Channel is not ready. Cannot configure the dispatcher")
-	}
-
-	// Just update the dispatcher config
-	reconcileErr := r.reconcile(ctx, channel)
-	if reconcileErr != nil {
-		logging.FromContext(ctx).Error("Error reconciling InMemoryChannel", zap.Error(reconcileErr))
-	} else {
-		logging.FromContext(ctx).Debug("InMemoryChannel reconciled")
-	}
-	return nil
-}
-
-func (r *Reconciler) reconcile(ctx context.Context, imc *v1alpha1.InMemoryChannel) error {
+func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1alpha1.InMemoryChannel) reconciler.Event {
 	// This is a special Reconciler that does the following:
 	// 1. Lists the inmemory channels.
 	// 2. Creates a multi-channel-fanout-config.
@@ -92,9 +51,9 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1alpha1.InMemoryChanne
 	}
 
 	inmemoryChannels := make([]*v1alpha1.InMemoryChannel, 0)
-	for _, channel := range channels {
-		if channel.Status.IsReady() {
-			inmemoryChannels = append(inmemoryChannels, channel)
+	for _, imc := range channels {
+		if imc.Status.IsReady() {
+			inmemoryChannels = append(inmemoryChannels, imc)
 		}
 	}
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -18,6 +18,7 @@ package dispatcher
 
 import (
 	"context"
+
 	"knative.dev/pkg/reconciler"
 
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -18,9 +18,10 @@ package dispatcher
 
 import (
 	"context"
-	"testing"
-
 	"knative.dev/eventing/pkg/channel"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	"knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
+	"testing"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
@@ -30,7 +31,6 @@ import (
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
-	"knative.dev/eventing/pkg/reconciler"
 	. "knative.dev/eventing/pkg/reconciler/testing"
 	reconciletesting "knative.dev/eventing/pkg/reconciler/testing"
 	"knative.dev/pkg/controller"
@@ -104,14 +104,16 @@ func TestAllCases(t *testing.T) {
 
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
-		return &Reconciler{
-			Base:                  reconciler.NewBase(ctx, controllerAgentName, cmw),
-			configStore:           channel.NewEventDispatcherConfigStore(logger),
+		r := &Reconciler{
 			inmemorychannelLister: listers.GetInMemoryChannelLister(),
-			// TODO fix
+			// TODO: FIx
 			inmemorychannelInformer: nil,
 			dispatcher:              &fakeDispatcher{},
+			configStore:             channel.NewEventDispatcherConfigStore(logger),
 		}
+		return inmemorychannel.NewReconciler(ctx, logger,
+			fakeeventingclient.Get(ctx), listers.GetInMemoryChannelLister(),
+			controller.GetEventRecorder(ctx), r)
 	}, false, logger))
 }
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -18,10 +18,11 @@ package dispatcher
 
 import (
 	"context"
+	"testing"
+
 	"knative.dev/eventing/pkg/channel"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
-	"testing"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"


### PR DESCRIPTION
## Proposed Changes

- migrate imc dispatcher to recgen
- move imc off reconciler.Base

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
