### PR TITLE
Update default API versions in tests to v1beta1

### DIFF
--- a/test/lib/resources/constants.go
+++ b/test/lib/resources/constants.go
@@ -27,9 +27,9 @@ const SystemNamespace = "knative-eventing"
 // API versions for the resources.
 const (
 	CoreAPIVersion      = "v1"
-	EventingAPIVersion  = "eventing.knative.dev/v1alpha1"
-	MessagingAPIVersion = "messaging.knative.dev/v1alpha1"
-	FlowsAPIVersion     = "flows.knative.dev/v1alpha1"
+	EventingAPIVersion  = "eventing.knative.dev/v1beta1"
+	MessagingAPIVersion = "messaging.knative.dev/v1beta1"
+	FlowsAPIVersion     = "flows.knative.dev/v1beta1"
 	ServingAPIVersion   = "serving.knative.dev/v1"
 )
 

--- a/test/lib/resources/constants.go
+++ b/test/lib/resources/constants.go
@@ -42,7 +42,7 @@ var (
 	// KServicesGVR is GroupVersionResource for Knative Service
 	KServicesGVR = schema.GroupVersionResource{
 		Group:    "serving.knative.dev",
-		Version:  "v1alpha1",
+		Version:  "v1",
 		Resource: "services",
 	}
 	// KServiceType is type of Knative Service


### PR DESCRIPTION
These are used in various places in eventing tests and should keep pace with our latest API versions.

I noticed one constant still uses v1alpha1 of serving. I don't know if that version is even served anymore but I updated it anyway.

## Proposed Changes

- Use v1beta1 versions of eventing, messaging, and flows groups by default in tests
