### PR TITLE
remove GO111MODULE=on in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,8 +17,6 @@
 # Documentation about this script and how to use it can be found
 # at https://github.com/knative/test-infra/tree/master/ci
 
-export GO111MODULE=on
-
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/release.sh
 
 # Yaml files to generate, and the source config dir for them.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Remove GO111MODULE=on in release.sh, which is the reason that dot release 0.14.2 failed - https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-eventing-dot-release/1255936911541800960

/cc @Harwayne 