### PR TITLE
 Port fanout.Config to SubscriberSpec v1beta1 

### DIFF
--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -120,6 +120,8 @@ var (
 	// Verify SubscribableType resources meet duck contracts.
 	_ duck.Populatable = (*SubscribableType)(nil)
 	_ apis.Listable    = (*SubscribableType)(nil)
+
+	_ apis.Convertible = (*SubscribableType)(nil)
 )
 
 // GetSubscribableTypeStatus method Returns the Default SubscribableStatus in this case it's SubscribableStatus

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+)
+
+// ConvertTo implements apis.Convertible
+// Converts source (from v1alpha1.SubscribableType) into v1beta1.Subscribable
+func (source *SubscribableType) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *duckv1beta1.Subscribable:
+		sink.ObjectMeta = source.ObjectMeta
+		source.Status.ConvertTo(ctx, &sink.Status)
+		return source.Spec.ConvertTo(ctx, &sink.Spec)
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
+	}
+}
+
+// ConvertTo helps implement apis.Convertible
+func (source *SubscribableTypeSpec) ConvertTo(ctx context.Context, sink *duckv1beta1.SubscribableSpec) error {
+	if source.Subscribable != nil {
+		sink.Subscribers = make([]duckv1beta1.SubscriberSpec, len(source.Subscribable.Subscribers))
+		for i, s := range source.Subscribable.Subscribers {
+			s.ConvertTo(ctx, &sink.Subscribers[i])
+		}
+	}
+	return nil
+}
+
+func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink *duckv1beta1.SubscriberSpec) {
+	sink.UID = source.UID
+	sink.Generation = source.Generation
+	sink.SubscriberURI = source.SubscriberURI
+	sink.ReplyURI = source.ReplyURI
+
+	if source.Delivery != nil {
+		sink.Delivery = source.Delivery
+	} else {
+		// If however, there's a Deprecated DeadLetterSinkURI, convert that up
+		// to DeliverySpec.
+		sink.Delivery = &duckv1beta1.DeliverySpec{
+			DeadLetterSink: &duckv1.Destination{
+				URI: source.DeadLetterSinkURI,
+			},
+		}
+	}
+}
+
+// ConvertTo helps implement apis.Convertible
+func (source *SubscribableTypeStatus) ConvertTo(ctx context.Context, sink *duckv1beta1.SubscribableStatus) {
+	if source.SubscribableStatus != nil &&
+		len(source.SubscribableStatus.Subscribers) > 0 {
+		sink.Subscribers = make([]duckv1beta1.SubscriberStatus, len(source.SubscribableStatus.Subscribers))
+		for i, ss := range source.SubscribableStatus.Subscribers {
+			sink.Subscribers[i] = duckv1beta1.SubscriberStatus{
+				UID:                ss.UID,
+				ObservedGeneration: ss.ObservedGeneration,
+				Ready:              ss.Ready,
+				Message:            ss.Message,
+			}
+		}
+	}
+}
+
+// ConvertFrom implements apis.Convertible.
+// Converts obj v1beta1.Subscribable into v1alpha1.Subscribable
+func (sink *SubscribableType) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *duckv1beta1.Subscribable:
+		sink.ObjectMeta = source.ObjectMeta
+		sink.Status.ConvertFrom(ctx, source.Status)
+		sink.Spec.ConvertFrom(ctx, source.Spec)
+		return nil
+	default:
+		return fmt.Errorf("unknown version, got: %T", source)
+	}
+}
+
+// ConvertFrom helps implement apis.Convertible
+func (sink *SubscribableTypeSpec) ConvertFrom(ctx context.Context, source duckv1beta1.SubscribableSpec) {
+	if len(source.Subscribers) > 0 {
+		sink.Subscribable = &Subscribable{
+			Subscribers: make([]SubscriberSpec, len(source.Subscribers)),
+		}
+		for i, s := range source.Subscribers {
+			sink.Subscribable.Subscribers[i].ConvertFrom(ctx, s)
+		}
+	}
+}
+
+func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, source duckv1beta1.SubscriberSpec) {
+	var deadLetterSinkURI *apis.URL
+	if source.Delivery != nil && source.Delivery.DeadLetterSink != nil {
+		deadLetterSinkURI = source.Delivery.DeadLetterSink.URI
+	}
+	sink.UID = source.UID
+	sink.Generation = source.Generation
+	sink.SubscriberURI = source.SubscriberURI
+	sink.ReplyURI = source.ReplyURI
+	sink.Delivery = source.Delivery
+	sink.DeadLetterSinkURI = deadLetterSinkURI
+
+}
+
+// ConvertFrom helps implement apis.Convertible
+func (sink *SubscribableTypeStatus) ConvertFrom(ctx context.Context, source duckv1beta1.SubscribableStatus) error {
+	if len(source.Subscribers) > 0 {
+		sink.SubscribableStatus = &SubscribableStatus{
+			Subscribers: make([]SubscriberStatus, len(source.Subscribers)),
+		}
+		for i, ss := range source.Subscribers {
+			sink.SubscribableStatus.Subscribers[i] = SubscriberStatus{
+				UID:                ss.UID,
+				ObservedGeneration: ss.ObservedGeneration,
+				Ready:              ss.Ready,
+				Message:            ss.Message,
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"knative.dev/pkg/apis"
+	pkgduckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"knative.dev/eventing/pkg/apis/duck/v1beta1"
+)
+
+func TestSubscribableTypeConversionBadType(t *testing.T) {
+	good, bad := &SubscribableType{}, &pkgduckv1.Addressable{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
+// Test v1alpha1 -> v1beta1 -> v1alpha1
+func TestSubscribableTypeConversion(t *testing.T) {
+	// Just one for now, just adding the for loop for ease of future changes.
+	versions := []apis.Convertible{&v1beta1.Subscribable{}}
+
+	linear := v1beta1.BackoffPolicyLinear
+
+	tests := []struct {
+		name string
+		in   *SubscribableType
+	}{{
+		name: "min configuration",
+		in: &SubscribableType{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec:   SubscribableTypeSpec{},
+			Status: SubscribableTypeStatus{},
+		},
+	}, {
+		name: "full configuration",
+		in: &SubscribableType{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec: SubscribableTypeSpec{
+				Subscribable: &Subscribable{
+					Subscribers: []SubscriberSpec{
+						{
+							UID:               "uid-1",
+							Generation:        7,
+							SubscriberURI:     apis.HTTP("subscriber.example.com"),
+							ReplyURI:          apis.HTTP("reply.example.com"),
+							DeadLetterSinkURI: apis.HTTP("subscriber.dls.example.com"),
+							Delivery: &v1beta1.DeliverySpec{
+								DeadLetterSink: &pkgduckv1.Destination{
+									Ref: &pkgduckv1.KReference{
+										Kind:       "dlKind",
+										Namespace:  "dlNamespace",
+										Name:       "dlName",
+										APIVersion: "dlAPIVersion",
+									},
+									URI: apis.HTTP("subscriber.dls.example.com"),
+								},
+								Retry:         pointer.Int32Ptr(5),
+								BackoffPolicy: &linear,
+								BackoffDelay:  pointer.StringPtr("5s"),
+							},
+						},
+					},
+				},
+			},
+			Status: SubscribableTypeStatus{
+				SubscribableStatus: &SubscribableStatus{
+					Subscribers: []SubscriberStatus{
+						{
+							UID:                "status-uid-1",
+							ObservedGeneration: 99,
+							Ready:              corev1.ConditionTrue,
+							Message:            "msg",
+						},
+					},
+				},
+			},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					t.Errorf("ConvertTo() = %v", err)
+				}
+				got := &SubscribableType{}
+				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					t.Errorf("ConvertFrom() = %v", err)
+				}
+				if diff := cmp.Diff(test.in, got); diff != "" {
+					t.Errorf("roundtrip (-want, +got) = %v", diff)
+				}
+			})
+		}
+	}
+}
+
+// Test v1beta1 -> v1alpha1 -> v1beta1
+func TestSubscribableTypeConversionWithV1Beta1(t *testing.T) {
+	// Just one for now, just adding the for loop for ease of future changes.
+	versions := []apis.Convertible{&SubscribableType{}}
+
+	linear := v1beta1.BackoffPolicyLinear
+
+	tests := []struct {
+		name string
+		in   *v1beta1.Subscribable
+	}{{
+		name: "min",
+		in: &v1beta1.Subscribable{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec:   v1beta1.SubscribableSpec{},
+			Status: v1beta1.SubscribableStatus{},
+		},
+	}, {
+		name: "full configuration",
+		in: &v1beta1.Subscribable{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec: v1beta1.SubscribableSpec{
+				Subscribers: []v1beta1.SubscriberSpec{
+					{
+						UID:           "uid-1",
+						Generation:    7,
+						SubscriberURI: apis.HTTP("subscriber.example.com"),
+						ReplyURI:      apis.HTTP("reply.example.com"),
+						Delivery: &v1beta1.DeliverySpec{
+							DeadLetterSink: &pkgduckv1.Destination{
+								Ref: &pkgduckv1.KReference{
+									Kind:       "dlKind",
+									Namespace:  "dlNamespace",
+									Name:       "dlName",
+									APIVersion: "dlAPIVersion",
+								},
+								URI: apis.HTTP("subscriber.dls.example.com"),
+							},
+							Retry:         pointer.Int32Ptr(5),
+							BackoffPolicy: &linear,
+							BackoffDelay:  pointer.StringPtr("5s"),
+						},
+					},
+				},
+			},
+			Status: v1beta1.SubscribableStatus{
+				Subscribers: []v1beta1.SubscriberStatus{
+					{
+						UID:                "status-uid-1",
+						ObservedGeneration: 99,
+						Ready:              corev1.ConditionTrue,
+						Message:            "msg",
+					},
+				},
+			},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := version.ConvertFrom(context.Background(), test.in); err != nil {
+					t.Errorf("ConvertTo() = %v", err)
+				}
+				got := &v1beta1.Subscribable{}
+				if err := ver.ConvertTo(context.Background(), got); err != nil {
+					t.Errorf("ConvertFrom() = %v", err)
+				}
+				if diff := cmp.Diff(test.in, got); diff != "" {
+					t.Errorf("roundtrip (-want, +got) = %v", diff)
+				}
+			})
+		}
+	}
+}

--- a/pkg/apis/duck/v1beta1/subscribable_types.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types.go
@@ -105,6 +105,8 @@ var (
 	// Verify SubscribableType resources meet duck contracts.
 	_ duck.Populatable = (*Subscribable)(nil)
 	_ apis.Listable    = (*Subscribable)(nil)
+
+	_ apis.Convertible = (*Subscribable)(nil)
 )
 
 // GetFullType implements duck.Implementable

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertTo implements apis.Convertible
+func (source *Subscribable) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (sink *Subscribable) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInMemoryChannelConversionBadType(t *testing.T) {
+	good, bad := &Subscribable{}, &Subscribable{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/channel/fanout/fanout_handler.go
+++ b/pkg/channel/fanout/fanout_handler.go
@@ -30,7 +30,7 @@ import (
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 )
 
@@ -138,5 +138,9 @@ func (f *Handler) dispatch(ctx context.Context, event cloudevents.Event) error {
 // makeFanoutRequest sends the request to exactly one subscription. It handles both the `call` and
 // the `sink` portions of the subscription.
 func (f *Handler) makeFanoutRequest(ctx context.Context, event cloudevents.Event, sub eventingduck.SubscriberSpec) error {
-	return f.dispatcher.DispatchEventWithDelivery(ctx, event, sub.SubscriberURI.String(), sub.ReplyURI.String(), &channel.DeliveryOptions{DeadLetterSink: sub.DeadLetterSinkURI.String()})
+	var opts *channel.DeliveryOptions
+	if sub.Delivery != nil {
+		opts = &channel.DeliveryOptions{DeadLetterSink: sub.Delivery.DeadLetterSink.URI.String()}
+	}
+	return f.dispatcher.DispatchEventWithDelivery(ctx, event, sub.SubscriberURI.String(), sub.ReplyURI.String(), opts)
 }

--- a/pkg/channel/fanout/fanout_handler_test.go
+++ b/pkg/channel/fanout/fanout_handler_test.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 )
 

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -33,7 +33,7 @@ import (
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 )
 
@@ -161,8 +161,8 @@ func (f *MessageHandler) makeFanoutRequest(ctx context.Context, message binding.
 		reply = sub.ReplyURI.URL()
 	}
 	var deadLetter *url.URL
-	if sub.DeadLetterSinkURI != nil {
-		deadLetter = sub.DeadLetterSinkURI.URL()
+	if sub.Delivery != nil && sub.Delivery.DeadLetterSink != nil && sub.Delivery.DeadLetterSink.URI != nil {
+		deadLetter = sub.Delivery.DeadLetterSink.URI.URL()
 	}
 	return f.dispatcher.DispatchMessage(ctx, message, additionalHeaders, destination, reply, deadLetter)
 }

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding"
 	bindingshttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
@@ -228,8 +227,13 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		subs = append(subs, sub)
 	}
 
+	// The test syncs using WaitGroups checking for subscriber/replier correctly invoked, but it doesn't sync on the async
+	// goroutine created by FanoutMessageHandler in async mode.
+	// So the test logger (zaptest) doesn't work, because it could log messages after the test is closed.
+	logger, _ := zap.NewDevelopment(zap.AddStacktrace(zap.WarnLevel))
+
 	h, err := NewMessageHandler(
-		zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
+		logger,
 		Config{
 			Subscriptions: subs,
 			AsyncHandler:  async,
@@ -249,7 +253,7 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		h.timeout = timeout
 	} else {
 		// Reasonable timeout for the tests.
-		h.timeout = 1 * time.Second
+		h.timeout = 10000 * time.Second
 	}
 
 	event := makeCloudEventNew()

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -249,7 +249,7 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		h.timeout = timeout
 	} else {
 		// Reasonable timeout for the tests.
-		h.timeout = 100 * time.Millisecond
+		h.timeout = 1 * time.Second
 	}
 
 	event := makeCloudEventNew()

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -32,7 +32,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 )
 

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_handler_test.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel/fanout"
 )
 

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -32,7 +32,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel/fanout"
 )
 

--- a/pkg/channel/multichannelfanout/parse_test.go
+++ b/pkg/channel/multichannelfanout/parse_test.go
@@ -23,10 +23,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	"knative.dev/pkg/apis"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/utils"
-	"knative.dev/pkg/apis"
 )
 
 func TestConfigMapData(t *testing.T) {

--- a/pkg/channel/swappable/swappable_message_handler_test.go
+++ b/pkg/channel/swappable/swappable_message_handler_test.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 )

--- a/pkg/channel/swappable/swappable_test.go
+++ b/pkg/channel/swappable/swappable_test.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 )


### PR DESCRIPTION
Fixes #2868

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- `v1beta1.Subscribable` & `v1alpha1.SubscribableType` implements `Convertible`
- Ported the `fanout.Config` to use `v1beta1.Subscribable` 