### PR TITLE
Use v1beta1 broker and channel spec for perf tests

### DIFF
--- a/test/performance/benchmarks/broker-imc/continuous/100-broker-imc-setup.yaml
+++ b/test/performance/benchmarks/broker-imc/continuous/100-broker-imc-setup.yaml
@@ -12,19 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Broker
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: imc
-  namespace: default
-spec:
+  name: config-broker
+data:
   channelTemplateSpec:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: InMemoryChannel
 
 ---
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: eventing.knative.dev/v1beta1
+kind: Broker
+metadata:
+  name: imc
+  namespace: default
+annotations:
+  eventing.knative.dev/broker.class: ChannelBasedBroker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-broker
+
+---
+
+apiVersion: eventing.knative.dev/v1beta1
 kind: Trigger
 metadata:
   name: broker-imc

--- a/test/performance/benchmarks/broker-imc/continuous/100-broker-imc-setup.yaml
+++ b/test/performance/benchmarks/broker-imc/continuous/100-broker-imc-setup.yaml
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: config-broker
 data:
-  channelTemplateSpec:
+  channelTemplateSpec: |
     apiVersion: messaging.knative.dev/v1beta1
     kind: InMemoryChannel
 
@@ -28,8 +28,9 @@ kind: Broker
 metadata:
   name: imc
   namespace: default
-annotations:
-  eventing.knative.dev/broker.class: ChannelBasedBroker
+  annotations:
+    eventing.knative.dev/broker.class: ChannelBasedBroker
+
 spec:
   config:
     apiVersion: v1

--- a/test/performance/benchmarks/channel-imc/continuous/100-channel-imc-setup.yaml
+++ b/test/performance/benchmarks/channel-imc/continuous/100-channel-imc-setup.yaml
@@ -80,7 +80,7 @@ roleRef:
 
 ---
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: InMemoryChannel
 metadata:
   name: channel-imc
@@ -89,14 +89,14 @@ metadata:
 ---
 
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: Subscription
 metadata:
   name: channel-imc-sub
   namespace: default
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: InMemoryChannel
     name: channel-imc
   subscriber:


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Use v1beta1 broker and channel spec for perf tests as per the changes in https://github.com/knative/eventing/pull/3083

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```