### PR TITLE
Add a way to make the `mtnamespace` controller behave like `namespace`.

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -54,6 +54,14 @@ spec:
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
 
+          # Due to the trivial per-Broker cost, we inject Brokers into every
+          # namespace by default. To change this default simply change this
+          # to "false".  To opt namespaces out of Broker injection, label
+          # them with:
+          #    knative-eventing-injection: disabled
+          - name: BROKER_INJECTION_DEFAULT
+            value: "true"
+
         securityContext:
           allowPrivilegeEscalation: false
 

--- a/pkg/reconciler/mtnamespace/namespace.go
+++ b/pkg/reconciler/mtnamespace/namespace.go
@@ -41,8 +41,12 @@ const (
 	brokerCreated = "BrokerCreated"
 )
 
+type labelFilter func(labels map[string]string) bool
+
 type Reconciler struct {
 	eventingClientSet clientset.Interface
+
+	filter labelFilter
 
 	// listers index properties about resources
 	brokerLister eventinglisters.BrokerLister
@@ -52,7 +56,7 @@ type Reconciler struct {
 var _ namespacereconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pkgreconciler.Event {
-	if ns.Labels[resources.InjectionLabelKey] == resources.InjectionDisabledLabelValue {
+	if r.filter(ns.Labels) {
 		logging.FromContext(ctx).Debug("Not reconciling Namespace")
 		return nil
 	}


### PR DESCRIPTION
- 🧽 Update or clean up current behavior

This adds a way to revert the `mtnamespace` controller to opt-in (similar to the `namespace` controller), but by default the setting is "enabled" due to the trivial per-Broker cost.

See also the conversation here: https://github.com/knative/docs/pull/2325

cc @grantr @matzew @lionelvillard @vaikas 

I'd be happy to add the same logic to the `namespace` controller's `envconfig` (but off by default) so that it is similarly configurable, if that symmetry is interesting to folks?