### PR TITLE
Use imc v1beta1 for default broker channel (not v1alpha1)

### DIFF
--- a/config/core/configmaps/default-broker-channel.yaml
+++ b/config/core/configmaps/default-broker-channel.yaml
@@ -21,5 +21,5 @@ metadata:
     eventing.knative.dev/release: devel
 data:
   channelTemplateSpec: |
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: InMemoryChannel


### PR DESCRIPTION
Fixes: knative/eventing#3002


----

#