### PR TITLE
Bump zipkin polling timeout to 5 minutes in tracing tests

### DIFF
--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -106,7 +106,7 @@ func tracingTest(
 	matches := assertEventMatch(t, client, loggerPodName, mustMatch)
 
 	traceID := getTraceIDHeader(t, matches)
-	trace, err := zipkin.JSONTracePred(traceID, 2*time.Minute, func(trace []model.SpanModel) bool {
+	trace, err := zipkin.JSONTracePred(traceID, 5*time.Minute, func(trace []model.SpanModel) bool {
 		tree, err := tracinghelper.GetTraceTree(trace)
 		if err != nil {
 			return false


### PR DESCRIPTION
Tracing tests would occasionally timeout with the 2 minute timeout causing test flakiness.

Fixes #2857
