### PR TITLE
Disable the autogenerated 'default' mt broker

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -54,13 +54,13 @@ spec:
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
 
-          # Due to the trivial per-Broker cost, we inject Brokers into every
+          # Due to the trivial per-Broker cost, we _can_ inject Brokers into every
           # namespace by default. To change this default simply change this
-          # to "false".  To opt namespaces out of Broker injection, label
+          # to "true".  To opt namespaces out of Broker injection, label
           # them with:
           #    knative-eventing-injection: disabled
           - name: BROKER_INJECTION_DEFAULT
-            value: "true"
+            value: "false"
 
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/reconciler/mtnamespace/controller.go
+++ b/pkg/reconciler/mtnamespace/controller.go
@@ -34,7 +34,7 @@ import (
 )
 
 type envConfig struct {
-	InjectionDefault bool `envconfig:"BROKER_INJECTION_DEFAULT" default:"true"`
+	InjectionDefault bool `envconfig:"BROKER_INJECTION_DEFAULT" default:"false"`
 }
 
 func onByDefault(labels map[string]string) bool {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -64,6 +64,8 @@ function install_broker() {
 function install_mt_broker() {
   ko apply --strict -f ${MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG} || return 1
   ko apply --strict -f ${MT_CHANNEL_BASED_BROKER_CONFIG_DIR} || return 1
+  wait_until_pods_running knative-eventing || return 1
+  kubectl -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing with MT Broker did not come up"
 }
 


### PR DESCRIPTION
Let's please DISABLE the "auto MT broker injection" for the 0.14 release.

**Potential issues** 

1. both (channel and mt) "default brokers" are called `default`:
I understand the name should have no impact. That's good, but let's than not auto generate all MT brokers, if we are NOT explicitly enable it. See 2)

2. Currently the "channel broker" is default, however, regardless the MT-broker still generates a lot of brokers (for all namespaces), with the name `default`. This prevents the `kubectl label namespace default knative-eventing-injection=enabled` to create a "channel broker" for my namespace. because the MT broker was already there :disappointed: 

3. Because it still generates all these brokers, but they are not functioning, see:
```
k get brokers --all-namespaces
NAMESPACE          NAME      READY   REASON                 URL                                                        AGE
default            default   False   EndpointsUnavailable   http://default-broker.default.svc.cluster.local            8s
knative-eventing   default   False   EndpointsUnavailable   http://default-broker.knative-eventing.svc.cluster.local   7s
knative-serving    default   False   EndpointsUnavailable   http://default-broker.knative-serving.svc.cluster.local    7s
kourier-system     default   False   EndpointsUnavailable   http://default-broker.kourier-system.svc.cluster.local     7s
kube-node-lease    default   False   EndpointsUnavailable   http://default-broker.kube-node-lease.svc.cluster.local    8s
kube-public        default   False   EndpointsUnavailable   http://default-broker.kube-public.svc.cluster.local        8s
kube-system        default   False   EndpointsUnavailable   http://default-broker.kube-system.svc.cluster.local        8s
```

And, like stated in 2. I can NOT generate a "non mt" broker, with the normal "injection" knative-eventing-injection=enabled, because the MT broker did already create one instance of itself for me, in all my namespaces.


** With this PR **

MT broker is "completely disabled", but can be deployed to knative. Has _no_ undesired sideeffect.


Turning it on, is like:

1. change the `config-br-defaults` ConfigMap and set the value of the `brokerClass` to `MTChannelBasedBroker`
2. change the `mt-broker-controller` Deployment, and set the `BROKER_INJECTION_DEFAULT` value to `true`. 

Now, all "default" MT brokers are good:

```
k get brokers --all-namespaces
NAMESPACE          NAME      READY   REASON   URL                                                                                 AGE
default            default   True             http://broker-ingress.knative-eventing.svc.cluster.local/default/default            10s
knative-eventing   default   True             http://broker-ingress.knative-eventing.svc.cluster.local/knative-eventing/default   12s
knative-serving    default   True             http://broker-ingress.knative-eventing.svc.cluster.local/knative-serving/default    10s
kourier-system     default   True             http://broker-ingress.knative-eventing.svc.cluster.local/kourier-system/default     12s
kube-node-lease    default   True             http://broker-ingress.knative-eventing.svc.cluster.local/kube-node-lease/default    10s
kube-public        default   True             http://broker-ingress.knative-eventing.svc.cluster.local/kube-public/default        11s
kube-system        default   True             http://broker-ingress.knative-eventing.svc.cluster.local/kube-system/default        11s

```







When _both_ brokers are deployed, with the following config:

`channelBased` configured default
`mt-channel-broker` is NOT the default, but has `BROKER_INJECTION_DEFAULT` set to `true`

There are a couple of issues:
* both brokers are called `default`. 

I get that we want that, but this kinda really prevents, that the mt-broker should 

due to conflicts with regular 'default' broker


```
NAMESPACE          NAME      READY   REASON                 URL                                                        AGE
default            default   True                           http://default-broker.default.svc.cluster.local            2m5s
knative-eventing   default   False   EndpointsUnavailable   http://default-broker.knative-eventing.svc.cluster.local   22s
knative-serving    default   False   EndpointsUnavailable   http://default-broker.knative-serving.svc.cluster.local    23s
kourier-system     default   False   EndpointsUnavailable   http://default-broker.kourier-system.svc.cluster.local     23s
kube-node-lease    default   False   EndpointsUnavailable   http://default-broker.kube-node-lease.svc.cluster.local    22s
kube-public        default   False   EndpointsUnavailable   http://default-broker.kube-public.svc.cluster.local        22s
kube-system        default   False   EndpointsUnavailable   http://default-broker.kube-system.svc.cluster.local        23s

```



Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>
