### PR TITLE
Conformance test for channelable-manipulator ClusterRole

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1582,7 +1582,6 @@
     "google.golang.org/grpc/status",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",
-    "k8s.io/api/authorization/v1beta1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/batch/v1beta1",
     "k8s.io/api/core/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1582,6 +1582,7 @@
     "google.golang.org/grpc/status",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",
+    "k8s.io/api/authorization/v1beta1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/batch/v1beta1",
     "k8s.io/api/core/v1",

--- a/config/core/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/core/roles/channelable-manipulator-clusterrole.yaml
@@ -25,3 +25,26 @@ aggregationRule:
       duck.knative.dev/channelable: "true"
 rules: [] # Rules are automatically filled in by the controller manager.
 
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: meta-channelable-manipulator
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/channelable: "true"
+# Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels
+  - channels/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/test/conformance/channel_channelable_manipulator_cluster_role_test.go
+++ b/test/conformance/channel_channelable_manipulator_cluster_role_test.go
@@ -1,0 +1,30 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	"knative.dev/eventing/test/conformance/helpers"
+	"knative.dev/eventing/test/lib"
+)
+
+func TestChannelChannelableManipulatorClusterRoleTest(t *testing.T) {
+	helpers.TestChannelChannelableManipulatorClusterRoleTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+}

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	authv1beta1 "k8s.io/api/authorization/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/test/lib"
+)
+
+const aggregationClusterRoleName = "channelable-manipulator"
+
+var permissionTestCaseVerbs = []string{"get", "list", "watch", "update", "patch"}
+
+func TestChannelChannelableManipulatorClusterRoleTestRunner(
+	t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption,
+) {
+
+	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := lib.Setup(st, true, options...)
+		defer lib.TearDown(client)
+
+		saName := "conformance-test-channel-manipulator"
+
+		client.CreateServiceAccountOrFail(saName)
+		client.CreateClusterRoleBindingOrFail(
+			saName,
+			aggregationClusterRoleName,
+			saName+"-cluster-role-binding",
+		)
+
+		for _, verb := range permissionTestCaseVerbs {
+			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q", verb), func(t *testing.T) {
+				serviceAccountCanDoVerbOnResource(st, client, channel, saName, verb)
+			})
+		}
+	})
+}
+
+func serviceAccountCanDoVerbOnResource(st *testing.T, client *lib.Client, channel metav1.TypeMeta, saName string, verb string) {
+	// From spec: (...) ClusterRole MUST include permissions to create, get, list, watch, patch,
+	// and update the CRD's custom objects and their status.
+	allowed, err := isAllowed(saName, client, verb, channel)
+	if err != nil {
+		client.T.Fatalf("Error while checking if %q is not allowed on %q : %q", verb, channel, err)
+	}
+	if !allowed {
+		client.T.Fatalf("Operation %q is not allowed on : %q", verb, channel)
+	}
+}
+
+func isAllowed(saName string, client *lib.Client, verb string, typeMeta metav1.TypeMeta) (bool, error) {
+	gvr, _ := meta.UnsafeGuessKindToResource(typeMeta.GroupVersionKind())
+
+	r, err := client.Kube.Kube.AuthorizationV1beta1().SubjectAccessReviews().Create(&authv1beta1.SubjectAccessReview{
+		Spec: authv1beta1.SubjectAccessReviewSpec{
+			User: fmt.Sprintf("system:serviceaccount:%s:%s", client.Namespace, saName),
+			ResourceAttributes: &authv1beta1.ResourceAttributes{
+				Verb:     verb,
+				Group:    gvr.Group,
+				Version:  gvr.Version,
+				Resource: gvr.Resource,
+			},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return r.Status.Allowed, nil
+}

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -17,13 +17,16 @@ limitations under the License.
 package helpers
 
 import (
-	"fmt"
-	authv1beta1 "k8s.io/api/authorization/v1beta1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"testing"
 
+	"fmt"
+
+	authv1beta1 "k8s.io/api/authorization/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/names"
+
 	"knative.dev/eventing/test/lib"
 )
 
@@ -41,18 +44,17 @@ func TestChannelChannelableManipulatorClusterRoleTestRunner(
 		client := lib.Setup(st, true, options...)
 		defer lib.TearDown(client)
 
-		saName := "conformance-test-channel-manipulator"
-
-		client.CreateServiceAccountOrFail(saName)
-		client.CreateClusterRoleBindingOrFail(
-			saName,
-			aggregationClusterRoleName,
-			saName+"-cluster-role-binding",
-		)
-
 		gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
 
 		for _, verb := range permissionTestCaseVerbs {
+			saName := names.SimpleNameGenerator.GenerateName("conformance-test-channel-manipulator-")
+			client.CreateServiceAccountOrFail(saName)
+			client.CreateClusterRoleBindingOrFail(
+				saName,
+				aggregationClusterRoleName,
+				saName+"-cluster-role-binding",
+			)
+
 			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q", verb), func(t *testing.T) {
 				serviceAccountCanDoVerbOnResource(st, client, gvr, "", saName, verb)
 			})

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -46,29 +46,28 @@ func TestChannelChannelableManipulatorClusterRoleTestRunner(
 
 		gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
 
+		saName := names.SimpleNameGenerator.GenerateName("conformance-test-channel-manipulator-")
+		client.CreateServiceAccountOrFail(saName)
+		client.CreateClusterRoleBindingOrFail(
+			saName,
+			aggregationClusterRoleName,
+			saName+"-cluster-role-binding",
+		)
+
 		for _, verb := range permissionTestCaseVerbs {
-			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q on %q", verb, gvr), func(t *testing.T) {
-				serviceAccountCanDoVerbOnResource(st, client, gvr, "", verb)
+			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %s on %s", verb, gvr), func(t *testing.T) {
+				serviceAccountCanDoVerbOnResource(st, client, gvr, "", saName, verb)
 			})
-			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q on status subresource of %q", verb, gvr), func(t *testing.T) {
-				serviceAccountCanDoVerbOnResource(st, client, gvr, "status", verb)
+			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %s on status subresource of %s", verb, gvr), func(t *testing.T) {
+				serviceAccountCanDoVerbOnResource(st, client, gvr, "status", saName, verb)
 			})
 		}
 	})
 }
 
-func serviceAccountCanDoVerbOnResource(st *testing.T, client *lib.Client, gvr schema.GroupVersionResource, subresource string, verb string) {
+func serviceAccountCanDoVerbOnResource(st *testing.T, client *lib.Client, gvr schema.GroupVersionResource, subresource string, saName string, verb string) {
 	// From spec: (...) ClusterRole MUST include permissions to create, get, list, watch, patch,
 	// and update the CRD's custom objects and their status.
-
-	saName := names.SimpleNameGenerator.GenerateName("conformance-test-channel-manipulator-")
-	client.CreateServiceAccountOrFail(saName)
-	client.CreateClusterRoleBindingOrFail(
-		saName,
-		aggregationClusterRoleName,
-		saName+"-cluster-role-binding",
-	)
-
 	allowed, err := isAllowed(saName, client, verb, gvr, subresource)
 	if err != nil {
 		client.T.Fatalf("Error while checking if %q is not allowed on %s.%s/%s subresource:%q. err: %q", verb, gvr.Resource, gvr.Group, gvr.Version, subresource, err)

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -55,10 +55,10 @@ func TestChannelChannelableManipulatorClusterRoleTestRunner(
 				saName+"-cluster-role-binding",
 			)
 
-			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q", verb), func(t *testing.T) {
+			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q on %q", verb, gvr), func(t *testing.T) {
 				serviceAccountCanDoVerbOnResource(st, client, gvr, "", saName, verb)
 			})
-			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q on status subresource", verb), func(t *testing.T) {
+			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %q on status subresource of %q", verb, gvr), func(t *testing.T) {
 				serviceAccountCanDoVerbOnResource(st, client, gvr, "status", saName, verb)
 			})
 		}

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -21,7 +21,7 @@ import (
 
 	"fmt"
 
-	authv1beta1 "k8s.io/api/authorization/v1beta1"
+	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,6 +53,7 @@ func TestChannelChannelableManipulatorClusterRoleTestRunner(
 			aggregationClusterRoleName,
 			saName+"-cluster-role-binding",
 		)
+		client.WaitForAllTestResourcesReadyOrFail()
 
 		for _, verb := range permissionTestCaseVerbs {
 			t.Run(fmt.Sprintf("ChannelableManipulatorClusterRole can do %s on %s", verb, gvr), func(t *testing.T) {
@@ -79,10 +80,10 @@ func serviceAccountCanDoVerbOnResource(st *testing.T, client *lib.Client, gvr sc
 
 func isAllowed(saName string, client *lib.Client, verb string, gvr schema.GroupVersionResource, subresource string) (bool, error) {
 
-	r, err := client.Kube.Kube.AuthorizationV1beta1().SubjectAccessReviews().Create(&authv1beta1.SubjectAccessReview{
-		Spec: authv1beta1.SubjectAccessReviewSpec{
+	r, err := client.Kube.Kube.AuthorizationV1().SubjectAccessReviews().Create(&authv1.SubjectAccessReview{
+		Spec: authv1.SubjectAccessReviewSpec{
 			User: fmt.Sprintf("system:serviceaccount:%s:%s", client.Namespace, saName),
-			ResourceAttributes: &authv1beta1.ResourceAttributes{
+			ResourceAttributes: &authv1.ResourceAttributes{
 				Verb:        verb,
 				Group:       gvr.Group,
 				Version:     gvr.Version,


### PR DESCRIPTION
Fixes #1846

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Conformance tests for channelable-manipulator ClusterRole
- channelable-manipulator ClusterRole for meta `Channel`. see the comment https://github.com/knative/eventing/pull/3038#pullrequestreview-398213011

**Verification:**
```
go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestChannelChannelableManipulatorClusterRoleTest$
```