### PR TITLE
Moved MessageDispatcher initialization and configuration

### DIFF
--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -48,7 +48,7 @@ type Config struct {
 	Subscriptions []eventingduck.SubscriberSpec `json:"subscriptions"`
 	// AsyncHandler controls whether the Subscriptions are called synchronous or asynchronously.
 	// It is expected to be false when used as a sidecar.
-	AsyncHandler     bool `json:"asyncHandler,omitempty"`
+	AsyncHandler bool `json:"asyncHandler,omitempty"`
 }
 
 // Handler is a http.Handler that takes a single request in and fans it out to N other servers.

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -49,7 +49,6 @@ type Config struct {
 	// AsyncHandler controls whether the Subscriptions are called synchronous or asynchronously.
 	// It is expected to be false when used as a sidecar.
 	AsyncHandler     bool `json:"asyncHandler,omitempty"`
-	DispatcherConfig channel.EventDispatcherConfig
 }
 
 // Handler is a http.Handler that takes a single request in and fans it out to N other servers.
@@ -57,7 +56,7 @@ type MessageHandler struct {
 	config Config
 
 	receiver   *channel.MessageReceiver
-	dispatcher *channel.MessageDispatcherImpl
+	dispatcher channel.MessageDispatcher
 
 	// TODO: Plumb context through the receiver and dispatcher and use that to store the timeout,
 	// rather than a member variable.
@@ -67,11 +66,11 @@ type MessageHandler struct {
 }
 
 // NewHandler creates a new fanout.MessageHandler.
-func NewMessageHandler(logger *zap.Logger, config Config) (*MessageHandler, error) {
+func NewMessageHandler(logger *zap.Logger, messageDispatcher channel.MessageDispatcher, config Config) (*MessageHandler, error) {
 	handler := &MessageHandler{
 		logger:     logger,
 		config:     config,
-		dispatcher: channel.NewMessageDispatcherFromConfig(logger, config.DispatcherConfig),
+		dispatcher: messageDispatcher,
 		timeout:    defaultTimeout,
 	}
 	// The receiver function needs to point back at the handler itself, so set it up after

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -251,10 +251,14 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 		t.Fatal(err)
 	}
 
-	h, err := NewMessageHandler(logger, Config{
-		Subscriptions: subs,
-		AsyncHandler:  async,
-	})
+	h, err := NewMessageHandler(
+		logger,
+		channel.NewMessageDispatcher(logger),
+		Config{
+			Subscriptions: subs,
+			AsyncHandler:  async,
+		},
+	)
 	if err != nil {
 		t.Fatalf("NewHandler failed. Error:%s", err)
 	}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
@@ -47,10 +47,9 @@ func makeChannelKeyFromConfig(config ChannelConfig) string {
 // on, and then delegates handling of that request to the single fanout.MessageHandler corresponding to
 // that Channel.
 type MessageHandler struct {
-	logger            *zap.Logger
-	handlers          map[string]*fanout.MessageHandler
-	messageDispatcher channel.MessageDispatcher
-	config            Config
+	logger   *zap.Logger
+	handlers map[string]*fanout.MessageHandler
+	config   Config
 }
 
 // NewHandler creates a new Handler.
@@ -72,10 +71,9 @@ func NewMessageHandler(ctx context.Context, logger *zap.Logger, messageDispatche
 	}
 
 	return &MessageHandler{
-		logger:            logger,
-		config:            conf,
-		handlers:          handlers,
-		messageDispatcher: messageDispatcher,
+		logger:   logger,
+		config:   conf,
+		handlers: handlers,
 	}, nil
 }
 
@@ -88,8 +86,8 @@ func (h *MessageHandler) ConfigDiff(updated Config) string {
 
 // CopyWithNewConfig creates a new copy of this Handler with all the fields identical, except the
 // new Handler uses conf, rather than copying the existing Handler's config.
-func (h *MessageHandler) CopyWithNewConfig(ctx context.Context, conf Config) (*MessageHandler, error) {
-	return NewMessageHandler(ctx, h.logger, h.messageDispatcher, conf)
+func (h *MessageHandler) CopyWithNewConfig(ctx context.Context, dispatcherConfig channel.EventDispatcherConfig, conf Config) (*MessageHandler, error) {
+	return NewMessageHandler(ctx, h.logger, channel.NewMessageDispatcherFromConfig(h.logger, dispatcherConfig), conf)
 }
 
 // ServeHTTP delegates the actual handling of the request to a fanout.MessageHandler, based on the

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 )
 
@@ -63,7 +64,13 @@ func TestNewMessageHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+			_, err := NewMessageHandler(
+				context.TODO(),
+				logger,
+				channel.NewMessageDispatcher(logger),
+				tc.config,
+			)
 			if tc.createErr != "" {
 				if err == nil {
 					t.Errorf("Expected NewHandler error: '%v'. Actual nil", tc.createErr)
@@ -112,7 +119,13 @@ func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
 	if cmp.Equal(orig, updated) {
 		t.Errorf("Orig and updated must be different")
 	}
-	h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), orig)
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+	h, err := NewMessageHandler(
+		context.TODO(),
+		logger,
+		channel.NewMessageDispatcher(logger),
+		orig,
+	)
 	if err != nil {
 		t.Errorf("Unable to create handler, %v", err)
 	}
@@ -182,7 +195,8 @@ func TestConfigDiffMessageHandler(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.orig)
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+			h, err := NewMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger), tc.orig)
 			if err != nil {
 				t.Errorf("Unable to create handler: %v", err)
 			}
@@ -277,7 +291,8 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 			// Rewrite the replaceDomains to call the server we just created.
 			replaceDomains(tc.config, server.URL[7:])
 
-			h, err := NewMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())), tc.config)
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+			h, err := NewMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger), tc.config)
 			if err != nil {
 				t.Fatalf("Unexpected NewHandler error: '%v'", err)
 			}

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -132,7 +132,7 @@ func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
 	if !cmp.Equal(h.config, orig) {
 		t.Errorf("Incorrect config. Expected '%v'. Actual '%v'", orig, h.config)
 	}
-	newH, err := h.CopyWithNewConfig(context.TODO(), updated)
+	newH, err := h.CopyWithNewConfig(context.TODO(), channel.EventDispatcherConfig{}, updated)
 	if err != nil {
 		t.Errorf("Unable to copy handler: %v", err)
 	}

--- a/pkg/channel/swappable/swappable_message_handler_test.go
+++ b/pkg/channel/swappable/swappable_message_handler_test.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 )
@@ -79,7 +80,8 @@ func TestMessageHandler(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+			h, err := NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -125,7 +127,8 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			h, err := NewEmptyMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+			h, err := NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 			if err != nil {
 				t.Errorf("Unexpected error creating handler: %v", err)
 			}
@@ -153,7 +156,8 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 }
 
 func TestMessageHandler_NilConfigChange(t *testing.T) {
-	h, err := NewEmptyMessageHandler(context.TODO(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())))
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+	h, err := NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 	if err != nil {
 		t.Errorf("Unexpected error creating handler: %v", err)
 	}

--- a/pkg/channel/swappable/swappable_message_handler_test.go
+++ b/pkg/channel/swappable/swappable_message_handler_test.go
@@ -137,7 +137,7 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 			defer server.Close()
 
 			rc := replaceDomains(tc.initialConfig, server.URL[7:])
-			err = h.UpdateConfig(context.TODO(), &rc)
+			err = h.UpdateConfig(context.TODO(), channel.EventDispatcherConfig{}, &rc)
 			if err != nil {
 				t.Errorf("Unexpected error updating to initial config: %v", tc.initialConfig)
 			}
@@ -146,7 +146,7 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 			// Try to update to the new config, it will fail. But we should still be able to hit the
 			// original server.
 			ruc := replaceDomains(tc.badUpdateConfig, server.URL[7:])
-			err = h.UpdateConfig(context.TODO(), &ruc)
+			err = h.UpdateConfig(context.TODO(), channel.EventDispatcherConfig{}, &ruc)
 			if err == nil {
 				t.Errorf("Expected an error when updating to a bad config.")
 			}
@@ -162,7 +162,7 @@ func TestMessageHandler_NilConfigChange(t *testing.T) {
 		t.Errorf("Unexpected error creating handler: %v", err)
 	}
 
-	err = h.UpdateConfig(context.TODO(), nil)
+	err = h.UpdateConfig(context.TODO(), channel.EventDispatcherConfig{}, nil)
 	if err == nil {
 		t.Errorf("Expected an error when updating to a nil config.")
 	}
@@ -174,7 +174,7 @@ func updateConfigAndTest(t *testing.T, h *MessageHandler, config multichannelfan
 
 	rc := replaceDomains(config, server.URL[7:])
 	orig := h.fanout.Load()
-	err := h.UpdateConfig(context.TODO(), &rc)
+	err := h.UpdateConfig(context.TODO(), channel.EventDispatcherConfig{}, &rc)
 	if err != nil {
 		t.Errorf("Unexpected error updating config: %+v", err)
 	}

--- a/pkg/inmemorychannel/message_dispatcher.go
+++ b/pkg/inmemorychannel/message_dispatcher.go
@@ -21,13 +21,14 @@ import (
 
 	"go.uber.org/zap"
 
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 	"knative.dev/eventing/pkg/channel/swappable"
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
 type MessageDispatcher interface {
-	UpdateConfig(ctx context.Context, config *multichannelfanout.Config) error
+	UpdateConfig(ctx context.Context, dispatcherConfig channel.EventDispatcherConfig, config *multichannelfanout.Config) error
 }
 
 type InMemoryMessageDispatcher struct {
@@ -45,8 +46,8 @@ type InMemoryMessageDispatcherArgs struct {
 	Logger       *zap.Logger
 }
 
-func (d *InMemoryMessageDispatcher) UpdateConfig(ctx context.Context, config *multichannelfanout.Config) error {
-	return d.handler.UpdateConfig(ctx, config)
+func (d *InMemoryMessageDispatcher) UpdateConfig(ctx context.Context, dispatcherConfig channel.EventDispatcherConfig, config *multichannelfanout.Config) error {
+	return d.handler.UpdateConfig(ctx, dispatcherConfig, config)
 }
 
 // Start starts the inmemory dispatcher's message processing.

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -49,7 +49,7 @@ import (
 
 func TestNewMessageDispatcher(t *testing.T) {
 	logger := logtesting.TestLogger(t).Desugar()
-	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger)
+	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 
 	if err != nil {
 		t.Fatalf("Failed to create handler")
@@ -73,7 +73,7 @@ func TestNewMessageDispatcher(t *testing.T) {
 // This test emulates a real dispatcher usage
 func TestDispatcher_close(t *testing.T) {
 	logger := logtesting.TestLogger(t).Desugar()
-	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger)
+	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 	// tracing publishing is configured to let the code pass in all "critical" branches
 	tracing.SetupStaticPublishing(logger.Sugar(), "localhost", tracing.AlwaysSample)
 
-	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger)
+	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,8 +230,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 				Name:      "channela",
 				HostName:  "channela.svc",
 				FanoutConfig: fanout.Config{
-					AsyncHandler:     false,
-					DispatcherConfig: channel.EventDispatcherConfig{},
+					AsyncHandler: false,
 					Subscriptions: []eventingduck.SubscriberSpec{{
 						UID:           "aaaa",
 						Generation:    1,
@@ -253,8 +252,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 				Name:      "channelb",
 				HostName:  "channelb.svc",
 				FanoutConfig: fanout.Config{
-					AsyncHandler:     false,
-					DispatcherConfig: channel.EventDispatcherConfig{},
+					AsyncHandler: false,
 					Subscriptions: []eventingduck.SubscriberSpec{{
 						UID:           "bbbb",
 						Generation:    1,
@@ -265,7 +263,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 		},
 	}
 
-	err = sh.UpdateConfig(context.TODO(), &config)
+	err = sh.UpdateConfig(context.TODO(), channel.EventDispatcherConfig{}, &config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"time"
 
-	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
 	"knative.dev/pkg/logging"
+
+	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1alpha1/inmemorychannel"
 
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
@@ -59,7 +60,7 @@ func NewController(
 		logger.Fatalw("Error setting up trace publishing", zap.Error(err))
 	}
 
-	sh, err := swappable.NewEmptyMessageHandler(ctx, logger.Desugar())
+	sh, err := swappable.NewEmptyMessageHandler(ctx, logger.Desugar(), channel.NewMessageDispatcher(logger.Desugar()))
 	if err != nil {
 		logger.Fatalw("Error creating swappable.MessageHandler", zap.Error(err))
 	}
@@ -91,7 +92,7 @@ func NewController(
 	// Watch for configmap changes and trigger imc reconciliation by enqueuing imcs.
 	configStore := channel.NewEventDispatcherConfigStore(logging.FromContext(ctx), resyncIMCs)
 	configStore.WatchConfigs(cmw)
-	r.configStore = configStore
+	r.eventDispatcherConfigStore = configStore
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -29,14 +29,15 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"knative.dev/pkg/controller"
+	logtesting "knative.dev/pkg/logging/testing"
+	. "knative.dev/pkg/reconciler/testing"
+
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/messaging/v1alpha1"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 	. "knative.dev/eventing/pkg/reconciler/testing"
 	reconciletesting "knative.dev/eventing/pkg/reconciler/testing"
-	"knative.dev/pkg/controller"
-	logtesting "knative.dev/pkg/logging/testing"
-	. "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -108,9 +109,9 @@ func TestAllCases(t *testing.T) {
 		r := &Reconciler{
 			inmemorychannelLister: listers.GetInMemoryChannelLister(),
 			// TODO: FIx
-			inmemorychannelInformer: nil,
-			dispatcher:              &fakeDispatcher{},
-			configStore:             channel.NewEventDispatcherConfigStore(logger),
+			inmemorychannelInformer:    nil,
+			dispatcher:                 &fakeDispatcher{},
+			eventDispatcherConfigStore: channel.NewEventDispatcherConfigStore(logger),
 		}
 		return inmemorychannel.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetInMemoryChannelLister(),
@@ -120,7 +121,7 @@ func TestAllCases(t *testing.T) {
 
 type fakeDispatcher struct{}
 
-func (d *fakeDispatcher) UpdateConfig(ctx context.Context, config *multichannelfanout.Config) error {
+func (d *fakeDispatcher) UpdateConfig(_ context.Context, _ channel.EventDispatcherConfig, _ *multichannelfanout.Config) error {
 	// TODO set error
 	return nil
 }


### PR DESCRIPTION
With this patch one `channel.MessageDispatcher` is created for one `multichannelfanout.MessageHandler`, which means one http client. This should reduce memory usage/resource allocations (although i didn't tested it) and it's useful for mocking (followup PR will use this change to mock the dispatcher for micro benchmarks).

## Release notes

```
Now the MaxIdleConnections setting configured via config-imc-event-dispatcher applies to all channels registered in the dispatcher instance at the same time, because the dispatcher now uses the same http client instance for all channels 
```