### PR TITLE
Upgrade test status set to skip if errors found

### DIFF
--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -34,7 +34,7 @@ const (
 	readyMessage = "prober ready"
 )
 
-func TestProbe(t *testing.T) {
+func TestContinuousEventsPropagationWithProber(t *testing.T) {
 	// We run the prober as a golang test because it fits in nicely with
 	// the rest of our integration tests, and AssertProberDefault needs
 	// a *testing.T. Unfortunately, "go test" intercepts signals, so we


### PR DESCRIPTION
Fixes #3178 

## Proposed Changes

- Upgrade test status set to skip if errors found and `FailOnMissingEvents` is false
- Rename `TestProbe` to more meaningful `TestContinuousEventsPropagationWithProber`

follow up to #2388