### PR TITLE
Increasing the webhook resources

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -42,12 +42,12 @@ spec:
         resources:
           requests:
             # taken from serving.
-            cpu: 20m
-            memory: 20Mi
+            cpu: 100m
+            memory: 100Mi
           limits:
             # taken from serving.
-            cpu: 200m
-            memory: 200Mi
+            cpu: 500m
+            memory: 500Mi
 
         env:
         - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

- align values with serving


## Context / Background

since we "borrowed" these values from serving (as per comment on the touched yaml), I am here pointing to a PR and related discussions:

* issue: https://github.com/knative/serving/issues/7195
* issue: https://github.com/knative/pkg/issues/1152
* PR https://github.com/knative/serving/pull/8048/files

In the spirit of keeping the values similar, I am changing those.


That said on larger clusters we also noticed OOMKilled of the webhook, I'd prefer bumping the limit to 1G, since our webhook currently scales fairly linearly with namespaces so this would in theory allow ~1000 namespaces which sounds sufficient to me for the time being.

Thoughts? 

@grantr @vaikas 

That said, the value is now configurable on the operator side, so an override to something like 1G can be done there, as well, see:  https://github.com/knative/operator/pull/51  