### PR TITLE
Add namespace to Trigger's structural schema

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -104,6 +104,9 @@ spec:
                       kind:
                         type: string
                         minLength: 1
+                      namespace:
+                        type: string
+                        minLength: 1
                       name:
                         type: string
                         minLength: 1
@@ -152,6 +155,9 @@ spec:
                         type: string
                         minLength: 1
                       kind:
+                        type: string
+                        minLength: 1
+                      namespace:
                         type: string
                         minLength: 1
                       name:


### PR DESCRIPTION
Fixes #2972

## Proposed Changes

- Add the missing `namespace` attribute under `.spec.subscriber.ref` (Trigger CRD)