### PR TITLE
Remove t.Fatal calls from goroutines.

### DIFF
--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -237,7 +237,7 @@ func TestIngressHandler_Start(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		if err := handler.Start(ctx); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 	// Need time for the handler to start up. Wait.

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -145,7 +145,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 	// Start the dispatcher
 	go func() {
 		if err := dispatcher.Start(serverCtx); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 

--- a/pkg/mtbroker/ingress/ingress_handler_test.go
+++ b/pkg/mtbroker/ingress/ingress_handler_test.go
@@ -202,7 +202,7 @@ func TestIngressHandler_Start(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		if err := handler.Start(ctx); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 	// Need time for the handler to start up. Wait.


### PR DESCRIPTION
Fixes #3164

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

t.Fatal[f] must not be called in a goroutine different from the test itself: https://golang.org/pkg/testing/#T