### PR TITLE
relax the validation logic to allow for more broker classes

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -23,6 +23,16 @@ metadata:
 spec:
   group: eventing.knative.dev
   preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # this is a work around so we don't need to flush out the
+      # schema for each version at this time as well as ensure
+      # that different Broker Classes that might have different
+      # fields that are not in the Broker Spec will work.
+      #
+      # see issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Broker
     plural: brokers
@@ -57,99 +67,6 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              config:
-                type: object
-                description: "Reference to the configuration for the Broker."
-                required:
-                  - apiVersion
-                  - kind
-                  - name
-                properties:
-                  apiVersion:
-                    type: string
-                    description: "API version of the configuration."
-                    minLength: 1
-                  kind:
-                    type: string
-                    description: "Kind of the configuration."
-                    minLength: 1
-                  name:
-                    type: string
-                    description: "Name of the configuration."
-                    minLength: 1
-                  namespace:
-                    type: string
-                    description: "Namespace of the configuration."
-                    minLength: 1
-              channelTemplateSpec:
-                type: object
-                description: "Channel implementation which dictates the durability guarantees of events to the Broker. If not specified then the default channel is used. More information: https://knative.dev/docs/eventing/channels/default-channels."
-                required:
-                  - apiVersion
-                  - kind
-                properties:
-                  apiVersion:
-                    type: string
-                    description: "API version of the channel implementation."
-                    minLength: 1
-                  kind:
-                    type: string
-                    description: "Kind of the channel implementation to use (InMemoryChannel, KafkaChannel, etc.)."
-                    minLength: 1
-                  spec:
-                    type: object
-              delivery:
-                description: "Broker delivery options. More information: https://knative.dev/docs/eventing/event-delivery."
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
   - name: v1beta1
     served: true
     storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              config:
-                type: object
-                description: "Reference to the configuration for the Broker."
-                required:
-                  - apiVersion
-                  - kind
-                  - name
-                properties:
-                  apiVersion:
-                    type: string
-                    description: "API version of the configuration."
-                    minLength: 1
-                  kind:
-                    type: string
-                    description: "Kind of the configuration."
-                    minLength: 1
-                  name:
-                    type: string
-                    description: "Name of the configuration."
-                    minLength: 1
-                  namespace:
-                    type: string
-                    description: "Namespace of the configuration."
-                    minLength: 1
-              delivery:
-                description: "Broker delivery options. More information: https://knative.dev/docs/eventing/event-delivery."
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Relax the validation of the fields allowed in the Broker to allow for different Broker Class implementations that might have additional fields.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
