### PR TITLE
Use correct names for the containers

### DIFF
--- a/config/brokers/channel-broker/deployments/controller.yaml
+++ b/config/brokers/channel-broker/deployments/controller.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: eventing-controller
 
       containers:
-      - name: eventing-controller
+      - name: broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/channel_broker
 

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: eventing-controller
 
       containers:
-      - name: eventing-controller
+      - name: mt-broker-controller
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/mtchannel_broker
 


### PR DESCRIPTION
the containers on the different brokers are not the `eventing-controller`. They are broker-controllers...

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

