### PR TITLE
Fixing upgrade job so it will work with istio auto-injection

### DIFF
--- a/config/upgrade/v0.14.0/upgrade.yaml
+++ b/config/upgrade/v0.14.0/upgrade.yaml
@@ -7,6 +7,9 @@ metadata:
     eventing.knative.dev/release: devel
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: eventing-controller
       restartPolicy: Never


### PR DESCRIPTION
Fixes #3009

Backports #3010

## Proposed Changes

- Add `sidecar.istio.io/inject: "false"` to upgrade job

- 🐛 Fix bug

**Release Note**

```release-note
Fixes issue where v0.14.0-upgrade would fail when istio auto-injection is enabled
```
