### PR TITLE
0.14 patch: Fixing subscriberUri path in additionalPrinterColumns

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -51,7 +51,7 @@ spec:
       JSONPath: .spec.broker
     - name: Subscriber_URI
       type: string
-      JSONPath: .status.subscriberURI
+      JSONPath: .status.subscriberUri
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
porting #3013 to `release-0.14` branch

```release-note
- 🐛 Fix bug SUBSCRIBER_URI was not printed on for triggers

```