### PR TITLE
Backport: Adding webhook details to eventtypes CRD

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -31,6 +31,12 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: eventing-webhook
+        namespace: knative-eventing
   preserveUnknownFields: false
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #2999 and porting to 0.14

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adding webhook details to eventtypes CRD 
-
-

Got now:

```
{"level":"info","ts":"2020-04-29T08:22:58.949Z","logger":"eventing-webhook","caller":"conversion/reconciler.go:104","msg":"CRD is up to date","commit":"b17b158","knative.dev/traceid":"f02aacc1-e080-4e2b-ad15-65741f0858e6","knative.dev/key":"eventtypes.eventing.knative.dev"}
```

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug adding webhook details to eventypes CRD for conversion
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
