### PR TITLE
Addressing tracing issues in FanoutMessageHandler & MessageReceiver

### DIFF
--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -164,8 +164,5 @@ func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.
 	if sub.Delivery != nil && sub.Delivery.DeadLetterSink != nil && sub.Delivery.DeadLetterSink.URI != nil {
 		deadLetter = sub.Delivery.DeadLetterSink.URI.URL()
 	}
-	if sub.Delivery != nil && sub.Delivery.DeadLetterSink != nil && sub.Delivery.DeadLetterSink.URI != nil {
-		deadLetter = sub.Delivery.DeadLetterSink.URI.URL()
-	}
 	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, destination, reply, deadLetter)
 }

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -164,5 +164,8 @@ func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.
 	if sub.Delivery != nil && sub.Delivery.DeadLetterSink != nil && sub.Delivery.DeadLetterSink.URI != nil {
 		deadLetter = sub.Delivery.DeadLetterSink.URI.URL()
 	}
+	if sub.Delivery != nil && sub.Delivery.DeadLetterSink != nil && sub.Delivery.DeadLetterSink.URI != nil {
+		deadLetter = sub.Delivery.DeadLetterSink.URI.URL()
+	}
 	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, destination, reply, deadLetter)
 }

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -227,23 +227,21 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		subs = append(subs, sub)
 	}
 
-	// The test syncs using WaitGroups checking for subscriber/replier correctly invoked, but it doesn't sync on the async
-	// goroutine created by FanoutMessageHandler in async mode.
-	// So the test logger (zaptest) doesn't work, because it could log messages after the test is closed.
-	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.WarnLevel))
+	logger, err := zap.NewDevelopment(zap.AddStacktrace(zap.DebugLevel))
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	h, err := NewMessageHandler(
-		logger,
-		Config{
-			Subscriptions: subs,
-			AsyncHandler:  async,
-		})
+	h, err := NewMessageHandler(logger, Config{
+		Subscriptions: subs,
+		AsyncHandler:  async,
+	})
 	if err != nil {
 		t.Fatalf("NewHandler failed. Error:%s", err)
 	}
 
 	if receiverFunc != nil {
-		receiver, err := channel.NewMessageReceiver(receiverFunc, zap.NewNop())
+		receiver, err := channel.NewMessageReceiver(receiverFunc, logger)
 		if err != nil {
 			t.Fatalf("NewEventReceiver failed. Error:%s", err)
 		}

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -25,6 +25,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
+	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -156,6 +157,9 @@ func (d *MessageDispatcherImpl) DispatchMessage(ctx context.Context, initialMess
 
 func (d *MessageDispatcherImpl) executeRequest(ctx context.Context, url *url.URL, message cloudevents.Message, additionalHeaders nethttp.Header) (cloudevents.Message, nethttp.Header, error) {
 	d.logger.Debug("Dispatching event", zap.String("url", url.String()))
+
+	ctx, span := trace.StartSpan(ctx, "knative.dev", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
 
 	req, err := d.sender.NewCloudEventRequestWithTarget(ctx, url.String())
 	if err != nil {

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package multichannelfanout
 
 import (
-	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -292,18 +290,19 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			res := httptest.ResponseRecorder{}
+			responseRecorder := httptest.ResponseRecorder{}
 
-			h.ServeHTTP(&res, req)
-			if res.Code != tc.expectedStatusCode {
-				t.Errorf("Unexpected status code. Expected %v, actual %v", tc.expectedStatusCode, res.Code)
+			h.ServeHTTP(&responseRecorder, req)
+			response := responseRecorder.Result()
+			if response.StatusCode != tc.expectedStatusCode {
+				t.Errorf("Unexpected status code. Expected %v, actual %v", tc.expectedStatusCode, response.StatusCode)
 			}
 
 			var message binding.Message
-			if res.Body != nil {
-				message = bindingshttp.NewMessage(res.Header(), ioutil.NopCloser(bytes.NewReader(res.Body.Bytes())))
+			if response.Body != nil {
+				message = bindingshttp.NewMessage(response.Header, response.Body)
 			} else {
-				message = bindingshttp.NewMessage(res.Header(), nil)
+				message = bindingshttp.NewMessage(response.Header, nil)
 			}
 			if message.ReadEncoding() != binding.EncodingUnknown {
 				t.Errorf("Expected EncodingUnkwnown. Actual: %v", message.ReadEncoding())

--- a/pkg/kncloudevents/message_client.go
+++ b/pkg/kncloudevents/message_client.go
@@ -66,7 +66,7 @@ func (s *HttpMessageSender) Send(req *nethttp.Request) (*nethttp.Response, error
 type HttpMessageReceiver struct {
 	port int
 
-	handler  *nethttp.ServeMux
+	handler  nethttp.Handler
 	server   *nethttp.Server
 	addr     net.Addr
 	listener net.Listener
@@ -85,13 +85,13 @@ func (recv *HttpMessageReceiver) StartListen(ctx context.Context, handler nethtt
 		return err
 	}
 
-	recv.handler = nethttp.NewServeMux()
+	recv.handler = handler
 
 	recv.server = &nethttp.Server{
 		Addr: recv.listener.Addr().String(),
 		Handler: &ochttp.Handler{
 			Propagation: &tracecontext.HTTPFormat{},
-			Handler:     handler,
+			Handler:     recv.handler,
 		},
 	}
 


### PR DESCRIPTION
Also enabled logging on `FanoutMessageHandler`, in order to detect future flakyness on that test

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>