### PR TITLE
Generate names with kmeta.ChildName. Delete deprecated named resources

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -37,6 +37,7 @@ import (
 	listers "knative.dev/eventing/pkg/client/listers/sources/v1alpha1"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler/apiserversource/resources"
+	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/controller"
@@ -50,6 +51,7 @@ const (
 	// Name of the corev1.Events emitted from the reconciliation process
 	apiserversourceDeploymentCreated = "ApiServerSourceDeploymentCreated"
 	apiserversourceDeploymentUpdated = "ApiServerSourceDeploymentUpdated"
+	apiserversourceDeploymentDeleted = "ApiServerSourceDeploymentDeleted"
 
 	component = "apiserversource"
 )
@@ -170,6 +172,15 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1alpha1.Api
 
 	ra, err := r.kubeClientSet.AppsV1().Deployments(src.Namespace).Get(expected.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
+		// Issue #2842: Adater deployment name uses kmeta.ChildName. If a deployment by the previous name pattern is found, it should
+		// be deleted. This might cause temporary downtime.
+		if deprecatedName := utils.GenerateFixedName(adapterArgs.Source, fmt.Sprintf("apiserversource-%s", adapterArgs.Source.Name)); deprecatedName != expected.Name {
+			if err := r.kubeClientSet.AppsV1().Deployments(src.Namespace).Delete(deprecatedName, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("error deleting deprecated named deployment: %v", err)
+			}
+			controller.GetEventRecorder(ctx).Eventf(src, corev1.EventTypeNormal, apiserversourceDeploymentDeleted, "Deprecated deployment removed: \"%s/%s\"", src.Namespace, deprecatedName)
+		}
+
 		ra, err = r.kubeClientSet.AppsV1().Deployments(src.Namespace).Create(expected)
 		msg := "Deployment created"
 		if err != nil {

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
-	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -45,7 +44,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Source.Namespace,
-			Name:      utils.GenerateFixedName(args.Source, fmt.Sprintf("apiserversource-%s", args.Source.Name)),
+			Name:      kmeta.ChildName(fmt.Sprintf("apiserversource-%s-", args.Source.Name), string(args.Source.GetUID())),
 			Labels:    args.Labels,
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(args.Source),

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
+	"knative.dev/pkg/kmeta"
 	_ "knative.dev/pkg/metrics/testing"
 )
 
@@ -100,7 +101,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 	want := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "source-namespace",
-			Name:      fmt.Sprintf("apiserversource-%s-1234", name),
+			Name:      kmeta.ChildName(fmt.Sprintf("apiserversource-%s-", name), string(src.UID)),
 			Labels: map[string]string{
 				"test-key1": "test-value1",
 				"test-key2": "test-value2",

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1478,7 +1478,7 @@ func TestReconcile(t *testing.T) {
 				)}...),
 			WantErr: false,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, subscriptionDeleted, fmt.Sprintf("Deprecated subscription removed: \"%s/%s\"", testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name)),
+				Eventf(corev1.EventTypeNormal, subscriptionDeleted, `Deprecated subscription removed: "%s/%s"`, testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name),
 				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -79,9 +79,11 @@ const (
 	filterContainerName  = "filter"
 	ingressContainerName = "ingress"
 
-	triggerChannel channelType = "TriggerChannel"
-	triggerName                = "test-trigger"
-	triggerUID                 = "test-trigger-uid"
+	triggerChannel  channelType = "TriggerChannel"
+	triggerName                 = "test-trigger"
+	triggerUID                  = "test-trigger-uid"
+	triggerNameLong             = "test-trigger-name-is-a-long-name"
+	triggerUIDLong              = "cafed00d-cafed00d-cafed00d-cafed00d-cafed00d"
 
 	subscriberURI     = "http://example.com/subscriber/"
 	subscriberKind    = "Service"
@@ -1464,6 +1466,40 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDependencyReady(),
 				),
 			}},
+		}, {
+			Name: "Trigger has deprecated named subscriber",
+			Key:  testKey,
+			Objects: allBrokerObjectsReadyPlus([]runtime.Object{
+				makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong),
+				NewTrigger(triggerNameLong, testNS, brokerName,
+					WithTriggerUID(triggerUIDLong),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithInitTriggerConditions,
+				)}...),
+			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, subscriptionDeleted, fmt.Sprintf("Deprecated subscription removed: \"%s/%s\"", testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name)),
+				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerNameLong, testNS, brokerName,
+					WithTriggerUID(triggerUIDLong),
+					WithTriggerSubscriberURI(subscriberURI),
+					// The first reconciliation will initialize the status conditions.
+					WithInitTriggerConditions,
+					WithTriggerBrokerReady(),
+					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerSubscriberResolvedSucceeded(),
+					WithTriggerDependencyReady(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeIngressSubscriptionWithCustomData(triggerNameLong, triggerUIDLong),
+			},
+			WantDeletes: []clientgotesting.DeleteActionImpl{{
+				Name: makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name,
+			}},
 		},
 	}
 
@@ -1740,6 +1776,17 @@ func makeIngressSubscription() *messagingv1alpha1.Subscription {
 	return resources.NewSubscription(makeTrigger(), createTriggerChannelRef(), makeBrokerRef(), makeServiceURI(), makeEmptyDelivery())
 }
 
+func makeIngressSubscriptionWithCustomData(triggerName, triggerUID string) *messagingv1alpha1.Subscription {
+	t := makeTrigger()
+	t.Name = triggerName
+	t.UID = types.UID(triggerUID)
+
+	uri := makeServiceURI()
+	uri.Path = fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID)
+
+	return resources.NewSubscription(t, createTriggerChannelRef(), makeBrokerRef(), uri, makeEmptyDelivery())
+}
+
 func makeTrigger() *v1alpha1.Trigger {
 	return &v1alpha1.Trigger{
 		TypeMeta: metav1.TypeMeta{
@@ -1863,6 +1910,15 @@ func makeIngressSubscriptionNotOwnedByTrigger() *messagingv1alpha1.Subscription 
 
 func makeReadySubscription() *messagingv1alpha1.Subscription {
 	s := makeIngressSubscription()
+	s.Status = *v1alpha1.TestHelper.ReadySubscriptionStatus()
+	return s
+}
+
+func makeReadySubscriptionDeprecatedName(triggerName, triggerUID string) *messagingv1alpha1.Subscription {
+	s := makeIngressSubscription()
+	t := NewTrigger(triggerName, testNS, brokerName)
+	t.UID = types.UID(triggerUID)
+	s.Name = utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", brokerName, triggerName))
 	s.Status = *v1alpha1.TestHelper.ReadySubscriptionStatus()
 	return s
 }

--- a/pkg/reconciler/broker/resources/subscription.go
+++ b/pkg/reconciler/broker/resources/subscription.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
-	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,7 +37,7 @@ func MakeSubscription(b *v1alpha1.Broker, c *duckv1alpha1.Channelable, svc *core
 	return &messagingv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: b.Namespace,
-			Name:      utils.GenerateFixedName(b, fmt.Sprintf("internal-ingress-%s", b.Name)),
+			Name:      kmeta.ChildName(fmt.Sprintf("internal-ingress-%s", b.Name), string(b.GetUID())),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(b),
 			},
@@ -75,7 +74,7 @@ func NewSubscription(t *v1alpha1.Trigger, brokerTrigger, brokerRef *corev1.Objec
 	return &messagingv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
-			Name:      utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)),
+			Name:      kmeta.ChildName(fmt.Sprintf("%s-%s-", t.Spec.Broker, t.Name), string(t.GetUID())),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(t),
 			},

--- a/pkg/reconciler/broker/resources/subscription_test.go
+++ b/pkg/reconciler/broker/resources/subscription_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,6 +30,7 @@ import (
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
 )
 
 func TestMakeSubscription(t *testing.T) {
@@ -106,7 +108,8 @@ func TestNewSubscription(t *testing.T) {
 	trigger := &v1alpha1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "t-namespace",
-			Name:      "t-name",
+			Name:      "t-name-is-a-long-name",
+			UID:       "cafed00d-cafed00d-cafed00d-cafed00d",
 		},
 		Spec: v1alpha1.TriggerSpec{
 			Broker: "broker-name",
@@ -132,17 +135,18 @@ func TestNewSubscription(t *testing.T) {
 	want := &messagingv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "t-namespace",
-			Name:      "broker-name-t-name-",
+			Name:      kmeta.ChildName(fmt.Sprintf("%s-%s-", "broker-name", "t-name-is-a-long-name"), "cafed00d-cafed00d-cafed00d-cafed00d"),
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "eventing.knative.dev/v1alpha1",
 				Kind:               "Trigger",
-				Name:               "t-name",
+				Name:               "t-name-is-a-long-name",
+				UID:                "cafed00d-cafed00d-cafed00d-cafed00d",
 				Controller:         &TrueValue,
 				BlockOwnerDeletion: &TrueValue,
 			}},
 			Labels: map[string]string{
 				eventing.BrokerLabelKey:        "broker-name",
-				"eventing.knative.dev/trigger": "t-name",
+				"eventing.knative.dev/trigger": "t-name-is-a-long-name",
 			},
 		},
 		Spec: messagingv1alpha1.SubscriptionSpec{

--- a/pkg/reconciler/broker/trigger.go
+++ b/pkg/reconciler/broker/trigger.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
 	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/eventing/pkg/reconciler/trigger/path"
+	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
@@ -48,6 +49,7 @@ const (
 	subscriptionDeleteFailed  = "SubscriptionDeleteFailed"
 	subscriptionCreateFailed  = "SubscriptionCreateFailed"
 	subscriptionGetFailed     = "SubscriptionGetFailed"
+	subscriptionDeleted       = "SubscriptionDeleted"
 )
 
 func (r *Reconciler) reconcileTrigger(ctx context.Context, b *v1alpha1.Broker, t *v1alpha1.Trigger, filterSvc kmeta.Accessor) error {
@@ -121,6 +123,15 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *v1alpha1.B
 	sub, err := r.subscriptionLister.Subscriptions(t.Namespace).Get(expected.Name)
 	// If the resource doesn't exist, we'll create it.
 	if apierrs.IsNotFound(err) {
+		// Issue #2842: Subscription name uses kmeta.ChildName. If a subscription by the previous name pattern is found, it should
+		// be deleted. This might cause temporary downtime.
+		if deprecatedName := utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)); deprecatedName != expected.Name {
+			if err := r.eventingClientSet.MessagingV1alpha1().Subscriptions(t.Namespace).Delete(deprecatedName, &metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
+				return nil, fmt.Errorf("error deleting deprecated named subscription: %v", err)
+			}
+			controller.GetEventRecorder(ctx).Eventf(t, corev1.EventTypeNormal, subscriptionDeleted, "Deprecated subscription removed: \"%s/%s\"", t.Namespace, deprecatedName)
+		}
+
 		logging.FromContext(ctx).Info("Creating subscription")
 		sub, err = r.eventingClientSet.MessagingV1alpha1().Subscriptions(t.Namespace).Create(expected)
 		if err != nil {

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -992,7 +992,7 @@ func TestReconcile(t *testing.T) {
 				)}...),
 			WantErr: false,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, subscriptionDeleted, fmt.Sprintf("Deprecated subscription removed: \"%s/%s\"", testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name)),
+				Eventf(corev1.EventTypeNormal, subscriptionDeleted, `Deprecated subscription removed: "%s/%s"`, testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name),
 				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -67,8 +67,10 @@ const (
 	testNS     = "test-namespace"
 	brokerName = "test-broker"
 
-	triggerName = "test-trigger"
-	triggerUID  = "test-trigger-uid"
+	triggerName     = "test-trigger"
+	triggerUID      = "test-trigger-uid"
+	triggerNameLong = "test-trigger-name-is-a-long-name"
+	triggerUIDLong  = "cafed00d-cafed00d-cafed00d-cafed00d-cafed00d"
 
 	subscriberURI     = "http://example.com/subscriber/"
 	subscriberKind    = "Service"
@@ -975,6 +977,45 @@ func TestReconcile(t *testing.T) {
 				),
 			}},
 		},
+
+		{
+			Name: "Trigger has deprecated named subscriber",
+			Key:  testKey,
+			Objects: allBrokerObjectsReadyPlus([]runtime.Object{
+				makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong),
+				makeReadyPingSource(),
+				NewTrigger(triggerNameLong, testNS, brokerName,
+					WithTriggerUID(triggerUIDLong),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithInitTriggerConditions,
+					WithDependencyAnnotation(dependencyAnnotation),
+				)}...),
+			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, subscriptionDeleted, fmt.Sprintf("Deprecated subscription removed: \"%s/%s\"", testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name)),
+				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerNameLong, testNS, brokerName,
+					WithTriggerUID(triggerUIDLong),
+					WithTriggerSubscriberURI(subscriberURI),
+					// The first reconciliation will initialize the status conditions.
+					WithInitTriggerConditions,
+					WithDependencyAnnotation(dependencyAnnotation),
+					WithTriggerBrokerReady(),
+					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerSubscriberResolvedSucceeded(),
+					WithTriggerDependencyReady(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeReadySubscriptionWithCustomData(triggerNameLong, triggerUIDLong),
+			},
+			WantDeletes: []clientgotesting.DeleteActionImpl{{
+				Name: makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name,
+			}},
+		},
 	}
 
 	logger := logtesting.TestLogger(t)
@@ -1216,6 +1257,26 @@ func makeReadySubscription() *messagingv1alpha1.Subscription {
 	s := makeFilterSubscription()
 	s.Status = *v1alpha1.TestHelper.ReadySubscriptionStatus()
 	return s
+}
+
+func makeReadySubscriptionDeprecatedName(triggerName, triggerUID string) *messagingv1alpha1.Subscription {
+	s := makeFilterSubscription()
+	t := NewTrigger(triggerName, testNS, brokerName)
+	t.UID = types.UID(triggerUID)
+	s.Name = utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", brokerName, triggerName))
+	s.Status = *v1alpha1.TestHelper.ReadySubscriptionStatus()
+	return s
+}
+
+func makeReadySubscriptionWithCustomData(triggerName, triggerUID string) *messagingv1alpha1.Subscription {
+	t := makeTrigger()
+	t.Name = triggerName
+	t.UID = types.UID(triggerUID)
+
+	uri := makeServiceURI()
+	uri.Path = fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID)
+
+	return resources.NewSubscription(t, createTriggerChannelRef(), makeBrokerRef(), uri, makeEmptyDelivery())
 }
 
 func makeSubscriberAddressableAsUnstructured() *unstructured.Unstructured {

--- a/pkg/reconciler/mtbroker/resources/subscription.go
+++ b/pkg/reconciler/mtbroker/resources/subscription.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	messagingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
-	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -38,7 +37,7 @@ func NewSubscription(t *v1alpha1.Trigger, brokerTrigger, brokerRef *corev1.Objec
 	return &messagingv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
-			Name:      utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)),
+			Name:      kmeta.ChildName(fmt.Sprintf("%s-%s-", t.Spec.Broker, t.Name), string(t.GetUID())),
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(t),
 			},

--- a/pkg/reconciler/mtbroker/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger.go
@@ -33,8 +33,10 @@ import (
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
 	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/eventing/pkg/reconciler/trigger/path"
+	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 )
@@ -47,6 +49,7 @@ const (
 	subscriptionDeleteFailed  = "SubscriptionDeleteFailed"
 	subscriptionCreateFailed  = "SubscriptionCreateFailed"
 	subscriptionGetFailed     = "SubscriptionGetFailed"
+	subscriptionDeleted       = "SubscriptionDeleted"
 )
 
 func (r *Reconciler) reconcileTrigger(ctx context.Context, b *v1alpha1.Broker, t *v1alpha1.Trigger) error {
@@ -117,6 +120,15 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *v1alpha1.B
 	sub, err := r.subscriptionLister.Subscriptions(t.Namespace).Get(expected.Name)
 	// If the resource doesn't exist, we'll create it.
 	if apierrs.IsNotFound(err) {
+		// Issue #2842: Subscription name uses kmeta.ChildName. If a subscription by the previous name pattern is found, it should
+		// be deleted. This might cause temporary downtime.
+		if deprecatedName := utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)); deprecatedName != expected.Name {
+			if err := r.eventingClientSet.MessagingV1alpha1().Subscriptions(t.Namespace).Delete(deprecatedName, &metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
+				return nil, fmt.Errorf("error deleting deprecated named subscription: %v", err)
+			}
+			controller.GetEventRecorder(ctx).Eventf(t, corev1.EventTypeNormal, subscriptionDeleted, "Deprecated subscription removed: \"%s/%s\"", t.Namespace, deprecatedName)
+		}
+
 		logging.FromContext(ctx).Info("Creating subscription")
 		sub, err = r.eventingClientSet.MessagingV1alpha1().Subscriptions(t.Namespace).Create(expected)
 		if err != nil {

--- a/pkg/reconciler/pingsource/controller/resources/receive_adapter.go
+++ b/pkg/reconciler/pingsource/controller/resources/receive_adapter.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
-	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -81,7 +80,7 @@ func MakeReceiveAdapter(args *Args) *v1.Deployment {
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Source.Namespace,
-			Name:      utils.GenerateFixedName(args.Source, fmt.Sprintf("pingsource-%s", name)),
+			Name:      kmeta.ChildName(fmt.Sprintf("pingsource-%s-", name), string(args.Source.GetUID())),
 			Labels:    args.Labels,
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(args.Source),

--- a/pkg/reconciler/testing/apiserversource.go
+++ b/pkg/reconciler/testing/apiserversource.go
@@ -23,8 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
-	"knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
 )
 
 // ApiServerSourceOption enables further configuration of a ApiServer.
@@ -74,7 +74,7 @@ func WithApiServerSourceSinkDepRef(uri string) ApiServerSourceOption {
 
 func WithApiServerSourceDeploymentUnavailable(s *v1alpha1.ApiServerSource) {
 	// The Deployment uses GenerateName, so its name is empty.
-	name := utils.GenerateFixedName(s, fmt.Sprintf("apiserversource-%s", s.Name))
+	name := kmeta.ChildName(fmt.Sprintf("apiserversource-%s-", s.Name), string(s.GetUID()))
 	s.Status.PropagateDeploymentAvailability(NewDeployment(name, "any"))
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -114,6 +114,8 @@ func ToDNS1123Subdomain(name string) string {
 
 // GenerateFixedName generates a fixed name for the given owning resource and human readable prefix.
 // The name's length will be short enough to be valid for K8s Services.
+//
+// Deprecated, use knative.dev/pkg/kmeta.ChildName instead.
 func GenerateFixedName(owner metav1.Object, prefix string) string {
 	uid := string(owner.GetUID())
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/2842

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

**Description**
- There are 2 functions used to generate names for child objects. The one we should stick to is `kmeta.ChildName` while the one we should no longer use is `util.GenerateFixedName`
- For short generated names we can make both functions return the same name, but for long ones they do not.
- We can't be backwards compatible if we want to use only one function. This PR implements [this candidate solution](https://github.com/knative/eventing/pull/2800#discussion_r397909782) that will:
    - If the resource with the new name is found, behave as usual
    - If the resource with the new name is not found, look for the resource with the old name
      - If the resource with the old name is found, delete it
      - Create the resource with the new name

**Notice**

Some of the code added here, mainly tests and the bridging logic that looks for previously named resources, will need to be deleted after the deprecation period. Tests haven't been refactored to address the needs for long named resources, since all that code will be gone.

There are usages of `util.GenerateFixedName` at other sources at [eventing-contrib](https://github.com/knative/eventing-contrib/search?q=GenerateFixedName&unscoped_q=GenerateFixedName) and at the [sample-source](https://github.com/knative/sample-source/blob/b93378f82933237f1125f02d716f607820a6bf93/pkg/reconciler/sample/resources/receive_adapter.go#L47). I have opened an [issue](https://github.com/knative/sample-source/issues/42) to track the later

**Deprecation**

Ideally `util.GenerateFixedName` would be removed to avoid further usage in 2(?) releases. A comment has been added to the function as a warning. Probably some further notice is needed.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Use a common generated names pattern for all objects

In order to homogenize all generated names API Server source, Ping source and Subscriptions might need to be regenerated with the new names. This release will delete any of those resources named with a non compatible pattern and create new ones. This may cause a temporary downtime.
```


<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
