### PR TITLE
Fixes the aggregated cluster roles for PodSpecable.

### DIFF
--- a/config/core/roles/podspecable-binding-clusterrole.yaml
+++ b/config/core/roles/podspecable-binding-clusterrole.yaml
@@ -33,7 +33,7 @@ metadata:
   name: builtin-podspecable-binding
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
 # Do not use this role directly. These rules will be added to the "podspecable-binding role.
 rules:
 


### PR DESCRIPTION
- 🐛 Fix bug

This works fine for SinkBinding because it gets Addressable, but other bindings aren't so fortunate.
