### PR TITLE
Fixed FanoutMessageHandler and improved coverage

### DIFF
--- a/pkg/channel/event_receiver.go
+++ b/pkg/channel/event_receiver.go
@@ -45,6 +45,13 @@ func (e *UnknownChannelError) Error() string {
 	return fmt.Sprintf("unknown channel: %v", e.c)
 }
 
+// UnknownHostError represents the error when a ResolveMessageChannelFromHostHeader func cannot resolve an host
+type UnknownHostError string
+
+func (e UnknownHostError) Error() string {
+	return fmt.Sprintf("cannot map host to channel: %s", string(e))
+}
+
 // EventReceiver starts a server to receive new events for the channel dispatcher. The new
 // event is emitted via the receiver function.
 type EventReceiver struct {
@@ -62,6 +69,7 @@ type ReceiverOptions func(*EventReceiver) error
 
 // ResolveChannelFromHostFunc function enables EventReceiver to get the Channel Reference from incoming request HostHeader
 // before calling receiverFunc.
+// Returns UnknownHostError if the channel is not found, otherwise returns a generic error.
 type ResolveChannelFromHostFunc func(string) (ChannelReference, error)
 
 // ResolveChannelFromHostHeader is a ReceiverOption for NewEventReceiver which enables the caller to overwrite the

--- a/pkg/channel/fanout/fanout_handler_test.go
+++ b/pkg/channel/fanout/fanout_handler_test.go
@@ -38,7 +38,7 @@ import (
 // servers.
 var (
 	replaceSubscriber = apis.HTTP("replaceSubscriber")
-	replaceChannel    = apis.HTTP("replaceChannel")
+	replaceReplier    = apis.HTTP("replaceReplier")
 )
 
 func makeCloudEvent() cloudevents.Event {
@@ -95,7 +95,7 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 		"reply fails": {
 			subs: []eventingduck.SubscriberSpec{
 				{
-					ReplyURI: replaceChannel,
+					ReplyURI: replaceReplier,
 				},
 			},
 			channel: func(writer http.ResponseWriter, _ *http.Request) {
@@ -118,7 +118,7 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -132,7 +132,7 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -146,11 +146,11 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber:     callableSucceed,
@@ -162,15 +162,15 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -184,15 +184,15 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -223,7 +223,7 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 				if sub.SubscriberURI == replaceSubscriber {
 					sub.SubscriberURI = apis.HTTP(callableServer.URL[7:]) // strip the leading 'http://'
 				}
-				if sub.ReplyURI == replaceChannel {
+				if sub.ReplyURI == replaceReplier {
 					sub.ReplyURI = apis.HTTP(channelServer.URL[7:]) // strip the leading 'http://'
 				}
 				subs = append(subs, sub)

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -73,6 +73,7 @@ func createMessageReceiverFunction(f *MessageHandler) func(context.Context, chan
 	if f.config.AsyncHandler {
 		return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, transformers []binding.TransformerFactory, additionalHeaders nethttp.Header) error {
 			if len(f.config.Subscriptions) == 0 {
+				// Nothing to do here, finish the message and return
 				_ = message.Finish(nil)
 				return nil
 			}
@@ -97,6 +98,7 @@ func createMessageReceiverFunction(f *MessageHandler) func(context.Context, chan
 	}
 	return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, transformers []binding.TransformerFactory, additionalHeaders nethttp.Header) error {
 		if len(f.config.Subscriptions) == 0 {
+			// Nothing to do here, finish the message and return
 			_ = message.Finish(nil)
 			return nil
 		}

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"errors"
 	nethttp "net/http"
+	"net/url"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -71,18 +72,43 @@ func NewMessageHandler(logger *zap.Logger, config Config) (*MessageHandler, erro
 func createMessageReceiverFunction(f *MessageHandler) func(context.Context, channel.ChannelReference, binding.Message, []binding.TransformerFactory, nethttp.Header) error {
 	if f.config.AsyncHandler {
 		return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, transformers []binding.TransformerFactory, additionalHeaders nethttp.Header) error {
+			if len(f.config.Subscriptions) == 0 {
+				_ = message.Finish(nil)
+				return nil
+			}
+
 			parentSpan := trace.FromContext(ctx)
+			// Message buffering here is done before starting the dispatch goroutine
+			// Because the message could be closed before the buffering happens
+			bufferedMessage, err := buffering.CopyMessage(ctx, message, transformers...)
+			if err != nil {
+				return err
+			}
+			// We don't need the original message anymore
+			_ = message.Finish(nil)
 			go func() {
 				// Run async dispatch with background context.
 				ctx = trace.NewContext(context.Background(), parentSpan)
 				// Any returned error is already logged in f.dispatch().
-				_ = f.dispatch(ctx, message, transformers, additionalHeaders)
+				_ = f.dispatch(ctx, bufferedMessage, additionalHeaders)
 			}()
 			return nil
 		}
 	}
 	return func(ctx context.Context, _ channel.ChannelReference, message binding.Message, transformers []binding.TransformerFactory, additionalHeaders nethttp.Header) error {
-		return f.dispatch(ctx, message, transformers, additionalHeaders)
+		if len(f.config.Subscriptions) == 0 {
+			_ = message.Finish(nil)
+			return nil
+		}
+
+		// We buffer the message to send it several times
+		bufferedMessage, err := buffering.CopyMessage(ctx, message, transformers...)
+		if err != nil {
+			return err
+		}
+		// We don't need the original message anymore
+		_ = message.Finish(nil)
+		return f.dispatch(ctx, bufferedMessage, additionalHeaders)
 	}
 }
 
@@ -92,16 +118,8 @@ func (f *MessageHandler) ServeHTTP(response nethttp.ResponseWriter, request *net
 
 // dispatch takes the event, fans it out to each subscription in f.config. If all the fanned out
 // events return successfully, then return nil. Else, return an error.
-func (f *MessageHandler) dispatch(ctx context.Context, originalMessage binding.Message, transformers []binding.TransformerFactory, additionalHeaders nethttp.Header) error {
+func (f *MessageHandler) dispatch(ctx context.Context, bufferedMessage binding.Message, additionalHeaders nethttp.Header) error {
 	subs := len(f.config.Subscriptions)
-
-	// We buffer the message to send it several times
-	bufferedMessage, err := buffering.CopyMessage(ctx, originalMessage, transformers...)
-	if err != nil {
-		return err
-	}
-	// We don't need the original message anymore
-	_ = originalMessage.Finish(nil)
 
 	// Bind the lifecycle of the buffered message to the number of subs
 	bufferedMessage = buffering.WithAcksBeforeFinish(bufferedMessage, subs)
@@ -132,5 +150,17 @@ func (f *MessageHandler) dispatch(ctx context.Context, originalMessage binding.M
 // makeFanoutRequest sends the request to exactly one subscription. It handles both the `call` and
 // the `sink` portions of the subscription.
 func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.Message, additionalHeaders nethttp.Header, sub eventingduck.SubscriberSpec) error {
-	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, sub.SubscriberURI.URL(), sub.ReplyURI.URL(), sub.DeadLetterSinkURI.URL())
+	var destination *url.URL
+	if sub.SubscriberURI != nil {
+		destination = sub.SubscriberURI.URL()
+	}
+	var reply *url.URL
+	if sub.ReplyURI != nil {
+		reply = sub.ReplyURI.URL()
+	}
+	var deadLetter *url.URL
+	if sub.DeadLetterSinkURI != nil {
+		deadLetter = sub.DeadLetterSinkURI.URL()
+	}
+	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, destination, reply, deadLetter)
 }

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -132,5 +132,5 @@ func (f *MessageHandler) dispatch(ctx context.Context, originalMessage binding.M
 // makeFanoutRequest sends the request to exactly one subscription. It handles both the `call` and
 // the `sink` portions of the subscription.
 func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.Message, additionalHeaders nethttp.Header, sub eventingduck.SubscriberSpec) error {
-	return f.dispatcher.DispatchMessageWithDelivery(ctx, message, additionalHeaders, sub.SubscriberURI.String(), sub.ReplyURI.String(), &channel.DeliveryOptions{DeadLetterSink: sub.DeadLetterSinkURI.String()})
+	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, sub.SubscriberURI.URL(), sub.ReplyURI.URL(), sub.DeadLetterSinkURI.URL())
 }

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,20 +37,22 @@ import (
 
 func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 	testCases := map[string]struct {
-		receiverFunc   channel.UnbufferedMessageReceiverFunc
-		timeout        time.Duration
-		subs           []eventingduck.SubscriberSpec
-		subscriber     func(http.ResponseWriter, *http.Request)
-		channel        func(http.ResponseWriter, *http.Request)
-		expectedStatus int
-		asyncHandler   bool
-		skip           string
+		receiverFunc        channel.UnbufferedMessageReceiverFunc
+		timeout             time.Duration
+		subs                []eventingduck.SubscriberSpec
+		subscriber          func(http.ResponseWriter, *http.Request)
+		subscriberReqs      int
+		replier             func(http.ResponseWriter, *http.Request)
+		replierReqs         int
+		expectedStatus      int
+		asyncExpectedStatus int
 	}{
 		"rejected by receiver": {
 			receiverFunc: func(context.Context, channel.ChannelReference, binding.Message, []binding.TransformerFactory, http.Header) error {
 				return errors.New("rejected by test-receiver")
 			},
-			expectedStatus: http.StatusInternalServerError,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusInternalServerError,
 		},
 		"fanout times out": {
 			timeout: time.Millisecond,
@@ -62,28 +65,34 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 				time.Sleep(time.Second)
 				writer.WriteHeader(http.StatusAccepted)
 			},
-			expectedStatus: http.StatusInternalServerError,
+			subscriberReqs:      1,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"zero subs succeed": {
-			subs:           []eventingduck.SubscriberSpec{},
-			expectedStatus: http.StatusAccepted,
+			subs:                []eventingduck.SubscriberSpec{},
+			expectedStatus:      http.StatusAccepted,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"empty sub succeeds": {
 			subs: []eventingduck.SubscriberSpec{
 				{},
 			},
-			expectedStatus: http.StatusAccepted,
+			expectedStatus:      http.StatusAccepted,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"reply fails": {
 			subs: []eventingduck.SubscriberSpec{
 				{
-					ReplyURI: replaceChannel,
+					ReplyURI: replaceReplier,
 				},
 			},
-			channel: func(writer http.ResponseWriter, _ *http.Request) {
+			replier: func(writer http.ResponseWriter, _ *http.Request) {
 				writer.WriteHeader(http.StatusNotFound)
 			},
-			expectedStatus: http.StatusInternalServerError,
+			replierReqs:         1,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"subscriber fails": {
 			subs: []eventingduck.SubscriberSpec{
@@ -94,156 +103,186 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 			subscriber: func(writer http.ResponseWriter, _ *http.Request) {
 				writer.WriteHeader(http.StatusNotFound)
 			},
-			expectedStatus: http.StatusInternalServerError,
+			subscriberReqs:      1,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"subscriber succeeds, result fails": {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
-			channel: func(writer http.ResponseWriter, _ *http.Request) {
+			replier: func(writer http.ResponseWriter, _ *http.Request) {
 				writer.WriteHeader(http.StatusForbidden)
 			},
-			expectedStatus: http.StatusInternalServerError,
+			subscriberReqs:      1,
+			replierReqs:         1,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"one sub succeeds": {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
-			channel: func(writer http.ResponseWriter, _ *http.Request) {
+			replier: func(writer http.ResponseWriter, _ *http.Request) {
 				writer.WriteHeader(http.StatusAccepted)
 			},
-			expectedStatus: http.StatusAccepted,
+			subscriberReqs:      1,
+			replierReqs:         1,
+			expectedStatus:      http.StatusAccepted,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"one sub succeeds, one sub fails": {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
-			subscriber:     callableSucceed,
-			channel:        (&succeedOnce{}).handler,
-			expectedStatus: http.StatusInternalServerError,
+			subscriber:          callableSucceed,
+			replier:             (&succeedOnce{}).handler,
+			subscriberReqs:      2,
+			replierReqs:         2,
+			expectedStatus:      http.StatusInternalServerError,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 		"all subs succeed": {
 			subs: []eventingduck.SubscriberSpec{
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 				{
 					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
+					ReplyURI:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
-			channel: func(writer http.ResponseWriter, _ *http.Request) {
+			replier: func(writer http.ResponseWriter, _ *http.Request) {
 				writer.WriteHeader(http.StatusAccepted)
 			},
-			expectedStatus: http.StatusAccepted,
-		},
-		"all subs succeed with async handler": {
-			subs: []eventingduck.SubscriberSpec{
-				{
-					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
-				},
-				{
-					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
-				},
-				{
-					SubscriberURI: replaceSubscriber,
-					ReplyURI:      replaceChannel,
-				},
-			},
-			subscriber: callableSucceed,
-			channel: func(writer http.ResponseWriter, _ *http.Request) {
-				writer.WriteHeader(http.StatusAccepted)
-			},
-			expectedStatus: http.StatusAccepted,
-			asyncHandler:   true,
+			subscriberReqs:      3,
+			replierReqs:         3,
+			expectedStatus:      http.StatusAccepted,
+			asyncExpectedStatus: http.StatusAccepted,
 		},
 	}
 	for n, tc := range testCases {
-		t.Run(n, func(t *testing.T) {
-			if tc.skip != "" {
-				t.Skip(tc.skip)
-			}
-			callableServer := httptest.NewServer(&fakeHandler{
-				handler: tc.subscriber,
-			})
-			defer callableServer.Close()
-			channelServer := httptest.NewServer(&fakeHandler{
-				handler: tc.channel,
-			})
-			defer channelServer.Close()
-
-			// Rewrite the subs to use the servers we just started.
-			subs := make([]eventingduck.SubscriberSpec, 0)
-			for _, sub := range tc.subs {
-				if sub.SubscriberURI == replaceSubscriber {
-					sub.SubscriberURI = apis.HTTP(callableServer.URL[7:]) // strip the leading 'http://'
-				}
-				if sub.ReplyURI == replaceChannel {
-					sub.ReplyURI = apis.HTTP(channelServer.URL[7:]) // strip the leading 'http://'
-				}
-				subs = append(subs, sub)
-			}
-
-			h, err := NewMessageHandler(zap.NewNop(), Config{Subscriptions: subs})
-			if err != nil {
-				t.Fatalf("NewHandler failed. Error:%s", err)
-			}
-			if tc.asyncHandler {
-				h.config.AsyncHandler = true
-			}
-			if tc.receiverFunc != nil {
-				receiver, err := channel.NewMessageReceiver(tc.receiverFunc, zap.NewNop())
-				if err != nil {
-					t.Fatalf("NewEventReceiver failed. Error:%s", err)
-				}
-				h.receiver = receiver
-			}
-			if tc.timeout != 0 {
-				h.timeout = tc.timeout
-			} else {
-				// Reasonable timeout for the tests.
-				h.timeout = 100 * time.Millisecond
-			}
-
-			event := makeCloudEventNew()
-			req := httptest.NewRequest(http.MethodPost, "http://channelname.channelnamespace/", nil)
-
-			ctx := context.Background()
-			err = bindingshttp.WriteRequest(ctx, binding.ToMessage(&event), req, binding.TransformerFactories{})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			resp := httptest.ResponseRecorder{}
-
-			h.ServeHTTP(&resp, req)
-			if resp.Code != tc.expectedStatus {
-				t.Errorf("Unexpected status code. Expected %v, Actual %v", tc.expectedStatus, resp.Code)
-			}
+		t.Run("sync - "+n, func(t *testing.T) {
+			testFanoutMessageHandler(t, false, tc.receiverFunc, tc.timeout, tc.subs, tc.subscriber, tc.subscriberReqs, tc.replier, tc.replierReqs, tc.expectedStatus)
 		})
+		t.Run("async - "+n, func(t *testing.T) {
+			testFanoutMessageHandler(t, true, tc.receiverFunc, tc.timeout, tc.subs, tc.subscriber, tc.subscriberReqs, tc.replier, tc.replierReqs, tc.asyncExpectedStatus)
+		})
+	}
+}
+
+func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.UnbufferedMessageReceiverFunc, timeout time.Duration, inSubs []eventingduck.SubscriberSpec, subscriberHandler func(http.ResponseWriter, *http.Request), subscriberReqs int, replierHandler func(http.ResponseWriter, *http.Request), replierReqs int, expectedStatus int) {
+	var subscriberServerWg *sync.WaitGroup
+	if subscriberReqs != 0 {
+		subscriberServerWg = &sync.WaitGroup{}
+		subscriberServerWg.Add(subscriberReqs)
+	}
+	subscriberServer := httptest.NewServer(&fakeHandlerWithWg{
+		wg:      subscriberServerWg,
+		handler: subscriberHandler,
+	})
+	defer subscriberServer.Close()
+
+	var replierServerWg *sync.WaitGroup
+	if replierReqs != 0 {
+		replierServerWg = &sync.WaitGroup{}
+		replierServerWg.Add(replierReqs)
+	}
+	replyServer := httptest.NewServer(&fakeHandlerWithWg{
+		wg:      replierServerWg,
+		handler: replierHandler,
+	})
+	defer replyServer.Close()
+
+	// Rewrite the subs to use the servers we just started.
+	subs := make([]eventingduck.SubscriberSpec, 0)
+	for _, sub := range inSubs {
+		if sub.SubscriberURI == replaceSubscriber {
+			sub.SubscriberURI = apis.HTTP(subscriberServer.URL[7:]) // strip the leading 'http://'
+		}
+		if sub.ReplyURI == replaceReplier {
+			sub.ReplyURI = apis.HTTP(replyServer.URL[7:]) // strip the leading 'http://'
+		}
+		subs = append(subs, sub)
+	}
+
+	h, err := NewMessageHandler(zap.NewNop(), Config{
+		Subscriptions: subs,
+		AsyncHandler:  async,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler failed. Error:%s", err)
+	}
+
+	if receiverFunc != nil {
+		receiver, err := channel.NewMessageReceiver(receiverFunc, zap.NewNop())
+		if err != nil {
+			t.Fatalf("NewEventReceiver failed. Error:%s", err)
+		}
+		h.receiver = receiver
+	}
+	if timeout != 0 {
+		h.timeout = timeout
+	} else {
+		// Reasonable timeout for the tests.
+		h.timeout = 100 * time.Millisecond
+	}
+
+	event := makeCloudEventNew()
+	req := httptest.NewRequest(http.MethodPost, "http://channelname.channelnamespace/", nil)
+
+	ctx := context.Background()
+	err = bindingshttp.WriteRequest(ctx, binding.ToMessage(&event), req, binding.TransformerFactories{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.ResponseRecorder{}
+
+	h.ServeHTTP(&resp, req)
+	if resp.Code != expectedStatus {
+		t.Errorf("Unexpected status code. Expected %v, Actual %v", expectedStatus, resp.Code)
+	}
+
+	if subscriberServerWg != nil {
+		subscriberServerWg.Wait()
+	}
+	if replierServerWg != nil {
+		replierServerWg.Wait()
+	}
+}
+
+type fakeHandlerWithWg struct {
+	wg      *sync.WaitGroup
+	handler func(http.ResponseWriter, *http.Request)
+}
+
+func (h *fakeHandlerWithWg) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_ = r.Body.Close()
+	h.handler(w, r)
+	if h.wg != nil {
+		h.wg.Done()
 	}
 }
 

--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -528,11 +528,18 @@ func TestDispatchMessage(t *testing.T) {
 				t.Fatal(err)
 			}
 			message = binding.ToMessage(ev)
+			finishInvoked := 0
+			message = binding.WithFinish(message, func(err error) {
+				finishInvoked++
+			})
 
 			err = md.DispatchMessage(ctx, message, utils.PassThroughHeaders(tc.header), destination, reply, deadLetterSink)
 
 			if tc.expectedErr != (err != nil) {
 				t.Errorf("Unexpected error from DispatchMessage. Expected %v. Actual: %v", tc.expectedErr, err)
+			}
+			if finishInvoked != 1 {
+				t.Errorf("Finish should be invoked exactly one time. Actual: %d", finishInvoked)
 			}
 			if tc.expectedDestRequest != nil {
 				rv := destHandler.popRequest(t)

--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -37,7 +38,7 @@ func TestDispatchMessage(t *testing.T) {
 	testCases := map[string]struct {
 		sendToDestination         bool
 		sendToReply               bool
-		hasDeliveryOptions        bool
+		hasDeadLetterSink         bool
 		eventExtensions           map[string]string
 		header                    http.Header
 		body                      string
@@ -310,8 +311,8 @@ func TestDispatchMessage(t *testing.T) {
 			},
 		},
 		"invalid destination and delivery option": {
-			sendToDestination:  true,
-			hasDeliveryOptions: true,
+			sendToDestination: true,
+			hasDeadLetterSink: true,
 			header: map[string][]string{
 				// do-not-forward should not get forwarded.
 				"do-not-forward": {"header"},
@@ -374,9 +375,9 @@ func TestDispatchMessage(t *testing.T) {
 			},
 		},
 		"destination and invalid reply and delivery option": {
-			sendToDestination:  true,
-			sendToReply:        true,
-			hasDeliveryOptions: true,
+			sendToDestination: true,
+			sendToReply:       true,
+			hasDeadLetterSink: true,
 			header: map[string][]string{
 				// do-not-forward should not get forwarded.
 				"do-not-forward": {"header"},
@@ -490,8 +491,8 @@ func TestDispatchMessage(t *testing.T) {
 
 			var deadLetterSinkHandler *fakeHandler
 			var deadLetterSinkServer *httptest.Server
-			var deliveryOptions *DeliveryOptions
-			if tc.hasDeliveryOptions {
+			var deadLetterSink *url.URL
+			if tc.hasDeadLetterSink {
 				deadLetterSinkHandler = &fakeHandler{
 					t:        t,
 					response: tc.fakeDeadLetterResponse,
@@ -500,8 +501,7 @@ func TestDispatchMessage(t *testing.T) {
 				deadLetterSinkServer = httptest.NewServer(deadLetterSinkHandler)
 				defer deadLetterSinkServer.Close()
 
-				dls := getDomain(t, true, deadLetterSinkServer.URL)
-				deliveryOptions = &DeliveryOptions{DeadLetterSink: dls}
+				deadLetterSink = getOnlyDomainURL(t, true, deadLetterSinkServer.URL)
 			}
 
 			event := cloudevents.NewEvent(cloudevents.VersionV1)
@@ -516,24 +516,20 @@ func TestDispatchMessage(t *testing.T) {
 			ctx := context.Background()
 
 			md := NewMessageDispatcher(zap.NewNop())
-			destination := getDomain(t, tc.sendToDestination, destServer.URL)
-			reply := getDomain(t, tc.sendToReply, replyServer.URL)
 
-			// We need this to eventually setup the default uuid and time now (as the event receiver would do)
+			destination := getOnlyDomainURL(t, tc.sendToDestination, destServer.URL)
+			reply := getOnlyDomainURL(t, tc.sendToReply, replyServer.URL)
+
+			// We need to do message -> event -> message to emulate the same transformers the event receiver would do
 			message := binding.ToMessage(&event)
 			var err error
 			ev, err := binding.ToEvent(ctx, message, binding.TransformerFactories{transformer.AddTimeNow})
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			message = binding.ToMessage(ev)
 
-			if tc.hasDeliveryOptions {
-				err = md.DispatchMessageWithDelivery(ctx, message, utils.PassThroughHeaders(tc.header), destination, reply, deliveryOptions)
-			} else {
-				err = md.DispatchMessage(ctx, message, utils.PassThroughHeaders(tc.header), destination, reply)
-			}
+			err = md.DispatchMessage(ctx, message, utils.PassThroughHeaders(tc.header), destination, reply, deadLetterSink)
 
 			if tc.expectedErr != (err != nil) {
 				t.Errorf("Unexpected error from DispatchMessage. Expected %v. Actual: %v", tc.expectedErr, err)
@@ -561,4 +557,17 @@ func TestDispatchMessage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getOnlyDomainURL(t *testing.T, shouldSend bool, serverURL string) *url.URL {
+	if shouldSend {
+		server, err := url.Parse(serverURL)
+		if err != nil {
+			t.Errorf("Bad serverURL: %q", serverURL)
+		}
+		return &url.URL{
+			Host: server.Host,
+		}
+	}
+	return nil
 }

--- a/pkg/channel/message_receiver_test.go
+++ b/pkg/channel/message_receiver_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding/test"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/go-cmp/cmp"
+	"go.opencensus.io/trace"
 	_ "knative.dev/pkg/system/testing"
 
 	"knative.dev/eventing/pkg/utils"
@@ -94,6 +95,7 @@ func TestMessageReceiver_ServeHTTP(t *testing.T) {
 					return err
 				}
 
+				// Check payload
 				var payload string
 				err = e.DataAs(&payload)
 				if err != nil {
@@ -102,23 +104,31 @@ func TestMessageReceiver_ServeHTTP(t *testing.T) {
 				if payload != "event-body" {
 					return fmt.Errorf("test receiver func -- bad payload: %v", payload)
 				}
+
+				// Check headers
 				expectedHeaders := make(nethttp.Header)
 				expectedHeaders.Add("x-requEst-id", "1234")
 				expectedHeaders.Add("knatIve-will-pass-through", "true")
 				expectedHeaders.Add("knatIve-will-pass-through", "always")
-
 				if diff := cmp.Diff(expectedHeaders, additionalHeaders); diff != "" {
 					return fmt.Errorf("test receiver func -- bad headers (-want, +got): %s", diff)
 				}
-				var h interface{}
-				var ok bool
-				if h, ok = e.Extensions()[EventHistory]; !ok {
-					return fmt.Errorf("test receiver func -- history not added: %v", err)
+
+				// Check history
+				if h, ok := e.Extensions()[EventHistory]; !ok {
+					return fmt.Errorf("test receiver func -- history not added")
+				} else {
+					expectedHistory := "test-name.test-namespace.svc." + utils.GetClusterDomainName()
+					if h != expectedHistory {
+						return fmt.Errorf("test receiver func -- bad history: %v", h)
+					}
 				}
-				expectedHistory := "test-name.test-namespace.svc." + utils.GetClusterDomainName()
-				if h != expectedHistory {
-					return fmt.Errorf("test receiver func -- bad history: %v", h)
+
+				// Check traceparent
+				if tr, ok := e.Extensions()["traceparent"]; !ok || tr == "" {
+					return fmt.Errorf("test receiver func -- trace not added or empty: %s", tr)
 				}
+
 				return nil
 			},
 			expected: nethttp.StatusAccepted,
@@ -150,6 +160,8 @@ func TestMessageReceiver_ServeHTTP(t *testing.T) {
 			}
 
 			req := httptest.NewRequest(tc.method, "http://"+tc.host+tc.path, nil)
+			reqCtx, _ := trace.StartSpan(context.TODO(), "bla")
+			req = req.WithContext(reqCtx)
 			req.Host = tc.host
 
 			err = http.WriteRequest(context.TODO(), binding.ToMessage(&event), req, binding.TransformerFactories{})


### PR DESCRIPTION
This PR should settle all FanoutMessageHandler flakyness

## Proposed Changes

* Fix the flakyness of `FanoutMessageHandler`
* Fix to `MessageDispatcher` (now all messages are correctly `Finish`ed)
* A refactoring of `MessageDispatcher` API and implementation to reduce cognitive complexity
* Fix `ResolveChannelFromHost` 404