### PR TITLE
Move CMP to knative-internal category

### DIFF
--- a/config/brokers/channel-broker/resources/configmappropagation.yaml
+++ b/config/brokers/channel-broker/resources/configmappropagation.yaml
@@ -30,8 +30,7 @@ spec:
     plural: configmappropagations
     singular: configmappropagation
     categories:
-      - knative
-      - eventing
+      - knative-internal
     shortNames:
       - kcmp
       - cmp


### PR DESCRIPTION
## Proposed Changes

- move cmp to just `knative-internal` category, like done on serving

