### PR TITLE
Add the missing label eventing.knative.dev/release to the ConfigMaps

### DIFF
--- a/config/core/configmaps/default-broker-channel.yaml
+++ b/config/core/configmaps/default-broker-channel.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-br-default-channel
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 data:
   channelTemplateSpec: |
     apiVersion: messaging.knative.dev/v1alpha1

--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: config-br-defaults
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |

--- a/config/core/configmaps/default-channel.yaml
+++ b/config/core/configmaps/default-channel.yaml
@@ -17,6 +17,8 @@ kind: ConfigMap
 metadata:
   name: default-ch-webhook
   namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-ch-config: |


### PR DESCRIPTION
Fixes #2950

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- This PR adds the missing label `eventing.knative.dev/release` to the ConfigMaps.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
