### PR TITLE
Fix mtbroker trace exporting by fixing service names.

### DIFF
--- a/cmd/mtbroker/filter/main.go
+++ b/cmd/mtbroker/filter/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 
 	broker "knative.dev/eventing/cmd/mtbroker"
 	"knative.dev/eventing/pkg/mtbroker/filter"
+	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/eventing/pkg/tracing"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
@@ -119,10 +121,7 @@ func main() {
 	// Watch the observability config map and dynamically update request logs.
 	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(sl, atomicLevel, component))
 
-	bin := tracing.BrokerFilterName(tracing.BrokerFilterNameArgs{
-		Namespace:  env.Namespace,
-		BrokerName: "cluster",
-	})
+	bin := fmt.Sprintf("%s.%s", names.BrokerFilterName, system.Namespace())
 	if err = tracing.SetupDynamicPublishing(sl, configMapWatcher, bin, tracingconfig.ConfigName); err != nil {
 		logger.Fatal("Error setting up trace publishing", zap.Error(err))
 	}

--- a/cmd/mtbroker/ingress/main.go
+++ b/cmd/mtbroker/ingress/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 	broker "knative.dev/eventing/pkg/mtbroker"
 	"knative.dev/eventing/pkg/mtbroker/ingress"
+	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/eventing/pkg/tracing"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/configmap"
@@ -128,10 +130,7 @@ func main() {
 	// Watch the observability config map and dynamically update request logs.
 	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(sl, atomicLevel, component))
 
-	bin := tracing.BrokerIngressName(tracing.BrokerIngressNameArgs{
-		Namespace:  system.Namespace(),
-		BrokerName: "cluster",
-	})
+	bin := fmt.Sprintf("%s.%s", names.BrokerIngressName, system.Namespace())
 	if err = tracing.SetupDynamicPublishing(sl, configMapWatcher, bin, tracingconfig.ConfigName); err != nil {
 		logger.Fatal("Error setting up trace publishing", zap.Error(err))
 	}

--- a/pkg/reconciler/mtbroker/broker.go
+++ b/pkg/reconciler/mtbroker/broker.go
@@ -56,9 +56,6 @@ const (
 	// Name of the corev1.Events emitted from the Broker reconciliation process.
 	brokerReconcileError = "BrokerReconcileError"
 	brokerReconciled     = "BrokerReconciled"
-
-	BrokerFilterName  = "broker-filter"
-	BrokerIngressName = "broker-ingress"
 )
 
 type Reconciler struct {
@@ -170,7 +167,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, b *v1alpha1.Broker) pkgr
 	b.Status.TriggerChannel = &chanMan.ref
 	b.Status.PropagateTriggerChannelReadiness(&triggerChan.Status)
 
-	filterEndpoints, err := r.endpointsLister.Endpoints(system.Namespace()).Get(BrokerFilterName)
+	filterEndpoints, err := r.endpointsLister.Endpoints(system.Namespace()).Get(names.BrokerFilterName)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Problem getting endpoints for filter", zap.String("namespace", system.Namespace()), zap.Error(err))
 		b.Status.MarkFilterFailed("ServiceFailure", "%v", err)
@@ -178,7 +175,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, b *v1alpha1.Broker) pkgr
 	}
 	b.Status.PropagateFilterAvailability(filterEndpoints)
 
-	ingressEndpoints, err := r.endpointsLister.Endpoints(system.Namespace()).Get(BrokerIngressName)
+	ingressEndpoints, err := r.endpointsLister.Endpoints(system.Namespace()).Get(names.BrokerIngressName)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Problem getting endpoints for ingress", zap.String("namespace", system.Namespace()), zap.Error(err))
 		b.Status.MarkIngressFailed("ServiceFailure", "%v", err)

--- a/pkg/reconciler/mtbroker/controller.go
+++ b/pkg/reconciler/mtbroker/controller.go
@@ -35,6 +35,7 @@ import (
 	subscriptioninformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1alpha1/subscription"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker"
 	"knative.dev/eventing/pkg/duck"
+	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
 	client "knative.dev/pkg/client/injection/kube/client"
@@ -149,14 +150,14 @@ func NewController(
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.ChainFilterFuncs(
 			pkgreconciler.NamespaceFilterFunc(system.Namespace()),
-			pkgreconciler.NameFilterFunc(BrokerFilterName)),
+			pkgreconciler.NameFilterFunc(names.BrokerFilterName)),
 		Handler: controller.HandleAll(grCb),
 	})
 	// Resync for the ingress.
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.ChainFilterFuncs(
 			pkgreconciler.NamespaceFilterFunc(system.Namespace()),
-			pkgreconciler.NameFilterFunc(BrokerIngressName)),
+			pkgreconciler.NameFilterFunc(names.BrokerIngressName)),
 		Handler: controller.HandleAll(grCb),
 	})
 

--- a/pkg/reconciler/names/mtbroker.go
+++ b/pkg/reconciler/names/mtbroker.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package names
+
+const (
+	BrokerFilterName  = "broker-filter"
+	BrokerIngressName = "broker-ingress"
+)


### PR DESCRIPTION
Uses the broker-filter and broker-ingress service names that were
previously exported by the mtbroker reconciler. Moves the service
names to the names package since importing the reconciler package
causes the injector to inject the informers used by the mtbroker
reconciler.

Fixes #2809
