### PR TITLE
Allow config opt-in in source.ConfigWatcher

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -79,7 +79,7 @@ type Reconciler struct {
 	sinkResolver   *resolver.URIResolver
 	loggingContext context.Context
 
-	configs reconcilersource.EnvVarsGenerator
+	configs reconcilersource.ConfigAccessor
 }
 
 var _ apiserversourcereconciler.Interface = (*Reconciler)(nil)

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -79,7 +79,7 @@ type Reconciler struct {
 	sinkResolver   *resolver.URIResolver
 	loggingContext context.Context
 
-	configs *reconcilersource.ConfigWatcher
+	configs reconcilersource.EnvVarsGenerator
 }
 
 var _ apiserversourcereconciler.Interface = (*Reconciler)(nil)

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -58,7 +58,7 @@ func NewController(
 		apiserversourceLister: apiServerSourceInformer.Lister(),
 		ceSource:              GetCfgHost(ctx),
 		loggingContext:        ctx,
-		configs:               reconcilersource.StartWatchingSourceConfigurations(ctx, component, cmw),
+		configs:               reconcilersource.WatchConfigurations(ctx, component, cmw),
 	}
 
 	env := &envConfig{}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -20,18 +20,17 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/kmeta"
-	"knative.dev/pkg/system"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/eventing/pkg/adapter/apiserver"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
-	"knative.dev/eventing/pkg/reconciler/source"
+	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/system"
 )
 
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
@@ -41,12 +40,12 @@ type ReceiveAdapterArgs struct {
 	Source  *v1alpha2.ApiServerSource
 	Labels  map[string]string
 	SinkURI string
-	Configs source.EnvVarsGenerator
+	Configs reconcilersource.ConfigAccessor
 }
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
 // ApiServer Sources.
-func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*v1.Deployment, error) {
+func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 	replicas := int32(1)
 
 	env, err := makeEnv(args)
@@ -54,7 +53,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*v1.Deployment, error) {
 		return nil, fmt.Errorf("error generating env vars: %w", err)
 	}
 
-	return &v1.Deployment{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: args.Source.Namespace,
 			Name:      kmeta.ChildName(fmt.Sprintf("apiserversource-%s-", args.Source.Name), string(args.Source.GetUID())),
@@ -63,7 +62,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*v1.Deployment, error) {
 				*kmeta.NewControllerRef(args.Source),
 			},
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: args.Labels,
 			},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -41,7 +41,7 @@ type ReceiveAdapterArgs struct {
 	Source  *v1alpha2.ApiServerSource
 	Labels  map[string]string
 	SinkURI string
-	Configs *source.ConfigWatcher
+	Configs source.EnvVarsGenerator
 }
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
@@ -51,7 +51,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*v1.Deployment, error) {
 
 	env, err := makeEnv(args)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error generating env vars: %w", err)
 	}
 
 	return &v1.Deployment{
@@ -105,7 +105,7 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 	for _, r := range args.Source.Spec.Resources {
 		gv, err := schema.ParseGroupVersion(r.APIVersion)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse APIVersion, %s", err)
+			return nil, fmt.Errorf("failed to parse APIVersion: %w", err)
 		}
 		gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(r.Kind))
 

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/api/apps/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -72,12 +73,13 @@ func TestMakeReceiveAdapter(t *testing.T) {
 			"test-key2": "test-value2",
 		},
 		SinkURI: "sink-uri",
+		Configs: &source.EmptyVarsGenerator{},
 	})
 
 	one := int32(1)
 	trueValue := true
 
-	want := &v1.Deployment{
+	want := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "source-namespace",
 			Name:      kmeta.ChildName(fmt.Sprintf("apiserversource-%s-", name), string(src.UID)),
@@ -96,7 +98,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 				},
 			},
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"test-key1": "test-value1",

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -24,9 +24,10 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/kmeta"
 
 	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
+	"knative.dev/eventing/pkg/reconciler/source"
+	"knative.dev/pkg/kmeta"
 
 	_ "knative.dev/pkg/metrics/testing"
 	_ "knative.dev/pkg/system/testing"
@@ -147,14 +148,13 @@ func TestMakeReceiveAdapter(t *testing.T) {
 									Name:  "METRICS_DOMAIN",
 									Value: "knative.dev/eventing",
 								}, {
-									Name:  "K_METRICS_CONFIG",
+									Name:  source.EnvLoggingCfg,
 									Value: "",
 								}, {
-									Name:  "K_LOGGING_CONFIG",
+									Name:  source.EnvMetricsCfg,
 									Value: "",
-								},
-								{
-									Name:  "K_TRACING_CONFIG",
+								}, {
+									Name:  source.EnvTracingCfg,
 									Value: "",
 								},
 							},

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -20,143 +20,212 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/configmap"
-	pkgLogging "knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
-	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"knative.dev/eventing/pkg/logging"
+	"knative.dev/pkg/configmap"
+	pkglogging "knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	tracingconfig "knative.dev/pkg/tracing/config"
 )
 
+const (
+	EnvLoggingCfg = "K_LOGGING_CONFIG"
+	EnvMetricsCfg = "K_METRICS_CONFIG"
+	EnvTracingCfg = "K_TRACING_CONFIG"
+)
+
+// ConfigWatcher keeps track of logging, metrics and tracing configurations by
+// watching corresponding ConfigMaps.
 type ConfigWatcher struct {
 	logger *zap.Logger
 
 	component string
 
-	loggingConfig *pkgLogging.Config
-	metricsConfig *metrics.ExporterOptions
-	tracingCfg    *tracingconfig.Config
+	loggingCfg *pkglogging.Config
+	metricsCfg *metrics.ExporterOptions
+	tracingCfg *tracingconfig.Config
 }
 
-func StartWatchingSourceConfigurations(loggingContext context.Context, component string, cmw configmap.Watcher) *ConfigWatcher {
-	cw := ConfigWatcher{
-		logger:    logging.FromContext(loggingContext),
+// configWatcherOption is a function option for ConfigWatchers.
+type configWatcherOption func(*ConfigWatcher, configmap.Watcher)
+
+// WatchConfigurations returns a ConfigWatcher initialized with the given
+// options. If no option is passed, the ConfigWatcher observes ConfigMaps for
+// logging, metrics and tracing.
+func WatchConfigurations(loggingCtx context.Context, component string,
+	cmw configmap.Watcher, opts ...configWatcherOption) *ConfigWatcher {
+
+	cw := &ConfigWatcher{
+		logger:    logging.FromContext(loggingCtx),
 		component: component,
 	}
 
+	if len(opts) == 0 {
+		WithLogging(cw, cmw)
+		WithMetrics(cw, cmw)
+		WithTracing(cw, cmw)
+
+	} else {
+		for _, opt := range opts {
+			opt(cw, cmw)
+		}
+	}
+
+	return cw
+}
+
+// StartWatchingSourceConfigurations runs WatchConfigurations with all configurations.
+// For backwards compatibility only.
+func StartWatchingSourceConfigurations(loggingCtx context.Context, component string, cmw configmap.Watcher) *ConfigWatcher {
+	return WatchConfigurations(loggingCtx, component, cmw,
+		WithLogging,
+		WithMetrics,
+		WithTracing,
+	)
+}
+
+// WithLogging observes a logging ConfigMap.
+func WithLogging(cw *ConfigWatcher, cmw configmap.Watcher) {
+	watchConfigMap(cmw, pkglogging.ConfigMapName(), cw.updateFromLoggingConfigMap)
+}
+
+// WithMetrics observes a metrics ConfigMap.
+func WithMetrics(cw *ConfigWatcher, cmw configmap.Watcher) {
+	watchConfigMap(cmw, metrics.ConfigMapName(), cw.updateFromMetricsConfigMap)
+}
+
+// WithTracing observes a tracing ConfigMap.
+func WithTracing(cw *ConfigWatcher, cmw configmap.Watcher) {
+	watchConfigMap(cmw, tracingconfig.ConfigName, cw.updateFromTracingConfigMap)
+}
+
+func watchConfigMap(cmw configmap.Watcher, cmName string, obs configmap.Observer) {
 	if dcmw, ok := cmw.(configmap.DefaultingWatcher); ok {
 		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: pkgLogging.ConfigMapName()},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName},
 			Data:       map[string]string{},
-		}, cw.UpdateFromLoggingConfigMap)
-		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: metrics.ConfigMapName()},
-			Data:       map[string]string{},
-		}, cw.UpdateFromMetricsConfigMap)
-		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: tracingconfig.ConfigName},
-			Data:       map[string]string{},
-		}, cw.UpdateFromTracingConfigMap)
+		}, obs)
+
 	} else {
-		cmw.Watch(pkgLogging.ConfigMapName(), cw.UpdateFromLoggingConfigMap)
-		cmw.Watch(metrics.ConfigMapName(), cw.UpdateFromMetricsConfigMap)
-		cmw.Watch(tracingconfig.ConfigName, cw.UpdateFromTracingConfigMap)
-	}
-
-	return &cw
-}
-
-func (r *ConfigWatcher) UpdateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		logcfg, err := pkgLogging.NewConfigFromConfigMap(cfg)
-		if err != nil {
-			r.logger.Warn("failed to create logging config from configmap", zap.String("cfg.Name", cfg.Name))
-			return
-		}
-		r.loggingConfig = logcfg
-		r.logger.Debug("Update from logging ConfigMap", zap.Any("ConfigMap", cfg))
+		cmw.Watch(cmName, obs)
 	}
 }
 
-func (r *ConfigWatcher) UpdateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		r.metricsConfig = &metrics.ExporterOptions{
-			Domain:    metrics.Domain(),
-			Component: r.component,
-			ConfigMap: cfg.Data,
-		}
-		r.logger.Debug("Update from metrics ConfigMap", zap.Any("ConfigMap", cfg))
-	}
-}
-
-func (r *ConfigWatcher) UpdateFromTracingConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		tracingCfg, err := tracingconfig.NewTracingConfigFromMap(cfg.Data)
-		if err != nil {
-			r.logger.Warn("failed to create tracing config from configmap", zap.String("cfg.Name", cfg.Name))
-			return
-		}
-
-		r.tracingCfg = tracingCfg
-		r.logger.Debug("Update from tracing ConfigMap", zap.Any("ConfigMap", cfg))
-	}
-}
-
-func (r *ConfigWatcher) LoggingConfig() *pkgLogging.Config {
-	if r == nil {
+// LoggingConfig returns the logging configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) LoggingConfig() *pkglogging.Config {
+	if cw == nil {
 		return nil
 	}
-	return r.loggingConfig
+	return cw.loggingCfg
 }
 
-func (r *ConfigWatcher) MetricsConfig() *metrics.ExporterOptions {
-	if r == nil {
+// MetricsConfig returns the metrics configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) MetricsConfig() *metrics.ExporterOptions {
+	if cw == nil {
 		return nil
 	}
-	return r.metricsConfig
+	return cw.metricsCfg
 }
 
-func (r *ConfigWatcher) TracingConfig() *tracingconfig.Config {
-	if r == nil {
+// TracingConfig returns the tracing configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) TracingConfig() *tracingconfig.Config {
+	if cw == nil {
 		return nil
 	}
-	return r.tracingCfg
+	return cw.tracingCfg
 }
 
+func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
+	}
+
+	delete(cfg.Data, "_example")
+
+	loggingCfg, err := pkglogging.NewConfigFromConfigMap(cfg)
+	if err != nil {
+		cw.logger.Warn("failed to create logging config from ConfigMap", zap.String("cfg.Name", cfg.Name))
+		return
+	}
+
+	cw.loggingCfg = loggingCfg
+
+	cw.logger.Debug("Updated logging config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+func (cw *ConfigWatcher) updateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
+	}
+
+	delete(cfg.Data, "_example")
+
+	cw.metricsCfg = &metrics.ExporterOptions{
+		Domain:    metrics.Domain(),
+		Component: cw.component,
+		ConfigMap: cfg.Data,
+	}
+
+	cw.logger.Debug("Updated metrics config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+func (cw *ConfigWatcher) updateFromTracingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
+	}
+
+	delete(cfg.Data, "_example")
+
+	tracingCfg, err := tracingconfig.NewTracingConfigFromMap(cfg.Data)
+	if err != nil {
+		cw.logger.Warn("failed to create tracing config from ConfigMap", zap.String("cfg.Name", cfg.Name))
+		return
+	}
+
+	cw.tracingCfg = tracingCfg
+
+	cw.logger.Debug("Updated tracing config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+// ToEnvVars serializes the contents of the ConfigWatcher to individual
+// environment variables.
 func (r *ConfigWatcher) ToEnvVars() []corev1.EnvVar {
-	loggingConfig, err := pkgLogging.LoggingConfigToJson(r.LoggingConfig())
+	envs := make([]corev1.EnvVar, 0, 3)
+
+	loggingCfg, err := pkglogging.LoggingConfigToJson(r.LoggingConfig())
 	if err != nil {
 		r.logger.Warn("Error while serializing logging config", zap.Error(err))
 	}
 
-	metricsConfig, err := metrics.MetricsOptionsToJson(r.MetricsConfig())
+	metricsCfg, err := metrics.MetricsOptionsToJson(r.MetricsConfig())
 	if err != nil {
 		r.logger.Warn("Error while serializing metrics config", zap.Error(err))
 	}
 
-	tracingConfig, err := tracingconfig.TracingConfigToJson(r.TracingConfig())
+	tracingCfg, err := tracingconfig.TracingConfigToJson(r.TracingConfig())
 	if err != nil {
 		r.logger.Warn("Error while serializing tracing config", zap.Error(err))
 	}
 
-	return []corev1.EnvVar{
-		{
-			Name:  "K_METRICS_CONFIG",
-			Value: metricsConfig,
-		}, {
-			Name:  "K_LOGGING_CONFIG",
-			Value: loggingConfig,
-		}, {
-			Name:  "K_TRACING_CONFIG",
-			Value: tracingConfig,
-		},
+	envs = maybeAppendEnvVar(envs, EnvLoggingCfg, loggingCfg, r.LoggingConfig() != nil)
+	envs = maybeAppendEnvVar(envs, EnvMetricsCfg, metricsCfg, r.MetricsConfig() != nil)
+	envs = maybeAppendEnvVar(envs, EnvTracingCfg, tracingCfg, r.TracingConfig() != nil)
+
+	return envs
+}
+
+// maybeAppendEnvVar appends an EnvVar with the given name and value only if
+// the condition boolean is true.
+func maybeAppendEnvVar(envs []corev1.EnvVar, name, val string, cond bool) []corev1.EnvVar {
+	if !cond {
+		return envs
 	}
+
+	return append(envs, corev1.EnvVar{
+		Name:  name,
+		Value: val,
+	})
 }

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -37,6 +37,12 @@ const (
 	EnvTracingCfg = "K_TRACING_CONFIG"
 )
 
+type EnvVarsGenerator interface {
+	ToEnvVars() []corev1.EnvVar
+}
+
+var _ EnvVarsGenerator = (*ConfigWatcher)(nil)
+
 // ConfigWatcher keeps track of logging, metrics and tracing configurations by
 // watching corresponding ConfigMaps.
 type ConfigWatcher struct {
@@ -228,4 +234,18 @@ func maybeAppendEnvVar(envs []corev1.EnvVar, name, val string, cond bool) []core
 		Name:  name,
 		Value: val,
 	})
+}
+
+// EmptyVarsGenerator generates empty env vars. Intended to be used in tests.
+type EmptyVarsGenerator struct{}
+
+var _ EnvVarsGenerator = (*EmptyVarsGenerator)(nil)
+
+// ToEnvVars implements EnvVarsGenerator.
+func (*EmptyVarsGenerator) ToEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: EnvLoggingCfg},
+		{Name: EnvMetricsCfg},
+		{Name: EnvTracingCfg},
+	}
 }

--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -37,48 +37,101 @@ import (
 const testComponent = "test_component"
 
 func TestNewConfigWatcher_defaults(t *testing.T) {
-	ctx := loggingtesting.TestContextWithLogger(t)
-	cw := WatchConfigurations(ctx, testComponent, newTestConfigMapWatcher())
+	testCases := []struct {
+		name                  string
+		cmw                   configmap.Watcher
+		expectLoggingContains string
+		expectMetricsContains string
+		expectTracingContains string
+	}{
+		{
+			name:                  "With pre-filled sample data",
+			cmw:                   configMapWatcherWithSampleData(),
+			expectLoggingContains: `"zap-logger-config":"{\"level\": \"fatal\"}"`,
+			expectMetricsContains: `"ConfigMap":{"metrics.backend":"test"}`,
+			expectTracingContains: `"zipkin-endpoint":"zipkin.test"`,
+		},
+		{
+			name: "With empty data",
+			cmw:  configMapWatcherWithEmptyData(),
+			// logging defaults to Knative's defaults
+			expectLoggingContains: `{"zap-logger-config":"{\n  \"level\": \"info\"`,
+			// metrics defaults to empty ConfigMap
+			expectMetricsContains: `"ConfigMap":{}`,
+			// tracing defaults to None backend
+			expectTracingContains: `"backend":"none"`,
+		},
+	}
 
-	assert.NotNil(t, cw.LoggingConfig(), "logging config should not be nil")
-	assert.NotNil(t, cw.MetricsConfig(), "metrics config should not be nil")
-	assert.NotNil(t, cw.TracingConfig(), "tracing config should not be nil")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := loggingtesting.TestContextWithLogger(t)
+			cw := WatchConfigurations(ctx, testComponent, tc.cmw)
 
-	envs := cw.ToEnvVars()
+			assert.NotNil(t, cw.LoggingConfig(), "logging config should be enabled")
+			assert.NotNil(t, cw.MetricsConfig(), "metrics config should be enabled")
+			assert.NotNil(t, cw.TracingConfig(), "tracing config should be enabled")
 
-	const expectEnvs = 3
-	require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
+			envs := cw.ToEnvVars()
 
-	assert.Equal(t, EnvLoggingCfg, envs[0].Name, "first env var is logging config")
-	assert.Contains(t, envs[0].Value, "zap-logger-config")
+			const expectEnvs = 3
+			require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
 
-	assert.Equal(t, EnvMetricsCfg, envs[1].Name, "second env var is metrics config")
-	assert.Contains(t, envs[1].Value, `"metrics.backend":"prometheus"`)
+			assert.Equal(t, EnvLoggingCfg, envs[0].Name, "first env var is logging config")
+			assert.Contains(t, envs[0].Value, tc.expectLoggingContains)
 
-	assert.Equal(t, EnvTracingCfg, envs[2].Name, "third env var is tracing config")
-	assert.Contains(t, envs[2].Value, `"backend":"zipkin"`)
+			assert.Equal(t, EnvMetricsCfg, envs[1].Name, "second env var is metrics config")
+			assert.Contains(t, envs[1].Value, tc.expectMetricsContains)
+
+			assert.Equal(t, EnvTracingCfg, envs[2].Name, "third env var is tracing config")
+			assert.Contains(t, envs[2].Value, tc.expectTracingContains)
+		})
+	}
 }
 
 func TestNewConfigWatcher_withOptions(t *testing.T) {
-	ctx := loggingtesting.TestContextWithLogger(t)
-	cw := WatchConfigurations(ctx, testComponent, newTestConfigMapWatcher(),
-		WithMetrics,
-	)
+	testCases := []struct {
+		name                  string
+		cmw                   configmap.Watcher
+		expectMetricsContains string
+	}{
+		{
+			name:                  "With pre-filled sample data",
+			cmw:                   configMapWatcherWithSampleData(),
+			expectMetricsContains: `"ConfigMap":{"metrics.backend":"test"}`,
+		},
+		{
+			name: "With empty data",
+			cmw:  configMapWatcherWithEmptyData(),
+			// metrics defaults to empty ConfigMap
+			expectMetricsContains: `"ConfigMap":{}`,
+		},
+	}
 
-	assert.Nil(t, cw.LoggingConfig(), "logging config should be nil")
-	assert.Nil(t, cw.TracingConfig(), "tracing config should be nil")
-	assert.NotNil(t, cw.MetricsConfig(), "metrics config should not be nil")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := loggingtesting.TestContextWithLogger(t)
+			cw := WatchConfigurations(ctx, testComponent, tc.cmw,
+				WithMetrics,
+			)
 
-	envs := cw.ToEnvVars()
+			assert.Nil(t, cw.LoggingConfig(), "logging config should be disabled")
+			assert.Nil(t, cw.TracingConfig(), "tracing config should be disabled")
+			assert.NotNil(t, cw.MetricsConfig(), "metrics config should be enabled")
 
-	const expectEnvs = 1
-	require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
+			envs := cw.ToEnvVars()
 
-	assert.Equal(t, EnvMetricsCfg, envs[0].Name, "env var is metrics config")
-	assert.Contains(t, envs[0].Value, `"metrics.backend":"prometheus"`)
+			const expectEnvs = 1
+			require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
+
+			assert.Equal(t, EnvMetricsCfg, envs[0].Name, "env var is metrics config")
+			assert.Contains(t, envs[0].Value, tc.expectMetricsContains)
+		})
+	}
 }
 
-func newTestConfigMapWatcher() configmap.Watcher {
+// configMapWatcherWithSampleData constructs a Watcher for static sample data.
+func configMapWatcherWithSampleData() configmap.Watcher {
 	return configmap.NewStaticWatcher(
 		newTestConfigMap(logging.ConfigMapName(), loggingConfigMapData()),
 		newTestConfigMap(metrics.ConfigMapName(), metricsConfigMapData()),
@@ -86,7 +139,21 @@ func newTestConfigMapWatcher() configmap.Watcher {
 	)
 }
 
+// configMapWatcherWithEmptyData constructs a Watcher for empty data.
+func configMapWatcherWithEmptyData() configmap.Watcher {
+	return configmap.NewStaticWatcher(
+		newTestConfigMap(logging.ConfigMapName(), nil),
+		newTestConfigMap(metrics.ConfigMapName(), nil),
+		newTestConfigMap(tracingconfig.ConfigName, nil),
+	)
+}
+
 func newTestConfigMap(name string, data map[string]string) *corev1.ConfigMap {
+	if data == nil {
+		data = make(map[string]string, 1)
+	}
+
+	// _example key is always appended to mimic Knative's release manifests
 	data["_example"] = "test-config"
 
 	return &corev1.ConfigMap{
@@ -100,12 +167,12 @@ func newTestConfigMap(name string, data map[string]string) *corev1.ConfigMap {
 // ConfigMap data generators
 func loggingConfigMapData() map[string]string {
 	return map[string]string{
-		"zap-logger-config": `{"level": "info"}`,
+		"zap-logger-config": `{"level": "fatal"}`,
 	}
 }
 func metricsConfigMapData() map[string]string {
 	return map[string]string{
-		"metrics.backend": "prometheus",
+		"metrics.backend": "test",
 	}
 }
 func tracingConfigMapData() map[string]string {


### PR DESCRIPTION
## Proposed Changes

* Allow `source.ConfigWatcher`'s constructor to accept options for watching selected configs instead of all of them. `ToEnv()` will only return enabled configurations.
* Rename constructor from `StartWatchingSourceConfigurations` to `WatchConfigurations` (the former is kept as an alias).
* Improve tests.
* Document methods.

Examples:

watch logging, metrics and tracing configs (default when no option is passed)
```golang
WatchConfigurations(ctx, component, cmw)
```
watch logging and metrics configs, exclude tracing
```golang
WatchConfigurations(ctx, component, cmw,
	WithLogging,
	WithMetrics,
)
```