### PR TITLE
cleanup: remove unnecessary nil check before range

### DIFF
--- a/pkg/kncloudevents/utils.go
+++ b/pkg/kncloudevents/utils.go
@@ -30,10 +30,8 @@ func WriteHttpRequestWithAdditionalHeaders(ctx context.Context, message binding.
 		return err
 	}
 
-	if additionalHeaders != nil {
-		for k, v := range additionalHeaders {
-			req.Header[k] = v
-		}
+	for k, v := range additionalHeaders {
+		req.Header[k] = v
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
nil check before range is unnecessary in golang, this pr remove the if check.
