### PR TITLE
prevent a panic when we have CRDS labeled as sources without correct RBAC.

### DIFF
--- a/pkg/reconciler/source/crd/crd.go
+++ b/pkg/reconciler/source/crd/crd.go
@@ -192,6 +192,11 @@ func (r *Reconciler) reconcileController(ctx context.Context, crd *v1beta1.Custo
 
 	// Source Duck controller constructor
 	sdc := duck.NewController(crd.Name, *gvr, *gvk)
+	if sdc == nil {
+		logging.FromContext(ctx).Error("Source Duck Controller is nil.", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
+		return nil
+	}
+
 	// Source Duck controller context
 	sdctx, cancel := context.WithCancel(r.ogctx)
 	// Source Duck controller instantiation
@@ -205,8 +210,10 @@ func (r *Reconciler) reconcileController(ctx context.Context, crd *v1beta1.Custo
 
 	logging.FromContext(ctx).Info("Starting Source Duck Controller", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
 	go func(c *controller.Impl) {
-		if err := c.Run(controller.DefaultThreadsPerController, sdctx.Done()); err != nil {
-			logging.FromContext(ctx).Error("Unable to start Source Duck Controller", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
+		if c != nil {
+			if err := c.Run(controller.DefaultThreadsPerController, sdctx.Done()); err != nil {
+				logging.FromContext(ctx).Error("Unable to start Source Duck Controller", zap.String("GVR", gvr.String()), zap.String("GVK", gvk.String()))
+			}
 		}
 	}(rc.controller)
 	return nil


### PR DESCRIPTION
prevent a panic when we have old CRDs installed in the cluster that are labeled Source but are not correctly installed.

## Proposed Changes

- fixes a panic seen in local cluster.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
