### PR TITLE
Remove unused ReconcilerName const from reconcilers

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -49,11 +49,6 @@ import (
 	"knative.dev/pkg/resolver"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler
-	ReconcilerName = "Brokers"
-)
-
 type envConfig struct {
 	IngressImage          string `envconfig:"BROKER_INGRESS_IMAGE" required:"true"`
 	IngressServiceAccount string `envconfig:"BROKER_INGRESS_SERVICE_ACCOUNT" required:"true"`

--- a/pkg/reconciler/eventtype/controller.go
+++ b/pkg/reconciler/eventtype/controller.go
@@ -31,11 +31,6 @@ import (
 	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/eventtype"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler.
-	ReconcilerName = "EventTypes"
-)
-
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events
 // TODO remove https://github.com/knative/eventing/issues/2750

--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -37,13 +37,8 @@ import (
 	"knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler
-	ReconcilerName = "InMemoryChannels"
-
-	// TODO: this should be passed in on the env.
-	dispatcherName = "imc-dispatcher"
-)
+// TODO: this should be passed in on the env.
+const dispatcherName = "imc-dispatcher"
 
 type envConfig struct {
 	Image string `envconfig:"DISPATCHER_IMAGE" required:"true"`

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -81,7 +81,6 @@ func NewController(
 		inmemorychannelLister:   inmemorychannelInformer.Lister(),
 		inmemorychannelInformer: informer,
 	}
-	//	impl := controller.NewImpl(r, r.Logger, ReconcilerName)
 	impl := inmemorychannelreconciler.NewImpl(ctx, r)
 
 	// Nothing to filer, enqueue all imcs if configmap updates.

--- a/pkg/reconciler/mtbroker/controller.go
+++ b/pkg/reconciler/mtbroker/controller.go
@@ -50,13 +50,9 @@ import (
 	"knative.dev/pkg/system"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler
-	ReconcilerName = "Brokers"
-	// controllerAgentName is the string used by this controller to identify
-	// itself when creating events.
-	controllerAgentName = "mt-broker-controller"
-)
+// controllerAgentName is the string used by this controller to identify itself
+// when creating events.
+const controllerAgentName = "mt-broker-controller"
 
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events

--- a/pkg/reconciler/mtnamespace/controller.go
+++ b/pkg/reconciler/mtnamespace/controller.go
@@ -33,11 +33,6 @@ import (
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler
-	ReconcilerName = "Namespace" // TODO: Namespace is not a very good name for this controller.
-)
-
 type envConfig struct {
 	InjectionDefault bool `envconfig:"BROKER_INJECTION_DEFAULT" default:"true"`
 }

--- a/pkg/reconciler/pingsource/controller/controller.go
+++ b/pkg/reconciler/pingsource/controller/controller.go
@@ -37,11 +37,6 @@ import (
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 )
 
-const (
-	// ReconcilerName is the name of the reconciler
-	ReconcilerName = "PingSources"
-)
-
 // envConfig will be used to extract the required environment variables using
 // github.com/kelseyhightower/envconfig. If this configuration cannot be extracted, then
 // NewController will panic.


### PR DESCRIPTION
## Proposed Changes

Just a small code cleanup.

- Remove unused ReconcilerName const from reconcilers.
    The reconciler name (actually work queue name) is set in the injection code for reconcilers that use `NewImpl` from injection-gen.

Note: `reconciler/source/duck` and `reconciler/source/crd` are still using `controller.NewImpl`.