### PR TITLE
[release-0.14] Fix channel subscribers patching for v1alpha1 channels. (#2986)

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -473,7 +473,7 @@ func (r *Reconciler) updateChannelRemoveSubscription(ctx context.Context, channe
 			return
 		}
 	}
-	r.updateChannelAddSubscriptionV1Alpha1(ctx, channel, sub)
+	r.updateChannelRemoveSubscriptionV1Alpha1(ctx, channel, sub)
 }
 
 func (r *Reconciler) updateChannelRemoveSubscriptionV1Beta1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1alpha1.Subscription) {
@@ -482,6 +482,21 @@ func (r *Reconciler) updateChannelRemoveSubscriptionV1Beta1(ctx context.Context,
 			channel.Spec.Subscribers = append(
 				channel.Spec.Subscribers[:i],
 				channel.Spec.Subscribers[i+1:]...)
+			return
+		}
+	}
+}
+
+func (r *Reconciler) updateChannelRemoveSubscriptionV1Alpha1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1alpha1.Subscription) {
+	if channel.Spec.Subscribable == nil {
+		return
+	}
+
+	for i, v := range channel.Spec.Subscribable.Subscribers {
+		if v.UID == sub.UID {
+			channel.Spec.Subscribable.Subscribers = append(
+				channel.Spec.Subscribable.Subscribers[:i],
+				channel.Spec.Subscribable.Subscribers[i+1:]...)
 			return
 		}
 	}

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -957,6 +957,9 @@ func TestAllCases(t *testing.T) {
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,
 					WithInMemoryChannelAddress(channelDNS),
+					WithInMemoryChannelSubscribers([]eventingduck.SubscriberSpec{
+						{UID: subscriptionUID, SubscriberURI: subscriberURI},
+					}),
 				),
 			},
 			Key:     testNS + "/" + subscriptionName,
@@ -966,9 +969,7 @@ func TestAllCases(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "SubscriberRemoved", "Subscription was removed from channel \"origin\""),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchSubscribers(testNS, channelName, []eventingduck.SubscriberSpec{
-					{UID: subscriptionUID, SubscriberURI: serviceURI},
-				}),
+				patchSubscribers(testNS, channelName, nil),
 				patchRemoveFinalizers(testNS, subscriptionName),
 			},
 		}, {
@@ -1017,9 +1018,7 @@ func TestAllCases(t *testing.T) {
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchSubscribers(testNS, channelName, []eventingduck.SubscriberSpec{
-					{UID: subscriptionUID, SubscriberURI: serviceURI},
-				}),
+				patchSubscribers(testNS, channelName, nil),
 			},
 		}, {
 			Name: "subscription deleted - channel does not exists",


### PR DESCRIPTION
Backports #2986 (fix for #2985) to 0.14.

## Proposed Changes

- added missing logic (accidentaly became unused after #2682 and removed by #2906)
- updated related test cases

**Release Note**
```release-note
Fix bug with channel subscribers not being patched properly (#2985)
```