### PR TITLE
Indicate HA deployment for eventing-controller

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

As per https://github.com/knative/operator/issues/73, indicate the HA deployments (the only one is `eventing-controller` deployment)

## Proposed Changes
- Indicate the HA deployments (the only one is `eventing-controller` deployment)

Operator PR that will allow the operator to read the label is on its way