### PR TITLE
New event-sender image

### DIFF
--- a/test/lib/event_sender.go
+++ b/test/lib/event_sender.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package lib
 
 import (
@@ -31,7 +47,7 @@ func (c *Client) SendEvent(
 	senderName string,
 	uri string,
 	event cloudevents.Event,
-    option ...sender.EventSenderOption,
+	option ...sender.EventSenderOption,
 ) error {
 	namespace := c.Namespace
 	pod, err := sender.EventSenderPod("event-sender", senderName, uri, event, option...)
@@ -44,4 +60,3 @@ func (c *Client) SendEvent(
 	}
 	return nil
 }
-

--- a/test/lib/event_sender.go
+++ b/test/lib/event_sender.go
@@ -1,0 +1,47 @@
+package lib
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"knative.dev/eventing/test/lib/resources/sender"
+)
+
+// SendEventToAddressable will send the given event to the given Addressable.
+func (c *Client) SendEventToAddressable(
+	senderName,
+	addressableName string,
+	typemeta *metav1.TypeMeta,
+	event cloudevents.Event,
+	option ...sender.EventSenderOption,
+) {
+	uri, err := c.GetAddressableURI(addressableName, typemeta)
+	if err != nil {
+		c.T.Fatalf("Failed to get the URI for %v-%s", typemeta, addressableName)
+	}
+	if err = c.SendEvent(senderName, uri, event, option...); err != nil {
+		c.T.Fatalf("Failed to send event %v with tracing to %s: %v", event, uri, err)
+	}
+}
+
+// SendEvent will create a sender pod, which will send the given event to the given url.
+func (c *Client) SendEvent(
+	senderName string,
+	uri string,
+	event cloudevents.Event,
+    option ...sender.EventSenderOption,
+) error {
+	namespace := c.Namespace
+	pod, err := sender.EventSenderPod("event-sender", senderName, uri, event, option...)
+	if err != nil {
+		return err
+	}
+	c.CreatePodOrFail(pod)
+	if err := pkgTest.WaitForPodRunning(c.Kube, senderName, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/test/lib/operation.go
+++ b/test/lib/operation.go
@@ -46,6 +46,7 @@ func (c *Client) LabelNamespace(labels map[string]string) error {
 }
 
 // SendFakeEventToAddressableOrFail will send the given event to the given Addressable.
+// Deprecated: you should use SendEventToAddressable
 func (c *Client) SendFakeEventToAddressableOrFail(
 	senderName,
 	addressableName string,
@@ -62,6 +63,7 @@ func (c *Client) SendFakeEventToAddressableOrFail(
 }
 
 // SendFakeEventWithTracingToAddressableOrFail will send the given event with tracing to the given Addressable.
+// Deprecated: you should use SendEventToAddressable
 func (c *Client) SendFakeEventWithTracingToAddressableOrFail(
 	senderName,
 	addressableName string,
@@ -90,6 +92,7 @@ func (c *Client) GetAddressableURI(addressableName string, typeMeta *metav1.Type
 }
 
 // sendFakeEventToAddress will create a sender pod, which will send the given event to the given url.
+// Deprecated: you should use SendEvent
 func (c *Client) sendFakeEventToAddress(
 	senderName string,
 	uri string,
@@ -108,6 +111,7 @@ func (c *Client) sendFakeEventToAddress(
 }
 
 // sendFakeEventWithTracingToAddress will create a sender pod, which will send the given event with tracing to the given url.
+// Deprecated: you should use SendEvent
 func (c *Client) sendFakeEventWithTracingToAddress(
 	senderName string,
 	uri string,

--- a/test/lib/resources/kube.go
+++ b/test/lib/resources/kube.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	pkgTest "knative.dev/pkg/test"
 
-	"knative.dev/eventing/test/lib/cloudevents"
+	cetest "knative.dev/eventing/test/lib/cloudevents"
 )
 
 // PodOption enables further configuration of a Pod.
@@ -41,18 +41,21 @@ type PodOption func(*corev1.Pod)
 type RoleOption func(*rbacv1.Role)
 
 // EventSenderPod creates a Pod that sends a single event to the given address.
-func EventSenderPod(name string, sink string, event *cloudevents.CloudEvent) (*corev1.Pod, error) {
+// Deprecated: use sender.EventSenderPod
+func EventSenderPod(name string, sink string, event *cetest.CloudEvent) (*corev1.Pod, error) {
 	return eventSenderPodImage("sendevents", name, sink, event, false)
 }
 
 // EventSenderTracingPod creates a Pod that sends a single event to the given address.
-func EventSenderTracingPod(name string, sink string, event *cloudevents.CloudEvent) (*corev1.Pod, error) {
+// Deprecated: use sender.EventSenderPod
+func EventSenderTracingPod(name string, sink string, event *cetest.CloudEvent) (*corev1.Pod, error) {
 	return eventSenderPodImage("sendevents", name, sink, event, true)
 }
 
-func eventSenderPodImage(imageName string, name string, sink string, event *cloudevents.CloudEvent, addTracing bool) (*corev1.Pod, error) {
+// Deprecated: use sender.EventSenderPod
+func eventSenderPodImage(imageName string, name string, sink string, event *cetest.CloudEvent, addTracing bool) (*corev1.Pod, error) {
 	if event.Encoding == "" {
-		event.Encoding = cloudevents.DefaultEncoding
+		event.Encoding = cetest.DefaultEncoding
 	}
 	eventExtensionsBytes, err := json.Marshal(event.Extensions)
 	eventExtensions := string(eventExtensionsBytes)
@@ -129,7 +132,7 @@ func eventLoggerPod(imageName string, name string) *corev1.Pod {
 }
 
 // EventTransformationPod creates a Pod that transforms events received.
-func EventTransformationPod(name string, event *cloudevents.CloudEvent) *corev1.Pod {
+func EventTransformationPod(name string, event *cetest.CloudEvent) *corev1.Pod {
 	const imageName = "transformevents"
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/lib/resources/sender/sender.go
+++ b/test/lib/resources/sender/sender.go
@@ -1,0 +1,82 @@
+package sender
+
+import (
+	"encoding/json"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgTest "knative.dev/pkg/test"
+)
+
+type EventSenderOption func(*corev1.Pod)
+
+// EnableTracing enables tracing in sender pod
+func EnableTracing() EventSenderOption {
+	return func(pod *corev1.Pod) {
+		pod.Spec.Containers[0].Args = append(
+			pod.Spec.Containers[0].Args,
+			"-add-tracing",
+			"true",
+		)
+	}
+}
+
+// EnableIncrementalId creates a new incremental id for each event sent from the sender pod
+func EnableIncrementalId() EventSenderOption {
+	return func(pod *corev1.Pod) {
+		pod.Spec.Containers[0].Args = append(
+			pod.Spec.Containers[0].Args,
+			"-incremental-id",
+			"true",
+		)
+	}
+}
+
+// WithEncoding forces the encoding of the event to send from the sender pod
+func WithEncoding(encoding cloudevents.Encoding) EventSenderOption {
+	return func(pod *corev1.Pod) {
+		pod.Spec.Containers[0].Args = append(
+			pod.Spec.Containers[0].Args,
+			"-event-encoding",
+			encoding.String(),
+		)
+	}
+}
+
+// EventSenderPod creates a Pod that sends events to the given address.
+func EventSenderPod(imageName string, name string, sink string, event cloudevents.Event, options ...EventSenderOption) (*corev1.Pod, error) {
+	encodedEvent, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-sink",
+		sink,
+		"-event",
+		string(encodedEvent),
+	}
+
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            imageName,
+				Image:           pkgTest.ImagePath(imageName),
+				ImagePullPolicy: corev1.PullAlways,
+				Args:            args,
+			}},
+			// Never restart the event sender Pod.
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	for _, opt := range options {
+		opt(p)
+	}
+
+	return p, nil
+}

--- a/test/lib/resources/sender/sender.go
+++ b/test/lib/resources/sender/sender.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sender
 
 import (

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
+
+	"knative.dev/eventing/pkg/tracing"
+)
+
+var (
+	sink          string
+	inputEvent    string
+	eventEncoding string
+	periodStr     string
+	delayStr      string
+	maxMsgStr     string
+	addTracing    bool
+	incrementalId bool
+)
+
+func init() {
+	flag.StringVar(&sink, "sink", "", "The sink url for the message destination.")
+	flag.StringVar(&inputEvent, "event", "", "Event JSON encoded")
+	flag.StringVar(&eventEncoding, "event-encoding", "binary", "The encoding of the cloud event: [binary, structured].")
+	flag.StringVar(&periodStr, "period", "5", "The number of seconds between messages.")
+	flag.StringVar(&delayStr, "delay", "5", "The number of seconds to wait before sending messages.")
+	flag.StringVar(&maxMsgStr, "max-messages", "1", "The number of messages to attempt to send. 0 for unlimited.")
+	flag.BoolVar(&addTracing, "add-tracing", false, "Should tracing be added to events sent.")
+	flag.BoolVar(&incrementalId, "incremental-id", false, "Override the event id with an incremental id.")
+}
+
+func parseDurationStr(durationStr string, defaultDuration int) time.Duration {
+	var duration time.Duration
+	if d, err := strconv.Atoi(durationStr); err != nil {
+		duration = time.Duration(defaultDuration) * time.Second
+	} else {
+		duration = time.Duration(d) * time.Second
+	}
+	return duration
+}
+
+func main() {
+	flag.Parse()
+	period := parseDurationStr(periodStr, 5)
+	delay := parseDurationStr(delayStr, 5)
+
+	maxMsg := 1
+	if m, err := strconv.Atoi(maxMsgStr); err == nil {
+		maxMsg = m
+	}
+
+	defer func() {
+		var err error
+		r := recover()
+		if r != nil {
+			err = r.(error)
+			log.Printf("recovered from panic: %v", err)
+		}
+	}()
+
+	if delay > 0 {
+		log.Printf("will sleep for %s", delay)
+		time.Sleep(delay)
+		log.Printf("awake, continuing")
+	}
+
+	ctx := context.Background()
+	switch eventEncoding {
+	case "binary":
+		ctx = cloudevents.WithEncodingBinary(ctx)
+	case "structured":
+		ctx = cloudevents.WithEncodingStructured(ctx)
+	default:
+		log.Fatalf("unsupported encoding option: %q\n", eventEncoding)
+	}
+
+	t, err := cloudevents.NewHTTP(cloudevents.WithTarget(sink))
+	if err != nil {
+		log.Fatalf("failed to create transport, %v", err)
+	}
+
+	if addTracing {
+		log.Println("Adding tracing")
+		logger, _ := zap.NewDevelopment()
+		if err := tracing.SetupStaticPublishing(logger.Sugar(), "", tracing.AlwaysSample); err != nil {
+			log.Fatalf("Unable to setup trace publishing: %v", err)
+		}
+	}
+
+	c, err := cloudevents.NewClient(t,
+		cloudevents.WithTimeNow(),
+		cloudevents.WithUUIDs(),
+	)
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	var baseEvent cloudevents.Event
+	if err := json.Unmarshal([]byte(inputEvent), &baseEvent); err != nil {
+		log.Fatalf("Unable to unmarshal the event from json: %v", err)
+	}
+
+	sequence := 0
+
+	ticker := time.NewTicker(period)
+	for {
+		event := baseEvent.Clone()
+
+		sequence++
+		event.SetExtension("sequence", sequence)
+
+		if incrementalId {
+			event.SetID(fmt.Sprintf("%d", sequence))
+		}
+
+		if responseEvent, result := c.Request(ctx, event); !cloudevents.IsACK(result) {
+			log.Printf("send returned an error: %v\n", result)
+		} else if responseEvent != nil {
+			log.Printf("Got response from %s\n%s\n", sink, *responseEvent)
+		}
+
+		// Wait for next tick
+		<-ticker.C
+		// Only send a limited number of messages.
+		if maxMsg != 0 && maxMsg == sequence {
+			return
+		}
+	}
+}

--- a/test/test_images/event-sender/pod.yaml
+++ b/test/test_images/event-sender/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: event-sender
+spec:
+  containers:
+    - name: event-sender
+      image: ko://knative.dev/eventing/test/test_images/event-sender
+


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This image is meant to replace the old `sendevents`, helping transitioning the tests to sdk-go v2 #3034 

After we get this one in and #3229 we can slowly start porting the test code to use only sdk-go v2 and remove the internal `Cloudevent` representation

## Proposed Changes

- New image has exactly the same functionalities as before, but it uses sdk-go v2 and doesn't use the internal lib/cloudevents. This image doesn't replace the previous one and introduces new apis to use it. 
