### PR TITLE
Fixing subscriberUri path in additionalPrinterColumns

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -51,7 +51,7 @@ spec:
       JSONPath: .spec.broker
     - name: Subscriber_URI
       type: string
-      JSONPath: .status.subscriberURI
+      JSONPath: .status.subscriberUri
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #3012

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Correcting the jsonpath in `triggers.eventing.knative.dev` CRD: (notice the different case of `subscriberURI` vs `subscriberUri `)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

-->

```release-note
- 🐛 Fix bug SUBSCRIBER_URI was not printed on for triggers

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
