### PR TITLE
Cont'd: indicate HA deployment for eventing-controller

### DIFF
--- a/config/brokers/channel-broker/deployments/controller.yaml
+++ b/config/brokers/channel-broker/deployments/controller.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
+    knative.dev/high-availability: "true"
 spec:
   replicas: 0
   selector:

--- a/config/channels/in-memory-channel/500-controller.yaml
+++ b/config/channels/in-memory-channel/500-controller.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:

--- a/config/channels/in-memory-channel/500-dispatcher.yaml
+++ b/config/channels/in-memory-channel/500-dispatcher.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
+    namespace: knative-eventing
 spec:
   replicas: 1
   selector:

--- a/config/channels/in-memory-channel/500-dispatcher.yaml
+++ b/config/channels/in-memory-channel/500-dispatcher.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    namespace: knative-eventing
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Found more leader-elected components and HA deployments, on top of https://github.com/knative/eventing/pull/3311

Ref: https://github.com/knative/eventing/blame/master/config/core/configmaps/leader-election.yaml#L62