### PR TITLE
Add lberk to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
 - nachocano
 - lionelvillard
 - slinkydeveloper
+- lberk
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,
@@ -23,10 +24,11 @@ reviewers:
 - nachocano
 - lionelvillard
 - slinkydeveloper
+- lberk
+
 # Add reviewers below
 - liu-cong
 - yolocs
 - aslom
-- lberk
 - nlopezgi
 - aliok


### PR DESCRIPTION
Criteria from https://github.com/knative/community/blob/master/ROLES.md#approver

Reviewer of the codebase for at least 3 months:

First reviews:
[Eventing] https://github.com/knative/eventing/pull/1601 July 30, 2019

Primary reviewer for at least 10 substantial PRs to the codebase [11].
#3924
#3954
#2759
#3447
#3964
#3313
#3226
#3224
#3070
#3050
#3016
 
Reviewed at least 30 PRs to the codebase [30]
eventing:
#3964
#3958
#3955
#3954
#3947
#3924
#3902
#3897
#3762
#3742
#3447
#3395
#3361
#3251
#3243
#3226
#3224
#3223
#3221
#3202
#3184
#3180
#3070
#3050
#3016
#3070
#2759
#2700
#2258
#1601

Nominated by an area lead with no objections from other leads:
@matzew

Proposals Authored & Submitted:
[Eventing contrib vs Sandbox](https://docs.google.com/document/d/1UcMNGKTjKdxLY_IVI7Xv5ZSOXAiO9DUrcuw2gkt74qY/edit)
[knative github labels](https://docs.google.com/document/d/1yODTSzoZBhYsatnYcujCnHQ6_wWWRHqJ-MlASOlp-C4/edit)

I'm following the observed pattern of approver status across both
eventing and contrib repos, if that's not appropriate, I'd be happy to
take feedback accordingly!