### PR TITLE
fix issue 3014

### DIFF
--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion.go
@@ -28,8 +28,6 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/apis/messaging"
-
-	//	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
 )
 
@@ -39,6 +37,9 @@ func (source *InMemoryChannel) ConvertTo(ctx context.Context, obj apis.Convertib
 	switch sink := obj.(type) {
 	case *v1beta1.InMemoryChannel:
 		sink.ObjectMeta = source.ObjectMeta
+		if sink.Annotations == nil {
+			sink.Annotations = make(map[string]string)
+		}
 		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 		source.Status.ConvertTo(ctx, &sink.Status)
 		return source.Spec.ConvertTo(ctx, &sink.Spec)
@@ -88,6 +89,9 @@ func (sink *InMemoryChannel) ConvertFrom(ctx context.Context, obj apis.Convertib
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, source.Status)
 		sink.Spec.ConvertFrom(ctx, source.Spec)
+		if sink.Annotations == nil {
+			sink.Annotations = make(map[string]string)
+		}
 		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 		return nil
 	default:

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion.go
@@ -27,6 +27,9 @@ import (
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/apis/messaging"
+
+	//	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
 )
 
@@ -36,6 +39,7 @@ func (source *InMemoryChannel) ConvertTo(ctx context.Context, obj apis.Convertib
 	switch sink := obj.(type) {
 	case *v1beta1.InMemoryChannel:
 		sink.ObjectMeta = source.ObjectMeta
+		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 		source.Status.ConvertTo(ctx, &sink.Status)
 		return source.Spec.ConvertTo(ctx, &sink.Spec)
 	default:
@@ -84,6 +88,7 @@ func (sink *InMemoryChannel) ConvertFrom(ctx context.Context, obj apis.Convertib
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, source.Status)
 		sink.Spec.ConvertFrom(ctx, source.Spec)
+		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 		return nil
 	default:
 		return fmt.Errorf("unknown version, got: %T", source)

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion_test.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_conversion_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -160,6 +161,12 @@ func TestInMemoryChannelConversion(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+				// Make sure the annotation specifies the correct duck.
+				if test.in.Annotations == nil {
+					test.in.Annotations = make(map[string]string)
+				}
+				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+
 				if diff := cmp.Diff(test.in, got); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}
@@ -285,6 +292,12 @@ func TestInMemoryChannelConversionWithV1Beta1(t *testing.T) {
 				if err := ver.ConvertTo(context.Background(), got); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+				// Make sure the annotation specifies the correct duck.
+				if test.in.Annotations == nil {
+					test.in.Annotations = make(map[string]string)
+				}
+				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
+
 				if diff := cmp.Diff(test.in, got); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
@@ -31,7 +31,7 @@ func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 	if imc.Annotations == nil {
 		imc.Annotations = make(map[string]string)
 	}
-	imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "alpha1"
+	imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 
 	imc.Spec.SetDefaults(ctx)
 }

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
@@ -31,7 +31,9 @@ func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 	if imc.Annotations == nil {
 		imc.Annotations = make(map[string]string)
 	}
-	imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+	if _, ok := imc.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
+		imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+	}
 
 	imc.Spec.SetDefaults(ctx)
 }

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
@@ -23,12 +23,15 @@ import (
 )
 
 func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
-	// Set the duck subscription to indicate that we support
-	// v1beta1 version of the Subscribable.
+	// Set the duck subscription to the stored version of the duck
+	// we support. Reason for this is that the stored version will
+	// not get a chance to get modified, but for newer versions
+	// conversion webhook will be able to take a crack at it and
+	// can modify it to match the duck shape.
 	if imc.Annotations == nil {
 		imc.Annotations = make(map[string]string)
 	}
-	imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
+	imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "alpha1"
 
 	imc.Spec.SetDefaults(ctx)
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -347,8 +347,6 @@ func (r *Reconciler) trackAndFetchChannel(ctx context.Context, sub *v1alpha1.Sub
 // If the Channel is a channels.messaging type (hence, it's only a factory for
 // underlying channels), fetch and validate the "backing" channel.
 func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription) (*eventingduckv1alpha1.ChannelableCombined, pkgreconciler.Event) {
-	logging.FromContext(ctx).Info("GETTING channel", zap.Any("channel", sub.Spec.Channel))
-
 	// 1. Track the channel pointed by subscription.
 	//   a. If channel is a Channel.messaging.knative.dev
 	obj, err := r.trackAndFetchChannel(ctx, sub, sub.Spec.Channel)
@@ -415,6 +413,9 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription)
 	// v1alpha1 supports v1alpha1 Subscribable duck so override it here.
 	// If there are other channels that have this lying behaviour, add them here...
 	if gvk.Kind == "InMemoryChannel" && gvk.Version == "v1alpha1" {
+		if ch.Annotations == nil {
+			ch.Annotations = make(map[string]string)
+		}
 		ch.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 	}
 

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -347,6 +347,8 @@ func (r *Reconciler) trackAndFetchChannel(ctx context.Context, sub *v1alpha1.Sub
 // If the Channel is a channels.messaging type (hence, it's only a factory for
 // underlying channels), fetch and validate the "backing" channel.
 func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription) (*eventingduckv1alpha1.ChannelableCombined, pkgreconciler.Event) {
+	logging.FromContext(ctx).Info("Getting channel", zap.Any("channel", sub.Spec.Channel))
+
 	// 1. Track the channel pointed by subscription.
 	//   a. If channel is a Channel.messaging.knative.dev
 	obj, err := r.trackAndFetchChannel(ctx, sub, sub.Spec.Channel)

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -408,18 +408,19 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1alpha1.Subscription)
 		return nil, err
 	}
 
-	gvk = obj.GetObjectKind().GroupVersionKind()
+	retCh := ch.DeepCopy()
+	gvk = retCh.GetObjectKind().GroupVersionKind()
 	// IMC has been know to lie about the duck version it supports. We know that
 	// v1alpha1 supports v1alpha1 Subscribable duck so override it here.
 	// If there are other channels that have this lying behaviour, add them here...
 	if gvk.Kind == "InMemoryChannel" && gvk.Version == "v1alpha1" {
-		if ch.Annotations == nil {
-			ch.Annotations = make(map[string]string)
+		if retCh.Annotations == nil {
+			retCh.Annotations = make(map[string]string)
 		}
-		ch.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+		retCh.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
 	}
 
-	return ch, nil
+	return retCh, nil
 }
 
 func isNilOrEmptyDeliveryDeadLetterSink(delivery *eventingduckv1beta1.DeliverySpec) bool {

--- a/test/e2e/channel_single_event_test.go
+++ b/test/e2e/channel_single_event_test.go
@@ -38,6 +38,7 @@ func TestSingleBinaryEventForChannel(t *testing.T) {
 		t,
 		cloudevents.Binary,
 		"v1alpha1",
+		"",
 		channelTestRunner,
 	)
 }
@@ -47,6 +48,7 @@ func TestSingleStructuredEventForChannel(t *testing.T) {
 		t,
 		cloudevents.Structured,
 		"v1alpha1",
+		"",
 		channelTestRunner,
 	)
 }
@@ -56,6 +58,17 @@ func TestSingleBinaryEventForChannelV1Beta1(t *testing.T) {
 		t,
 		cloudevents.Binary,
 		"v1beta1",
+		"",
+		channelTestRunner,
+	)
+}
+
+func TestSingleBinaryEventForChannelV1Beta1SubscribeToV1Alpha1(t *testing.T) {
+	helpers.SingleEventForChannelTestHelper(
+		t,
+		cloudevents.Binary,
+		"v1beta1",
+		"messaging.knative.dev/v1alpha1",
 		channelTestRunner,
 	)
 }
@@ -65,6 +78,7 @@ func TestSingleStructuredEventForChannelV1Beta1(t *testing.T) {
 		t,
 		cloudevents.Structured,
 		"v1beta1",
+		"",
 		channelTestRunner,
 	)
 }

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -36,8 +36,14 @@ const (
 )
 
 // SingleEventForChannelTestHelper is the helper function for channel_single_event_test
+// channelVersion can be used to override which version you want to create the
+// subscription against. For example, you could create a v1beta1 channel, but create
+// a subscription to its v1alpha1 version by using channelVersion to override it.
+// channelVersion == "" means that the version of the channel subscribed to is not
+// modified.
 func SingleEventForChannelTestHelper(t *testing.T, encoding string,
 	subscriptionVersion subscriptionVersion,
+	channelVersion string,
 	channelTestRunner lib.ChannelTestRunner,
 	options ...lib.SetupClientOption) {
 	channelName := "e2e-singleevent-channel-" + encoding
@@ -57,6 +63,11 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding string,
 		pod := resources.EventLoggerPod(loggerPodName)
 		client.CreatePodOrFail(pod, lib.WithService(loggerPodName))
 
+		// If the caller specified a different version, override it here.
+		if channelVersion != "" {
+			st.Logf("Changing API version from: %q to %q", channel.APIVersion, channelVersion)
+			channel.APIVersion = channelVersion
+		}
 		// create subscription to subscribe the channel, and forward the received events to the logger service
 		switch subscriptionVersion {
 		case subscriptionV1alpha1:

--- a/test/lib/duck/resource_checks.go
+++ b/test/lib/duck/resource_checks.go
@@ -35,7 +35,7 @@ import (
 const (
 	// The interval and timeout used for polling in checking resource states.
 	interval = 1 * time.Second
-	timeout  = 4 * time.Minute
+	timeout  = 2 * time.Minute
 )
 
 // WaitForResourceReady polls the status of the MetaResource from client


### PR DESCRIPTION
Fixes #3014

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Return the correct duck shape for IMC. Before this, it would get defaulted to v1beta1 which means that even when read through the v1alpha1 API, it would lie and say it's a v1beta1 duck, which it's not. So, default to _lowest_ version of the duck that we know, which is the same as the stored one, since when that is read through the API server no conversion hooks are invoked and hence we can't modify it. For up conversion to v1beta1, change the duck annotation to the one that it actually supports.
- Also reduce the test timeouts from 4 minutes to 2 minutes.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug - Fix issue #3014 
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
