### PR TITLE
Channel header single event helper port to new test images

### DIFF
--- a/test/conformance/header_test.go
+++ b/test/conformance/header_test.go
@@ -21,16 +21,16 @@ package conformance
 import (
 	"testing"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib/cloudevents"
 )
 
-// The Channel MUST pass through all tracing information as CloudEvents attributes
-func TestMustPassTracingHeaders(t *testing.T) {
-	t.Logf("Starting channel tracing headers test")
-	helpers.SingleEventHelperForChannelTestHelper(
+// The Channel MUST pass through all tracing information
+func TestChannelForwardHeadersPrependedWithKnative(t *testing.T) {
+	helpers.SingleEventWithKnativeHeaderHelperForChannelTestHelper(
 		t,
-		cloudevents.DefaultEncoding,
+		cloudevents.EncodingBinary,
 		channelTestRunner,
 	)
 }

--- a/test/lib/resources/sender/sender.go
+++ b/test/lib/resources/sender/sender.go
@@ -18,6 +18,7 @@ package sender
 
 import (
 	"encoding/json"
+	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -56,6 +57,22 @@ func WithEncoding(encoding cloudevents.Encoding) EventSenderOption {
 			pod.Spec.Containers[0].Args,
 			"-event-encoding",
 			encoding.String(),
+		)
+	}
+}
+
+// WithEncoding forces the encoding of the event to send from the sender pod
+func WithAdditionalHeaders(headers map[string]string) EventSenderOption {
+	var kv []string
+	for k, v := range headers {
+		kv = append(kv, k+"="+v)
+	}
+	serializedHeaders := strings.Join(kv, ",")
+	return func(pod *corev1.Pod) {
+		pod.Spec.Containers[0].Args = append(
+			pod.Spec.Containers[0].Args,
+			"-additional-headers",
+			serializedHeaders,
 		)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Part of #3267

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Channel header single event helper port to new test images
- Also changed the test header (testing the tracing header was pointless, given we already have tests for tracing which correctly test the trace tree creation)
