### PR TITLE
Remove the explicit default, since 0.14 knows how to deal with it.

### DIFF
--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,11 +20,6 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # An inactive but valid configuration follows; see example.
-  resourceLock: "leases"
-  leaseDuration: "15s"
-  renewDeadline: "10s"
-  retryPeriod: "2s"
   _example: |
     ################################
     #                              #

--- a/pkg/leaderelection/leader_election_test.go
+++ b/pkg/leaderelection/leader_election_test.go
@@ -93,8 +93,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestServingConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-leader-election",
-		"resourceLock", "leaseDuration", "renewDeadline", "retryPeriod")
+	actual, example := ConfigMapsFromTestFile(t, "config-leader-election")
 	for _, test := range []struct {
 		name string
 		data *corev1.ConfigMap


### PR DESCRIPTION
This is analogous to https://github.com/knative/serving/pull/7843
Removing the explicit default, since in 0.14 we added feature to LE to have a standard default.

/assign @n3wscott @vaikas 


- 🧽 Update or clean up current behavior
