### PR TITLE
Status conformance tests for channels

### DIFF
--- a/test/conformance/channel_status_test.go
+++ b/test/conformance/channel_status_test.go
@@ -1,0 +1,30 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"knative.dev/eventing/test/conformance/helpers"
+	"knative.dev/eventing/test/lib"
+)
+
+func TestChannelStatus(t *testing.T) {
+	helpers.ChannelStatusTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+}

--- a/test/conformance/helpers/channel.go
+++ b/test/conformance/helpers/channel.go
@@ -31,11 +31,11 @@ func getChannelDuckTypeSupportVersion(channelName string, client *lib.Client, ch
 	metaResource := resources.NewMetaResource(channelName, client.Namespace, channel)
 	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})
 	if err != nil {
-		return "", errors.Wrapf(err, "Unable to GET the channel %q", metaResource)
+		return "", errors.Wrapf(err, "Unable to GET the channel %v", metaResource)
 	}
 	channelable, ok := obj.(*eventingduckv1beta1.Channelable)
 	if !ok {
-		return "", errors.Wrapf(err, "Unable to cast the channel %q", metaResource)
+		return "", errors.Wrapf(err, "Unable to cast the channel %v", metaResource)
 	}
 	return channelable.ObjectMeta.Annotations[SubscribableAnnotationKey], nil
 }

--- a/test/conformance/helpers/channel.go
+++ b/test/conformance/helpers/channel.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"github.com/pkg/errors"
+	"knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/duck"
+	"knative.dev/eventing/test/lib/resources"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+)
+
+func getChannelDuckTypeSupportVersion(channelName string, client *lib.Client, channel *metav1.TypeMeta) (string, error) {
+	metaResource := resources.NewMetaResource(channelName, client.Namespace, channel)
+	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})
+	if err != nil {
+		return "", errors.Wrapf(err, "Unable to GET the channel %q", metaResource)
+	}
+	channelable, ok := obj.(*eventingduckv1beta1.Channelable)
+	if !ok {
+		return "", errors.Wrapf(err, "Unable to cast the channel %q", metaResource)
+	}
+	return channelable.ObjectMeta.Annotations[SubscribableAnnotationKey], nil
+}
+
+func getChannelAsV1Beta1Channelable(channelName string, client *lib.Client, channel metav1.TypeMeta) (*eventingduckv1beta1.Channelable, error) {
+	metaResource := resources.NewMetaResource(channelName, client.Namespace, &channel)
+	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to get the channel as v1beta1 Channel duck type: %q", channel)
+	}
+	channelable, ok := obj.(*eventingduckv1beta1.Channelable)
+	if !ok {
+		return nil, errors.Errorf("Unable to cast channel %q to v1beta1 duck type", channel)
+	}
+
+	return channelable, nil
+}
+
+func getChannelAsV1Alpha1Channelable(channelName string, client *lib.Client, channel metav1.TypeMeta) (*eventingduckv1alpha1.Channelable, error) {
+	metaResource := resources.NewMetaResource(channelName, client.Namespace, &channel)
+	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1alpha1.Channelable{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to get the channel as v1alpha1 Channel duck type: %q", channel)
+	}
+	channelable, ok := obj.(*eventingduckv1alpha1.Channelable)
+	if !ok {
+		return nil, errors.Errorf("Unable to cast channel %q to v1alpha1 duck type", channel)
+	}
+
+	return channelable, nil
+}

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -57,7 +57,7 @@ func channelHasRequiredStatus(st *testing.T, client *lib.Client, channel metav1.
 
 	dtsv, err := getChannelDuckTypeSupportVersion(channelName, client, &channel)
 	if err != nil {
-		st.Fatalf("Unable to check Channel duck type support version for: %q", channel)
+		st.Fatalf("Unable to check Channel duck type support version for %q: %q", channel, err)
 	}
 
 	if dtsv == "" || dtsv == "v1alpha1" {

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/eventing/test/lib"
+)
+
+const (
+	SubscribableAnnotationKey = "messaging.knative.dev/subscribable"
+)
+
+// ChannelStatusTestHelperWithChannelTestRunner runs the Channel metadata tests for all Channels in
+// the ChannelTestRunner.
+func ChannelStatusTestHelperWithChannelTestRunner(
+	t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption,
+) {
+
+	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := lib.Setup(st, true, options...)
+		defer lib.TearDown(client)
+
+		t.Run("Channel has required status fields", func(t *testing.T) {
+			channelHasRequiredStatus(st, client, channel, options...)
+		})
+	})
+}
+
+func channelHasRequiredStatus(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
+	st.Logf("Running channel status conformance test with channel %q", channel)
+
+	channelName := "channel-req-labels"
+
+	client.T.Logf("Creating channel %+v-%s", channel, channelName)
+	client.CreateChannelOrFail(channelName, &channel)
+	client.WaitForResourceReadyOrFail(channelName, &channel)
+
+	dtsv, err := getChannelDuckTypeSupportVersion(channelName, client, &channel)
+	if err != nil {
+		st.Fatalf("Unable to check Channel duck type support version for: %q", channel)
+	}
+
+	if dtsv == "" || dtsv == "v1alpha1" {
+		// treat missing annotation value as v1alpha1, as written in the spec
+		channelable, err := getChannelAsV1Alpha1Channelable(channelName, client, channel)
+		if err != nil {
+			st.Fatalf("Unable to get channel %q to v1alpha1 duck type: %q", channel, err)
+		}
+
+		// SPEC: Channel CRD MUST have a status subresource which contains address
+		if channelable.Status.AddressStatus.Address == nil {
+			st.Fatalf("%q does not have status.address", channel)
+		}
+
+		// SPEC: When the channel instance is ready to receive events status.address.hostname and
+		// status.address.url MUST be populated
+		if channelable.Status.AddressStatus.Address.Hostname == "" {
+			st.Fatalf("No hostname found for %q", channel)
+		}
+		if channelable.Status.AddressStatus.Address.URL.IsEmpty() {
+			st.Fatalf("No hostname found for %q", channel)
+		}
+	} else if dtsv == "v1beta1" {
+		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
+		if err != nil {
+			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)
+		}
+
+		// SPEC: Channel CRD MUST have a status subresource which contains address
+		if channelable.Status.AddressStatus.Address == nil {
+			st.Fatalf("%q does not have status.address", channel)
+		}
+
+		// SPEC: When the channel instance is ready to receive events status.address.hostname and
+		// status.address.url MUST be populated
+		if channelable.Status.Address.URL.IsEmpty() {
+			st.Fatalf("No hostname found for %q", channel)
+		}
+	} else {
+		st.Fatalf("Channel doesn't support v1alpha1 nor v1beta1 Channel duck types: %q", channel)
+	}
+}


### PR DESCRIPTION
Fixes #2992

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Conformance tests for Channel status
- Does not include tests for https://github.com/knative/eventing/issues/2993 nor https://github.com/knative/eventing/issues/1958

**Verification happy case**:
```
go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestChannelStatus$ -channels="messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel"
```

**Verification unhappy case**:
To make the test fail for a non-compliant channel: 
- create a CRD like following
```
cat <<EOS |kubectl apply -f -
---
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: foochannels.example.com
spec:
  group: example.com
  versions:
    - name: v1
      served: true
      storage: true
  scope: Namespaced
  names:
    plural: foochannels
    singular: foochannel
    kind: FooChannel
EOS
```
- comment out the `client.WaitForResourceReadyOrFail(channelName, &channel)` line as the CR for that CRD won't be `Ready` never ever
- Run the test:
```
go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestChannelStatus$ -channels="example.com/v1:FooChannel"
```

The test will fail:
```
{"FooChannel" "example.com/v1"} does not have status.address
```