### PR TITLE
Removed all usages of old asserts and using the new StartEventRecord

### DIFF
--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -132,18 +132,13 @@ func tracingTest(
 // assertEventMatch verifies that recorder pod contains at least one event that
 // matches mustMatch. It is used to show that the expected event was sent to
 // the logger Pod.  It returns a list of the matching events.
-func assertEventMatch(t *testing.T, client *lib.Client, recorderPodName string,
-	mustMatch cetest.EventMatcher) []recordevents.EventInfo {
+func assertEventMatch(t *testing.T, client *lib.Client, recorderPodName string, mustMatch cetest.EventMatcher) []recordevents.EventInfo {
 	targetTracker, err := recordevents.NewEventInfoStore(client, recorderPodName)
 	if err != nil {
 		t.Fatalf("Pod tracker failed: %v", err)
 	}
 	defer targetTracker.Cleanup()
-	matches, err := targetTracker.WaitAtLeastNMatch(recordevents.MatchEvent(mustMatch), 1)
-	if err != nil {
-		t.Fatalf("Expected messages not found: %v", err)
-	}
-	return matches
+	return targetTracker.AssertAtLeast(1, recordevents.MatchEvent(mustMatch))
 }
 
 // getTraceIDHeader gets the TraceID from the passed in events.  It returns the header from the

--- a/test/e2e/source_api_server_test.go
+++ b/test/e2e/source_api_server_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
 	"github.com/cloudevents/sdk-go/v2/event"
+	. "github.com/cloudevents/sdk-go/v2/test"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,8 +81,7 @@ func TestApiServerSource(t *testing.T) {
 				EventMode:          mode,
 				ServiceAccountName: serviceAccountName,
 			},
-			pod:      func(name string) *corev1.Pod { return resources.HelloWorldPod(name) },
-			expected: "",
+			pod: func(name string) *corev1.Pod { return resources.HelloWorldPod(name) },
 		},
 		{
 			name: "event-ref-match-label",
@@ -119,76 +120,62 @@ func TestApiServerSource(t *testing.T) {
 		},
 	}
 
-	client := setup(t, true)
-	defer tearDown(client)
-
-	// creates ServiceAccount and RoleBinding with a role for reading pods and events
-	r := resources.Role(roleName,
-		resources.WithRuleForRole(&rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"events", "pods"},
-			Verbs:     []string{"get", "list", "watch"}}))
-	client.CreateServiceAccountOrFail(serviceAccountName)
-	client.CreateRoleOrFail(r)
-	client.CreateRoleBindingOrFail(
-		serviceAccountName,
-		lib.RoleKind,
-		roleName,
-		fmt.Sprintf("%s-%s", serviceAccountName, roleName),
-		client.Namespace,
-	)
-
 	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup client
+			client := setup(t, true)
+			defer tearDown(client)
 
-		// create event logger pod and service
-		loggerPodName := fmt.Sprintf("%s-%s", baseLoggerPodName, tc.name)
-		tc.spec.Sink = duckv1.Destination{Ref: resources.ServiceKRef(loggerPodName)}
+			// creates ServiceAccount and RoleBinding with a role for reading pods and events
+			r := resources.Role(roleName,
+				resources.WithRuleForRole(&rbacv1.PolicyRule{
+					APIGroups: []string{""},
+					Resources: []string{"events", "pods"},
+					Verbs:     []string{"get", "list", "watch"}}))
+			client.CreateServiceAccountOrFail(serviceAccountName)
+			client.CreateRoleOrFail(r)
+			client.CreateRoleBindingOrFail(
+				serviceAccountName,
+				lib.RoleKind,
+				roleName,
+				fmt.Sprintf("%s-%s", serviceAccountName, roleName),
+				client.Namespace,
+			)
 
-		loggerPod := resources.EventRecordPod(loggerPodName)
-		client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
-		targetTracker, err := recordevents.NewEventInfoStore(client, loggerPodName)
-		if err != nil {
-			t.Fatalf("Pod tracker failed: %v", err)
-		}
-		defer targetTracker.Cleanup()
+			// create event record
+			recordEventPodName := fmt.Sprintf("%s-%s", baseLoggerPodName, tc.name)
+			tc.spec.Sink = duckv1.Destination{Ref: resources.ServiceKRef(recordEventPodName)}
+			eventTracker, _ := recordevents.StartEventRecordOrFail(client, recordEventPodName)
+			defer eventTracker.Cleanup()
 
-		apiServerSource := eventingtesting.NewApiServerSource(
-			fmt.Sprintf("%s-%s", baseApiServerSourceName, tc.name),
-			client.Namespace,
-			eventingtesting.WithApiServerSourceSpec(tc.spec),
-		)
+			apiServerSource := eventingtesting.NewApiServerSource(
+				fmt.Sprintf("%s-%s", baseApiServerSourceName, tc.name),
+				client.Namespace,
+				eventingtesting.WithApiServerSourceSpec(tc.spec),
+			)
 
-		client.CreateApiServerSourceOrFail(apiServerSource)
+			client.CreateApiServerSourceOrFail(apiServerSource)
 
-		// wait for all test resources to be ready
-		client.WaitForAllTestResourcesReadyOrFail()
+			// wait for all test resources to be ready
+			client.WaitForAllTestResourcesReadyOrFail()
 
-		helloworldPod := tc.pod(fmt.Sprintf("%s-%s", baseHelloworldPodName, tc.name))
-		client.CreatePodOrFail(helloworldPod)
+			helloworldPod := tc.pod(fmt.Sprintf("%s-%s", baseHelloworldPodName, tc.name))
+			client.CreatePodOrFail(helloworldPod)
 
-		// verify the logger service receives the event(s)
-		// TODO(chizhg): right now it's only doing a very basic check by looking for the tc.data word,
-		//                we can add a json matcher to improve it in the future.
+			// verify the logger service receives the event(s)
+			// TODO(chizhg): right now it's only doing a very basic check by looking for the tc.data word,
+			//                we can add a json matcher to improve it in the future.
 
-		if tc.expected == "" {
-			time.Sleep(10 * time.Second)
-			ev, _, err := targetTracker.Find(recordevents.MatchEvent(func(have event.Event) error {
-				//TODO This really needs to be no-op?
-				return nil
-			}))
-			if err != nil {
-				t.Fatalf("Saw error looking for events: %v", err)
+			// Run asserts
+			if tc.expected == "" {
+				time.Sleep(10 * time.Second)
+				eventTracker.AssertNot(recordevents.Any())
+			} else {
+				eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
+					recordevents.DataContains(tc.expected),
+				))
 			}
-			if len(ev) != 0 {
-				t.Fatalf("Log is not empty in logger pod %q: %d events seen", loggerPodName, len(ev))
-			}
-
-		} else {
-			err = targetTracker.WaitMatchSourceData("", tc.expected, 1, -1)
-			if err != nil {
-				t.Fatalf("Error watching for data %s event in pod %s: %v", tc.expected, loggerPodName, err)
-			}
-		}
+		})
 	}
 }
 

--- a/test/e2e/source_sinkbinding_v1alpha2_test.go
+++ b/test/e2e/source_sinkbinding_v1alpha2_test.go
@@ -19,14 +19,13 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	ce "github.com/cloudevents/sdk-go/v2"
+	. "github.com/cloudevents/sdk-go/v2/test"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -34,7 +33,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/tracker"
 
-	"knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 
@@ -48,20 +46,15 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 		// the heartbeats image is built from test_images/heartbeats
 		imageName = "heartbeats"
 
-		loggerPodName = "e2e-sink-binding-logger-pod-v1alpha2dep"
+		recordEventPodName = "e2e-sink-binding-logger-pod-v1alpha2dep"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventRecordPod(loggerPodName)
-	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
-	targetTracker, err := recordevents.NewEventInfoStore(client, loggerPodName)
-	if err != nil {
-		t.Fatalf("Pod tracker failed: %v", err)
-	}
-	defer targetTracker.Cleanup()
+	eventTracker, _ := recordevents.StartEventRecordOrFail(client, recordEventPodName)
+	defer eventTracker.Cleanup()
 
 	extensionSecret := string(uuid.NewUUID())
 
@@ -69,7 +62,7 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 	sinkBinding := eventingtesting.NewSinkBindingV1Alpha2(
 		sinkBindingName,
 		client.Namespace,
-		eventingtesting.WithSinkV1A2(duckv1.Destination{Ref: resources.KnativeRefForService(loggerPodName, client.Namespace)}),
+		eventingtesting.WithSinkV1A2(duckv1.Destination{Ref: resources.KnativeRefForService(recordEventPodName, client.Namespace)}),
 		eventingtesting.WithSubjectV1A2(tracker.Reference{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -82,7 +75,7 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 	)
 	client.CreateSinkBindingV1Alpha2OrFail(sinkBinding)
 
-	data := fmt.Sprintf("TestSinkBindingDeployment%s", uuid.NewUUID())
+	message := fmt.Sprintf("TestSinkBindingDeployment%s", uuid.NewUUID())
 	client.CreateDeploymentOrFail(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: client.Namespace,
@@ -105,7 +98,7 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 						Name:            imageName,
 						Image:           pkgTest.ImagePath(imageName),
 						ImagePullPolicy: corev1.PullAlways,
-						Args:            []string{"--msg=" + data},
+						Args:            []string{"--msg=" + message},
 						Env: []corev1.EnvVar{{
 							Name:  "POD_NAME",
 							Value: deploymentName,
@@ -123,32 +116,11 @@ func TestSinkBindingV1Alpha2Deployment(t *testing.T) {
 	client.WaitForAllTestResourcesReadyOrFail()
 
 	// Look for events with expected data, and sinkbinding extension
-	expectedCount := 2
-	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
-	matchFunc := func(ev ce.Event) error {
-		if expectedSource != ev.Source() {
-			return fmt.Errorf("expected source %s, saw %s", expectedSource, ev.Source())
-		}
-		ext := ev.Extensions()
-		value, found := ext["sinkbinding"]
-		if !found {
-			return fmt.Errorf("didn't find extension sinkbinding")
-		}
-		if value != extensionSecret {
-			return fmt.Errorf("expension sinkbinding didn't match %s, saw %s", extensionSecret, value)
-		}
-		db := ev.Data()
-		if !strings.Contains(string(db), data) {
-			return fmt.Errorf("expected substring %s in %s", data, string(db))
-		}
-		return nil
-	}
-
-	_, err = targetTracker.WaitAtLeastNMatch(recordevents.MatchEvent(matchFunc), expectedCount)
-	if err != nil {
-		t.Fatalf("Data %s, extension %q does not appear at least %d times in events of logger pod %q: %v", data, extensionSecret, expectedCount, loggerPodName, err)
-
-	}
+	eventTracker.AssertAtLeast(2, recordevents.MatchEvent(
+		recordevents.MatchHeartBeatsImageMessage(message),
+		HasSource(fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)),
+		HasExtension("sinkbinding", extensionSecret),
+	))
 }
 
 func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
@@ -158,26 +130,21 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 		// the heartbeats image is built from test_images/heartbeats
 		imageName = "heartbeats"
 
-		loggerPodName = "e2e-sink-binding-logger-pod-v1alpha2c"
+		recordEventPodName = "e2e-sink-binding-logger-pod-v1alpha2c"
 	)
 
 	client := setup(t, true)
 	defer tearDown(client)
 
 	// create event logger pod and service
-	loggerPod := resources.EventRecordPod(loggerPodName)
-	client.CreatePodOrFail(loggerPod, lib.WithService(loggerPodName))
-	targetTracker, err := recordevents.NewEventInfoStore(client, loggerPodName)
-	if err != nil {
-		t.Fatalf("Pod tracker failed: %v", err)
-	}
-	defer targetTracker.Cleanup()
+	eventTracker, _ := recordevents.StartEventRecordOrFail(client, recordEventPodName)
+	defer eventTracker.Cleanup()
 
 	// create sink binding
 	sinkBinding := eventingtesting.NewSinkBindingV1Alpha2(
 		sinkBindingName,
 		client.Namespace,
-		eventingtesting.WithSinkV1A2(duckv1.Destination{Ref: resources.KnativeRefForService(loggerPodName, client.Namespace)}),
+		eventingtesting.WithSinkV1A2(duckv1.Destination{Ref: resources.KnativeRefForService(recordEventPodName, client.Namespace)}),
 		eventingtesting.WithSubjectV1A2(tracker.Reference{
 			APIVersion: "batch/v1",
 			Kind:       "Job",
@@ -191,7 +158,7 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 	)
 	client.CreateSinkBindingV1Alpha2OrFail(sinkBinding)
 
-	data := fmt.Sprintf("TestSinkBindingCronJob%s", uuid.NewUUID())
+	message := fmt.Sprintf("TestSinkBindingCronJob%s", uuid.NewUUID())
 	client.CreateCronJobOrFail(&batchv1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: client.Namespace,
@@ -213,7 +180,7 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 								Name:            imageName,
 								Image:           pkgTest.ImagePath(imageName),
 								ImagePullPolicy: corev1.PullAlways,
-								Args:            []string{"--msg=" + data},
+								Args:            []string{"--msg=" + message},
 								Env: []corev1.EnvVar{{
 									Name:  "ONE_SHOT",
 									Value: "true",
@@ -236,10 +203,9 @@ func TestSinkBindingV1Alpha2CronJob(t *testing.T) {
 	client.WaitForAllTestResourcesReadyOrFail()
 
 	// verify the logger service receives the event
-	expectedCount := 2
-	expectedSource := fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)
-	if err := targetTracker.WaitMatchSourceData(expectedSource, data, expectedCount, -1); err != nil {
-		t.Fatalf("String %q does not appear at least %d times in logs of logger pod %q: %v", data, expectedCount, loggerPodName, err)
-	}
+	eventTracker.AssertAtLeast(2, recordevents.MatchEvent(
+		recordevents.MatchHeartBeatsImageMessage(message),
+		HasSource(fmt.Sprintf("https://knative.dev/eventing/test/heartbeats/#%s/%s", client.Namespace, deploymentName)),
+	))
 
 }

--- a/test/lib/recordevents/event_info_matchers.go
+++ b/test/lib/recordevents/event_info_matchers.go
@@ -18,12 +18,22 @@ package recordevents
 
 import (
 	"fmt"
+	"strings"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/event"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 )
 
 // Does the provided EventInfo match some criteria
 type EventInfoMatcher func(EventInfo) error
+
+// Matcher that never fails
+func Any() EventInfoMatcher {
+	return func(ei EventInfo) error {
+		return nil
+	}
+}
 
 // Convert a matcher that checks valid messages to a function
 // that checks EventInfo structures, returning an error for any that don't
@@ -35,5 +45,32 @@ func MatchEvent(evf ...cetest.EventMatcher) EventInfoMatcher {
 		} else {
 			return cetest.AllOf(evf...)(*ei.Event)
 		}
+	}
+}
+
+func MatchHeartBeatsImageMessage(expectedMsg string) cetest.EventMatcher {
+	return cetest.AllOf(
+		cetest.HasDataContentType(cloudevents.ApplicationJSON),
+		func(have cloudevents.Event) error {
+			var m map[string]interface{}
+			err := have.DataAs(&m)
+			if err != nil {
+				return fmt.Errorf("cannot parse heartbeats message %s", err.Error())
+			}
+			if m["msg"].(string) != expectedMsg {
+				return fmt.Errorf("heartbeats message don't match. Expected: '%s', Actual: '%s'", expectedMsg, m["msg"].(string))
+			}
+			return nil
+		},
+	)
+}
+
+func DataContains(expectedContainedString string) cetest.EventMatcher {
+	return func(have event.Event) error {
+		dataAsString := string(have.Data())
+		if strings.Contains(dataAsString, expectedContainedString) {
+			return fmt.Errorf("data '%s' doesn't contain '%s'", dataAsString, expectedContainedString)
+		}
+		return nil
 	}
 }

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -18,12 +18,10 @@ package recordevents
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -216,82 +214,10 @@ func (ei *EventInfoStore) Find(f EventInfoMatcher) ([]EventInfo, SearchedInfo, e
 	return allMatch, sInfo, nil
 }
 
-// Wait a long time (currently 4 minutes) until the provided function matches at least
-// five events. The matching events are returned if we find at least n. If the
-// function times out, an error is returned.
-// If you need to perform assert on the result (aka you want to fail if error != nil), then use AssertAtLeast
-func (ei *EventInfoStore) WaitAtLeastNMatch(f EventInfoMatcher, min int) ([]EventInfo, error) {
-	var matchRet []EventInfo
-	var internalErr error
-
-	wait.PollImmediate(ei.retryInterval, ei.timeout, func() (bool, error) {
-		allMatch, sInfo, err := ei.Find(f)
-		if err != nil {
-			internalErr = fmt.Errorf("FAIL MATCHING: unexpected error during find: %v", err)
-			return false, nil
-		}
-		count := len(allMatch)
-		if count < min {
-			internalErr = fmt.Errorf("FAIL MATCHING: saw %d/%d matching events. recent events: (%s)",
-				count, min, &sInfo)
-			return false, nil
-		}
-		matchRet = allMatch
-		internalErr = nil
-		return true, nil
-	})
-	return matchRet, internalErr
-}
-
-// Deprecated: use AssertAtLeast
-func (ei *EventInfoStore) MustWaitAtLeastNMatch(t testing.TB, f EventInfoMatcher, n int) []EventInfo {
-	events, err := ei.WaitAtLeastNMatch(f, n)
-	if err != nil {
-		t.Fatalf("Timeout waiting for %d matches. Error: %v", n, err)
-	}
-
-	return events
-}
-
-// Wait for at least minCount events with source exactly matching source and data contained within the event
-// data field.  If source is the empty string, don't check the source.  If maxCount is >0, return an error
-// if more than maxCount entries are seen.
-// Deprecated: use AssertInRange
-func (ei *EventInfoStore) WaitMatchSourceData(source string, data string, minCount int, maxCount int) error {
-	matchFunc := func(ev cloudevents.Event) error {
-		if source != "" && ev.Source() != source {
-			return fmt.Errorf("mismatched source: expected %s, saw %s", source, ev.Source())
-		}
-		db := ev.Data()
-		body := string(db)
-		if strings.Contains(body, data) {
-			return nil
-		} else {
-			return fmt.Errorf("didn't find substring (%s) in data (%s)", data, body)
-		}
-	}
-	// verify the logger service receives the event and only once
-	match, err := ei.WaitAtLeastNMatch(MatchEvent(matchFunc), minCount)
-	if err != nil {
-		return fmt.Errorf("error waiting for event: %v", err)
-	}
-	if maxCount > 0 && len(match) > maxCount {
-		return fmt.Errorf("expected <= %d events, saw %d", maxCount, len(match))
-	}
-	return nil
-}
-
-// Deprecated: use AssertInRange
-func (ei *EventInfoStore) AssertWaitMatchSourceData(tb testing.TB, source string, data string, minCount int, maxCount int) {
-	if err := ei.WaitMatchSourceData(source, data, minCount, maxCount); err != nil {
-		tb.Fatalf("Timeout waiting for source %q and data %q. It does not appear at least %d times in the event record pod %q: %v", source, data, minCount, ei.podName, err)
-	}
-}
-
 // Assert that there are at least min number of matches of f.
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertAtLeast(min int, f EventInfoMatcher) []EventInfo {
-	events, err := ei.WaitAtLeastNMatch(f, min)
+	events, err := ei.waitAtLeastNMatch(f, min)
 	if err != nil {
 		ei.tb.Fatalf("Timeout waiting for at least %d matches. Error: %v", min, err)
 	}
@@ -328,4 +254,31 @@ func (ei *EventInfoStore) AssertNot(f EventInfoMatcher) []EventInfo {
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertExact(n int, f EventInfoMatcher) []EventInfo {
 	return ei.AssertInRange(n, n, f)
+}
+
+// Wait a long time (currently 4 minutes) until the provided function matches at least
+// five events. The matching events are returned if we find at least n. If the
+// function times out, an error is returned.
+// If you need to perform assert on the result (aka you want to fail if error != nil), then use AssertAtLeast
+func (ei *EventInfoStore) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]EventInfo, error) {
+	var matchRet []EventInfo
+	var internalErr error
+
+	wait.PollImmediate(ei.retryInterval, ei.timeout, func() (bool, error) {
+		allMatch, sInfo, err := ei.Find(f)
+		if err != nil {
+			internalErr = fmt.Errorf("FAIL MATCHING: unexpected error during find: %v", err)
+			return false, nil
+		}
+		count := len(allMatch)
+		if count < min {
+			internalErr = fmt.Errorf("FAIL MATCHING: saw %d/%d matching events. recent events: (%s)",
+				count, min, &sInfo)
+			return false, nil
+		}
+		matchRet = allMatch
+		internalErr = nil
+		return true, nil
+	})
+	return matchRet, internalErr
 }

--- a/test/lib/recordevents/event_info_store_test.go
+++ b/test/lib/recordevents/event_info_store_test.go
@@ -250,7 +250,7 @@ func TestWaitForN(t *testing.T) {
 			}
 		}
 
-		allMatch, waitErr = ei.WaitAtLeastNMatch(MatchEvent(matchFunc), 2)
+		allMatch, waitErr = ei.waitAtLeastNMatch(MatchEvent(matchFunc), 2)
 		wg.Done()
 	}()
 	var tCalls int


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Part of #3267

## Proposed Changes

- Removed all usages and methods of `AssertWaitMatchSourceData`
- When possible, removed manual event record creation and used `recordevents.StartEventRecordOrFail(client, recordEventsPodName)`