### PR TITLE
Refactor ChannelTestRunner to ComponentTestRunner

### DIFF
--- a/test/conformance/broker_control_plane_test.go
+++ b/test/conformance/broker_control_plane_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestBrokerV1Beta1ControlPlane(t *testing.T) {
-	helpers.BrokerV1Beta1ControlPlaneTestHelperWithChannelTestRunner(t, brokerClass, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.BrokerV1Beta1ControlPlaneTestHelperWithChannelTestRunner(t, brokerClass, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/broker_tracing_test.go
+++ b/test/conformance/broker_tracing_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestBrokerTracing(t *testing.T) {
-	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, brokerClass, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.BrokerTracingTestHelperWithChannelTestRunner(t, brokerClass, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_addressable_resolver_cluster_role_test.go
+++ b/test/conformance/channel_addressable_resolver_cluster_role_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelAddressableResolverClusterRoleTest(t *testing.T) {
-	helpers.TestChannelAddressableResolverClusterRoleTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.TestChannelAddressableResolverClusterRoleTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_channelable_manipulator_cluster_role_test.go
+++ b/test/conformance/channel_channelable_manipulator_cluster_role_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelChannelableManipulatorClusterRoleTest(t *testing.T) {
-	helpers.TestChannelChannelableManipulatorClusterRoleTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.TestChannelChannelableManipulatorClusterRoleTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_crd_metadata_test.go
+++ b/test/conformance/channel_crd_metadata_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelCRDMetadata(t *testing.T) {
-	helpers.ChannelCRDMetadataTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelCRDMetadataTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_crd_name_test.go
+++ b/test/conformance/channel_crd_name_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelCRDName(t *testing.T) {
-	helpers.ChannelCRDNameTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelCRDNameTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_spec_test.go
+++ b/test/conformance/channel_spec_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelSpec(t *testing.T) {
-	helpers.ChannelSpecTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelSpecTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_status_subscriber_test.go
+++ b/test/conformance/channel_status_subscriber_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelStatusSubscriber(t *testing.T) {
-	helpers.ChannelStatusSubscriberTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelStatusSubscriberTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_status_test.go
+++ b/test/conformance/channel_status_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelStatus(t *testing.T) {
-	helpers.ChannelStatusTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelStatusTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/channel_tracing_test.go
+++ b/test/conformance/channel_tracing_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelTracingWithReply(t *testing.T) {
-	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+	helpers.ChannelTracingTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/conformance/helpers/broker_control_plane_test_helper.go
+++ b/test/conformance/helpers/broker_control_plane_test_helper.go
@@ -39,7 +39,7 @@ import (
 func BrokerV1Beta1ControlPlaneTestHelperWithChannelTestRunner(
 	t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	setupClient ...lib.SetupClientOption,
 ) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {

--- a/test/conformance/helpers/broker_control_plane_test_helper.go
+++ b/test/conformance/helpers/broker_control_plane_test_helper.go
@@ -24,7 +24,7 @@ import (
 
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/resources"
 )
@@ -39,12 +39,12 @@ import (
 func BrokerV1Beta1ControlPlaneTestHelperWithChannelTestRunner(
 	t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ComponentsTestRunner,
-	setupClient ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	setupClient ...testlib.SetupClientOption,
 ) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(t, true, setupClient...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(t, true, setupClient...)
+		defer testlib.TearDown(client)
 		brokerName := "br"
 		triggerNoBroker := "trigger-no-broker"
 		triggerWithBroker := "trigger-with-broker"
@@ -76,12 +76,12 @@ func BrokerV1Beta1ControlPlaneTestHelperWithChannelTestRunner(
 
 }
 
-func TriggerV1Beta1BeforeBrokerHelper(t *testing.T, triggerName string, client *lib.Client) {
+func TriggerV1Beta1BeforeBrokerHelper(t *testing.T, triggerName string, client *testlib.Client) {
 	const etLogger = "logger"
 	const loggerPodName = "logger-pod"
 
 	logPod := resources.EventRecordPod(loggerPodName)
-	client.CreatePodOrFail(logPod, lib.WithService(loggerPodName))
+	client.CreatePodOrFail(logPod, testlib.WithService(loggerPodName))
 	client.WaitForAllTestResourcesReadyOrFail() //Can't do this for the trigger because it's not 'ready' yet
 	client.CreateTriggerOrFailV1Beta1(triggerName,
 		resources.WithAttributesTriggerFilterV1Beta1(eventingv1beta1.TriggerAnyFilter, etLogger, map[string]interface{}{}),
@@ -89,7 +89,7 @@ func TriggerV1Beta1BeforeBrokerHelper(t *testing.T, triggerName string, client *
 	)
 }
 
-func BrokerV1Beta1CreatedToReadyHelper(t *testing.T, brokerName, brokerClass string, client *lib.Client, channel metav1.TypeMeta) {
+func BrokerV1Beta1CreatedToReadyHelper(t *testing.T, brokerName, brokerClass string, client *testlib.Client, channel metav1.TypeMeta) {
 	client.CreateBrokerConfigMapOrFail(brokerName, &channel)
 
 	broker := client.CreateBrokerV1Beta1OrFail(
@@ -98,20 +98,20 @@ func BrokerV1Beta1CreatedToReadyHelper(t *testing.T, brokerName, brokerClass str
 		resources.WithConfigMapForBrokerConfig(),
 	)
 
-	client.WaitForResourceReadyOrFail(broker.Name, lib.BrokerTypeMeta)
+	client.WaitForResourceReadyOrFail(broker.Name, testlib.BrokerTypeMeta)
 
 }
 
-func ReadyBrokerV1Beta1AvailableHelper(t *testing.T, brokerName string, client *lib.Client) {
-	client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
-	obj := resources.NewMetaResource(brokerName, client.Namespace, lib.BrokerTypeMeta)
+func ReadyBrokerV1Beta1AvailableHelper(t *testing.T, brokerName string, client *testlib.Client) {
+	client.WaitForResourceReadyOrFail(brokerName, testlib.BrokerTypeMeta)
+	obj := resources.NewMetaResource(brokerName, client.Namespace, testlib.BrokerTypeMeta)
 	_, err := duck.GetAddressableURI(client.Dynamic, obj)
 	if err != nil {
 		t.Fatalf("Broker is not addressable %v", err)
 	}
 }
 
-func TriggerV1Beta1ReadyBrokerReadyHelper(t *testing.T, triggerName, brokerName string, client *lib.Client) {
+func TriggerV1Beta1ReadyBrokerReadyHelper(t *testing.T, triggerName, brokerName string, client *testlib.Client) {
 	const etLogger = "logger"
 	const loggerPodName = "logger-pod"
 
@@ -121,10 +121,10 @@ func TriggerV1Beta1ReadyBrokerReadyHelper(t *testing.T, triggerName, brokerName 
 		resources.WithBrokerV1Beta1(brokerName),
 	)
 
-	client.WaitForResourceReadyOrFail(trigger.Name, lib.TriggerTypeMeta)
+	client.WaitForResourceReadyOrFail(trigger.Name, testlib.TriggerTypeMeta)
 }
 
-func TriggerV1Beta1ReadyAfterBrokerIncludesSubURI(t *testing.T, triggerName, brokerName string, client *lib.Client) {
+func TriggerV1Beta1ReadyAfterBrokerIncludesSubURI(t *testing.T, triggerName, brokerName string, client *testlib.Client) {
 	tr, err := client.Eventing.EventingV1beta1().Triggers(client.Namespace).Get(triggerName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error: Could not get trigger %s: %v", triggerName, err)
@@ -145,8 +145,8 @@ func TriggerV1Beta1ReadyAfterBrokerIncludesSubURI(t *testing.T, triggerName, bro
 
 }
 
-func TriggerV1Beta1ReadyIncludesSubURI(t *testing.T, triggerName string, client *lib.Client) {
-	client.WaitForResourceReadyOrFail(triggerName, lib.TriggerTypeMeta)
+func TriggerV1Beta1ReadyIncludesSubURI(t *testing.T, triggerName string, client *testlib.Client) {
+	client.WaitForResourceReadyOrFail(triggerName, testlib.TriggerTypeMeta)
 	tr, err := client.Eventing.EventingV1beta1().Triggers(client.Namespace).Get(triggerName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error: Could not get trigger %s: %v", tr.Name, err)

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	"knative.dev/eventing/pkg/utils"
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
@@ -39,10 +39,10 @@ import (
 func BrokerTracingTestHelperWithChannelTestRunner(
 	t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ComponentsTestRunner,
-	setupClient lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	setupClient testlib.SetupClientOption,
 ) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		tracingTest(t, setupClient, setupBrokerTracing(brokerClass), channel)
 	})
 }
@@ -65,7 +65,7 @@ func setupBrokerTracing(brokerClass string) SetupTracingTestInfrastructureFunc {
 	return func(
 		t *testing.T,
 		channel *metav1.TypeMeta,
-		client *lib.Client,
+		client *testlib.Client,
 		loggerPodName string,
 		senderPublishTrace bool,
 	) (tracinghelper.TestSpanTree, cetest.EventMatcher) {
@@ -80,7 +80,7 @@ func setupBrokerTracing(brokerClass string) SetupTracingTestInfrastructureFunc {
 
 		// Create a logger (EventRecord) Pod and a K8s Service that points to it.
 		logPod := resources.EventRecordPod(loggerPodName)
-		client.CreatePodOrFail(logPod, lib.WithService(loggerPodName))
+		client.CreatePodOrFail(logPod, testlib.WithService(loggerPodName))
 
 		// Create a Trigger that receives events (type=bar) and sends them to the logger Pod.
 		loggerTrigger := client.CreateTriggerOrFailV1Beta1(
@@ -98,7 +98,7 @@ func setupBrokerTracing(brokerClass string) SetupTracingTestInfrastructureFunc {
 			senderName,
 			[]byte(eventBody),
 		)
-		client.CreatePodOrFail(eventTransformerPod, lib.WithService(eventTransformerPod.Name))
+		client.CreatePodOrFail(eventTransformerPod, testlib.WithService(eventTransformerPod.Name))
 
 		// Create a Trigger that receives events (type=foo) and sends them to the transformer Pod.
 		transformerTrigger := client.CreateTriggerOrFailV1Beta1(
@@ -122,9 +122,9 @@ func setupBrokerTracing(brokerClass string) SetupTracingTestInfrastructureFunc {
 
 		// Send the CloudEvent (either with or without tracing inside the SendEvents Pod).
 		if senderPublishTrace {
-			client.SendEventToAddressable(senderName, broker.Name, lib.BrokerTypeMeta, event, sender.EnableTracing())
+			client.SendEventToAddressable(senderName, broker.Name, testlib.BrokerTypeMeta, event, sender.EnableTracing())
 		} else {
-			client.SendEventToAddressable(senderName, broker.Name, lib.BrokerTypeMeta, event)
+			client.SendEventToAddressable(senderName, broker.Name, testlib.BrokerTypeMeta, event)
 		}
 
 		domain := utils.GetClusterDomainName()

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -35,11 +35,11 @@ import (
 )
 
 // BrokerTracingTestHelperWithChannelTestRunner runs the Broker tracing tests for all Channels in
-// the ChannelTestRunner.
+// the ComponentsTestRunner.
 func BrokerTracingTestHelperWithChannelTestRunner(
 	t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	setupClient lib.SetupClientOption,
 ) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {

--- a/test/conformance/helpers/channel.go
+++ b/test/conformance/helpers/channel.go
@@ -18,7 +18,7 @@ package helpers
 
 import (
 	"github.com/pkg/errors"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/resources"
 
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func getChannelDuckTypeSupportVersion(channelName string, client *lib.Client, channel *metav1.TypeMeta) (string, error) {
+func getChannelDuckTypeSupportVersion(channelName string, client *testlib.Client, channel *metav1.TypeMeta) (string, error) {
 	metaResource := resources.NewMetaResource(channelName, client.Namespace, channel)
 	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})
 	if err != nil {
@@ -55,7 +55,7 @@ func getChannelDuckTypeSupportVersion(channelName string, client *lib.Client, ch
 	return channelable.ObjectMeta.Annotations[SubscribableAnnotationKey], nil
 }
 
-func getChannelAsV1Beta1Channelable(channelName string, client *lib.Client, channel metav1.TypeMeta) (*eventingduckv1beta1.Channelable, error) {
+func getChannelAsV1Beta1Channelable(channelName string, client *testlib.Client, channel metav1.TypeMeta) (*eventingduckv1beta1.Channelable, error) {
 	metaResource := resources.NewMetaResource(channelName, client.Namespace, &channel)
 	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})
 	if err != nil {
@@ -69,7 +69,7 @@ func getChannelAsV1Beta1Channelable(channelName string, client *lib.Client, chan
 	return channelable, nil
 }
 
-func getChannelAsV1Alpha1Channelable(channelName string, client *lib.Client, channel metav1.TypeMeta) (*eventingduckv1alpha1.Channelable, error) {
+func getChannelAsV1Alpha1Channelable(channelName string, client *testlib.Client, channel metav1.TypeMeta) (*eventingduckv1alpha1.Channelable, error) {
 	metaResource := resources.NewMetaResource(channelName, client.Namespace, &channel)
 	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1alpha1.Channelable{})
 	if err != nil {

--- a/test/conformance/helpers/channel_addressable_resolver_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_addressable_resolver_cluster_role_test_helper.go
@@ -25,21 +25,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelAddressableResolverClusterRoleTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
 	const aggregationClusterRoleName = "addressable-resolver"
 	var permissionTestCaseVerbs = []string{"get", "list", "watch"}
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
 

--- a/test/conformance/helpers/channel_addressable_resolver_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_addressable_resolver_cluster_role_test_helper.go
@@ -30,7 +30,7 @@ import (
 
 func TestChannelAddressableResolverClusterRoleTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -30,7 +30,7 @@ import (
 
 func TestChannelChannelableManipulatorClusterRoleTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -25,21 +25,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestChannelChannelableManipulatorClusterRoleTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
 	const aggregationClusterRoleName = "channelable-manipulator"
 	var permissionTestCaseVerbs = []string{"get", "list", "watch", "update", "patch"}
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
 

--- a/test/conformance/helpers/channel_crd_metadata_test_helper.go
+++ b/test/conformance/helpers/channel_crd_metadata_test_helper.go
@@ -22,13 +22,13 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/pkg/apis/messaging"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 var channelLabels = map[string]string{
 	messaging.SubscribableDuckVersionAnnotation: "true",
-	"duck.knative.dev/addressable":       "true",
+	"duck.knative.dev/addressable":              "true",
 }
 
 // ChannelCRDMetadataTestHelperWithChannelTestRunner runs the Channel CRD metadata tests for all

--- a/test/conformance/helpers/channel_crd_metadata_test_helper.go
+++ b/test/conformance/helpers/channel_crd_metadata_test_helper.go
@@ -22,11 +22,12 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/pkg/apis/messaging"
 )
 
 var channelLabels = map[string]string{
-	"messaging.knative.dev/subscribable": "true",
+	messaging.SubscribableDuckVersionAnnotation: "true",
 	"duck.knative.dev/addressable":       "true",
 }
 
@@ -34,13 +35,13 @@ var channelLabels = map[string]string{
 // Channel resources in the ComponentsTestRunner.
 func ChannelCRDMetadataTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		t.Run("Channel is namespaced", func(t *testing.T) {
 			channelIsNamespaced(st, client, channel)
@@ -54,7 +55,7 @@ func ChannelCRDMetadataTestHelperWithChannelTestRunner(
 	})
 }
 
-func channelIsNamespaced(st *testing.T, client *lib.Client, channel metav1.TypeMeta) {
+func channelIsNamespaced(st *testing.T, client *testlib.Client, channel metav1.TypeMeta) {
 	// From spec: Each channel is namespaced
 
 	apiResource, err := getApiResource(client, channel)
@@ -66,7 +67,7 @@ func channelIsNamespaced(st *testing.T, client *lib.Client, channel metav1.TypeM
 	}
 }
 
-func channelCRDHasRequiredLabels(client *lib.Client, channel metav1.TypeMeta) {
+func channelCRDHasRequiredLabels(client *testlib.Client, channel metav1.TypeMeta) {
 	// From spec:
 	// Each channel MUST have the following:
 	//   label of messaging.knative.dev/subscribable: "true"
@@ -75,7 +76,7 @@ func channelCRDHasRequiredLabels(client *lib.Client, channel metav1.TypeMeta) {
 	validateRequiredLabels(client, channel, channelLabels)
 }
 
-func channelCRDHasProperCategory(st *testing.T, client *lib.Client, channel metav1.TypeMeta) {
+func channelCRDHasProperCategory(st *testing.T, client *testlib.Client, channel metav1.TypeMeta) {
 	// From spec:
 	// Each channel MUST have the following: the category channel
 
@@ -95,7 +96,7 @@ func channelCRDHasProperCategory(st *testing.T, client *lib.Client, channel meta
 	}
 }
 
-func getApiResource(client *lib.Client, typeMeta metav1.TypeMeta) (*metav1.APIResource, error) {
+func getApiResource(client *testlib.Client, typeMeta metav1.TypeMeta) (*metav1.APIResource, error) {
 	gvr, _ := meta.UnsafeGuessKindToResource(typeMeta.GroupVersionKind())
 	apiResourceList, err := client.Kube.Kube.Discovery().ServerResourcesForGroupVersion(gvr.GroupVersion().String())
 	if err != nil {

--- a/test/conformance/helpers/channel_crd_name_test_helper.go
+++ b/test/conformance/helpers/channel_crd_name_test_helper.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 const (
@@ -33,13 +33,13 @@ const (
 // Channel resources in the ComponentsTestRunner.
 func ChannelCRDNameTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		t.Run("Channel name has required suffix", func(t *testing.T) {
 			channelNameHasRequiredSuffix(st, client, channel)
@@ -47,7 +47,7 @@ func ChannelCRDNameTestHelperWithChannelTestRunner(
 	})
 }
 
-func channelNameHasRequiredSuffix(st *testing.T, client *lib.Client, channel metav1.TypeMeta) {
+func channelNameHasRequiredSuffix(st *testing.T, client *testlib.Client, channel metav1.TypeMeta) {
 	// From spec: The CRD's Kind SHOULD have the suffix Channel. The name MAY be just Channel.
 	if !strings.HasSuffix(channel.Kind, ChannelNameSuffix) {
 		client.T.Fatalf("Kind is not suffixed with %q : %q", ChannelNameSuffix, channel)

--- a/test/conformance/helpers/channel_crd_name_test_helper.go
+++ b/test/conformance/helpers/channel_crd_name_test_helper.go
@@ -30,10 +30,10 @@ const (
 )
 
 // ChannelCRDNameTestHelperWithChannelTestRunner runs the Channel CRD name tests for all
-// Channel resources in the ChannelTestRunner.
+// Channel resources in the ComponentsTestRunner.
 func ChannelCRDNameTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_header_single_event_helper.go
+++ b/test/conformance/helpers/channel_header_single_event_helper.go
@@ -42,7 +42,7 @@ EventSource ---> Channel ---> Subscription ---> Service(Logger)
 func SingleEventWithKnativeHeaderHelperForChannelTestHelper(
 	t *testing.T,
 	encoding cloudevents.Encoding,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 	channelName := "conformance-headers-channel-" + encoding.String()

--- a/test/conformance/helpers/channel_header_single_event_helper.go
+++ b/test/conformance/helpers/channel_header_single_event_helper.go
@@ -25,7 +25,7 @@ import (
 	uuid "github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
@@ -42,18 +42,18 @@ EventSource ---> Channel ---> Subscription ---> Service(Logger)
 func SingleEventWithKnativeHeaderHelperForChannelTestHelper(
 	t *testing.T,
 	encoding cloudevents.Encoding,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 	channelName := "conformance-headers-channel-" + encoding.String()
 	senderName := "conformance-headers-sender-" + encoding.String()
 	subscriptionName := "conformance-headers-subscription-" + encoding.String()
 	recordEventsPodName := "conformance-headers-recordevents-pod-" + encoding.String()
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		st.Logf("Running header conformance test with channel %q", channel)
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// create channel
 		st.Logf("Creating channel")
@@ -80,7 +80,7 @@ func SingleEventWithKnativeHeaderHelperForChannelTestHelper(
 		event := cloudevents.NewEvent()
 		event.SetID(eventID)
 		event.SetSource(senderName)
-		event.SetType(lib.DefaultEventType)
+		event.SetType(testlib.DefaultEventType)
 		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}

--- a/test/conformance/helpers/channel_spec_test_helper.go
+++ b/test/conformance/helpers/channel_spec_test_helper.go
@@ -28,19 +28,19 @@ import (
 
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/pkg/apis"
 )
 
 func ChannelSpecTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		t.Run("Channel spec allows subscribers", func(t *testing.T) {
 			if channel == channelv1beta1 {
@@ -51,7 +51,7 @@ func ChannelSpecTestHelperWithChannelTestRunner(
 	})
 }
 
-func channelSpecAllowsSubscribersArray(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
+func channelSpecAllowsSubscribersArray(st *testing.T, client *testlib.Client, channel metav1.TypeMeta, options ...testlib.SetupClientOption) {
 	st.Logf("Running channel spec conformance test with channel %s", channel)
 
 	dtsv, err := getChannelDuckTypeSupportVersionFromTypeMeta(client, channel)
@@ -123,7 +123,7 @@ func channelSpecAllowsSubscribersArray(st *testing.T, client *lib.Client, channe
 	}
 }
 
-func getChannelDuckTypeSupportVersionFromTypeMeta(client *lib.Client, channel metav1.TypeMeta) (string, error) {
+func getChannelDuckTypeSupportVersionFromTypeMeta(client *testlib.Client, channel metav1.TypeMeta) (string, error) {
 	// the only way is to create one and see
 	channelName := names.SimpleNameGenerator.GenerateName("channel-tmp-")
 

--- a/test/conformance/helpers/channel_spec_test_helper.go
+++ b/test/conformance/helpers/channel_spec_test_helper.go
@@ -34,7 +34,7 @@ import (
 
 func ChannelSpecTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_status_subscriber_test_helper.go
+++ b/test/conformance/helpers/channel_status_subscriber_test_helper.go
@@ -29,10 +29,10 @@ import (
 )
 
 // ChannelStatusSubscriberTestHelperWithChannelTestRunner runs the tests of
-// subscriber field of status for all Channels in the ChannelTestRunner.
+// subscriber field of status for all Channels in the ComponentsTestRunner.
 func ChannelStatusSubscriberTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_status_subscriber_test_helper.go
+++ b/test/conformance/helpers/channel_status_subscriber_test_helper.go
@@ -21,7 +21,7 @@ import (
 
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,13 +32,13 @@ import (
 // subscriber field of status for all Channels in the ComponentsTestRunner.
 func ChannelStatusSubscriberTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		t.Run("Channel has required status subscriber fields", func(t *testing.T) {
 			channelHasRequiredSubscriberStatus(st, client, channel, options...)
@@ -46,7 +46,7 @@ func ChannelStatusSubscriberTestHelperWithChannelTestRunner(
 	})
 }
 
-func channelHasRequiredSubscriberStatus(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
+func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, channel metav1.TypeMeta, options ...testlib.SetupClientOption) {
 	st.Logf("Running channel subscriber status conformance test with channel %q", channel)
 
 	channelName := "channel-req-status-subscriber"
@@ -57,7 +57,7 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *lib.Client, chann
 	client.WaitForResourceReadyOrFail(channelName, &channel)
 
 	pod := resources.EventRecordPod(subscriberServiceName + "-pod")
-	client.CreatePodOrFail(pod, lib.WithService(subscriberServiceName))
+	client.CreatePodOrFail(pod, testlib.WithService(subscriberServiceName))
 
 	subscription := client.CreateSubscriptionOrFail(
 		subscriberServiceName,

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -25,10 +25,10 @@ import (
 )
 
 // ChannelStatusTestHelperWithChannelTestRunner runs the Channel status tests for all Channels in
-// the ChannelTestRunner.
+// the ComponentsTestRunner.
 func ChannelStatusTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption,
 ) {
 

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -21,20 +21,20 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 // ChannelStatusTestHelperWithChannelTestRunner runs the Channel status tests for all Channels in
 // the ComponentsTestRunner.
 func ChannelStatusTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption,
 ) {
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		t.Run("Channel has required status fields", func(t *testing.T) {
 			channelHasRequiredStatus(st, client, channel, options...)
@@ -42,7 +42,7 @@ func ChannelStatusTestHelperWithChannelTestRunner(
 	})
 }
 
-func channelHasRequiredStatus(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
+func channelHasRequiredStatus(st *testing.T, client *testlib.Client, channel metav1.TypeMeta, options ...testlib.SetupClientOption) {
 	st.Logf("Running channel status conformance test with channel %q", channel)
 
 	channelName := "channel-req-status"

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -34,10 +34,10 @@ import (
 )
 
 // ChannelTracingTestHelperWithChannelTestRunner runs the Channel tracing tests for all Channels in
-// the ChannelTestRunner.
+// the ComponentsTestRunner.
 func ChannelTracingTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	setupClient lib.SetupClientOption,
 ) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
@@ -37,10 +37,10 @@ import (
 // the ComponentsTestRunner.
 func ChannelTracingTestHelperWithChannelTestRunner(
 	t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	setupClient lib.SetupClientOption,
+	channelTestRunner testlib.ComponentsTestRunner,
+	setupClient testlib.SetupClientOption,
 ) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		tracingTest(t, setupClient, setupChannelTracingWithReply, channel)
 	})
 }
@@ -54,7 +54,7 @@ func ChannelTracingTestHelperWithChannelTestRunner(
 func setupChannelTracingWithReply(
 	t *testing.T,
 	channel *metav1.TypeMeta,
-	client *lib.Client,
+	client *testlib.Client,
 	recordEventsPodName string,
 	senderPublishTrace bool,
 ) (tracinghelper.TestSpanTree, cetest.EventMatcher) {
@@ -68,7 +68,7 @@ func setupChannelTracingWithReply(
 
 	// Create the 'sink', a LogEvents Pod and a K8s Service that points to it.
 	recordEventsPod := resources.EventRecordPod(recordEventsPodName)
-	client.CreatePodOrFail(recordEventsPod, lib.WithService(recordEventsPodName))
+	client.CreatePodOrFail(recordEventsPod, testlib.WithService(recordEventsPodName))
 
 	// Create the subscriber, a Pod that mutates the event.
 	transformerPod := resources.EventTransformationPod(
@@ -77,7 +77,7 @@ func setupChannelTracingWithReply(
 		eventSource,
 		nil,
 	)
-	client.CreatePodOrFail(transformerPod, lib.WithService(transformerPod.Name))
+	client.CreatePodOrFail(transformerPod, testlib.WithService(transformerPod.Name))
 
 	// Create the Subscription linking the Channel to the mutator.
 	client.CreateSubscriptionOrFail(
@@ -104,7 +104,7 @@ func setupChannelTracingWithReply(
 	event := cloudevents.NewEvent()
 	event.SetID(eventID)
 	event.SetSource(senderName)
-	event.SetType(lib.DefaultEventType)
+	event.SetType(testlib.DefaultEventType)
 	body := fmt.Sprintf(`{"msg":"TestChannelTracing %s"}`, eventID)
 	if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 		t.Fatalf("Cannot set the payload of the event: %s", err.Error())

--- a/test/conformance/helpers/metadata.go
+++ b/test/conformance/helpers/metadata.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func validateRequiredLabels(client *testlib.Client, object metav1.TypeMeta, labels map[string]string) {
+	for k, v := range labels {
+		if !objectHasRequiredLabel(client, object, k, v) {
+			client.T.Fatalf("can't find label '%s=%s' in CRD %q", k, v, object)
+		}
+	}
+}
+
+func objectHasRequiredLabel(client *testlib.Client, object metav1.TypeMeta, key string, value string) bool {
+	gvr, _ := meta.UnsafeGuessKindToResource(object.GroupVersionKind())
+	crdName := gvr.Resource + "." + gvr.Group
+
+	crd, err := client.Apiextensions.CustomResourceDefinitions().Get(crdName, metav1.GetOptions{
+		TypeMeta: metav1.TypeMeta{},
+	})
+	if err != nil {
+		client.T.Errorf("error while getting %q:%v", object, err)
+	}
+	return crd.Labels[key] == value
+}

--- a/test/conformance/helpers/rbac.go
+++ b/test/conformance/helpers/rbac.go
@@ -21,10 +21,10 @@ import (
 
 	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
-func ServiceAccountCanDoVerbOnResourceOrFail(client *lib.Client, gvr schema.GroupVersionResource, subresource string, saName string, verb string) {
+func ServiceAccountCanDoVerbOnResourceOrFail(client *testlib.Client, gvr schema.GroupVersionResource, subresource string, saName string, verb string) {
 	r, err := client.Kube.Kube.AuthorizationV1().SubjectAccessReviews().Create(&authv1.SubjectAccessReview{
 		Spec: authv1.SubjectAccessReviewSpec{
 			User: fmt.Sprintf("system:serviceaccount:%s:%s", client.Namespace, saName),

--- a/test/conformance/helpers/tracing/zipkin.go
+++ b/test/conformance/helpers/tracing/zipkin.go
@@ -23,14 +23,14 @@ import (
 
 	"knative.dev/pkg/test/zipkin"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 
 	pkgtesting "knative.dev/pkg/configmap/testing"
 )
 
 // Setup sets up port forwarding to Zipkin and sets the knative-eventing tracing config to debug
 // mode (everything is sampled).
-func Setup(t *testing.T, client *lib.Client) {
+func Setup(t *testing.T, client *testlib.Client) {
 	// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
 	// TestMain.
 	if !zipkin.SetupZipkinTracing(client.Kube.Kube, t.Logf) {
@@ -47,7 +47,7 @@ var setTracingConfigOnce = sync.Once{}
 // instance and caused https://github.com/knative/eventing/issues/2040. So now we just ensure that
 // the tests that test tracing ensure that the requests are made with the sampled flag set to true.
 // TODO Do we need a tear down method to revert the config map to its original state?
-func setTracingConfigToZipkin(t *testing.T, client *lib.Client) {
+func setTracingConfigToZipkin(t *testing.T, client *testlib.Client) {
 	setTracingConfigOnce.Do(func() {
 		tracingConfig, exampleTracingConfig := pkgtesting.ConfigMapsFromTestFile(t, "config-tracing")
 		_, backendOk := tracingConfig.Data["backend"]

--- a/test/conformance/helpers/tracing_test_helper.go
+++ b/test/conformance/helpers/tracing_test_helper.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/test/zipkin"
 
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 )
 
@@ -38,7 +38,7 @@ import (
 type SetupTracingTestInfrastructureFunc func(
 	t *testing.T,
 	channel *metav1.TypeMeta,
-	client *lib.Client,
+	client *testlib.Client,
 	loggerPodName string,
 	senderPublishTrace bool,
 ) (tracinghelper.TestSpanTree, cetest.EventMatcher)
@@ -46,7 +46,7 @@ type SetupTracingTestInfrastructureFunc func(
 // tracingTest bootstraps the test and then executes the assertions on the received event and on the spans
 func tracingTest(
 	t *testing.T,
-	setupClient lib.SetupClientOption,
+	setupClient testlib.SetupClientOption,
 	setupInfrastructure SetupTracingTestInfrastructureFunc,
 	channel metav1.TypeMeta,
 ) {
@@ -54,8 +54,8 @@ func tracingTest(
 		recordEventsPodName = "recordevents"
 	)
 
-	client := lib.Setup(t, true, setupClient)
-	defer lib.TearDown(client)
+	client := testlib.Setup(t, true, setupClient)
+	defer testlib.TearDown(client)
 
 	// Do NOT call zipkin.CleanupZipkinTracingSetup. That will be called exactly once in
 	// TestMain.

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -26,15 +26,15 @@ import (
 	"knative.dev/eventing/test/lib"
 )
 
-var channelTestRunner lib.ChannelTestRunner
+var channelTestRunner lib.ComponentsTestRunner
 var brokerClass string
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeEventingFlags()
-		channelTestRunner = lib.ChannelTestRunner{
-			ChannelFeatureMap: lib.ChannelFeatureMap,
-			ChannelsToTest:    test.EventingFlags.Channels,
+		channelTestRunner = lib.ComponentsTestRunner{
+			ComponentFeatureMap: lib.ChannelFeatureMap,
+			ComponentsToTest:    test.EventingFlags.Channels,
 		}
 		brokerClass = test.EventingFlags.BrokerClass
 

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -23,17 +23,17 @@ import (
 	"knative.dev/pkg/test/zipkin"
 
 	"knative.dev/eventing/test"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
-var channelTestRunner lib.ComponentsTestRunner
+var channelTestRunner testlib.ComponentsTestRunner
 var brokerClass string
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeEventingFlags()
-		channelTestRunner = lib.ComponentsTestRunner{
-			ComponentFeatureMap: lib.ChannelFeatureMap,
+		channelTestRunner = testlib.ComponentsTestRunner{
+			ComponentFeatureMap: testlib.ChannelFeatureMap,
 			ComponentsToTest:    test.EventingFlags.Channels,
 		}
 		brokerClass = test.EventingFlags.BrokerClass

--- a/test/e2e/broker_with_many_triggers_test.go
+++ b/test/e2e/broker_with_many_triggers_test.go
@@ -25,14 +25,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgResources "knative.dev/eventing/pkg/reconciler/mtnamespace/resources"
 	"knative.dev/eventing/test/e2e/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 const defaultBrokerName = pkgResources.DefaultBrokerName
 
 var unsupportedChannelVersions = []string{"v1alpha1"}
 
-func DefaultBrokerCreator(_ *lib.Client) string {
+func DefaultBrokerCreator(_ *testlib.Client) string {
 	return defaultBrokerName
 }
 
@@ -41,7 +41,7 @@ func TestDefaultBrokerWithManyTriggers(t *testing.T) {
 }
 
 func TestChannelBasedBrokerWithManyTriggers(t *testing.T) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		for _, version := range unsupportedChannelVersions {
 			if strings.HasSuffix(channel.APIVersion, version) {
 				t.Skipf("unsupported %s channel version", version)

--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
@@ -51,8 +51,8 @@ Trigger3 filters the transformed event and sends it to Channel.
 */
 func BrokerChannelFlowWithTransformation(t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		senderName = "e2e-brokerchannel-sender"
 		brokerName = "e2e-brokerchannel-broker"
@@ -77,16 +77,16 @@ func BrokerChannelFlowWithTransformation(t *testing.T,
 		subscriptionName = "e2e-brokerchannel-subscription"
 	)
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		config := client.CreateBrokerConfigMapOrFail(brokerName, &channel)
 		//&channel
 
 		// create a new broker
 		client.CreateBrokerV1Beta1OrFail(brokerName, resources.WithBrokerClassForBrokerV1Beta1(brokerClass), resources.WithConfigForBrokerV1Beta1(config))
-		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
+		client.WaitForResourceReadyOrFail(brokerName, testlib.BrokerTypeMeta)
 
 		// eventToSend is the event sent as input of the test
 		eventToSend := cloudevents.NewEvent()
@@ -104,7 +104,7 @@ func BrokerChannelFlowWithTransformation(t *testing.T,
 			transformedEventSource,
 			[]byte(transformedBody),
 		)
-		client.CreatePodOrFail(transformationPod, lib.WithService(transformationPodName))
+		client.CreatePodOrFail(transformationPod, testlib.WithService(transformationPodName))
 
 		// create trigger1 to receive the original event, and do event transformation
 		client.CreateTriggerOrFailV1Beta1(
@@ -158,7 +158,7 @@ func BrokerChannelFlowWithTransformation(t *testing.T,
 		client.WaitForAllTestResourcesReadyOrFail()
 
 		// send CloudEvent to the broker
-		client.SendEventToAddressable(senderName, brokerName, lib.BrokerTypeMeta, eventToSend)
+		client.SendEventToAddressable(senderName, brokerName, testlib.BrokerTypeMeta, eventToSend)
 
 		// Assert the results on the event trackers
 		originalEventMatcher := recordevents.MatchEvent(AllOf(

--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -51,7 +51,7 @@ Trigger3 filters the transformed event and sends it to Channel.
 */
 func BrokerChannelFlowWithTransformation(t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		senderName = "e2e-brokerchannel-sender"

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -45,7 +45,7 @@ Note: the number denotes the sequence of the event that flows in this test case.
 */
 func EventTransformationForTriggerTestHelper(t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		senderName = "e2e-eventtransformation-sender"

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
@@ -45,8 +45,8 @@ Note: the number denotes the sequence of the event that flows in this test case.
 */
 func EventTransformationForTriggerTestHelper(t *testing.T,
 	brokerClass string,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		senderName = "e2e-eventtransformation-sender"
 		brokerName = "e2e-eventtransformation-broker"
@@ -66,16 +66,16 @@ func EventTransformationForTriggerTestHelper(t *testing.T,
 		recordEventsPodName   = "recordevents-pod"
 	)
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// Create a configmap used by the broker.
 		config := client.CreateBrokerConfigMapOrFail(brokerName, &channel)
 
 		// create a new broker
 		client.CreateBrokerV1Beta1OrFail(brokerName, resources.WithBrokerClassForBrokerV1Beta1(brokerClass), resources.WithConfigForBrokerV1Beta1(config))
-		client.WaitForResourceReadyOrFail(brokerName, lib.BrokerTypeMeta)
+		client.WaitForResourceReadyOrFail(brokerName, testlib.BrokerTypeMeta)
 
 		// create the transformation service
 		transformationPod := resources.EventTransformationPod(
@@ -84,7 +84,7 @@ func EventTransformationForTriggerTestHelper(t *testing.T,
 			transformedEventSource,
 			[]byte(transformedBody),
 		)
-		client.CreatePodOrFail(transformationPod, lib.WithService(transformationPodName))
+		client.CreatePodOrFail(transformationPod, testlib.WithService(transformationPodName))
 
 		// create trigger1 for event transformation
 		client.CreateTriggerOrFailV1Beta1(
@@ -117,7 +117,7 @@ func EventTransformationForTriggerTestHelper(t *testing.T,
 		if err := eventToSend.SetData(cloudevents.ApplicationJSON, []byte(eventBody)); err != nil {
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}
-		client.SendEventToAddressable(senderName, brokerName, lib.BrokerTypeMeta, eventToSend)
+		client.SendEventToAddressable(senderName, brokerName, testlib.BrokerTypeMeta, eventToSend)
 
 		// check if the logging service receives the correct event
 		eventTracker.AssertAtLeast(1, recordevents.MatchEvent(

--- a/test/e2e/helpers/channel_chain_test_helper.go
+++ b/test/e2e/helpers/channel_chain_test_helper.go
@@ -25,15 +25,15 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
 
 // ChannelChainTestHelper is the helper function for channel_chain_test
 func ChannelChainTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		senderName          = "e2e-channelchain-sender"
 		recordEventsPodName = "e2e-channelchain-recordevents-pod"
@@ -45,9 +45,9 @@ func ChannelChainTestHelper(t *testing.T,
 	subscriptionNames2 := []string{"e2e-channelchain-subs21"}
 	eventSource := fmt.Sprintf("http://%s.svc/", senderName)
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// create channels
 		client.CreateChannelsOrFail(channelNames, &channel)
@@ -79,7 +79,7 @@ func ChannelChainTestHelper(t *testing.T,
 		event := cloudevents.NewEvent()
 		event.SetID("dummy")
 		event.SetSource(eventSource)
-		event.SetType(lib.DefaultEventType)
+		event.SetType(testlib.DefaultEventType)
 
 		body := fmt.Sprintf(`{"msg":"TestSingleEvent %s"}`, uuid.New().String())
 		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {

--- a/test/e2e/helpers/channel_chain_test_helper.go
+++ b/test/e2e/helpers/channel_chain_test_helper.go
@@ -32,7 +32,7 @@ import (
 
 // ChannelChainTestHelper is the helper function for channel_chain_test
 func ChannelChainTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		senderName          = "e2e-channelchain-sender"

--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -31,7 +31,7 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/apis/messaging/config"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
@@ -50,12 +50,12 @@ const (
 
 // ChannelClusterDefaulterTestHelper is the helper function for channel_defaulter_test
 func ChannelClusterDefaulterTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// these tests cannot be run in parallel as they have cluster-wide impact
-		client := lib.Setup(st, false, options...)
-		defer lib.TearDown(client)
+		client := testlib.Setup(st, false, options...)
+		defer testlib.TearDown(client)
 
 		if err := updateDefaultChannelCM(client, func(conf *config.ChannelDefaults) {
 			setClusterDefaultChannel(conf, channel)
@@ -69,13 +69,13 @@ func ChannelClusterDefaulterTestHelper(t *testing.T,
 
 // ChannelNamespaceDefaulterTestHelper is the helper function for channel_defaulter_test
 func ChannelNamespaceDefaulterTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// we cannot run these tests in parallel as the updateDefaultChannelCM function is not thread-safe
 		// TODO(chizhg): make updateDefaultChannelCM thread-safe and run in parallel if the tests are taking too long to finish
-		client := lib.Setup(st, false, options...)
-		defer lib.TearDown(client)
+		client := testlib.Setup(st, false, options...)
+		defer testlib.TearDown(client)
 
 		if err := updateDefaultChannelCM(client, func(conf *config.ChannelDefaults) {
 			setNamespaceDefaultChannel(conf, client.Namespace, channel)
@@ -87,7 +87,7 @@ func ChannelNamespaceDefaulterTestHelper(t *testing.T,
 	})
 }
 
-func defaultChannelTestHelper(t *testing.T, client *lib.Client, expectedChannel metav1.TypeMeta) {
+func defaultChannelTestHelper(t *testing.T, client *testlib.Client, expectedChannel metav1.TypeMeta) {
 	channelName := "e2e-defaulter-channel"
 	senderName := "e2e-defaulter-sender"
 	subscriptionName := "e2e-defaulter-subscription"
@@ -104,7 +104,7 @@ func defaultChannelTestHelper(t *testing.T, client *lib.Client, expectedChannel 
 	client.CreateSubscriptionOrFail(
 		subscriptionName,
 		channelName,
-		lib.ChannelTypeMeta,
+		testlib.ChannelTypeMeta,
 		resources.WithSubscriberForSubscription(recordEventsPodName),
 	)
 
@@ -142,12 +142,12 @@ func defaultChannelTestHelper(t *testing.T, client *lib.Client, expectedChannel 
 	event.SetID("dummy")
 	eventSource := fmt.Sprintf("http://%s.svc/", senderName)
 	event.SetSource(eventSource)
-	event.SetType(lib.DefaultEventType)
+	event.SetType(testlib.DefaultEventType)
 	body := fmt.Sprintf(`{"msg":"TestSingleEvent %s"}`, uuid.New().String())
 	if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 		t.Fatalf("Cannot set the payload of the event: %s", err.Error())
 	}
-	client.SendEventToAddressable(senderName, channelName, lib.ChannelTypeMeta, event)
+	client.SendEventToAddressable(senderName, channelName, testlib.ChannelTypeMeta, event)
 
 	// verify the logger service receives the event
 	eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
@@ -157,7 +157,7 @@ func defaultChannelTestHelper(t *testing.T, client *lib.Client, expectedChannel 
 }
 
 // updateDefaultChannelCM will update the default channel configmap
-func updateDefaultChannelCM(client *lib.Client, updateConfig func(config *config.ChannelDefaults)) error {
+func updateDefaultChannelCM(client *testlib.Client, updateConfig func(config *config.ChannelDefaults)) error {
 	cmInterface := client.Kube.Kube.CoreV1().ConfigMaps(resources.SystemNamespace)
 
 	err := reconciler.RetryUpdateConflicts(func(attempts int) (err error) {

--- a/test/e2e/helpers/channel_defaulter_test_helper.go
+++ b/test/e2e/helpers/channel_defaulter_test_helper.go
@@ -50,7 +50,7 @@ const (
 
 // ChannelClusterDefaulterTestHelper is the helper function for channel_defaulter_test
 func ChannelClusterDefaulterTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// these tests cannot be run in parallel as they have cluster-wide impact
@@ -69,7 +69,7 @@ func ChannelClusterDefaulterTestHelper(t *testing.T,
 
 // ChannelNamespaceDefaulterTestHelper is the helper function for channel_defaulter_test
 func ChannelNamespaceDefaulterTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		// we cannot run these tests in parallel as the updateDefaultChannelCM function is not thread-safe

--- a/test/e2e/helpers/channel_dls_test_helper.go
+++ b/test/e2e/helpers/channel_dls_test_helper.go
@@ -32,7 +32,7 @@ import (
 
 // ChannelDeadLetterSinkTestHelper is the helper function for channel_deadlettersink_test
 func ChannelDeadLetterSinkTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		senderName          = "e2e-channelchain-sender"

--- a/test/e2e/helpers/channel_dls_test_helper.go
+++ b/test/e2e/helpers/channel_dls_test_helper.go
@@ -25,15 +25,15 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
 
 // ChannelDeadLetterSinkTestHelper is the helper function for channel_deadlettersink_test
 func ChannelDeadLetterSinkTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		senderName          = "e2e-channelchain-sender"
 		recordEventsPodName = "e2e-channel-dls-recordevents-pod"
@@ -42,9 +42,9 @@ func ChannelDeadLetterSinkTestHelper(t *testing.T,
 	// subscriptionNames corresponds to Subscriptions
 	subscriptionNames := []string{"e2e-channel-dls-subs1"}
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// create channels
 		client.CreateChannelsOrFail(channelNames, &channel)
@@ -71,7 +71,7 @@ func ChannelDeadLetterSinkTestHelper(t *testing.T,
 		event.SetID("dummy")
 		eventSource := fmt.Sprintf("http://%s.svc/", senderName)
 		event.SetSource(eventSource)
-		event.SetType(lib.DefaultEventType)
+		event.SetType(testlib.DefaultEventType)
 		body := fmt.Sprintf(`{"msg":"TestChannelDeadLetterSink %s"}`, uuid.New().String())
 		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())

--- a/test/e2e/helpers/channel_event_tranformation_test_helper.go
+++ b/test/e2e/helpers/channel_event_tranformation_test_helper.go
@@ -32,7 +32,7 @@ import (
 
 // EventTransformationForSubscriptionTestHelper is the helper function for channel_event_tranformation_test
 func EventTransformationForSubscriptionTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	senderName := "e2e-eventtransformation-sender"
 	channelNames := []string{"e2e-eventtransformation1", "e2e-eventtransformation2"}

--- a/test/e2e/helpers/channel_event_tranformation_test_helper.go
+++ b/test/e2e/helpers/channel_event_tranformation_test_helper.go
@@ -25,15 +25,15 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
 
 // EventTransformationForSubscriptionTestHelper is the helper function for channel_event_tranformation_test
 func EventTransformationForSubscriptionTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	senderName := "e2e-eventtransformation-sender"
 	channelNames := []string{"e2e-eventtransformation1", "e2e-eventtransformation2"}
 	eventSource := fmt.Sprintf("http://%s.svc/", senderName)
@@ -44,9 +44,9 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T,
 	transformationPodName := "e2e-eventtransformation-transformation-pod"
 	recordEventsPodName := "e2e-eventtransformation-recordevents-pod"
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// create channels
 		client.CreateChannelsOrFail(channelNames, &channel)
@@ -56,7 +56,7 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T,
 		eventAfterTransformation := cloudevents.NewEvent()
 		eventAfterTransformation.SetID("dummy-transformed")
 		eventAfterTransformation.SetSource(eventSource)
-		eventAfterTransformation.SetType(lib.DefaultEventType)
+		eventAfterTransformation.SetType(testlib.DefaultEventType)
 		transformedEventBody := fmt.Sprintf(`{"msg":"eventBody %s"}`, uuid.New().String())
 		if err := eventAfterTransformation.SetData(cloudevents.ApplicationJSON, []byte(transformedEventBody)); err != nil {
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
@@ -67,7 +67,7 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T,
 			eventAfterTransformation.Source(),
 			eventAfterTransformation.Data(),
 		)
-		client.CreatePodOrFail(transformationPod, lib.WithService(transformationPodName))
+		client.CreatePodOrFail(transformationPod, testlib.WithService(transformationPodName))
 
 		// create event logger pod and service as the subscriber
 		eventTracker, _ := recordevents.StartEventRecordOrFail(client, recordEventsPodName)
@@ -96,7 +96,7 @@ func EventTransformationForSubscriptionTestHelper(t *testing.T,
 		eventToSend := cloudevents.NewEvent()
 		eventToSend.SetID("dummy")
 		eventToSend.SetSource(eventSource)
-		eventToSend.SetType(lib.DefaultEventType)
+		eventToSend.SetType(testlib.DefaultEventType)
 		eventBody := fmt.Sprintf(`{"msg":"TestEventTransformation %s"}`, uuid.New().String())
 		if err := eventToSend.SetData(cloudevents.ApplicationJSON, []byte(eventBody)); err != nil {
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
@@ -46,17 +46,17 @@ const (
 func SingleEventForChannelTestHelper(t *testing.T, encoding cloudevents.Encoding,
 	subscriptionVersion SubscriptionVersion,
 	channelVersion string,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	channelName := "e2e-singleevent-channel-" + encoding.String()
 	senderName := "e2e-singleevent-sender-" + encoding.String()
 	subscriptionName := "e2e-singleevent-subscription-" + encoding.String()
 	eventRecorder := "e2e-singleevent-event-record-pod-" + encoding.String()
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		st.Logf("Run test with channel %q", channel)
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// create channel
 		client.CreateChannelOrFail(channelName, &channel)
@@ -92,7 +92,7 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding cloudevents.Encoding
 
 		eventSource := fmt.Sprintf("http://%s.svc/", senderName)
 		event.SetSource(eventSource)
-		event.SetType(lib.DefaultEventType)
+		event.SetType(testlib.DefaultEventType)
 
 		body := fmt.Sprintf(`{"msg":"TestSingleEvent %s"}`, uuid.New().String())
 		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -46,7 +46,7 @@ const (
 func SingleEventForChannelTestHelper(t *testing.T, encoding cloudevents.Encoding,
 	subscriptionVersion SubscriptionVersion,
 	channelVersion string,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	channelName := "e2e-singleevent-channel-" + encoding.String()
 	senderName := "e2e-singleevent-sender-" + encoding.String()

--- a/test/e2e/helpers/parallel_test_helper.go
+++ b/test/e2e/helpers/parallel_test_helper.go
@@ -38,7 +38,7 @@ type branchConfig struct {
 }
 
 func ParallelTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		senderPodName = "e2e-parallel"

--- a/test/e2e/helpers/parallel_test_helper.go
+++ b/test/e2e/helpers/parallel_test_helper.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/eventing/pkg/apis/flows/v1beta1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -38,8 +38,8 @@ type branchConfig struct {
 }
 
 func ParallelTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		senderPodName = "e2e-parallel"
 	)
@@ -57,9 +57,9 @@ func ParallelTestHelper(t *testing.T,
 			expected: "parallel-two-branches-pass-first-branch-only-branch-0-sub",
 		},
 	}
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		for _, tc := range table {
 			parallelBranches := make([]v1beta1.ParallelBranch, len(tc.branchesConfig))
@@ -67,12 +67,12 @@ func ParallelTestHelper(t *testing.T,
 				// construct filter services
 				filterPodName := fmt.Sprintf("parallel-%s-branch-%d-filter", tc.name, branchNumber)
 				filterPod := resources.EventFilteringPod(filterPodName, cse.filter)
-				client.CreatePodOrFail(filterPod, lib.WithService(filterPodName))
+				client.CreatePodOrFail(filterPod, testlib.WithService(filterPodName))
 
 				// construct branch subscriber
 				subPodName := fmt.Sprintf("parallel-%s-branch-%d-sub", tc.name, branchNumber)
 				subPod := resources.SequenceStepperPod(subPodName, subPodName)
-				client.CreatePodOrFail(subPod, lib.WithService(subPodName))
+				client.CreatePodOrFail(subPod, testlib.WithService(subPodName))
 
 				parallelBranches[branchNumber] = v1beta1.ParallelBranch{
 					Filter: &duckv1.Destination{
@@ -120,7 +120,7 @@ func ParallelTestHelper(t *testing.T,
 
 			eventSource := fmt.Sprintf("http://%s.svc/", senderPodName)
 			event.SetSource(eventSource)
-			event.SetType(lib.DefaultEventType)
+			event.SetType(testlib.DefaultEventType)
 			body := fmt.Sprintf(`{"msg":"TestFlowParallel %s"}`, uuid.New().String())
 			if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 				st.Fatalf("Cannot set the payload of the event: %s", err.Error())
@@ -129,7 +129,7 @@ func ParallelTestHelper(t *testing.T,
 			client.SendEventToAddressable(
 				senderPodName,
 				tc.name,
-				lib.FlowsParallelTypeMeta,
+				testlib.FlowsParallelTypeMeta,
 				event,
 			)
 

--- a/test/e2e/helpers/sequence_test_helper.go
+++ b/test/e2e/helpers/sequence_test_helper.go
@@ -27,15 +27,15 @@ import (
 	"knative.dev/eventing/pkg/apis/flows/v1beta1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func SequenceTestHelper(t *testing.T,
-	channelTestRunner lib.ComponentsTestRunner,
-	options ...lib.SetupClientOption) {
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
 	const (
 		sequenceName  = "e2e-sequence"
 		senderPodName = "e2e-sequence-sender-pod"
@@ -59,9 +59,9 @@ func SequenceTestHelper(t *testing.T,
 		msgAppender: "-step3",
 	}}
 
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
-		client := lib.Setup(st, true, options...)
-		defer lib.TearDown(client)
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
 
 		// construct steps for the sequence
 		steps := make([]v1beta1.SequenceStep, 0)
@@ -71,7 +71,7 @@ func SequenceTestHelper(t *testing.T,
 			msgAppender := config.msgAppender
 			stepperPod := resources.SequenceStepperPod(podName, msgAppender)
 
-			client.CreatePodOrFail(stepperPod, lib.WithService(podName))
+			client.CreatePodOrFail(stepperPod, testlib.WithService(podName))
 			// create a new step
 			step := v1beta1.SequenceStep{
 				Destination: duckv1.Destination{
@@ -123,7 +123,7 @@ func SequenceTestHelper(t *testing.T,
 		event.SetID("dummy")
 		eventSource := fmt.Sprintf("http://%s.svc/", senderPodName)
 		event.SetSource(eventSource)
-		event.SetType(lib.DefaultEventType)
+		event.SetType(testlib.DefaultEventType)
 		msg := fmt.Sprintf("TestSequence %s", uuid.New().String())
 		body := fmt.Sprintf(`{"msg":"%s"}`, msg)
 		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
@@ -132,7 +132,7 @@ func SequenceTestHelper(t *testing.T,
 		client.SendEventToAddressable(
 			senderPodName,
 			sequenceName,
-			lib.FlowsSequenceTypeMeta,
+			testlib.FlowsSequenceTypeMeta,
 			event)
 
 		// verify the logger service receives the correct transformed event

--- a/test/e2e/helpers/sequence_test_helper.go
+++ b/test/e2e/helpers/sequence_test_helper.go
@@ -34,7 +34,7 @@ import (
 )
 
 func SequenceTestHelper(t *testing.T,
-	channelTestRunner lib.ChannelTestRunner,
+	channelTestRunner lib.ComponentsTestRunner,
 	options ...lib.SetupClientOption) {
 	const (
 		sequenceName  = "e2e-sequence"

--- a/test/e2e/helpers/trigger_no_broker_test_helper.go
+++ b/test/e2e/helpers/trigger_no_broker_test_helper.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
@@ -33,8 +33,8 @@ import (
 // the Status is correctly reflected as failed with BrokerDoesNotExist. Then it will create
 // the broker and ensure that Trigger / Broker will get to Ready state.
 func TestTriggerNoBroker(t *testing.T, channel string, brokerCreator BrokerCreator) {
-	client := lib.Setup(t, true)
-	defer lib.TearDown(client)
+	client := testlib.Setup(t, true)
+	defer testlib.TearDown(client)
 	brokerName := strings.ToLower(channel)
 
 	subscriberName := "dumper-empty"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -20,18 +20,18 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
-var setup = lib.Setup
-var tearDown = lib.TearDown
-var channelTestRunner lib.ComponentsTestRunner
+var setup = testlib.Setup
+var tearDown = testlib.TearDown
+var channelTestRunner testlib.ComponentsTestRunner
 var brokerClass string
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
-	channelTestRunner = lib.ComponentsTestRunner{
-		ComponentFeatureMap: lib.ChannelFeatureMap,
+	channelTestRunner = testlib.ComponentsTestRunner{
+		ComponentFeatureMap: testlib.ChannelFeatureMap,
 		ComponentsToTest:    test.EventingFlags.Channels,
 	}
 	brokerClass = test.EventingFlags.BrokerClass

--- a/test/e2e/source_api_server_test.go
+++ b/test/e2e/source_api_server_test.go
@@ -32,7 +32,7 @@ import (
 	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	pkgResources "knative.dev/eventing/pkg/reconciler/mtnamespace/resources"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 )
@@ -134,7 +134,7 @@ func TestApiServerSource(t *testing.T) {
 			client.CreateRoleOrFail(r)
 			client.CreateRoleBindingOrFail(
 				serviceAccountName,
-				lib.RoleKind,
+				testlib.RoleKind,
 				roleName,
 				fmt.Sprintf("%s-%s", serviceAccountName, roleName),
 				client.Namespace,
@@ -199,7 +199,7 @@ func TestApiServerSourceV1Alpha2EventTypes(t *testing.T) {
 	client.CreateRoleOrFail(r)
 	client.CreateRoleBindingOrFail(
 		serviceAccountName,
-		lib.RoleKind,
+		testlib.RoleKind,
 		roleName,
 		fmt.Sprintf("%s-%s", serviceAccountName, roleName),
 		client.Namespace,
@@ -211,7 +211,7 @@ func TestApiServerSourceV1Alpha2EventTypes(t *testing.T) {
 	}
 
 	// Wait for default broker ready.
-	client.WaitForResourceReadyOrFail(pkgResources.DefaultBrokerName, lib.BrokerTypeMeta)
+	client.WaitForResourceReadyOrFail(pkgResources.DefaultBrokerName, testlib.BrokerTypeMeta)
 
 	// Create the api server source
 	apiServerSource := eventingtesting.NewApiServerSource(

--- a/test/e2e/source_ping_test.go
+++ b/test/e2e/source_ping_test.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -133,7 +133,7 @@ func TestPingSourceV1Alpha2EventTypes(t *testing.T) {
 	}
 
 	// Wait for default broker ready.
-	client.WaitForResourceReadyOrFail(pkgResources.DefaultBrokerName, lib.BrokerTypeMeta)
+	client.WaitForResourceReadyOrFail(pkgResources.DefaultBrokerName, testlib.BrokerTypeMeta)
 
 	// Create ping source
 	source := eventingtesting.NewPingSourceV1Alpha2(

--- a/test/e2e/trigger_dependency_annotation_test.go
+++ b/test/e2e/trigger_dependency_annotation_test.go
@@ -29,7 +29,7 @@ import (
 	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	pkgResources "knative.dev/eventing/pkg/reconciler/mtnamespace/resources"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/pkg/apis"
@@ -57,7 +57,7 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 		t.Fatalf("Error annotating namespace: %v", err)
 	}
 	// Wait for default broker ready.
-	client.WaitForResourceReadyOrFail(defaultBrokerName, lib.BrokerTypeMeta)
+	client.WaitForResourceReadyOrFail(defaultBrokerName, testlib.BrokerTypeMeta)
 
 	// Create subscribers.
 	eventTracker, _ := recordevents.StartEventRecordOrFail(client, subscriberName)
@@ -95,7 +95,7 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	client.CreatePingSourceV1Alpha2OrFail(pingSource)
 
 	// Trigger should become ready after pingSource was created
-	client.WaitForResourceReadyOrFail(triggerName, lib.TriggerTypeMeta)
+	client.WaitForResourceReadyOrFail(triggerName, testlib.TriggerTypeMeta)
 
 	eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
 		HasSource(sourcesv1alpha2.PingSourceSource(client.Namespace, pingSourceName)),

--- a/test/e2e/trigger_no_broker_test.go
+++ b/test/e2e/trigger_no_broker_test.go
@@ -23,11 +23,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/test/e2e/helpers"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestTriggerNoBroker(t *testing.T) {
-	channelTestRunner.RunTests(t, lib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		helpers.TestTriggerNoBroker(t, channel.Kind, helpers.ChannelBasedBrokerCreator(channel, brokerClass))
 	})
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testflags "knative.dev/eventing/test/flags"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 const (
@@ -50,7 +50,7 @@ func InitializeEventingFlags() {
 
 	// If no channel is passed through the flag, initialize it as the DefaultChannel.
 	if EventingFlags.Channels == nil || len(EventingFlags.Channels) == 0 {
-		EventingFlags.Channels = []metav1.TypeMeta{lib.DefaultChannel}
+		EventingFlags.Channels = []metav1.TypeMeta{testlib.DefaultChannel}
 	}
 
 	if EventingFlags.BrokerClass == "" {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -21,63 +21,31 @@ package test
 
 import (
 	"flag"
-	"fmt"
 	"log"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testflags "knative.dev/eventing/test/flags"
 	"knative.dev/eventing/test/lib"
 )
 
+const (
+	ChannelUsage = "The names of the channel type metas, separated by comma. " +
+		"Example: \"messaging.knative.dev/v1alpha1:InMemoryChannel," +
+		"messaging.cloud.google.com/v1alpha1:Channel,messaging.knative.dev/v1alpha1:KafkaChannel\"."
+	BrokerUsage = "Which brokerclass to test, requires the proper Broker " +
+		"implementation to have been installed, and only one value. brokerclass " +
+		"must be (for now) 'MTChannelBasedBroker'."
+)
+
 // EventingFlags holds the command line flags specific to knative/eventing.
-//var EventingFlags *EventingEnvironmentFlags
-var EventingFlags EventingEnvironmentFlags
-
-// Channels holds the Channels we want to run test against.
-type Channels []metav1.TypeMeta
-
-func (channels *Channels) String() string {
-	return fmt.Sprint(*channels)
-}
-
-// Set converts the input string to Channels.
-// The default Channel we will test against is InMemoryChannel.
-func (channels *Channels) Set(value string) error {
-	for _, channel := range strings.Split(value, ",") {
-		channel := strings.TrimSpace(channel)
-		split := strings.Split(channel, ":")
-		if len(split) != 2 {
-			log.Fatalf("The given Channel name %q is invalid, it needs to be in the form \"apiVersion:Kind\".", channel)
-		}
-		tm := metav1.TypeMeta{
-			APIVersion: split[0],
-			Kind:       split[1],
-		}
-		if !isValid(tm.Kind) {
-			log.Fatalf("The given channel name %q is invalid, tests cannot be run.\n", channel)
-		}
-
-		*channels = append(*channels, tm)
-	}
-	return nil
-}
-
-// Check if the channel name is valid.
-func isValid(channel string) bool {
-	return strings.HasSuffix(channel, "Channel")
-}
-
-// EventingEnvironmentFlags holds the e2e flags needed only by the eventing repo.
-type EventingEnvironmentFlags struct {
-	BrokerClass string
-	Channels
-}
+var EventingFlags testflags.EventingEnvironmentFlags
 
 // InitializeEventingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
 // go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func InitializeEventingFlags() {
-	flag.Var(&EventingFlags.Channels, "channels", "The names of the channel type metas, separated by comma. Example: \"messaging.knative.dev/v1alpha1:InMemoryChannel,messaging.cloud.google.com/v1alpha1:Channel,messaging.knative.dev/v1alpha1:KafkaChannel\".")
-	flag.StringVar(&EventingFlags.BrokerClass, "brokerclass", "MTChannelBasedBroker", "Which brokerclass to test, requires the proper Broker implementation to have been installed, and only one value. brokerclass must be (for now) 'MTChannelBasedBroker'.")
+
+	flag.Var(&EventingFlags.Channels, "channels", ChannelUsage)
+	flag.StringVar(&EventingFlags.BrokerClass, "brokerclass", "MTChannelBasedBroker", BrokerUsage)
 	flag.Parse()
 
 	// If no channel is passed through the flag, initialize it as the DefaultChannel.

--- a/test/flags/channels.go
+++ b/test/flags/channels.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Channels holds the Channels we want to run test against.
+type Channels []metav1.TypeMeta
+
+func (channels *Channels) String() string {
+	return fmt.Sprint(*channels)
+}
+
+// Set appends the input string to Channels.
+func (channels *Channels) Set(value string) error {
+	for _, channel := range strings.Split(value, ",") {
+		channel := strings.TrimSpace(channel)
+		split := strings.Split(channel, ":")
+		if len(split) != 2 {
+			log.Fatalf("The given Channel name %q is invalid, it needs to be in the form \"apiVersion:Kind\".", channel)
+		}
+		tm := metav1.TypeMeta{
+			APIVersion: split[0],
+			Kind:       split[1],
+		}
+		if !isValidChannel(tm.Kind) {
+			log.Fatalf("The given Channel name %q is invalid, tests cannot be run.\n", channel)
+		}
+
+		*channels = append(*channels, tm)
+	}
+	return nil
+}
+
+// Check if the channel name is valid.
+func isValidChannel(channel string) bool {
+	return strings.HasSuffix(channel, "Channel")
+}

--- a/test/flags/eventing_environment.go
+++ b/test/flags/eventing_environment.go
@@ -1,5 +1,6 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,27 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package flags
 
-import (
-	"os"
-	"testing"
-
-	"knative.dev/eventing/test"
-	"knative.dev/eventing/test/lib"
-)
-
-var setup = lib.Setup
-var tearDown = lib.TearDown
-var channelTestRunner lib.ComponentsTestRunner
-var brokerClass string
-
-func TestMain(m *testing.M) {
-	test.InitializeEventingFlags()
-	channelTestRunner = lib.ComponentsTestRunner{
-		ComponentFeatureMap: lib.ChannelFeatureMap,
-		ComponentsToTest:    test.EventingFlags.Channels,
-	}
-	brokerClass = test.EventingFlags.BrokerClass
-	os.Exit(m.Run())
+// EventingEnvironmentFlags holds the e2e flags needed only by the eventing repo.
+type EventingEnvironmentFlags struct {
+	BrokerClass string
+	Channels
 }

--- a/test/lib/config.go
+++ b/test/lib/config.go
@@ -39,7 +39,7 @@ var MessagingChannelTypeMeta = metav1.TypeMeta{
 	Kind:       resources.ChannelKind,
 }
 
-// ChannelFeatureMap saves the channel-features mapping.
+// ComponentFeatureMap saves the channel-features mapping.
 // Each pair means the channel support the list of features.
 var ChannelFeatureMap = map[metav1.TypeMeta][]Feature{
 	InMemoryChannelTypeMeta:  {FeatureBasic},

--- a/test/lib/recordevents/event_info.go
+++ b/test/lib/recordevents/event_info.go
@@ -35,7 +35,7 @@ import (
 
 	"knative.dev/pkg/test/logging"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
 // Port for the recordevents pod REST listener
@@ -110,7 +110,7 @@ type eventGetter struct {
 
 // Creates a forwarded port to the specified recordevents pod and waits until
 // it can successfully talk to the REST API.  Times out after timeoutEvRetry
-func newEventGetter(podName string, client *lib.Client, logf logging.FormatLogger) (eventGetterInterface, error) {
+func newEventGetter(podName string, client *testlib.Client, logf logging.FormatLogger) (eventGetterInterface, error) {
 	egi := &eventGetter{podName: podName, podNamespace: client.Namespace,
 		kubeClientset: client.Kube.Kube, podPort: RecordEventsPort, logf: logf}
 	err := egi.forwardPort()

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 )
 
@@ -83,7 +83,7 @@ func newTestableEventInfoStore(egi eventGetterInterface, retryInterval time.Dura
 // recordevents pod.  Calling this forwards the recordevents port to the local machine
 // and blocks waiting to connect to that pod.  Fails if it cannot connect within
 // the expected timeout (4 minutes currently)
-func NewEventInfoStore(client *lib.Client, podName string) (*EventInfoStore, error) {
+func NewEventInfoStore(client *testlib.Client, podName string) (*EventInfoStore, error) {
 	egi, err := newEventGetter(podName, client, client.T.Logf)
 	if err != nil {
 		return nil, err
@@ -95,9 +95,9 @@ func NewEventInfoStore(client *lib.Client, podName string) (*EventInfoStore, err
 }
 
 // Deploys a new recordevents pod and start the associated EventInfoStore
-func StartEventRecordOrFail(client *lib.Client, podName string) (*EventInfoStore, *corev1.Pod) {
+func StartEventRecordOrFail(client *testlib.Client, podName string) (*EventInfoStore, *corev1.Pod) {
 	eventRecordPod := resources.EventRecordPod(podName)
-	client.CreatePodOrFail(eventRecordPod, lib.WithService(podName))
+	client.CreatePodOrFail(eventRecordPod, testlib.WithService(podName))
 	eventTracker, err := NewEventInfoStore(client, podName)
 	if err != nil {
 		client.T.Fatalf("Failed to start the EventInfoStore associated to pod '%s': %v", podName, err)

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -45,29 +45,29 @@ const (
 	testPullSecretName = "kn-eventing-test-pull-secret"
 )
 
-// ChannelTestRunner is used to run tests against channels.
-type ChannelTestRunner struct {
-	ChannelFeatureMap map[metav1.TypeMeta][]Feature
-	ChannelsToTest    []metav1.TypeMeta
+// ComponentsTestRunner is used to run tests against different eventing components.
+type ComponentsTestRunner struct {
+	ComponentFeatureMap map[metav1.TypeMeta][]Feature
+	ComponentsToTest    []metav1.TypeMeta
 }
 
-// RunTests will use all channels that support the given feature, to run
+// RunTests will use all components that support the given feature, to run
 // a test for the testFunc.
-func (tr *ChannelTestRunner) RunTests(
+func (tr *ComponentsTestRunner) RunTests(
 	t *testing.T,
 	feature Feature,
-	testFunc func(st *testing.T, channel metav1.TypeMeta),
+	testFunc func(st *testing.T, component metav1.TypeMeta),
 ) {
 	t.Parallel()
-	for _, channel := range tr.ChannelsToTest {
-		// If a Channel is not present in the map, then assume it has all properties. This is so an
-		// unknown Channel can be specified via the --channel flag and have tests run.
-		// TODO Use a flag to specify the features of the flag based Channel, rather than assuming
+	for _, component := range tr.ComponentsToTest {
+		// If a component is not present in the map, then assume it has all properties. This is so an
+		// unknown component (e.g. a Channel) can be specified via a dedicated flag (e.g. --channels) and have tests run.
+		// TODO Use a flag to specify the features of the flag based component, rather than assuming
 		// it supports all features.
-		features, present := tr.ChannelFeatureMap[channel]
+		features, present := tr.ComponentFeatureMap[component]
 		if !present || contains(features, feature) {
-			t.Run(fmt.Sprintf("%s-%s", channel.Kind, channel.APIVersion), func(st *testing.T) {
-				testFunc(st, channel)
+			t.Run(fmt.Sprintf("%s-%s", component.Kind, component.APIVersion), func(st *testing.T) {
+				testFunc(st, component)
 			})
 		}
 	}

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -31,7 +31,7 @@ import (
 
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/tracing"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 )
 
@@ -124,7 +124,7 @@ func (er *eventRecorder) ServeHTTP(writer http.ResponseWriter, request *http.Req
 
 	er.es.StoreEvent(event, eventErr, map[string][]string(header))
 
-	headerNameList := lib.InterestingHeaders()
+	headerNameList := testlib.InterestingHeaders()
 	for _, headerName := range headerNameList {
 		if headerValue := header.Get(headerName); headerValue != "" {
 			log.Printf("Header %s: %s\n", headerName, headerValue)

--- a/test/test_images/wathola-forwarder/main_test.go
+++ b/test/test_images/wathola-forwarder/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/upgrade/prober/wathola/config"
 	"knative.dev/eventing/test/upgrade/prober/wathola/forwarder"
 )
@@ -34,7 +34,7 @@ func TestForwarderMain(t *testing.T) {
 	go main()
 	time.Sleep(time.Millisecond)
 	cancel := <-forwarder.Canceling
-	err := lib.WaitForReadiness(port, config.Log)
+	err := testlib.WaitForReadiness(port, config.Log)
 	assert.NoError(t, err)
 	assert.NotNil(t, instance)
 	cancel()

--- a/test/test_images/wathola-receiver/main_test.go
+++ b/test/test_images/wathola-receiver/main_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/phayes/freeport"
 	"go.uber.org/zap/zapcore"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/upgrade/prober/wathola/config"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 
@@ -35,7 +35,7 @@ func TestReceiverMain(t *testing.T) {
 	go main()
 	time.Sleep(time.Millisecond)
 	cancel := <-receiver.Canceling
-	err := lib.WaitForReadiness(port, config.Log)
+	err := testlib.WaitForReadiness(port, config.Log)
 	assert.NoError(t, err)
 	assert.NotNil(t, instance)
 

--- a/test/upgrade/main_test.go
+++ b/test/upgrade/main_test.go
@@ -25,13 +25,13 @@ import (
 
 var setup = lib.Setup
 var tearDown = lib.TearDown
-var channelTestRunner lib.ChannelTestRunner
+var channelTestRunner lib.ComponentsTestRunner
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
-	channelTestRunner = lib.ChannelTestRunner{
-		ChannelFeatureMap: lib.ChannelFeatureMap,
-		ChannelsToTest:    test.EventingFlags.Channels,
+	channelTestRunner = lib.ComponentsTestRunner{
+		ComponentFeatureMap: lib.ChannelFeatureMap,
+		ComponentsToTest:    test.EventingFlags.Channels,
 	}
 	os.Exit(m.Run())
 }

--- a/test/upgrade/main_test.go
+++ b/test/upgrade/main_test.go
@@ -20,17 +20,17 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 )
 
-var setup = lib.Setup
-var tearDown = lib.TearDown
-var channelTestRunner lib.ComponentsTestRunner
+var setup = testlib.Setup
+var tearDown = testlib.TearDown
+var channelTestRunner testlib.ComponentsTestRunner
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
-	channelTestRunner = lib.ComponentsTestRunner{
-		ComponentFeatureMap: lib.ChannelFeatureMap,
+	channelTestRunner = testlib.ComponentsTestRunner{
+		ComponentFeatureMap: testlib.ChannelFeatureMap,
 		ComponentsToTest:    test.EventingFlags.Channels,
 	}
 	os.Exit(m.Run())

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -27,7 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/pkg/apis"
@@ -67,7 +67,7 @@ func (p *prober) annotateNamespace() {
 func (p *prober) fetchBrokerUrl() (*apis.URL, error) {
 	namespace := p.config.Namespace
 	p.log.Debugf("Fetching %s broker URL for ns %s", brokerName, namespace)
-	meta := resources.NewMetaResource(brokerName, p.config.Namespace, lib.BrokerTypeMeta)
+	meta := resources.NewMetaResource(brokerName, p.config.Namespace, testlib.BrokerTypeMeta)
 	err := duck.WaitForResourceReady(p.client.Dynamic, meta)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (p *prober) fetchBrokerUrl() (*apis.URL, error) {
 
 func (p *prober) deployConfigMap() {
 	name := configName
-	lib.WaitFor(fmt.Sprintf("configmap be deployed: %v", name), func() error {
+	testlib.WaitFor(fmt.Sprintf("configmap be deployed: %v", name), func() error {
 		p.log.Infof("Deploying config map: %v", name)
 
 		brokerUrl, err := p.fetchBrokerUrl()
@@ -130,8 +130,8 @@ func (p *prober) deployTriggers() {
 		// update trigger with the new reference
 		_, err := triggers.Create(trigger)
 		ensure.NoError(err)
-		lib.WaitFor(fmt.Sprintf("trigger be ready: %v", name), func() error {
-			meta := resources.NewMetaResource(name, p.config.Namespace, lib.TriggerTypeMeta)
+		testlib.WaitFor(fmt.Sprintf("trigger be ready: %v", name), func() error {
+			meta := resources.NewMetaResource(name, p.config.Namespace, testlib.TriggerTypeMeta)
 			return duck.WaitForResourceReady(p.client.Dynamic, meta)
 		})
 	}

--- a/test/upgrade/prober/forwarder.go
+++ b/test/upgrade/prober/forwarder.go
@@ -21,7 +21,7 @@ import (
 	"github.com/wavesoftware/go-ensure"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/duck"
 	"knative.dev/eventing/test/lib/resources"
 	pkgTest "knative.dev/pkg/test"
@@ -39,12 +39,12 @@ func (p *prober) deployForwarder() {
 	ensure.NoError(err)
 
 	sc := p.servingClient()
-	lib.WaitFor(fmt.Sprintf("forwarder ksvc be ready: %v", forwarderName), func() error {
+	testlib.WaitFor(fmt.Sprintf("forwarder ksvc be ready: %v", forwarderName), func() error {
 		return duck.WaitForKServiceReady(sc, forwarderName, p.client.Namespace)
 	})
 
 	if p.config.Serving.ScaleToZero {
-		lib.WaitFor(fmt.Sprintf("forwarder scales to zero: %v", forwarderName), func() error {
+		testlib.WaitFor(fmt.Sprintf("forwarder scales to zero: %v", forwarderName), func() error {
 			return duck.WaitForKServiceScales(sc, forwarderName, p.client.Namespace, func(scale int) bool {
 				return scale == 0
 			})

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/wavesoftware/go-ensure"
 	"go.uber.org/zap"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 )
 
@@ -76,7 +76,7 @@ func NewConfig(namespace string) *Config {
 }
 
 // RunEventProber starts a single Prober of the given domain.
-func RunEventProber(log *zap.SugaredLogger, client *lib.Client, config *Config) Prober {
+func RunEventProber(log *zap.SugaredLogger, client *testlib.Client, config *Config) Prober {
 	pm := newProber(log, client, config)
 	pm.deploy()
 	return pm
@@ -103,7 +103,7 @@ func AssertEventProber(t *testing.T, prober Prober) {
 
 type prober struct {
 	log    *zap.SugaredLogger
-	client *lib.Client
+	client *testlib.Client
 	config *Config
 }
 
@@ -137,10 +137,10 @@ func (p *prober) deploy() {
 	if p.config.Serving.Use {
 		p.deployForwarder()
 	}
-	ensure.NoError(lib.AwaitForAll(p.log))
+	ensure.NoError(testlib.AwaitForAll(p.log))
 
 	p.deploySender()
-	ensure.NoError(lib.AwaitForAll(p.log))
+	ensure.NoError(testlib.AwaitForAll(p.log))
 	// allow sender to send at least some events, 2 sec wait
 	time.Sleep(2 * time.Second)
 	p.log.Infof("Prober is now sending events with interval of %v in "+
@@ -155,7 +155,7 @@ func (p *prober) remove() {
 	p.removeConfiguration()
 }
 
-func newProber(log *zap.SugaredLogger, client *lib.Client, config *Config) Prober {
+func newProber(log *zap.SugaredLogger, client *testlib.Client, config *Config) Prober {
 	return &prober{
 		log:    log,
 		client: client,

--- a/test/upgrade/prober/receiver.go
+++ b/test/upgrade/prober/receiver.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	watholaconfig "knative.dev/eventing/test/upgrade/prober/wathola/config"
 	pkgTest "knative.dev/pkg/test"
 )
@@ -89,7 +89,7 @@ func (p *prober) deployReceiverPod() {
 	_, err := p.client.Kube.CreatePod(pod)
 	ensure.NoError(err)
 
-	lib.WaitFor(fmt.Sprintf("receiver be ready: %v", receiverName), func() error {
+	testlib.WaitFor(fmt.Sprintf("receiver be ready: %v", receiverName), func() error {
 		return pkgTest.WaitForPodRunning(p.client.Kube, receiverName, p.client.Namespace)
 	})
 }

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -21,7 +21,7 @@ import (
 	"github.com/wavesoftware/go-ensure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	pkgTest "knative.dev/pkg/test"
 )
 
@@ -64,7 +64,7 @@ func (p *prober) deploySender() {
 		Create(pod)
 	ensure.NoError(err)
 
-	lib.WaitFor(fmt.Sprintf("sender pod be ready: %v", senderName), func() error {
+	testlib.WaitFor(fmt.Sprintf("sender pod be ready: %v", senderName), func() error {
 		return pkgTest.WaitForPodRunning(p.client.Kube, senderName, p.client.Namespace)
 	})
 }

--- a/test/upgrade/prober/wathola/receiver/services_test.go
+++ b/test/upgrade/prober/wathola/receiver/services_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/eventing/test/lib"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/upgrade/prober/wathola/config"
 	"knative.dev/eventing/test/upgrade/prober/wathola/event"
 	"knative.dev/eventing/test/upgrade/prober/wathola/sender"
@@ -44,7 +44,7 @@ func TestReceiverReceive(t *testing.T) {
 	go instance.Receive()
 	cancel := <-Canceling
 	defer cancel()
-	assert.NoError(t, lib.WaitForReadiness(port, config.Log))
+	assert.NoError(t, testlib.WaitForReadiness(port, config.Log))
 
 	// when
 	sendEvent(t, e1, port)


### PR DESCRIPTION
Related: #3122

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Refactor ChannelTestRunner to ComponentTestRunner
- Extracts `test/flags` package
