### PR TITLE
Remove all category from internal API ...

### DIFF
--- a/config/brokers/channel-broker/resources/configmappropagation.yaml
+++ b/config/brokers/channel-broker/resources/configmappropagation.yaml
@@ -30,7 +30,6 @@ spec:
     plural: configmappropagations
     singular: configmappropagation
     categories:
-      - all
       - knative
       - eventing
     shortNames:


### PR DESCRIPTION
removing `all` category, since this API is actually not for extrnal visibility use (e.g. `k get all`)

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

