### PR TITLE
change storage versions to v1beta1

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -67,7 +67,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -60,7 +60,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object
@@ -136,7 +136,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
   - name: v1beta1
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -72,7 +72,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -64,8 +64,8 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true
 

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -64,7 +64,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -142,7 +142,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -58,7 +58,7 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object
@@ -118,7 +118,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
   - name: v1beta1
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object

--- a/pkg/apis/messaging/v1alpha1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1alpha1/in_memory_channel_defaults.go
@@ -16,10 +16,26 @@ limitations under the License.
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+
+	"knative.dev/eventing/pkg/apis/messaging"
+)
 
 func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 	imc.Spec.SetDefaults(ctx)
+
+	// Set the duck subscription to the stored version of the duck
+	// we support. Reason for this is that the stored version will
+	// not get a chance to get modified, but for newer versions
+	// conversion webhook will be able to take a crack at it and
+	// can modify it to match the duck shape.
+	if imc.Annotations == nil {
+		imc.Annotations = make(map[string]string)
+	}
+	if _, ok := imc.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
+		imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
+	}
 }
 
 func (imcs *InMemoryChannelSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_defaults.go
@@ -32,7 +32,7 @@ func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 		imc.Annotations = make(map[string]string)
 	}
 	if _, ok := imc.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-		imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+		imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 	}
 
 	imc.Spec.SetDefaults(ctx)


### PR DESCRIPTION
Addresses #3095

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change storage version from v1alpha1 to v1beta1:
```
          - "parallels.flows.knative.dev"
          - "sequences.flows.knative.dev"
          - "eventtypes.eventing.knative.dev"
          - "triggers.eventing.knative.dev"
          - "channels.messaging.knative.dev"
          - "inmemorychannels.messaging.knative.dev"
          - "subscriptions.messaging.knative.dev"
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
Change storage versions from v1alpha1 to v1beta1:
          - "parallels.flows.knative.dev"
          - "sequences.flows.knative.dev"
          - "eventtypes.eventing.knative.dev"
          - "triggers.eventing.knative.dev"
          - "channels.messaging.knative.dev"
          - "inmemorychannels.messaging.knative.dev"
          - "subscriptions.messaging.knative.dev"

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
