### PR TITLE
rename subscription condition reference to references resolved

### DIFF
--- a/pkg/apis/messaging/v1alpha1/subscription_lifecycle.go
+++ b/pkg/apis/messaging/v1alpha1/subscription_lifecycle.go
@@ -29,7 +29,7 @@ const (
 	SubscriptionConditionReady = apis.ConditionReady
 	// SubscriptionConditionReferencesResolved has status True when all the specified references have been successfully
 	// resolved.
-	SubscriptionConditionReferencesResolved apis.ConditionType = "Resolved"
+	SubscriptionConditionReferencesResolved apis.ConditionType = "ReferencesResolved"
 
 	// SubscriptionConditionAddedToChannel has status True when controller has successfully added a
 	// subscription to the spec.channel resource.

--- a/pkg/apis/messaging/v1beta1/subscription_lifecycle.go
+++ b/pkg/apis/messaging/v1beta1/subscription_lifecycle.go
@@ -29,7 +29,7 @@ const (
 	SubscriptionConditionReady = apis.ConditionReady
 	// SubscriptionConditionReferencesResolved has status True when all the specified references have been successfully
 	// resolved.
-	SubscriptionConditionReferencesResolved apis.ConditionType = "Resolved"
+	SubscriptionConditionReferencesResolved apis.ConditionType = "ReferencesResolved"
 
 	// SubscriptionConditionAddedToChannel has status True when controller has successfully added a
 	// subscription to the spec.channel resource.


### PR DESCRIPTION
Fixes #2736

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Rename Subscription condition when references are resolved from `Resolved` to `ReferencesResolved`

Note: instead of using the suggested singular reference [here](https://github.com/knative/eventing/issues/2163#issuecomment-596630353) I have turned it into plural since it is resolving subscriber and maybe reply and dead letter sink.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
