### PR TITLE
Allow configuration of a custom PrometheusPort in source.ConfigWatcher

### DIFF
--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -89,22 +89,31 @@ func TestNewConfigWatcher_defaults(t *testing.T) {
 	}
 }
 
-func TestNewConfigWatcher_withOptions(t *testing.T) {
+func TestNewConfigWatcher_withMetricsOption(t *testing.T) {
 	testCases := []struct {
 		name                  string
+		opt                   configWatcherOption
 		cmw                   configmap.Watcher
 		expectMetricsContains string
 	}{
 		{
 			name:                  "With pre-filled sample data",
+			opt:                   WithMetrics,
 			cmw:                   configMapWatcherWithSampleData(),
 			expectMetricsContains: `"ConfigMap":{"metrics.backend":"test"}`,
 		},
 		{
 			name: "With empty data",
+			opt:  WithMetrics,
 			cmw:  configMapWatcherWithEmptyData(),
 			// metrics defaults to empty ConfigMap
 			expectMetricsContains: `"ConfigMap":{}`,
+		},
+		{
+			name:                  "With custom port",
+			opt:                   WithMetricsPort(9092),
+			cmw:                   configMapWatcherWithSampleData(),
+			expectMetricsContains: `"PrometheusPort":9092`,
 		},
 	}
 
@@ -112,7 +121,7 @@ func TestNewConfigWatcher_withOptions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := loggingtesting.TestContextWithLogger(t)
 			cw := WatchConfigurations(ctx, testComponent, tc.cmw,
-				WithMetrics,
+				tc.opt,
 			)
 
 			assert.Nil(t, cw.LoggingConfig(), "logging config should be disabled")


### PR DESCRIPTION
## Proposed Changes

- Add a new functional option `WithMetricsPort` that can configure the ConfigWatcher with a custom exporter (Prometheus) port .

Rational: the default port 9090 clashes with Serving's queue proxy when a receive adapter is deployed as a Knative Service. There is currently no way to make that work without explicitly disabling metrics by setting the `K_METRICS_CONFIG` env var to `""`.

Usage example:
```go
cw := WatchConfigurations(ctx, "my_component", cmw,
	WithLogging,
	WithMetricsPort(9092),
}
```