### PR TITLE
Use env var WEBHOOK_PORT to configure the webhook port

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -343,7 +343,7 @@ func main() {
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: logconfig.WebhookName(),
-		Port:        8443,
+		Port:        webhook.PortFromEnv(8443),
 		// SecretName must match the name of the Secret created in the configuration.
 		SecretName: "eventing-webhook-certs",
 	})

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -60,6 +60,8 @@ spec:
           value: knative.dev/eventing
         - name: WEBHOOK_NAME
           value: eventing-webhook
+        - name: WEBHOOK_PORT
+          value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
           # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`


### PR DESCRIPTION
Users can use env var WEBHOOK_PORT to configure the webhook port. If the env var is not set, the default port will be used.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```
