### PR TITLE
Add note to channel spec regarding channel subscription spec

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -183,7 +183,7 @@ Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/master/pkg/apis/duck/v1beta1/subscribable_types.go)
 
 Note: The array of subscribers MUST NOT be set directly on the generic Channel
-CR, but rather appended to the backing channel by the subscription itself.
+custom object, but rather appended to the backing channel by the subscription itself.
 
 #### Status Requirements
 

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -182,6 +182,9 @@ Each channel CRD MUST contain an array of subscribers:
 Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/master/pkg/apis/duck/v1beta1/subscribable_types.go)
 
+Note: the array of subscribers MUST NOT be set directly on the channel, but
+rather appended by the subscription itself.
+
 #### Status Requirements
 
 ##### v1alpha1 Status

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -183,7 +183,8 @@ Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/master/pkg/apis/duck/v1beta1/subscribable_types.go)
 
 Note: The array of subscribers MUST NOT be set directly on the generic Channel
-custom object, but rather appended to the backing channel by the subscription itself.
+custom object, but rather appended to the backing channel by the subscription
+itself.
 
 #### Status Requirements
 

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -182,9 +182,8 @@ Each channel CRD MUST contain an array of subscribers:
 Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/master/pkg/apis/duck/v1beta1/subscribable_types.go)
 
-Note: The array of subscribers MUST NOT be set directly on the generic
-Channel CR, but rather appended to the backing channel by the
-subscription itself.
+Note: The array of subscribers MUST NOT be set directly on the generic Channel
+CR, but rather appended to the backing channel by the subscription itself.
 
 #### Status Requirements
 

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -182,8 +182,9 @@ Each channel CRD MUST contain an array of subscribers:
 Each channel CRD MUST contain an array of subscribers:
 [`spec.subscribers`](https://github.com/knative/eventing/blob/master/pkg/apis/duck/v1beta1/subscribable_types.go)
 
-Note: the array of subscribers MUST NOT be set directly on the channel, but
-rather appended by the subscription itself.
+Note: The array of subscribers MUST NOT be set directly on the generic
+Channel CR, but rather appended to the backing channel by the
+subscription itself.
 
 #### Status Requirements
 


### PR DESCRIPTION
The spec.subscription fields shouldn't be set directly, rather
it should be set via the subscriptions themselves and then the status
should be propogated via the channel.

Related to:
#3050
#3051