### PR TITLE
Set timeout on admission webhooks

### DIFF
--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -32,3 +32,4 @@ webhooks:
     matchExpressions:
     - key: eventing.knative.dev/release
       operator: Exists
+  timeoutSeconds: 2

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -28,3 +28,4 @@ webhooks:
   sideEffects: None
   failurePolicy: Fail
   name: webhook.eventing.knative.dev
+  timeoutSeconds: 2

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -28,3 +28,4 @@ webhooks:
   sideEffects: None
   failurePolicy: Fail
   name: validation.webhook.eventing.knative.dev
+  timeoutSeconds: 2

--- a/config/core/webhooks/sinkbindings.yaml
+++ b/config/core/webhooks/sinkbindings.yaml
@@ -28,3 +28,4 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: sinkbindings.webhook.sources.knative.dev
+  timeoutSeconds: 2


### PR DESCRIPTION
## Proposed Changes

Sets admission webhook timeout explicitly to 2s (the default is 30). This is to avoid blocking the control plane if the webhooks are down or unresponsive.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set admission webhook timeouts = 2s
```