### PR TITLE
Set MT based broker the default choice

### DIFF
--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -23,7 +23,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |
     clusterDefault:
-      brokerClass: ChannelBasedBroker
+      brokerClass: MTChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: config-br-default-channel

--- a/test/config/st-channel-broker.yaml
+++ b/test/config/st-channel-broker.yaml
@@ -21,7 +21,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-br-config: |
     clusterDefault:
-      brokerClass: MTChannelBasedBroker
+      brokerClass: ChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: config-br-default-channel

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -38,10 +38,12 @@ readonly IN_MEMORY_CHANNEL_CRD_CONFIG_DIR="config/channels/in-memory-channel"
 # MT Channel Based Broker config.
 readonly MT_CHANNEL_BASED_BROKER_CONFIG_DIR="config/brokers/mt-channel-broker"
 # MT Channel Based Broker config.
-readonly MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG="test/config/mt-channel-broker.yaml"
+readonly MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG="config/core/configmaps/default-broker.yaml"
 
 # Channel Based Broker Controller.
 readonly CHANNEL_BASED_BROKER_CONTROLLER="config/brokers/channel-broker"
+# Channel Based Broker config.
+readonly CHANNEL_BASED_BROKER_DEFAULT_CONFIG="test/config/st-channel-broker.yaml"
 
 # Setup the Knative environment for running tests. This installs
 # Everything from the config dir but then removes the Channel Based Broker.
@@ -59,6 +61,7 @@ function knative_setup() {
 }
 
 function install_broker() {
+  ko apply --strict -f ${CHANNEL_BASED_BROKER_DEFAULT_CONFIG} || return 1
   ko apply --strict -f ${CHANNEL_BASED_BROKER_CONTROLLER} || return 1
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing with Broker did not come up"
 }


### PR DESCRIPTION
## Proposed Changes

This is the first step of #3139, which sets MT as default:
- MT the default

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note- 🧽 Update or clean up current behavior
the Single tenant broker is now DEPRECATED and no longer the default configuration. The "config-br-defaults" ConfigMap in the "knative-eventing" namespace is updated to reflect the new default choice for the `MTChannelBasedBroker` broker class. 
```

