### PR TITLE
Set correct namespace for namespace reconciliation events

### DIFF
--- a/pkg/reconciler/mtnamespace/namespace.go
+++ b/pkg/reconciler/mtnamespace/namespace.go
@@ -76,6 +76,10 @@ func (r *Reconciler) reconcileBroker(ctx context.Context, ns *corev1.Namespace) 
 		if err != nil {
 			return nil, err
 		}
+		// we want the event created in the namespace, and while ns is a cluster
+		// wide object, if don't do this we'll end with the event created
+		// in the default namespace, which is a bad UX in our case.
+		ns.SetNamespace(ns.Name)
 		controller.GetEventRecorder(ctx).Event(ns, corev1.EventTypeNormal, brokerCreated,
 			"Default eventing.knative.dev Broker created.")
 		return b, nil


### PR DESCRIPTION
Namespace events created during reconciliation end up in `default` namespace. This gives a bad and unexpected UX for Eventing users since in our case, the user is interacting with Triggers and Brokers that are in a specific namespace and expects Events being there.



Fixes #3084 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Enforcing namespace for namespace reconciliation events with regards to broker creation. 

**Release Note**

```release-note
When default broker is created via namespace reconciler, the Kubernetes events will be created in the correct namespace instead of some of them getting created in default namespace.
```
