### PR TITLE
WIP: No auto mt broker but setting MTChannelBased as default 

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -54,14 +54,6 @@ spec:
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
 
-          # Due to the trivial per-Broker cost, we _can_ inject Brokers into every
-          # namespace by default. To change this default simply change this
-          # to "true".  To opt namespaces out of Broker injection, label
-          # them with:
-          #    knative-eventing-injection: disabled
-          - name: BROKER_INJECTION_DEFAULT
-            value: "false"
-
         securityContext:
           allowPrivilegeEscalation: false
 

--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -23,7 +23,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |
     clusterDefault:
-      brokerClass: ChannelBasedBroker
+      brokerClass: MTChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: config-br-default-channel

--- a/pkg/reconciler/mtnamespace/controller.go
+++ b/pkg/reconciler/mtnamespace/controller.go
@@ -18,6 +18,8 @@ package mtnamespace
 
 import (
 	"context"
+
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
@@ -39,8 +41,6 @@ func NewController(
 
 	namespaceInformer := namespace.Get(ctx)
 	brokerInformer := broker.Get(ctx)
-
-
 	r := &Reconciler{
 		eventingClientSet: eventingclient.Get(ctx),
 		brokerLister:      brokerInformer.Lister(),

--- a/pkg/reconciler/mtnamespace/controller.go
+++ b/pkg/reconciler/mtnamespace/controller.go
@@ -19,7 +19,6 @@ package mtnamespace
 import (
 	"context"
 
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"

--- a/pkg/reconciler/mtnamespace/controller.go
+++ b/pkg/reconciler/mtnamespace/controller.go
@@ -18,12 +18,9 @@ package mtnamespace
 
 import (
 	"context"
-
-	"github.com/kelseyhightower/envconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	"knative.dev/eventing/pkg/reconciler/mtnamespace/resources"
 	namespacereconciler "knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -32,18 +29,6 @@ import (
 	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 )
-
-type envConfig struct {
-	InjectionDefault bool `envconfig:"BROKER_INJECTION_DEFAULT" default:"false"`
-}
-
-func onByDefault(labels map[string]string) bool {
-	return labels[resources.InjectionLabelKey] == resources.InjectionDisabledLabelValue
-}
-
-func offByDefault(labels map[string]string) bool {
-	return labels[resources.InjectionLabelKey] != resources.InjectionEnabledLabelValue
-}
 
 // NewController initializes the controller and is called by the generated code
 // Registers event handlers to enqueue events
@@ -55,20 +40,9 @@ func NewController(
 	namespaceInformer := namespace.Get(ctx)
 	brokerInformer := broker.Get(ctx)
 
-	var filter labelFilter
-
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		logging.FromContext(ctx).Fatalf("mtnamespace was unable to process environment: %v", err)
-	} else if env.InjectionDefault {
-		filter = onByDefault
-	} else {
-		filter = offByDefault
-	}
 
 	r := &Reconciler{
 		eventingClientSet: eventingclient.Get(ctx),
-		filter:            filter,
 		brokerLister:      brokerInformer.Lister(),
 	}
 

--- a/pkg/reconciler/mtnamespace/namespace.go
+++ b/pkg/reconciler/mtnamespace/namespace.go
@@ -38,12 +38,8 @@ const (
 	brokerCreated = "BrokerCreated"
 )
 
-type labelFilter func(labels map[string]string) bool
-
 type Reconciler struct {
 	eventingClientSet clientset.Interface
-
-	filter labelFilter
 
 	// listers index properties about resources
 	brokerLister eventinglisters.BrokerLister
@@ -53,7 +49,8 @@ type Reconciler struct {
 var _ namespacereconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pkgreconciler.Event {
-	if r.filter(ns.Labels) {
+
+	if ns.Labels[resources.InjectionLabelKey] != resources.InjectionEnabledLabelValue {
 		logging.FromContext(ctx).Debug("Not reconciling Namespace")
 		return nil
 	}

--- a/pkg/reconciler/mtnamespace/namespace_test.go
+++ b/pkg/reconciler/mtnamespace/namespace_test.go
@@ -47,116 +47,7 @@ func init() {
 	_ = eventingv1alpha1.AddToScheme(scheme.Scheme)
 }
 
-func TestEnabledByDefault(t *testing.T) {
-	// Events
-	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
-
-	// Object
-	namespace := NewNamespace(testNS,
-		WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-	)
-	broker := resources.MakeBroker(namespace)
-
-	table := TableTest{{
-		Name: "bad workqueue key",
-		// Make sure Reconcile handles bad keys.
-		Key: "too/many/parts",
-	}, {
-		Name: "key not found",
-		// Make sure Reconcile handles good keys that don't exist.
-		Key: "foo/not-found",
-	}, {
-		Name: "Namespace is not labeled",
-		Objects: []runtime.Object{
-			NewNamespace(testNS),
-		},
-		Key:                     testNS,
-		SkipNamespaceValidation: true,
-		WantErr:                 false,
-		WantEvents: []string{
-			brokerEvent,
-		},
-		WantCreates: []runtime.Object{
-			broker,
-		},
-	}, {
-		Name: "Namespace is labeled disabled",
-		Objects: []runtime.Object{
-			NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionDisabledLabels())),
-		},
-		Key: testNS,
-	}, {
-		Name: "Namespace is deleted no resources",
-		Objects: []runtime.Object{
-			NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-				WithNamespaceDeleted,
-			),
-		},
-		Key: testNS,
-	}, {
-		Name: "Namespace enabled",
-		Objects: []runtime.Object{
-			NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-			),
-		},
-		Key:                     testNS,
-		SkipNamespaceValidation: true,
-		WantErr:                 false,
-		WantEvents: []string{
-			brokerEvent,
-		},
-		WantCreates: []runtime.Object{
-			broker,
-		},
-	}, {
-		Name: "Namespace enabled, broker exists",
-		Objects: []runtime.Object{
-			NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-			),
-			resources.MakeBroker(NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionEnabledLabels()),
-			)),
-		},
-		Key:                     testNS,
-		SkipNamespaceValidation: true,
-		WantErr:                 false,
-	}, {
-		Name: "Namespace enabled, broker exists with no label",
-		Objects: []runtime.Object{
-			NewNamespace(testNS,
-				WithNamespaceLabeled(resources.InjectionDisabledLabels()),
-			),
-			&v1alpha1.Broker{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNS,
-					Name:      resources.DefaultBrokerName,
-				},
-			},
-		},
-		Key:                     testNS,
-		SkipNamespaceValidation: true,
-		WantErr:                 false,
-	}}
-
-	logger := logtesting.TestLogger(t)
-	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
-		r := &Reconciler{
-			eventingClientSet: fakeeventingclient.Get(ctx),
-			filter:            onByDefault,
-			brokerLister:      listers.GetV1Beta1BrokerLister(),
-		}
-
-		return namespacereconciler.NewReconciler(ctx, logger,
-			fakekubeclient.Get(ctx), listers.GetNamespaceLister(),
-			controller.GetEventRecorder(ctx), r)
-	}, false, logger))
-}
-
-func TestDisabledByDefault(t *testing.T) {
+func TestAllCases(t *testing.T) {
 	// Events
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 
@@ -250,7 +141,6 @@ func TestDisabledByDefault(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &Reconciler{
 			eventingClientSet: fakeeventingclient.Get(ctx),
-			filter:            offByDefault,
 			brokerLister:      listers.GetV1Beta1BrokerLister(),
 		}
 

--- a/test/config/channel-broker.yaml
+++ b/test/config/channel-broker.yaml
@@ -21,7 +21,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |
     clusterDefault:
-      brokerClass: MTChannelBasedBroker
+      brokerClass: ChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: config-br-default-channel

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -37,11 +37,11 @@ readonly IN_MEMORY_CHANNEL_CRD_CONFIG_DIR="config/channels/in-memory-channel"
 
 # MT Channel Based Broker config.
 readonly MT_CHANNEL_BASED_BROKER_CONFIG_DIR="config/brokers/mt-channel-broker"
-# MT Channel Based Broker config.
-readonly MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG="test/config/mt-channel-broker.yaml"
 
 # Channel Based Broker Controller.
 readonly CHANNEL_BASED_BROKER_CONTROLLER="config/brokers/channel-broker"
+# Channel Based Broker config.
+readonly CHANNEL_BASED_BROKER_DEFAULT_CONFIG="test/config/channel-broker.yaml"
 
 # Setup the Knative environment for running tests. This installs
 # Everything from the config dir but then removes the Channel Based Broker.
@@ -59,20 +59,18 @@ function knative_setup() {
 }
 
 function install_broker() {
+  ko apply --strict -f ${HANNEL_BASED_BROKER_DEFAULT_CONFIG} || return 1
   ko apply --strict -f ${CHANNEL_BASED_BROKER_CONTROLLER} || return 1
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing with Broker did not come up"
 }
 
 function install_mt_broker() {
-  ko apply --strict -f ${MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG} || return 1
   ko apply --strict -f ${MT_CHANNEL_BASED_BROKER_CONFIG_DIR} || return 1
-  wait_until_pods_running knative-eventing || return 1
-  kubectl -n knative-eventing set env deployment/mt-broker-controller BROKER_INJECTION_DEFAULT=true || return 1
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing with MT Broker did not come up"
 }
 
-function uninstall_broker() {
-  ko delete -f ${CHANNEL_BASED_BROKER_CONTROLLER} || return 1
+function uninstall_mt_broker() {
+  ko delete -f ${MT_CHANNEL_BASED_BROKER_CONFIG_DIR} || return 1
 }
 
 # Teardown the Knative environment after tests finish.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,16 +32,16 @@ source $(dirname $0)/e2e-common.sh
 
 initialize $@ --skip-istio-addon
 
-install_broker || fail_test "Could not install Channel Based Broker"
-
-echo "Running tests with Channel Based Broker"
-go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=ChannelBasedBroker  -channels=messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel || fail_test
-
-uninstall_broker || fail_test "Could not uninstall Channel Based Broker"
-
-install_mt_broker || fail_test "Could not uninstall MT Channel Based Broker"
+install_mt_broker || fail_test "Could not install Channel Based Broker"
 
 echo "Running tests with Multi Tenant Channel Based Broker"
 go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel || fail_test
+
+uninstall_mt_broker || fail_test "Could not uninstall Channel Based Broker"
+
+install_broker || fail_test "Could not uninstall MT Channel Based Broker"
+
+echo "Running tests with Channel Based Broker"
+go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=ChannelBasedBroker  -channels=messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.knative.dev/v1alpha1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel || fail_test
 
 success


### PR DESCRIPTION
Relates to #2935

## Background:

for the new MT broker there is a flag that enables to create brokers for all namespaces, it was compared to the default `ServiceAccount`.

## Proposed Changes

- This PR proposes to remove that flag. and will have no auto-creation of the brokers. It's based on a discussion that brokers are not like service accout.

However, the MTBroker is the one we want to stay (remove the other channelbased broker), and have it default. See  #2935

IMO the auto creation is also not really needed, since the usability of the MTChannelBased is much easier.  It allows simply broker creations via:

* `kubectl label namespace default knative-eventing-injection=enabled` (but we do not label automatically all namespaces like that)
* via yaml:
```yaml
apiVersion: eventing.knative.dev/v1beta1
kind: Broker
metadata:
  name: my-other-broker
```

* more complex yaml:

```yaml
apiVersion: eventing.knative.dev/v1beta1
kind: Broker
metadata:
  name: yet-another-broker
  annotations:
    eventing.knative.dev/broker.class: MTChannelBasedBroker
spec:
  config:
    apiVersion: v1
    kind: ConfigMap
    name: config-br-default-channel
    namespace: knative-eventing
```

also related #2984 

and this comment: https://github.com/knative/eventing/issues/2970#issuecomment-614739010  
(especially regarding the `ServiceAccount`)

