### PR TITLE
Trigger controller watches brokers to update trigger status immediately

### DIFF
--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -18,6 +18,7 @@ package trigger
 
 import (
 	"context"
+
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/apis/eventing"

--- a/pkg/reconciler/trigger/controller.go
+++ b/pkg/reconciler/trigger/controller.go
@@ -18,11 +18,15 @@ package trigger
 
 import (
 	"context"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/eventing/pkg/apis/eventing"
 
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
+	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
 	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/trigger"
@@ -52,5 +56,19 @@ func NewController(
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	// Watch brokers.
+	brokerInformer.Informer().AddEventHandler(controller.HandleAll(func(obj interface{}) {
+		if b, ok := obj.(*v1beta1.Broker); ok {
+			triggers, err := triggerInformer.Lister().Triggers(b.Namespace).List(labels.SelectorFromSet(map[string]string{eventing.BrokerLabelKey: b.Name}))
+			if err != nil {
+				logging.FromContext(ctx).Warn("Failed to list triggers", zap.String("Namespace", b.Namespace), zap.String("Broker", b.Name))
+				return
+			}
+			for _, trigger := range triggers {
+				impl.Enqueue(trigger)
+			}
+		}
+	}))
 	return impl
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Trigger controller watches brokers to update trigger status immediately. Without this, if a broker is deleted while its triggers still exist, the trigger READY status will still be True.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
