### PR TITLE
Move more e2e test log parsing to recordevents

### DIFF
--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	ce "github.com/cloudevents/sdk-go"
+	ce2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/openzipkin/zipkin-go/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -223,14 +224,14 @@ func setupBrokerTracing(brokerClass string) SetupInfrastructureFunc {
 				Children: []tracinghelper.TestSpanTree{expected},
 			}
 		}
-		matchFunc := func(ev ce.Event) bool {
+		matchFunc := func(ev ce2.Event) bool {
 			if ev.Source() != senderName {
 				return false
 			}
 			if ev.ID() != eventID {
 				return false
 			}
-			db, _ := ev.DataBytes()
+			db := ev.Data()
 			return strings.Contains(string(db), body)
 		}
 

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -224,15 +224,18 @@ func setupBrokerTracing(brokerClass string) SetupInfrastructureFunc {
 				Children: []tracinghelper.TestSpanTree{expected},
 			}
 		}
-		matchFunc := func(ev ce2.Event) bool {
+		matchFunc := func(ev ce2.Event) error {
 			if ev.Source() != senderName {
-				return false
+				return fmt.Errorf("expected source %s, saw %s", senderName, ev.Source())
 			}
 			if ev.ID() != eventID {
-				return false
+				return fmt.Errorf("expected id %s, saw %s", eventID, ev.ID())
 			}
 			db := ev.Data()
-			return strings.Contains(string(db), body)
+			if !strings.Contains(string(db), body) {
+				return fmt.Errorf("expected substring %s in data %s", body, string(db))
+			}
+			return nil
 		}
 
 		return expected, matchFunc

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	ce "github.com/cloudevents/sdk-go"
+	ce2 "github.com/cloudevents/sdk-go/v2"
 	"github.com/openzipkin/zipkin-go/model"
 	"go.opentelemetry.io/otel/api/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -335,14 +336,14 @@ func setupChannelTracingWithReply(
 		}
 	}
 
-	matchFunc := func(ev ce.Event) bool {
+	matchFunc := func(ev ce2.Event) bool {
 		if ev.Source() != senderName {
 			return false
 		}
 		if ev.ID() != eventID {
 			return false
 		}
-		db, _ := ev.DataBytes()
+		db := ev.Data()
 		return strings.Contains(string(db), body)
 	}
 

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -336,15 +336,18 @@ func setupChannelTracingWithReply(
 		}
 	}
 
-	matchFunc := func(ev ce2.Event) bool {
+	matchFunc := func(ev ce2.Event) error {
 		if ev.Source() != senderName {
-			return false
+			return fmt.Errorf("expected source %s, saw %s", senderName, ev.Source())
 		}
 		if ev.ID() != eventID {
-			return false
+			return fmt.Errorf("expected id %s, saw %s", eventID, ev.ID())
 		}
 		db := ev.Data()
-		return strings.Contains(string(db), body)
+		if !strings.Contains(string(db), body) {
+			return fmt.Errorf("expected substring %s in %s", body, string(db))
+		}
+		return nil
 	}
 
 	return expected, matchFunc

--- a/test/e2e/source_ping_test.go
+++ b/test/e2e/source_ping_test.go
@@ -41,15 +41,20 @@ func TestPingSourceV1Alpha1(t *testing.T) {
 		// Every 1 minute starting from now
 		schedule = "*/1 * * * *"
 
-		loggerPodName = "e2e-ping-source-logger-pod"
+		loggerPodName = "e2e-ping-source-logger-pod-v1alpha1"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// create cron job source
 	data := fmt.Sprintf("TestPingSource %s", uuid.NewUUID())
@@ -68,8 +73,9 @@ func TestPingSourceV1Alpha1(t *testing.T) {
 	client.WaitForAllTestResourcesReadyOrFail()
 
 	// verify the logger service receives the event and only once
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsCount(data, 1)); err != nil {
-		t.Fatalf("String %q not found or found multiple times in logs of logger pod %q: %v", data, loggerPodName, err)
+	err = targetTracker.WaitMatchSourceData(sourcesv1alpha1.PingSourceSource(client.Namespace, sourceName), data, 1, 1)
+	if err != nil {
+		t.Fatalf("Error watching for data %s event in pod %s: %v", data, loggerPodName, err)
 	}
 }
 
@@ -78,15 +84,20 @@ func TestPingSourceV1Alpha2(t *testing.T) {
 		sourceName = "e2e-ping-source"
 		// Every 1 minute starting from now
 
-		loggerPodName = "e2e-ping-source-logger-pod"
+		loggerPodName = "e2e-ping-source-logger-pod-v1alpha2"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// create cron job source
 	data := fmt.Sprintf("TestPingSource %s", uuid.NewUUID())
@@ -108,8 +119,9 @@ func TestPingSourceV1Alpha2(t *testing.T) {
 	client.WaitForAllTestResourcesReadyOrFail()
 
 	// verify the logger service receives the event and only once
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsCount(data, 1)); err != nil {
-		t.Fatalf("String %q not found or found multiple times in logs of logger pod %q: %v", data, loggerPodName, err)
+	err = targetTracker.WaitMatchSourceData(sourcesv1alpha2.PingSourceSource(client.Namespace, sourceName), data, 1, 1)
+	if err != nil {
+		t.Fatalf("Error watching for data %s event in pod %s: %v", data, loggerPodName, err)
 	}
 }
 
@@ -118,15 +130,20 @@ func TestPingSourceV1Alpha2ResourceScope(t *testing.T) {
 		sourceName = "e2e-ping-source"
 		// Every 1 minute starting from now
 
-		loggerPodName = "e2e-ping-source-logger-pod"
+		loggerPodName = "e2e-ping-source-logger-pod-v1alpha2rs"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// create cron job source
 	data := fmt.Sprintf("TestPingSource %s", uuid.NewUUID())
@@ -149,8 +166,9 @@ func TestPingSourceV1Alpha2ResourceScope(t *testing.T) {
 	client.WaitForAllTestResourcesReadyOrFail()
 
 	// verify the logger service receives the event and only once
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsCount(data, 1)); err != nil {
-		t.Fatalf("String %q not found or found multiple times in logs of logger pod %q: %v", data, loggerPodName, err)
+	err = targetTracker.WaitMatchSourceData(sourcesv1alpha2.PingSourceSource(client.Namespace, sourceName), data, 1, 1)
+	if err != nil {
+		t.Fatalf("Error watching for data %s event in pod %s: %v", data, loggerPodName, err)
 	}
 }
 
@@ -203,5 +221,4 @@ func TestPingSourceV1Alpha2EventTypes(t *testing.T) {
 		t.Fatalf("Invalid spec.type and/or spec.source for PingSource EventType, expected: type=%s source=%s, got: type=%s source=%s",
 			sourcesv1alpha2.PingSourceEventType, sourcesv1alpha2.PingSourceSource(client.Namespace, sourceName), et.Spec.Type, et.Spec.Source)
 	}
-
 }

--- a/test/e2e/source_sinkbinding_v1alpha1_test.go
+++ b/test/e2e/source_sinkbinding_v1alpha1_test.go
@@ -19,12 +19,14 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
+	ce "github.com/cloudevents/sdk-go/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -52,8 +54,13 @@ func TestSinkBindingDeployment(t *testing.T) {
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	extensionSecret := string(uuid.NewUUID())
 
@@ -114,15 +121,29 @@ func TestSinkBindingDeployment(t *testing.T) {
 	// wait for all test resources to be ready
 	client.WaitForAllTestResourcesReadyOrFail()
 
-	// verify the logger service receives the event
+	// Look for events with expected data, and sinkbinding extension
 	expectedCount := 2
-	// Look for body.
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(data, expectedCount)); err != nil {
-		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", data, expectedCount, loggerPodName, err)
+	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
+	matchFunc := func(ev ce.Event) bool {
+		if expectedSource != ev.Source() {
+			return false
+		}
+		ext := ev.Extensions()
+		value, found := ext["sinkbinding"]
+		if !found {
+			return false
+		}
+		if value != extensionSecret {
+			return false
+		}
+		db := ev.Data()
+		return strings.Contains(string(db), data)
 	}
-	// Look for extensions.
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(extensionSecret, expectedCount)); err != nil {
-		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", extensionSecret, expectedCount, loggerPodName, err)
+
+	_, err = targetTracker.WaitAtLeastNMatch(lib.ValidEvFunc(matchFunc), expectedCount)
+	if err != nil {
+		t.Fatalf("Data %s, extension %q does not appear at least %d times in events of logger pod %q: %v", data, extensionSecret, expectedCount, loggerPodName, err)
+
 	}
 }
 
@@ -140,8 +161,13 @@ func TestSinkBindingCronJob(t *testing.T) {
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// create sink binding
 	sinkBinding := eventingtesting.NewSinkBindingV1Alpha1(
@@ -207,7 +233,8 @@ func TestSinkBindingCronJob(t *testing.T) {
 
 	// verify the logger service receives the event
 	expectedCount := 2
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(data, expectedCount)); err != nil {
+	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
+	if err := targetTracker.WaitMatchSourceData(expectedSource, data, expectedCount, -1); err != nil {
 		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", data, expectedCount, loggerPodName, err)
 	}
 }

--- a/test/e2e/source_sinkbinding_v1alpha2_test.go
+++ b/test/e2e/source_sinkbinding_v1alpha2_test.go
@@ -19,12 +19,14 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
+	ce "github.com/cloudevents/sdk-go/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -45,15 +47,20 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 		// the heartbeats image is built from test_images/heartbeats
 		imageName = "heartbeats"
 
-		loggerPodName = "e2e-sink-binding-logger-pod"
+		loggerPodName = "e2e-sink-binding-logger-pod-v1alpha2dep"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	extensionSecret := string(uuid.NewUUID())
 
@@ -114,15 +121,29 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 	// wait for all test resources to be ready
 	client.WaitForAllTestResourcesReadyOrFail()
 
-	// verify the logger service receives the event
+	// Look for events with expected data, and sinkbinding extension
 	expectedCount := 2
-	// Look for body.
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(data, expectedCount)); err != nil {
-		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", data, expectedCount, loggerPodName, err)
+	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
+	matchFunc := func(ev ce.Event) bool {
+		if expectedSource != ev.Source() {
+			return false
+		}
+		ext := ev.Extensions()
+		value, found := ext["sinkbinding"]
+		if !found {
+			return false
+		}
+		if value != extensionSecret {
+			return false
+		}
+		db := ev.Data()
+		return strings.Contains(string(db), data)
 	}
-	// Look for extensions.
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(extensionSecret, expectedCount)); err != nil {
-		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", extensionSecret, expectedCount, loggerPodName, err)
+
+	_, err = targetTracker.WaitAtLeastNMatch(lib.ValidEvFunc(matchFunc), expectedCount)
+	if err != nil {
+		t.Fatalf("Data %s, extension %q does not appear at least %d times in events of logger pod %q: %v", data, extensionSecret, expectedCount, loggerPodName, err)
+
 	}
 }
 
@@ -133,15 +154,20 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 		// the heartbeats image is built from test_images/heartbeats
 		imageName = "heartbeats"
 
-		loggerPodName = "e2e-sink-binding-logger-pod"
+		loggerPodName = "e2e-sink-binding-logger-pod-v1alpha2c"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventLoggerPod(loggerPodName)
+	loggerPod := resources.EventRecordPod(loggerPodName)
 	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
+	targetTracker, err := client.NewEventInfoStore(loggerPodName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// create sink binding
 	sinkBinding := eventingtesting.NewSinkBindingV1Alpha2(
@@ -207,7 +233,9 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 
 	// verify the logger service receives the event
 	expectedCount := 2
-	if err := client.CheckLog(loggerPodName, lib.CheckerContainsAtLeast(data, expectedCount)); err != nil {
+	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
+	if err := targetTracker.WaitMatchSourceData(expectedSource, data, expectedCount, -1); err != nil {
 		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", data, expectedCount, loggerPodName, err)
 	}
+
 }

--- a/test/e2e/source_sinkbinding_v1alpha2_test.go
+++ b/test/e2e/source_sinkbinding_v1alpha2_test.go
@@ -124,20 +124,23 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 	// Look for events with expected data, and sinkbinding extension
 	expectedCount := 2
 	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
-	matchFunc := func(ev ce.Event) bool {
+	matchFunc := func(ev ce.Event) error {
 		if expectedSource != ev.Source() {
-			return false
+			return fmt.Errorf("expected source %s, saw %s", expectedSource, ev.Source())
 		}
 		ext := ev.Extensions()
 		value, found := ext["sinkbinding"]
 		if !found {
-			return false
+			return fmt.Errorf("didn't find extension sinkbinding")
 		}
 		if value != extensionSecret {
-			return false
+			return fmt.Errorf("expension sinkbinding didn't match %s, saw %s", extensionSecret, value)
 		}
 		db := ev.Data()
-		return strings.Contains(string(db), data)
+		if !strings.Contains(string(db), data) {
+			return fmt.Errorf("expected substring %s in %s", data, string(db))
+		}
+		return nil
 	}
 
 	_, err = targetTracker.WaitAtLeastNMatch(lib.ValidEvFunc(matchFunc), expectedCount)

--- a/test/e2e/trigger_dependency_annotation_test.go
+++ b/test/e2e/trigger_dependency_annotation_test.go
@@ -58,8 +58,13 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
 
 	// Create subscribers.
-	pod := resources.EventLoggerPod(subscriberName)
-	client.CreatePodOrFail(pod, lib.WithService(subscriberName))
+	loggerPod := resources.EventRecordPod(subscriberName)
+	client.CreatePodOrFail(loggerPod, lib.WithService(subscriberName))
+	targetTracker, err := client.NewEventInfoStore(subscriberName, t.Logf)
+	if err != nil {
+		t.Fatalf("Pod tracker failed: %v", err)
+	}
+	defer targetTracker.Cleanup()
 
 	// Wait for subscriber to become ready
 	client.WaitForAllTestResourcesReadyOrFail()
@@ -98,7 +103,8 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	// Trigger should become ready after pingSource was created
 	client.WaitForResourceReadyOrFail(triggerName, lib.TriggerTypeMeta)
 
-	if err := client.CheckLog(subscriberName, lib.CheckerContains(jsonData)); err != nil {
-		t.Fatalf("Event(s) not found in logs of subscriber pod %q: %v", subscriberName, err)
+	err = targetTracker.WaitMatchSourceData(sourcesv1alpha2.PingSourceSource(client.Namespace, pingSourceName), jsonData, 1, -1)
+	if err != nil {
+		t.Fatalf("Error watching for data %s event in pod %s: %v", jsonData, subscriberName, err)
 	}
 }

--- a/test/lib/checkevents.go
+++ b/test/lib/checkevents.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/pkg/test/logging"

--- a/test/lib/checkevents.go
+++ b/test/lib/checkevents.go
@@ -182,7 +182,7 @@ func (ei *EventInfoStore) Find(f EventInfoMatchFunc) ([]EventInfo, SearchedInfo,
 		return nil, sInfo, fmt.Errorf("error getting events %v", err)
 	}
 	for i := range allEvents {
-		if f(allEvents[i]) {
+		if f(allEvents[i]) == nil {
 			allMatch = append(allMatch, allEvents[i])
 		}
 		lastEvents = append(lastEvents, allEvents[i])
@@ -201,9 +201,9 @@ func (ei *EventInfoStore) Find(f EventInfoMatchFunc) ([]EventInfo, SearchedInfo,
 // that checks EventInfo structures, returning false for any that don't
 // contain valid events.
 func ValidEvFunc(evf EventMatchFunc) EventInfoMatchFunc {
-	return func(ei EventInfo) bool {
+	return func(ei EventInfo) error {
 		if ei.Event == nil {
-			return false
+			return fmt.Errorf("Saw nil event")
 		} else {
 			return evf(*ei.Event)
 		}
@@ -240,12 +240,17 @@ func (ei *EventInfoStore) WaitAtLeastNMatch(f EventInfoMatchFunc, n int) ([]Even
 // data field.  If source is the empty string, don't check the source.  If maxCount is >0, return an error
 // if more than maxCount entries are seen.
 func (ei *EventInfoStore) WaitMatchSourceData(source string, data string, minCount int, maxCount int) error {
-	matchFunc := func(ev cloudevents.Event) bool {
+	matchFunc := func(ev cloudevents.Event) error {
 		if source != "" && ev.Source() != source {
-			return false
+			return fmt.Errorf("mismatched source: expected %s, saw %s", source, ev.Source())
 		}
 		db := ev.Data()
-		return strings.Contains(string(db), data)
+		body := string(db)
+		if strings.Contains(body, data) {
+			return nil
+		} else {
+			return fmt.Errorf("didn't find substring (%s) in data (%s)", data, body)
+		}
 	}
 	// verify the logger service receives the event and only once
 	match, err := ei.WaitAtLeastNMatch(ValidEvFunc(matchFunc), minCount)
@@ -259,11 +264,11 @@ func (ei *EventInfoStore) WaitMatchSourceData(source string, data string, minCou
 }
 
 // Does the provided EventInfo match some criteria
-type EventInfoMatchFunc func(EventInfo) bool
+type EventInfoMatchFunc func(EventInfo) error
 
 // Does the provided event match some criteria
-type EventMatchFunc func(cloudevents.Event) bool
+type EventMatchFunc func(cloudevents.Event) error
 
-func MatchAllEvent(cloudevents.Event) bool {
-	return true
+func MatchAllEvent(cloudevents.Event) error {
+	return nil
 }

--- a/test/lib/checkevents_test.go
+++ b/test/lib/checkevents_test.go
@@ -139,7 +139,7 @@ func TestSequentialAndTrim(t *testing.T) {
 	subEv := totalEv[:10]
 	deg.setEv(1, subEv)
 	ei := newTestableEventInfoStore(deg, -1, -1)
-	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	allData, _, err := ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestSequentialAndTrim(t *testing.T) {
 	subEv = totalEv[10:19]
 	deg.setEv(11, subEv)
 
-	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	allData, _, err = ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
@@ -169,14 +169,14 @@ func TestOverlap(t *testing.T) {
 	subEv := totalEv[:10]
 	deg.setEv(1, subEv)
 	ei := newTestableEventInfoStore(deg, -1, -1)
-	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	allData, _, err := ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = totalEv[6:19]
 	deg.setEv(7, subEv)
-	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	allData, _, err = ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
@@ -193,14 +193,14 @@ func TestGap(t *testing.T) {
 	subEv := totalEv[:10]
 	deg.setEv(1, subEv)
 	ei := newTestableEventInfoStore(deg, -1, -1)
-	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	allData, _, err := ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = totalEv[11:19]
 	deg.setEv(12, subEv)
-	_, _, err = ei.Find(func(EventInfo) bool { return true })
+	_, _, err = ei.Find(func(EventInfo) error { return nil })
 	if err == nil {
 		t.Fatalf("Unexpected success from find")
 	}
@@ -216,14 +216,14 @@ func TestSequentialNoOp(t *testing.T) {
 	subEv := totalEv[:10]
 	deg.setEv(1, subEv)
 	ei := newTestableEventInfoStore(deg, -1, -1)
-	allData, _, err := ei.Find(func(EventInfo) bool { return true })
+	allData, _, err := ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
 	checkEvIDEqual(t, allData, expectedFull[:10])
 	subEv = []EventInfo{}
 	deg.setEv(11, subEv)
-	allData, _, err = ei.Find(func(EventInfo) bool { return true })
+	allData, _, err = ei.Find(func(EventInfo) error { return nil })
 	if err != nil {
 		t.Fatalf("Unexpected error from find: %v", err)
 	}
@@ -242,7 +242,15 @@ func TestWaitForN(t *testing.T) {
 	var waitErr error
 	var allMatch []EventInfo
 	go func() {
-		allMatch, waitErr = ei.WaitAtLeastNMatch(ValidEvFunc(func(ev cloudevents.Event) bool { return ev.ID() == "3" }), 2)
+		matchFunc := func(ev cloudevents.Event) error {
+			if ev.ID() == "3" {
+				return nil
+			} else {
+				return fmt.Errorf("mismatch %s %s", ev.ID(), "3")
+			}
+		}
+
+		allMatch, waitErr = ei.WaitAtLeastNMatch(ValidEvFunc(matchFunc), 2)
 		wg.Done()
 	}()
 	var tCalls int

--- a/test/lib/checkevents_test.go
+++ b/test/lib/checkevents_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 type dummyEventGet struct {

--- a/test/lib/requests.go
+++ b/test/lib/requests.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/lib/requests.go
+++ b/test/lib/requests.go
@@ -56,8 +56,9 @@ type MinMaxResponse struct {
 
 // Structure to hold information about an event seen by recordevents pod.
 type EventInfo struct {
-	// Set if the cloudevent received by the pod didn't pass validation
-	ValidationError string
+	// Set if the http request received by the pod couldn't be decoded or
+	// didn't pass validation
+	Error string
 	// Event received if the cloudevent received by the pod passed validation
 	Event *cloudevents.Event
 	// HTTPHeaders of the connection that delivered the event
@@ -70,7 +71,7 @@ func (ei *EventInfo) String() string {
 	if ei.Event != nil {
 		return ei.Event.String()
 	} else {
-		return fmt.Sprintf("invalid event \"%s\"", ei.ValidationError)
+		return fmt.Sprintf("invalid event \"%s\"", ei.Error)
 	}
 }
 
@@ -219,7 +220,7 @@ func (eg *eventGetter) getEntry(seqno int) (EventInfo, error) {
 	if err != nil {
 		return EventInfo{}, fmt.Errorf("error unmarshalling response %w", err)
 	}
-	if len(entryResponse.ValidationError) == 0 && entryResponse.Event == nil {
+	if len(entryResponse.Error) == 0 && entryResponse.Event == nil {
 		return EventInfo{}, fmt.Errorf("invalid decoded json: %+v", entryResponse)
 	}
 

--- a/test/lib/requests.go
+++ b/test/lib/requests.go
@@ -191,7 +191,7 @@ func (eg *eventGetter) getMinMax() (minRet int, maxRet int, errRet error) {
 	if err != nil {
 		return -1, -1, fmt.Errorf("error unmarshalling response %w", err)
 	}
-	if minMaxResponse.MinAvail == 0 || minMaxResponse.MaxSeen == 0 {
+	if minMaxResponse.MinAvail == 0 {
 		return -1, -1, fmt.Errorf("invalid decoded json: %+v", minMaxResponse)
 	}
 

--- a/test/test_images/recordevents/eventstore.go
+++ b/test/test_images/recordevents/eventstore.go
@@ -79,9 +79,9 @@ func (es *eventStore) StoreEvent(event *cloudevents.Event, evErr error, httpHead
 	var evInfoBytes []byte
 	if evErr != nil {
 		evInfo.HTTPHeaders = httpHeaders
-		evInfo.ValidationError = evErr.Error()
-		if evInfo.ValidationError == "" {
-			evInfo.ValidationError = "Unknown Incoming Error"
+		evInfo.Error = evErr.Error()
+		if evInfo.Error == "" {
+			evInfo.Error = "Unknown Incoming Error"
 		}
 		evInfoBytes, err = json.Marshal(&evInfo)
 		if err != nil {
@@ -94,9 +94,9 @@ func (es *eventStore) StoreEvent(event *cloudevents.Event, evErr error, httpHead
 
 		if err != nil {
 			evInfo.Event = nil
-			evInfo.ValidationError = err.Error()
-			if evInfo.ValidationError == "" {
-				evInfo.ValidationError = "Unknown Error"
+			evInfo.Error = err.Error()
+			if evInfo.Error == "" {
+				evInfo.Error = "Unknown Error"
 			}
 			evInfoBytes, err = json.Marshal(&evInfo)
 			if err != nil {

--- a/test/test_images/recordevents/eventstore.go
+++ b/test/test_images/recordevents/eventstore.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"knative.dev/eventing/test/lib"
 )
@@ -73,20 +73,35 @@ func (es *eventStore) checkAppendBlock() {
 }
 
 // Store the specified event.
-func (es *eventStore) StoreEvent(event cloudevents.Event, httpHeaders map[string][]string) {
+func (es *eventStore) StoreEvent(event *cloudevents.Event, evErr error, httpHeaders map[string][]string) {
 	var evInfo lib.EventInfo
-	evInfo.Event = &event
-	evInfo.HTTPHeaders = httpHeaders
-	evInfoBytes, err := json.Marshal(&evInfo)
-	if err != nil {
-		evInfo.Event = nil
-		evInfo.ValidationError = err.Error()
+	var err error
+	var evInfoBytes []byte
+	if evErr != nil {
+		evInfo.HTTPHeaders = httpHeaders
+		evInfo.ValidationError = evErr.Error()
 		if evInfo.ValidationError == "" {
-			evInfo.ValidationError = "Unknown Error"
+			evInfo.ValidationError = "Unknown Incoming Error"
 		}
 		evInfoBytes, err = json.Marshal(&evInfo)
 		if err != nil {
 			panic(fmt.Errorf("unexpected marshal error (%v) (%+v)", err, evInfo))
+		}
+	} else {
+		evInfo.Event = event
+		evInfo.HTTPHeaders = httpHeaders
+		evInfoBytes, err = json.Marshal(&evInfo)
+
+		if err != nil {
+			evInfo.Event = nil
+			evInfo.ValidationError = err.Error()
+			if evInfo.ValidationError == "" {
+				evInfo.ValidationError = "Unknown Error"
+			}
+			evInfoBytes, err = json.Marshal(&evInfo)
+			if err != nil {
+				panic(fmt.Errorf("unexpected marshal error (%v) (%+v)", err, evInfo))
+			}
 		}
 	}
 

--- a/test/test_images/recordevents/eventstore_test.go
+++ b/test/test_images/recordevents/eventstore_test.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"testing"
 
-	cloudevents "github.com/cloudevents/sdk-go"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 
 	"knative.dev/eventing/test/lib"
 )
@@ -54,7 +54,7 @@ func TestAddGetMany(t *testing.T) {
 		ce.SetType("knative.dev.test.event.a")
 		ce.SetSource("https://source.test.event.knative.dev/foo")
 		ce.SetID(strconv.FormatInt(int64(i), 10))
-		es.StoreEvent(ce, nil)
+		es.StoreEvent(&ce, nil, nil)
 		minAvail, maxSeen := es.MinMax()
 		if minAvail != 1 {
 			t.Fatalf("Pass %d Bad min: %d, expected %d", i, minAvail, 1)
@@ -127,7 +127,7 @@ func TestAddGetSingleValid(t *testing.T) {
 	ce.SetType(expectedType)
 	ce.SetSource(expectedSource)
 	ce.SetID(expectedID)
-	es.StoreEvent(ce, headers)
+	es.StoreEvent(&ce, nil, headers)
 	minAvail, maxSeen := es.MinMax()
 	if minAvail != maxSeen {
 		t.Fatalf("Expected match, saw %d, %d", minAvail, maxSeen)
@@ -181,7 +181,48 @@ func TestAddGetSingleInvalid(t *testing.T) {
 	ce.SetType("knative.dev.test.event.a")
 	// No source
 	ce.SetID("111")
-	es.StoreEvent(ce, headers)
+	es.StoreEvent(&ce, nil, headers)
+	minAvail, maxSeen := es.MinMax()
+	if minAvail != maxSeen {
+		t.Fatalf("Expected match, saw %d, %d", minAvail, maxSeen)
+	}
+
+	evInfoBytes, err := es.GetEventInfoBytes(minAvail)
+	if err != nil {
+		t.Fatalf("Error calling get: %v", err)
+	}
+	var evInfo lib.EventInfo
+	err = json.Unmarshal(evInfoBytes, &evInfo)
+	if err != nil {
+		t.Fatalf("Error unmarshalling stored JSON: %v", err)
+	}
+	if evInfo.Event != nil {
+		t.Fatalf("Unexpected event info: %+v", evInfo)
+	}
+	if len(evInfo.ValidationError) == 0 {
+		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.ValidationError)
+	}
+	if len(evInfo.HTTPHeaders) != 1 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if len(evInfo.HTTPHeaders["foo"]) != 2 {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+	if evInfo.HTTPHeaders["foo"][0] != "bar" || evInfo.HTTPHeaders["foo"][1] != "baz" {
+		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
+	}
+}
+
+func TestAddGetSingleInvalidError(t *testing.T) {
+	es := newEventStore()
+
+	headers := make(map[string][]string)
+	headers["foo"] = []string{"bar", "baz"}
+	ce := cloudevents.NewEvent(cloudevents.VersionV1)
+	ce.SetType("knative.dev.test.event.a")
+	ce.SetID("111")
+	ce.SetSource("nnn")
+	es.StoreEvent(&ce, fmt.Errorf("Error passed in"), headers)
 	minAvail, maxSeen := es.MinMax()
 	if minAvail != maxSeen {
 		t.Fatalf("Expected match, saw %d, %d", minAvail, maxSeen)
@@ -219,7 +260,7 @@ func helperFillCount(es *eventStore, count int) {
 		ce.SetType("knative.dev.test.event.a")
 		ce.SetSource("https://source.test.event.knative.dev/foo")
 		ce.SetID(strconv.FormatInt(int64(i), 10))
-		es.StoreEvent(ce, nil)
+		es.StoreEvent(&ce, nil, nil)
 	}
 }
 
@@ -264,7 +305,7 @@ func TestTrim(t *testing.T) {
 		ce.SetType("knative.dev.test.event.a")
 		ce.SetSource("https://source.test.event.knative.dev/foo")
 		ce.SetID(strconv.FormatInt(int64(count), 10))
-		es.StoreEvent(ce, nil)
+		es.StoreEvent(&ce, nil, nil)
 		addedMinAvail, addedMaxSeen := es.MinMax()
 		if addedMaxSeen != maxSeen+1 {
 			t.Fatalf("Add after trim resulted in bad maxSeen: expected %d, saw %d for trim %d",

--- a/test/test_images/recordevents/eventstore_test.go
+++ b/test/test_images/recordevents/eventstore_test.go
@@ -73,8 +73,8 @@ func TestAddGetMany(t *testing.T) {
 		if evInfo.Event == nil {
 			t.Fatalf("Unexpected empty event info event %d: %+v", i, evInfo)
 		}
-		if len(evInfo.ValidationError) != 0 {
-			t.Fatalf("Unexpected error for stored event %d: %s", i, evInfo.ValidationError)
+		if len(evInfo.Error) != 0 {
+			t.Fatalf("Unexpected error for stored event %d: %s", i, evInfo.Error)
 		}
 
 		// Make sure it's the expected event
@@ -146,8 +146,8 @@ func TestAddGetSingleValid(t *testing.T) {
 	if evInfo.Event == nil {
 		t.Fatalf("Unexpected empty event info event: %+v", evInfo)
 	}
-	if len(evInfo.ValidationError) != 0 {
-		t.Fatalf("Unexpected error for stored event: %s", evInfo.ValidationError)
+	if len(evInfo.Error) != 0 {
+		t.Fatalf("Unexpected error for stored event: %s", evInfo.Error)
 	}
 	if len(evInfo.HTTPHeaders) != 1 {
 		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
@@ -199,8 +199,8 @@ func TestAddGetSingleInvalid(t *testing.T) {
 	if evInfo.Event != nil {
 		t.Fatalf("Unexpected event info: %+v", evInfo)
 	}
-	if len(evInfo.ValidationError) == 0 {
-		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.ValidationError)
+	if len(evInfo.Error) == 0 {
+		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.Error)
 	}
 	if len(evInfo.HTTPHeaders) != 1 {
 		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)
@@ -240,8 +240,8 @@ func TestAddGetSingleInvalidError(t *testing.T) {
 	if evInfo.Event != nil {
 		t.Fatalf("Unexpected event info: %+v", evInfo)
 	}
-	if len(evInfo.ValidationError) == 0 {
-		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.ValidationError)
+	if len(evInfo.Error) == 0 {
+		t.Fatalf("Unexpected empty error for stored event: %s", evInfo.Error)
 	}
 	if len(evInfo.HTTPHeaders) != 1 {
 		t.Fatalf("Unexpected header contents for stored event: %+v", evInfo.HTTPHeaders)


### PR DESCRIPTION
Moves more of the e2e tests from log parsing to recordevents.  In addition to allowing more specific tests, this makes us more resilient to changes in log formatting.  This is particularly important for cloudevents v2 migration.

This also move test_images/recordevents and the test client side helpers to cloudevents v2.