### PR TITLE
[WIP] Print the Unready resource during test failure

### DIFF
--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -171,6 +171,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1beta1.InMemoryCha
 		})
 	}
 
+	// DO NOT SUBMIT - This is to view the failing error messages. It should not be submitted!
+	imc.Status.MarkChannelServiceFailed("testForced", "This should not be submitted, it makes the IMC always fail to become ready.")
+
 	// Ok, so now the Dispatcher Deployment & Service have been created, we're golden since the
 	// dispatcher watches the Channel and where it needs to dispatch events to.
 	return newReconciledNormal(imc.Namespace, imc.Name)

--- a/test/lib/operation.go
+++ b/test/lib/operation.go
@@ -130,8 +130,8 @@ func (c *Client) sendFakeEventWithTracingToAddress(
 func (c *Client) WaitForResourceReadyOrFail(name string, typemeta *metav1.TypeMeta) {
 	namespace := c.Namespace
 	metaResource := resources.NewMetaResource(name, namespace, typemeta)
-	if err := duck.WaitForResourceReady(c.Dynamic, metaResource); err != nil {
-		c.T.Fatalf("Failed to get %v-%s ready: %v", *typemeta, name, err)
+	if untyped, err := duck.WaitForResourceReady(c.Dynamic, metaResource); err != nil {
+		c.T.Fatalf("Failed to get %v-%s ready (%v): %v", *typemeta, name, untyped, err)
 	}
 }
 
@@ -140,8 +140,8 @@ func (c *Client) WaitForResourceReadyOrFail(name string, typemeta *metav1.TypeMe
 func (c *Client) WaitForResourcesReadyOrFail(typemeta *metav1.TypeMeta) {
 	namespace := c.Namespace
 	metaResourceList := resources.NewMetaResourceList(namespace, typemeta)
-	if err := duck.WaitForResourcesReady(c.Dynamic, metaResourceList); err != nil {
-		c.T.Fatalf("Failed to get all %v resources ready: %v", *typemeta, err)
+	if untypeds, err := duck.WaitForResourcesReady(c.Dynamic, metaResourceList); err != nil {
+		c.T.Fatalf("Failed to get all %v resources ready (%v): %v", *typemeta, untypeds, err)
 	}
 }
 

--- a/test/lib/tracker.go
+++ b/test/lib/tracker.go
@@ -151,8 +151,8 @@ func (t *Tracker) Clean(awaitDeletion bool) error {
 func (t *Tracker) WaitForKResourcesReady() error {
 	t.tc.Logf("Waiting for all KResources to become ready")
 	for _, metaResource := range t.resourcesToCheckStatus {
-		if err := duck.WaitForResourceReady(t.dynamicClient, &metaResource); err != nil {
-			return fmt.Errorf("failed waiting for %+v to become ready: %v", metaResource, err)
+		if untyped, err := duck.WaitForResourceReady(t.dynamicClient, &metaResource); err != nil {
+			return fmt.Errorf("failed waiting for %+v to become ready (%v): %v", metaResource, untyped, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- When a resource fails to become ready and that causes the test to fail, print the resource. The spec and status of that object may help debug what went wrong during the test.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```