### PR TITLE
Always pass zaptest logger with AddCaller to SUT in unit tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1575,6 +1575,7 @@
     "go.opentelemetry.io/otel/api/trace",
     "go.uber.org/atomic",
     "go.uber.org/zap",
+    "go.uber.org/zap/zaptest",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/status",

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -33,6 +33,7 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -339,7 +340,7 @@ func TestReceiver(t *testing.T) {
 			}
 			reporter := &mockReporter{}
 			r, err := NewHandler(
-				zap.NewNop(),
+				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				getFakeTriggerLister(correctURI),
 				reporter)
 			if tc.expectNewToFail {

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -28,6 +28,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v1"
 	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"knative.dev/eventing/pkg/broker"
 )
@@ -124,7 +125,7 @@ func TestIngressHandler_Receive_FAIL(t *testing.T) {
 			client, _ := cloudevents.NewDefaultClient()
 			reporter := &mockReporter{}
 			handler := Handler{
-				Logger:   zap.NewNop(),
+				Logger:   zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				CeClient: client,
 				ChannelURI: &url.URL{
 					Scheme: urlScheme,
@@ -158,7 +159,7 @@ func TestIngressHandler_Receive_Succeed(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:   zap.NewNop(),
+		Logger:   zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient: client,
 		ChannelURI: &url.URL{
 			Scheme: urlScheme,
@@ -192,7 +193,7 @@ func TestIngressHandler_Receive_NoTTL(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:   zap.NewNop(),
+		Logger:   zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient: client,
 		ChannelURI: &url.URL{
 			Scheme: urlScheme,
@@ -220,7 +221,7 @@ func TestIngressHandler_Start(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:   zap.NewNop(),
+		Logger:   zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient: client,
 		ChannelURI: &url.URL{
 			Scheme: urlScheme,

--- a/pkg/channel/event_dispatcher_test.go
+++ b/pkg/channel/event_dispatcher_test.go
@@ -30,6 +30,7 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -559,7 +560,7 @@ func TestDispatchEvent(t *testing.T) {
 			tctx.Header = tc.header
 			ctx = cehttp.WithTransportContext(ctx, tctx)
 
-			md := NewEventDispatcher(zap.NewNop())
+			md := NewEventDispatcher(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			destination := getDomain(t, tc.sendToDestination, destServer.URL)
 			reply := getDomain(t, tc.sendToReply, replyServer.URL)
 

--- a/pkg/channel/event_receiver_test.go
+++ b/pkg/channel/event_receiver_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/eventing/pkg/utils"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestEventReceiver_ServeHTTP(t *testing.T) {
@@ -132,7 +133,7 @@ func TestEventReceiver_ServeHTTP(t *testing.T) {
 			}
 
 			f := tc.receiverFunc
-			r, err := NewEventReceiver(f, zap.NewNop())
+			r, err := NewEventReceiver(f, zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Fatalf("Error creating new event receiver. Error:%s", err)
 			}

--- a/pkg/channel/fanout/fanout_handler_test.go
+++ b/pkg/channel/fanout/fanout_handler_test.go
@@ -28,6 +28,7 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -229,7 +230,9 @@ func TestFanoutHandler_ServeHTTP(t *testing.T) {
 				subs = append(subs, sub)
 			}
 
-			h, err := NewHandler(zap.NewNop(), Config{Subscriptions: subs})
+			h, err := NewHandler(
+				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
+				Config{Subscriptions: subs})
 			if err != nil {
 				t.Fatalf("NewHandler failed. Error:%s", err)
 			}

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	bindingshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -227,10 +228,12 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		subs = append(subs, sub)
 	}
 
-	h, err := NewMessageHandler(zap.NewNop(), Config{
-		Subscriptions: subs,
-		AsyncHandler:  async,
-	})
+	h, err := NewMessageHandler(
+		zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
+		Config{
+			Subscriptions: subs,
+			AsyncHandler:  async,
+		})
 	if err != nil {
 		t.Fatalf("NewHandler failed. Error:%s", err)
 	}

--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"knative.dev/eventing/pkg/utils"
 )
@@ -515,7 +516,7 @@ func TestDispatchMessage(t *testing.T) {
 
 			ctx := context.Background()
 
-			md := NewMessageDispatcher(zap.NewNop())
+			md := NewMessageDispatcher(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 
 			destination := getOnlyDomainURL(t, tc.sendToDestination, destServer.URL)
 			reply := getOnlyDomainURL(t, tc.sendToReply, replyServer.URL)

--- a/pkg/channel/message_receiver_test.go
+++ b/pkg/channel/message_receiver_test.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/eventing/pkg/utils"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestMessageReceiver_ServeHTTP(t *testing.T) {
@@ -148,7 +149,7 @@ func TestMessageReceiver_ServeHTTP(t *testing.T) {
 			}
 
 			f := tc.receiverFunc
-			r, err := NewMessageReceiver(f, zap.NewNop())
+			r, err := NewMessageReceiver(f, zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Fatalf("Error creating new event receiver. Error:%s", err)
 			}
@@ -193,7 +194,7 @@ func TestMessageReceiver_WrongRequest(t *testing.T) {
 	f := func(_ context.Context, _ ChannelReference, _ binding.Message, _ []binding.TransformerFactory, _ nethttp.Header) error {
 		return errors.New("test induced receiver function error")
 	}
-	r, err := NewMessageReceiver(f, zap.NewNop())
+	r, err := NewMessageReceiver(f, zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 	if err != nil {
 		t.Fatalf("Error creating new event receiver. Error:%s", err)
 	}
@@ -215,9 +216,12 @@ func TestMessageReceiver_UnknownHost(t *testing.T) {
 	f := func(_ context.Context, _ ChannelReference, _ binding.Message, _ []binding.TransformerFactory, _ nethttp.Header) error {
 		return errors.New("test induced receiver function error")
 	}
-	r, err := NewMessageReceiver(f, zap.NewNop(), ResolveMessageChannelFromHostHeader(func(s string) (reference ChannelReference, err error) {
-		return ChannelReference{}, UnknownHostError(s)
-	}))
+	r, err := NewMessageReceiver(
+		f,
+		zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
+		ResolveMessageChannelFromHostHeader(func(s string) (reference ChannelReference, err error) {
+			return ChannelReference{}, UnknownHostError(s)
+		}))
 	if err != nil {
 		t.Fatalf("Error creating new event receiver. Error:%s", err)
 	}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
@@ -26,6 +26,7 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -61,7 +62,7 @@ func TestNewHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewHandler(zap.NewNop(), tc.config)
+			_, err := NewHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
 			if tc.createErr != "" {
 				if err == nil {
 					t.Errorf("Expected NewHandler error: '%v'. Actual nil", tc.createErr)
@@ -110,7 +111,7 @@ func TestCopyWithNewConfig(t *testing.T) {
 	if cmp.Equal(orig, updated) {
 		t.Errorf("Orig and updated must be different")
 	}
-	h, err := NewHandler(zap.NewNop(), orig)
+	h, err := NewHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), orig)
 	if err != nil {
 		t.Errorf("Unable to create handler, %v", err)
 	}
@@ -180,7 +181,7 @@ func TestConfigDiff(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := NewHandler(zap.NewNop(), tc.orig)
+			h, err := NewHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.orig)
 			if err != nil {
 				t.Errorf("Unable to create handler: %v", err)
 			}
@@ -275,7 +276,7 @@ func TestServeHTTP(t *testing.T) {
 			// Rewrite the replaceDomains to call the server we just created.
 			replaceDomains(tc.config, server.URL[7:])
 
-			h, err := NewHandler(zap.NewNop(), tc.config)
+			h, err := NewHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
 			if err != nil {
 				t.Fatalf("Unexpected NewHandler error: '%v'", err)
 			}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -29,6 +29,7 @@ import (
 	bindingshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -59,7 +60,7 @@ func TestNewMessageHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.config)
+			_, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
 			if tc.createErr != "" {
 				if err == nil {
 					t.Errorf("Expected NewHandler error: '%v'. Actual nil", tc.createErr)
@@ -108,7 +109,7 @@ func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
 	if cmp.Equal(orig, updated) {
 		t.Errorf("Orig and updated must be different")
 	}
-	h, err := NewMessageHandler(context.TODO(), zap.NewNop(), orig)
+	h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), orig)
 	if err != nil {
 		t.Errorf("Unable to create handler, %v", err)
 	}
@@ -178,7 +179,7 @@ func TestConfigDiffMessageHandler(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.orig)
+			h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.orig)
 			if err != nil {
 				t.Errorf("Unable to create handler: %v", err)
 			}
@@ -273,7 +274,7 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 			// Rewrite the replaceDomains to call the server we just created.
 			replaceDomains(tc.config, server.URL[7:])
 
-			h, err := NewMessageHandler(context.TODO(), zap.NewNop(), tc.config)
+			h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
 			if err != nil {
 				t.Fatalf("Unexpected NewHandler error: '%v'", err)
 			}

--- a/pkg/channel/multichannelfanout/parse_test.go
+++ b/pkg/channel/multichannelfanout/parse_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/utils"
@@ -132,7 +133,7 @@ func TestConfigMapData(t *testing.T) {
 			if tc.name != "valid" {
 				return
 			}
-			c, e := Parse(zap.NewNop(), formatData(tc.config))
+			c, e := Parse(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), formatData(tc.config))
 			if tc.expectedErr {
 				if e == nil {
 					t.Errorf("Expected an error, actual nil")

--- a/pkg/channel/swappable/swappable_message_handler_test.go
+++ b/pkg/channel/swappable/swappable_message_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	bindingshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/channel/fanout"
@@ -71,7 +72,7 @@ func TestMessageHandler(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyMessageHandler(context.TODO(), zap.NewNop())
+			h, err := NewEmptyMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -117,7 +118,7 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyHandler(zap.NewNop())
+			h, err := NewEmptyHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -145,7 +146,7 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 }
 
 func TestMessageHandler_NilConfigChange(t *testing.T) {
-	h, err := NewEmptyMessageHandler(context.TODO(), zap.NewNop())
+	h, err := NewEmptyMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 	if err != nil {
 		t.Errorf("Unexpected error creating handler: %v", err)
 	}

--- a/pkg/channel/swappable/swappable_test.go
+++ b/pkg/channel/swappable/swappable_test.go
@@ -25,6 +25,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v1"
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -77,7 +78,7 @@ func TestHandler(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyHandler(zap.NewNop())
+			h, err := NewEmptyHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -123,7 +124,7 @@ func TestHandler_InvalidConfigChange(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyHandler(zap.NewNop())
+			h, err := NewEmptyHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -151,7 +152,7 @@ func TestHandler_InvalidConfigChange(t *testing.T) {
 }
 
 func TestHandler_NilConfigChange(t *testing.T) {
-	h, err := NewEmptyHandler(zap.NewNop())
+	h, err := NewEmptyHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
 	if err != nil {
 		t.Errorf("Unexpected error creating handler: %v", err)
 	}

--- a/pkg/mtbroker/filter/filter_handler_test.go
+++ b/pkg/mtbroker/filter/filter_handler_test.go
@@ -31,6 +31,7 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -336,7 +337,7 @@ func TestReceiver(t *testing.T) {
 			listers := reconcilertesting.NewListers(correctURI)
 			reporter := &mockReporter{}
 			r, err := NewHandler(
-				zap.NewNop(),
+				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				listers.GetTriggerLister(),
 				reporter,
 				8080)

--- a/pkg/mtbroker/ingress/ingress_handler_test.go
+++ b/pkg/mtbroker/ingress/ingress_handler_test.go
@@ -27,6 +27,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v1"
 	"github.com/cloudevents/sdk-go/v1/cloudevents/transport/http"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/eventing/pkg/broker"
 )
 
@@ -122,7 +123,7 @@ func TestIngressHandler_Receive_FAIL(t *testing.T) {
 			client, _ := cloudevents.NewDefaultClient()
 			reporter := &mockReporter{}
 			handler := Handler{
-				Logger:    zap.NewNop(),
+				Logger:    zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				CeClient:  client,
 				Reporter:  reporter,
 				Defaulter: broker.TTLDefaulter(zap.NewNop(), 5),
@@ -149,7 +150,7 @@ func TestIngressHandler_Receive_Succeed(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:    zap.NewNop(),
+		Logger:    zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient:  client,
 		Reporter:  reporter,
 		Defaulter: broker.TTLDefaulter(zap.NewNop(), 5),
@@ -176,7 +177,7 @@ func TestIngressHandler_Receive_NoTTL(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:   zap.NewNop(),
+		Logger:   zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient: client,
 		Reporter: reporter,
 	}
@@ -197,7 +198,7 @@ func TestIngressHandler_Start(t *testing.T) {
 	client := &fakeClient{}
 	reporter := &mockReporter{}
 	handler := Handler{
-		Logger:    zap.NewNop(),
+		Logger:    zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 		CeClient:  client,
 		Reporter:  reporter,
 		Defaulter: broker.TTLDefaulter(zap.NewNop(), 5),


### PR DESCRIPTION
This makes test output more useful by printing zap log messages on
test failure.
