### PR TITLE
Switch the metrics port of the Channel Based Broker components to 9092

### DIFF
--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -1651,7 +1651,7 @@ func containerPorts(httpInternal int32) []corev1.ContainerPort {
 		},
 		{
 			Name:          "metrics",
-			ContainerPort: 9090,
+			ContainerPort: 9092,
 		},
 	}
 }

--- a/pkg/reconciler/broker/resources/filter.go
+++ b/pkg/reconciler/broker/resources/filter.go
@@ -117,7 +117,7 @@ func MakeFilterDeployment(args *FilterArgs) *appsv1.Deployment {
 							ContainerPort: 8080,
 							Name:          "http",
 						}, {
-							ContainerPort: 9090,
+							ContainerPort: 9092,
 							Name:          "metrics",
 						}},
 					}},

--- a/pkg/reconciler/broker/resources/filter_test.go
+++ b/pkg/reconciler/broker/resources/filter_test.go
@@ -90,7 +90,7 @@ func TestMakeFilterDeployment(t *testing.T) {
               },
               {
                 "name": "metrics",
-                "containerPort": 9090
+                "containerPort": 9092
               }
             ],
             "env": [

--- a/pkg/reconciler/broker/resources/ingress.go
+++ b/pkg/reconciler/broker/resources/ingress.go
@@ -114,7 +114,7 @@ func MakeIngressDeployment(args *IngressArgs) *appsv1.Deployment {
 							ContainerPort: 8080,
 							Name:          "http",
 						}, {
-							ContainerPort: 9090,
+							ContainerPort: 9092,
 							Name:          "metrics",
 						}},
 					}},


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Switch the metrics port of the Channel Based Broker components to 9092
    - The change to using this port was in #2406.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```