### PR TITLE
Added slinkydeveloper as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ approvers:
 - matzew
 - nachocano
 - lionelvillard
+- slinkydeveloper
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,


### PR DESCRIPTION
From [ROLES.md](https://github.com/knative/community/blob/master/ROLES.md#approver):

> Reviewer of the codebase for at least 3 months.

First review [September 2019](https://github.com/knative/eventing/pull/1969)

> Primary reviewer for at least 10 substantial PRs to the codebase.

12 in eventing: https://github.com/knative/eventing/pulls?q=is%3Apr+-author%3Aslinkydeveloper+reviewed-by%3Aslinkydeveloper+-label%3Asize%2FS+-label%3Asize%2FXS

9 in eventing-contrib: https://github.com/knative/eventing-contrib/pulls?q=is%3Apr+-author%3Aslinkydeveloper+reviewed-by%3Aslinkydeveloper+-label%3Asize%2FS+-label%3Asize%2FXS

Examples:

* https://github.com/knative/eventing/pull/2813
* https://github.com/knative/eventing/pull/2867
* https://github.com/knative/eventing/pull/2257
* https://github.com/knative/eventing-contrib/pull/1072
* https://github.com/knative/eventing-contrib/pull/1165

> Reviewed at least 30 PRs to the codebase.

31 in eventing: https://github.com/knative/eventing/pulls?q=is%3Apr+reviewed-by%3Aslinkydeveloper

17 in eventing-contrib: https://github.com/knative/eventing-contrib/pulls?q=is%3Apr+reviewed-by%3Aslinkydeveloper

**Author**:

36 in eventing: https://github.com/knative/eventing/pulls?q=is%3Apr+author%3Aslinkydeveloper+

36 in eventing-contrib: https://github.com/knative/eventing-contrib/pulls?q=is%3Apr+author%3Aslinkydeveloper+

> Nominated by an area lead with no objections from other leads

@matzew
