### PR TITLE
Allow the Generated reconciler code to handle init

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -92,8 +92,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1alpha2.ApiServ
 	//     - Will be garbage collected by K8s when this CronJobSource is deleted.
 	// 3. Create the EventType that it can emit.
 	//     - Will be garbage collected by K8s when this CronJobSource is deleted.
-	source.Status.InitializeConditions()
-
 	dest := source.Spec.Sink.DeepCopy()
 	if dest.Ref != nil {
 		// To call URIFromDestination(), dest.Ref must have a Namespace. If there is

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -60,8 +60,6 @@ var _ channelreconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1beta1.Channel) pkgreconciler.Event {
-	c.Status.InitializeConditions()
-
 	// 1. Create the backing Channel CRD, if it doesn't exist.
 	// 2. Propagate the backing Channel CRD Status, Address, and SubscribableStatus into this Channel.
 

--- a/pkg/reconciler/containersource/containersource.go
+++ b/pkg/reconciler/containersource/containersource.go
@@ -70,8 +70,6 @@ var _ containersource.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1alpha2.ContainerSource) pkgreconciler.Event {
-	source.Status.InitializeConditions()
-
 	_, err := r.reconcileSinkBinding(ctx, source)
 	if err != nil {
 		logging.FromContext(ctx).Error("Error reconciling SinkBinding", zap.Error(err))

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -53,9 +53,6 @@ var _ eventtypereconciler.Interface = (*Reconciler)(nil)
 // 2. Verify the Broker is ready.
 // TODO remove https://github.com/knative/eventing/issues/2750
 func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta1.EventType) pkgreconciler.Event {
-	et.Status.InitializeConditions()
-	et.Status.ObservedGeneration = et.Generation
-
 	b, err := r.getBroker(ctx, et)
 	if err != nil {
 		if apierrs.IsNotFound(err) {

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -96,8 +96,6 @@ type Reconciler struct {
 var _ inmemorychannelreconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1beta1.InMemoryChannel) pkgreconciler.Event {
-	imc.Status.InitializeConditions()
-
 	// We reconcile the status of the Channel by looking at:
 	// 1. Dispatcher Deployment for it's readiness.
 	// 2. Dispatcher k8s Service for it's existence.

--- a/pkg/reconciler/mtbroker/broker.go
+++ b/pkg/reconciler/mtbroker/broker.go
@@ -127,8 +127,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *v1beta1.Broker) pkgre
 
 func (r *Reconciler) reconcileKind(ctx context.Context, b *v1beta1.Broker) (*corev1.ObjectReference, pkgreconciler.Event) {
 	logging.FromContext(ctx).Infow("Reconciling", zap.Any("Broker", b))
-	b.Status.InitializeConditions()
-	b.Status.ObservedGeneration = b.Generation
 
 	// 1. Trigger Channel is created for all events. Triggers will Subscribe to this Channel.
 	// 2. Check that Filter / Ingress deployment (shared within cluster are there)

--- a/pkg/reconciler/parallel/parallel.go
+++ b/pkg/reconciler/parallel/parallel.go
@@ -67,8 +67,6 @@ type Reconciler struct {
 var _ parallelreconciler.Interface = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, p *v1beta1.Parallel) pkgreconciler.Event {
-	p.Status.InitializeConditions()
-
 	// Reconciling parallel is pretty straightforward, it does the following things:
 	// 1. Create a channel fronting the whole parallel and one filter channel per branch.
 	// 2. For each of the Branches:

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -118,9 +118,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1alpha2.PingSou
 	//     - Will be garbage collected by K8s when this PingSource is deleted.
 	// 3. Create the EventType that it can emit.
 	//     - Will be garbage collected by K8s when this PingSource is deleted.
-	source.Status.ObservedGeneration = source.Generation
-
-	source.Status.InitializeConditions()
 
 	dest := source.Spec.Sink.DeepCopy()
 	if dest.Ref != nil {

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -65,8 +65,6 @@ var _ sequencereconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, s *v1beta1.Sequence) pkgreconciler.Event {
-	s.Status.InitializeConditions()
-
 	// Reconciling sequence is pretty straightforward, it does the following things:
 	// 1. Create a channel fronting the whole sequence
 	// 2. For each of the Steps, create a Subscription to the previous Channel

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -88,8 +88,6 @@ var _ subscriptionreconciler.Finalizer = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
-	subscription.Status.InitializeConditions()
-
 	// Find the channel for this subscription.
 	channel, err := r.getChannel(ctx, subscription)
 	if err != nil {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The gen-reconciler code should now handle setting ObservedGeneration and initializing conditions. This change simplifies by letting the upstream code handle it.
