### PR TITLE
do not allow brokers to be created with channeltemplatespec

### DIFF
--- a/pkg/apis/eventing/v1alpha1/broker_validation.go
+++ b/pkg/apis/eventing/v1alpha1/broker_validation.go
@@ -31,16 +31,16 @@ func (b *Broker) Validate(ctx context.Context) *apis.FieldError {
 func (bs *BrokerSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 
-	// Validate the new channelTemplate.
-	// TODO: As part of https://github.com/knative/eventing/issues/2128
-	// Also make sure this gets rejected. It would break our tests
-	// and assumptions to do this right now.
-	//	if bs.ChannelTemplate == nil {
-	//		errs = errs.Also(apis.ErrMissingField("channelTemplateSpec"))
-	//	} else
-	if bs.ChannelTemplate != nil {
-		if cte := messagingv1beta1.IsValidChannelTemplate(bs.ChannelTemplate); cte != nil {
-			errs = errs.Also(cte.ViaField("channelTemplateSpec"))
+	// As of v0.15 do not allow creation of new Brokers with the channel template.
+	if apis.IsInCreate(ctx) {
+		if bs.ChannelTemplate != nil {
+			errs = errs.Also(apis.ErrDisallowedFields("channelTemplate"))
+		}
+	} else {
+		if bs.ChannelTemplate != nil {
+			if cte := messagingv1beta1.IsValidChannelTemplate(bs.ChannelTemplate); cte != nil {
+				errs = errs.Also(cte.ViaField("channelTemplateSpec"))
+			}
 		}
 	}
 

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -89,7 +89,7 @@ func setupBrokerTracing(brokerClass string) SetupInfrastructureFunc {
 			client.CreateRBACResourcesForBrokers()
 		}
 		// Create a configmap used by the broker.
-		client.CreateBrokerConfigMapOrFail("default", channel)
+		client.CreateBrokerConfigMapOrFail("br", channel)
 
 		broker := client.CreateBrokerV1Beta1OrFail(
 			"br",

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -88,10 +88,13 @@ func setupBrokerTracing(brokerClass string) SetupInfrastructureFunc {
 			client.CreateConfigMapPropagationOrFail(defaultCMPName)
 			client.CreateRBACResourcesForBrokers()
 		}
-		broker := client.CreateBrokerOrFail(
+		// Create a configmap used by the broker.
+		client.CreateBrokerConfigMapOrFail("default", channel)
+
+		broker := client.CreateBrokerV1Beta1OrFail(
 			"br",
-			resources.WithBrokerClassForBroker(brokerClass),
-			resources.WithChannelTemplateForBroker(channel),
+			resources.WithBrokerClassForBrokerV1Beta1(brokerClass),
+			resources.WithConfigMapForBrokerConfig(),
 		)
 
 		// Create a logger (EventRecord) Pod and a K8s Service that points to it.

--- a/test/e2e/broker_config_test.go
+++ b/test/e2e/broker_config_test.go
@@ -23,7 +23,7 @@ import (
 	"knative.dev/eventing/test/e2e/helpers"
 )
 
-// TestBrokerDeadLetterSink tests Broker's DeadLetterSink
+// TestBrokerWithConfig tests Broker using Config instead of channel templates.
 func TestBrokerWithConfig(t *testing.T) {
 	helpers.TestBrokerWithConfig(t, brokerClass, channelTestRunner)
 }

--- a/test/e2e/helpers/broker_channel_flow_test_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_test_helper.go
@@ -63,14 +63,16 @@ func BrokerChannelFlowTestHelper(t *testing.T,
 
 		if brokerClass == eventing.ChannelBrokerClassValue {
 			// create required RBAC resources including ServiceAccounts and ClusterRoleBindings for Brokers
-			// create required RBAC resources including ServiceAccounts and ClusterRoleBindings for Brokers
 			client.CreateRBACResourcesForBrokers()
 		}
 
+		// Create a configmap used by the broker.
+		client.CreateBrokerConfigMapOrFail(brokerName, &channel)
+
 		// create a new broker
-		client.CreateBrokerOrFail(brokerName,
-			resources.WithBrokerClassForBroker(brokerClass),
-			resources.WithChannelTemplateForBroker(&channel))
+		client.CreateBrokerV1Beta1OrFail(brokerName,
+			resources.WithBrokerClassForBrokerV1Beta1(brokerClass),
+			resources.WithConfigMapForBrokerConfig())
 		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
 
 		// create the event we want to transform to

--- a/test/e2e/helpers/broker_dls_test_helper.go
+++ b/test/e2e/helpers/broker_dls_test_helper.go
@@ -61,11 +61,14 @@ func BrokerDeadLetterSinkTestHelper(t *testing.T,
 
 		delivery := resources.Delivery(resources.WithDeadLetterSinkForDelivery(loggerPodName))
 
+		// Create a configmap used by the broker.
+		client.CreateBrokerConfigMapOrFail(brokerName, &channel)
+
 		// create a new broker
-		client.CreateBrokerOrFail(brokerName,
-			resources.WithBrokerClassForBroker(brokerClass),
-			resources.WithChannelTemplateForBroker(&channel),
-			resources.WithDeliveryForBroker(delivery))
+		client.CreateBrokerV1Beta1OrFail(brokerName,
+			resources.WithBrokerClassForBrokerV1Beta1(brokerClass),
+			resources.WithConfigMapForBrokerConfig(),
+			resources.WithDeliveryForBrokerV1Beta1(delivery))
 
 		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
 

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -61,8 +61,11 @@ func EventTransformationForTriggerTestHelper(t *testing.T,
 			client.CreateRBACResourcesForBrokers()
 		}
 
+		// Create a configmap used by the broker.
+		config := client.CreateBrokerConfigMapOrFail(brokerName, &channel)
+
 		// create a new broker
-		client.CreateBrokerOrFail(brokerName, resources.WithBrokerClassForBroker(brokerClass), resources.WithChannelTemplateForBroker(&channel))
+		client.CreateBrokerV1Beta1OrFail(brokerName, resources.WithBrokerClassForBrokerV1Beta1(brokerClass), resources.WithConfigForBrokerV1Beta1(config))
 		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
 
 		// create the event we want to transform to

--- a/test/e2e/helpers/broker_with_config_helper.go
+++ b/test/e2e/helpers/broker_with_config_helper.go
@@ -70,7 +70,7 @@ func TestBrokerWithConfig(t *testing.T,
 		//&channel
 
 		// create a new broker
-		client.CreateBrokerV1Beta1OrFail(brokerName, resources.WithBrokerClassForBrokerV1Beta1(brokerClass), resources.WithChannelTemplateForBrokerV1Beta1(config))
+		client.CreateBrokerV1Beta1OrFail(brokerName, resources.WithBrokerClassForBrokerV1Beta1(brokerClass), resources.WithConfigForBrokerV1Beta1(config))
 		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
 
 		// create the event we want to transform to

--- a/test/lib/resources/eventing.go
+++ b/test/lib/resources/eventing.go
@@ -187,6 +187,29 @@ func WithChannelTemplateForBroker(channelTypeMeta *metav1.TypeMeta) BrokerOption
 	}
 }
 
+// WithConfigMapForBrokerConfig returns a function that configures the ConfigMap
+// for the Spec.Config for a given Broker. Note that the CM must exist and has
+// to be in the same namespace as the Broker and have the same Name. Typically
+// you'd do this by calling client.CreateBrokerConfigMapOrFail and then call this
+// method.
+// If those don't apply to your ConfigMap, look at WithConfigForBrokerV1Beta1
+func WithConfigMapForBrokerConfig() BrokerV1Beta1Option {
+	return func(b *eventingv1beta1.Broker) {
+		b.Spec.Config = &duckv1.KReference{
+			Name:       b.Name,
+			Namespace:  b.Namespace,
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		}
+	}
+}
+
+func WithConfigForBrokerV1Beta1(config *duckv1.KReference) BrokerV1Beta1Option {
+	return func(b *eventingv1beta1.Broker) {
+		b.Spec.Config = config
+	}
+}
+
 // WithBrokerClassForBrokerV1Beta1 returns a function that adds a brokerClass
 // annotation to the given Broker.
 func WithBrokerClassForBrokerV1Beta1(brokerClass string) BrokerV1Beta1Option {
@@ -200,16 +223,17 @@ func WithBrokerClassForBrokerV1Beta1(brokerClass string) BrokerV1Beta1Option {
 	}
 }
 
-// WithChannelTemplateForBrokerV1Beta1 returns a function that adds a Config to the given Broker.
-func WithChannelTemplateForBrokerV1Beta1(config *duckv1.KReference) BrokerV1Beta1Option {
-	return func(b *eventingv1beta1.Broker) {
-		b.Spec.Config = config
-	}
-}
-
 // WithDeliveryForBroker returns a function that adds a Delivery for the given Broker.
 func WithDeliveryForBroker(delivery *eventingduckv1beta1.DeliverySpec) BrokerOption {
 	return func(b *eventingv1alpha1.Broker) {
+		b.Spec.Delivery = delivery
+	}
+}
+
+// WithDeliveryForBrokerV1Beta1 returns a function that adds a Delivery for the given
+// v1beta1 Broker.
+func WithDeliveryForBrokerV1Beta1(delivery *eventingduckv1beta1.DeliverySpec) BrokerV1Beta1Option {
+	return func(b *eventingv1beta1.Broker) {
 		b.Spec.Delivery = delivery
 	}
 }


### PR DESCRIPTION
Fixes #3066 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do not allow creation of new Brokers with ChannelTemplateSpec anymore

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🗑️ Remove feature or internal logic.
Creation of new Brokers using Spec.ChannelTemplate is now disallowed.
action required: Change broker creation workflow to use Spec.Config instead. While doing that, also switch to using v1beta1 Broker API.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
None. All the examples already were ported to use Config instead of ChannelTemplate while ago.
-->
