### PR TITLE
Upgrade script for patching broker annotation

### DIFF
--- a/cmd/upgrade/v0.14.0/main.go
+++ b/cmd/upgrade/v0.14.0/main.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+
+	versioned "knative.dev/eventing/pkg/client/clientset/versioned"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	broker "knative.dev/eventing/pkg/upgrader/broker/v0.14.0"
+)
+
+func main() {
+	ctx := signals.NewContext()
+	cfg := sharedmain.ParseAndGetConfigOrDie()
+	ctx = context.WithValue(ctx, kubeclient.Key{}, kubernetes.NewForConfigOrDie(cfg))
+	ctx = context.WithValue(ctx, eventingclient.Key{}, versioned.NewForConfigOrDie(cfg))
+	broker.Upgrade(ctx)
+}

--- a/cmd/upgrade/v0.14.0/main.go
+++ b/cmd/upgrade/v0.14.0/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	//	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"context"
 

--- a/cmd/upgrade/v0.14.0/main.go
+++ b/cmd/upgrade/v0.14.0/main.go
@@ -21,6 +21,8 @@ import (
 	//	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"context"
+	"fmt"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -37,5 +39,8 @@ func main() {
 	cfg := sharedmain.ParseAndGetConfigOrDie()
 	ctx = context.WithValue(ctx, kubeclient.Key{}, kubernetes.NewForConfigOrDie(cfg))
 	ctx = context.WithValue(ctx, eventingclient.Key{}, versioned.NewForConfigOrDie(cfg))
-	broker.Upgrade(ctx)
+	if err := broker.Upgrade(ctx); err != nil {
+		fmt.Printf("Broker Upgrade failed with: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/config/upgrade/v0.14.0/README.md
+++ b/config/upgrade/v0.14.0/README.md
@@ -1,13 +1,11 @@
 # Upgrade script required to upgrade to v0.14.0 of Eventing
 
-This directory contains a job that upgrades (patches) all
-the Brokers to have an annotation that specifies which
-BrokerClass should be reconciling it. Prior to v0.13.0 there
-was only the ChannelBasedBroker and it was not necessary.
-However in v0.14.0 we introduced BrokerClass and in order
-for existing Brokers to continue to be reconciled, they
-need to be patched to include the BrokerClass annotation
-like so.
+This directory contains a job that upgrades (patches) all the Brokers to have an
+annotation that specifies which BrokerClass should be reconciling it. Prior to
+v0.13.0 there was only the ChannelBasedBroker and it was not necessary. However
+in v0.14.0 we introduced BrokerClass and in order for existing Brokers to
+continue to be reconciled, they need to be patched to include the BrokerClass
+annotation like so.
 
 ```
   annotations:
@@ -21,9 +19,8 @@ To run the upgrade script:
 ko apply -f ./upgrade.yaml
 ```
 
-It will create a job called v0.14.0-upgrade in the knative-eventing
-namespace. If you installed to different namespace, you need to
-modify the upgrade.yaml appropriately. Also the job by default
-runs as `eventing-controller` service account, you can also modify
-that but the service account will need to have permissions
-to list `Namespace`s, list and patch `Broker`s.
+It will create a job called v0.14.0-upgrade in the knative-eventing namespace.
+If you installed to different namespace, you need to modify the upgrade.yaml
+appropriately. Also the job by default runs as `eventing-controller` service
+account, you can also modify that but the service account will need to have
+permissions to list `Namespace`s, list and patch `Broker`s. 

--- a/config/upgrade/v0.14.0/README.md
+++ b/config/upgrade/v0.14.0/README.md
@@ -23,4 +23,4 @@ It will create a job called v0.14.0-upgrade in the knative-eventing namespace.
 If you installed to different namespace, you need to modify the upgrade.yaml
 appropriately. Also the job by default runs as `eventing-controller` service
 account, you can also modify that but the service account will need to have
-permissions to list `Namespace`s, list and patch `Broker`s. 
+permissions to list `Namespace`s, list and patch `Broker`s.

--- a/config/upgrade/v0.14.0/README.md
+++ b/config/upgrade/v0.14.0/README.md
@@ -1,0 +1,29 @@
+# Upgrade script required to upgrade to v0.14.0 of Eventing
+
+This directory contains a job that upgrades (patches) all
+the Brokers to have an annotation that specifies which
+BrokerClass should be reconciling it. Prior to v0.13.0 there
+was only the ChannelBasedBroker and it was not necessary.
+However in v0.14.0 we introduced BrokerClass and in order
+for existing Brokers to continue to be reconciled, they
+need to be patched to include the BrokerClass annotation
+like so.
+
+```
+  annotations:
+    eventing.knative.dev/broker.class: ChannelBasedBroker
+
+```
+
+To run the upgrade script:
+
+```shell
+ko apply -f ./upgrade.yaml
+```
+
+It will create a job called v0.14.0-upgrade in the knative-eventing
+namespace. If you installed to different namespace, you need to
+modify the upgrade.yaml appropriately. Also the job by default
+runs as `eventing-controller` service account, you can also modify
+that but the service account will need to have permissions
+to list `Namespace`s, list and patch `Broker`s.

--- a/config/upgrade/v0.14.0/upgrade.yaml
+++ b/config/upgrade/v0.14.0/upgrade.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: v0.14.0-upgrade
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  template:
+    spec:
+      serviceAccountName: eventing-controller
+      restartPolicy: Never
+      containers:
+      - name: upgrade-brokers
+        image: ko://knative.dev/eventing/cmd/upgrade/v0.14.0/
+

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,6 +27,7 @@ COMPONENTS=(
   ["channel-broker.yaml"]="config/brokers/channel-broker"
   ["mt-channel-broker.yaml"]="config/brokers/mt-channel-broker"
   ["in-memory-channel.yaml"]="config/channels/in-memory-channel"
+  ["upgrade-to-v0.14.0.yaml"]="config/upgrade/v0.14.0"
 )
 readonly COMPONENTS
 

--- a/pkg/upgrader/broker/v0.14.0/upgrader.go
+++ b/pkg/upgrader/broker/v0.14.0/upgrader.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	types "k8s.io/apimachinery/pkg/types"
+	"knative.dev/eventing/pkg/apis/eventing"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	"knative.dev/pkg/apis/duck"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/logging"
+)
+
+// Upgrade upgrades all the brokers by applying an Annotation to all the
+// ones that do not have them. This is necessary to ensure that existing Brokers
+// that do not have Annotation will continue to be reconciled by the existing
+// ChannelBasedBroker
+func Upgrade(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+	kubeClient := kubeclient.Get(ctx)
+	eventingClient := eventingclient.Get(ctx)
+	nsClient := kubeClient.CoreV1().Namespaces()
+	namespaces, err := nsClient.List(metav1.ListOptions{})
+	if err != nil {
+		logger.Warnf("Failed to list namespaces: %v", err)
+		return err
+	}
+	for _, ns := range namespaces.Items {
+		logger.Infof("Processing Brokers in namespace: %q", ns.Name)
+		brokerClient := eventingClient.EventingV1alpha1().Brokers(ns.Name)
+		brokers, err := brokerClient.List(metav1.ListOptions{})
+		if err != nil {
+			logger.Warnf("Failed to list brokers for namespace %q: %v", ns.Name, err)
+			return err
+		}
+		for _, broker := range brokers.Items {
+			logger.Infof("Processing Broker \"%s/%s\"", broker.Namespace, broker.Name)
+
+			annotations := broker.ObjectMeta.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string, 1)
+			}
+			if brokerClass, present := annotations[eventing.BrokerClassKey]; present {
+				logger.Infof("Annotation found \"%s/%s\" => %q", broker.Namespace, broker.Name, brokerClass)
+				continue
+			}
+
+			// No annotations, or missing, add it...
+			modified := broker.DeepCopy()
+			modifiedAnnotations := modified.ObjectMeta.GetAnnotations()
+			if modifiedAnnotations == nil {
+				modifiedAnnotations = make(map[string]string, 1)
+			}
+			if _, present := modifiedAnnotations[eventing.BrokerClassKey]; !present {
+				modifiedAnnotations[eventing.BrokerClassKey] = eventing.ChannelBrokerClassValue
+				modified.ObjectMeta.SetAnnotations(modifiedAnnotations)
+			}
+			patch, err := duck.CreateMergePatch(broker, modified)
+			if err != nil {
+				logger.Warnf("Failed to create patch for \"%s/%s\" : %v", broker.Namespace, broker.Name, err)
+				return err
+			}
+			logger.Infof("Patch: %q", string(patch))
+			// If there is nothing to patch, we are good, just return.
+			// Empty patch is {}, hence we check for that.
+			if len(patch) <= 2 {
+				logger.Warnf("no diffs found...")
+				continue
+			}
+			patched, err := brokerClient.Patch(broker.Name, types.MergePatchType, patch)
+			if err != nil {
+				logger.Warnf("Failed to patch \"%s/%s\" : %v", broker.Namespace, broker.Name, err)
+			}
+			logger.Infof("Patched \"%s/%s\" successfully new Annotations: %+v", broker.Namespace, broker.Name, patched.ObjectMeta.GetAnnotations())
+		}
+	}
+	return nil
+}

--- a/pkg/upgrader/broker/v0.14.0/upgrader_test.go
+++ b/pkg/upgrader/broker/v0.14.0/upgrader_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+	"reflect"
+
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
+	_ "knative.dev/eventing/pkg/client/clientset/versioned"
+	"knative.dev/eventing/pkg/client/clientset/versioned/scheme"
+	versionedscheme "knative.dev/eventing/pkg/client/clientset/versioned/scheme"
+	_ "knative.dev/pkg/reconciler/testing"
+)
+
+const (
+	testns     = "testnamespace"
+	testns2    = "testnamespace2"
+	testbroker = "testbroker"
+)
+
+var (
+	annotationExists          = map[string]string{"eventing.knative.dev/broker.class": "ChannelBasedBroker"}
+	annotationExistsAndOthers = map[string]string{
+		"eventing.knative.dev/broker.class": "ChannelBasedBroker",
+		"eventing.knative.dev/creator":      "system:serviceaccount:knative-eventing:eventing-controller",
+	}
+	annotationOthers = map[string]string{
+		"otherannotation/":             "somethingelse",
+		"eventing.knative.dev/creator": "system:serviceaccount:knative-eventing:eventing-controller",
+	}
+	patchbytes = []byte("{\"metadata\":{\"annotations\":{\"eventing.knative.dev/broker.class\":\"ChannelBasedBroker\"}}}")
+)
+
+func TestUpgrade(t *testing.T) {
+	brokers := []runtime.Object{
+		broker("b1", testns2, map[string]string{}),
+		broker("b2", testns, annotationExists),
+		broker("b3", testns, annotationExistsAndOthers),
+		broker("b4", testns, annotationOthers),
+	}
+
+	ctx, cs := fakeeventingclient.With(context.Background(), brokers...)
+	ctx = context.WithValue(ctx, kubeclient.Key{}, fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testns}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testns2}},
+	))
+	var patches []clientgotesting.PatchAction
+	cs.PrependReactor("patch", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		patches = append(patches, action.(clientgotesting.PatchAction))
+		// Not important what we ret, it's just logged
+		return true, broker("b1", testns, annotationExists), nil
+	})
+	err := Upgrade(ctx)
+	if err != nil {
+		t.Errorf("Failed to process namespace: %v", err)
+	}
+	if len(patches) != 2 {
+		t.Errorf("expected 2 patches, got %d", len(patches))
+	}
+	// Note these get processed in different order than when doing a single namespace
+	// because they are in different namespaces
+	if patches[1].GetName() != "b1" {
+		t.Errorf("expected patch to %q, got %q", "b1", patches[1].GetName())
+	}
+	if patches[1].GetPatchType() != types.MergePatchType {
+		t.Errorf("expected patchtype %+v, got %+v", types.MergePatchType, patches[1].GetPatchType())
+	}
+	if !reflect.DeepEqual(patches[1].GetPatch(), patchbytes) {
+		t.Errorf("expected patchbytes %q, got %q", string(patchbytes), string(patches[1].GetPatch()))
+	}
+	if patches[0].GetName() != "b4" {
+		t.Errorf("expected patch to %q, got %q", "b4", patches[0].GetName())
+	}
+	if patches[0].GetPatchType() != types.MergePatchType {
+		t.Errorf("expected patchtype to %+v, got %+v", types.MergePatchType, patches[0].GetPatchType())
+	}
+	if !reflect.DeepEqual(patches[0].GetPatch(), patchbytes) {
+		t.Errorf("expected patchbytes %q, got %q", string(patchbytes), string(patches[0].GetPatch()))
+	}
+}
+
+func TestProcessNamespace(t *testing.T) {
+	brokers := []runtime.Object{
+		broker("b1", testns, map[string]string{}),
+		broker("b2", testns, annotationExists),
+		broker("b3", testns, annotationExistsAndOthers),
+		broker("b4", testns, annotationOthers),
+	}
+
+	ctx, cs := fakeeventingclient.With(context.Background(), brokers...)
+	var patches []clientgotesting.PatchAction
+	cs.PrependReactor("patch", "*", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		patches = append(patches, action.(clientgotesting.PatchAction))
+		// Not important what we ret, it's just logged
+		return true, broker("b1", testns, annotationExists), nil
+	})
+	err := ProcessNamespace(ctx, testns)
+	if err != nil {
+		t.Errorf("Failed to process namespace: %v", err)
+	}
+	if len(patches) != 2 {
+		t.Errorf("expected 2 patches, got %d", len(patches))
+	}
+	if patches[0].GetName() != "b1" {
+		t.Errorf("expected patch to %q, got %q", "b1", patches[0].GetName())
+	}
+	if patches[0].GetPatchType() != types.MergePatchType {
+		t.Errorf("expected patchtype %+v, got %+v", types.MergePatchType, patches[0].GetPatchType())
+	}
+	if !reflect.DeepEqual(patches[0].GetPatch(), patchbytes) {
+		t.Errorf("expected patchbytes %q, got %q", string(patchbytes), string(patches[0].GetPatch()))
+	}
+	if patches[1].GetName() != "b4" {
+		t.Errorf("expected patch to %q, got %q", "b4", patches[1].GetName())
+	}
+	if patches[1].GetPatchType() != types.MergePatchType {
+		t.Errorf("expected patchtype to %+v, got %+v", types.MergePatchType, patches[1].GetPatchType())
+	}
+	if !reflect.DeepEqual(patches[1].GetPatch(), patchbytes) {
+		t.Errorf("expected patchbytes %q, got %q", string(patchbytes), string(patches[1].GetPatch()))
+	}
+}
+
+func TestProcessBroker(t *testing.T) {
+	testcases := map[string]struct {
+		in          *v1alpha1.Broker
+		expectPatch []byte
+	}{
+		"nilannotations": {
+			&v1alpha1.Broker{ObjectMeta: metav1.ObjectMeta{Name: testbroker}},
+			[]byte("{\"metadata\":{\"annotations\":{\"eventing.knative.dev/broker.class\":\"ChannelBasedBroker\"}}}"),
+		},
+		"empty": {
+			broker(testbroker, testns, map[string]string{}),
+			[]byte("{\"metadata\":{\"annotations\":{\"eventing.knative.dev/broker.class\":\"ChannelBasedBroker\"}}}"),
+		},
+		"existing": {
+			broker(testbroker, testns, annotationExists),
+			[]byte{},
+		},
+		"existingandothers": {
+			broker(testbroker, testns, annotationExistsAndOthers),
+			[]byte{},
+		},
+		"onlyothers": {
+			broker(testbroker, testns, annotationOthers),
+			[]byte("{\"metadata\":{\"annotations\":{\"eventing.knative.dev/broker.class\":\"ChannelBasedBroker\"}}}"),
+		},
+	}
+
+	for _, tc := range testcases {
+		ctx, _ := fakeeventingclient.With(context.Background(), tc.in)
+		patch, err := ProcessBroker(ctx, *tc.in)
+		if err != nil {
+			t.Errorf("Failed to process broker: %v", err)
+		}
+		if !reflect.DeepEqual(patch, tc.expectPatch) {
+			t.Errorf("Patches differ : want: %q got: %q", tc.expectPatch, patch)
+		}
+
+	}
+}
+
+func broker(name, namespace string, annotations map[string]string) *v1alpha1.Broker {
+	return &v1alpha1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+func init() {
+	versionedscheme.AddToScheme(scheme.Scheme)
+}


### PR DESCRIPTION
Fixes #2840

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Introduce a script that runs as a job that will patch all Brokers without BrokerClass annotation to ChannelBasedBroker
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
* action required * You have to run the provided upgrade script, or something like this to update all the Brokers with the proper BrokerClass or they will not continue to be reconciled after 0.14 cuts.
Details for the script are in:
config/upgrade/v0.14.0/README.md
Release artifact is:
https://github.com/knative/eventing/releases
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
