### PR TITLE
wire delivery through to subscriptions

### DIFF
--- a/pkg/reconciler/sequence/resources/subscription.go
+++ b/pkg/reconciler/sequence/resources/subscription.go
@@ -56,6 +56,7 @@ func NewSubscription(stepNumber int, s *v1beta1.Sequence) *messagingv1beta1.Subs
 				Ref: s.Spec.Steps[stepNumber].Destination.Ref,
 				URI: s.Spec.Steps[stepNumber].Destination.URI,
 			},
+			Delivery: s.Spec.Steps[stepNumber].Delivery,
 		},
 	}
 	// If it's not the last step, use the next channel as the reply to, if it's the very


### PR DESCRIPTION
Fixes #2977 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Propagate SequenceStep.Delivery to underlying Subscription.
- Better error reporting in the status. Report the failed channel/subscription in the status.
- add failure tests, which led to above point.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Sequence now properly propagates the Delivery options to underlying Subscriptions.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
