### PR TITLE
Rename FailOnMissingEvents flag to FailOnErrors for upgrade tests

### DIFF
--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -52,7 +52,7 @@ func TestContinuousEventsPropagationWithProber(t *testing.T) {
 	config := prober.NewConfig(client.Namespace)
 
 	// FIXME: https://github.com/knative/eventing/issues/2665
-	config.FailOnMissingEvents = false
+	config.FailOnErrors = false
 
 	// Use zap.SugarLogger instead of t.Logf because we want to see failures
 	// inline with other logs instead of buffered until the end.

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -50,11 +50,11 @@ type Prober interface {
 
 // Config represents a configuration for prober
 type Config struct {
-	Namespace           string
-	Interval            time.Duration
-	Serving             ServingConfig
-	FinishedSleep       time.Duration
-	FailOnMissingEvents bool
+	Namespace     string
+	Interval      time.Duration
+	Serving       ServingConfig
+	FinishedSleep time.Duration
+	FailOnErrors  bool
 }
 
 type ServingConfig struct {
@@ -64,10 +64,10 @@ type ServingConfig struct {
 
 func NewConfig(namespace string) *Config {
 	return &Config{
-		Namespace:           namespace,
-		Interval:            Interval,
-		FinishedSleep:       5 * time.Second,
-		FailOnMissingEvents: true,
+		Namespace:     namespace,
+		Interval:      Interval,
+		FinishedSleep: 5 * time.Second,
+		FailOnErrors:  true,
 		Serving: ServingConfig{
 			Use:         false,
 			ScaleToZero: true,
@@ -116,15 +116,15 @@ func (p *prober) servingClient() resources.ServingClient {
 
 func (p *prober) ReportErrors(t *testing.T, errors []error) {
 	for _, err := range errors {
-		if p.config.FailOnMissingEvents {
+		if p.config.FailOnErrors {
 			t.Error(err)
 		} else {
 			p.log.Warnf("Silenced FAIL: %v", err)
 		}
 	}
-	if len(errors) > 0 && !p.config.FailOnMissingEvents {
+	if len(errors) > 0 && !p.config.FailOnErrors {
 		t.Skipf(
-			"Found %d errors, but FailOnMissingEvents is false. Skipping test.",
+			"Found %d errors, but FailOnErrors is false. Skipping test.",
 			len(errors),
 		)
 	}


### PR DESCRIPTION
Fixes #3191 

## Proposed Changes

- Rename FailOnMissingEvents flag to FailOnErrors for upgrade tests