### PR TITLE
Use CRD & Webhook v1 APIs

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
@@ -22,15 +22,38 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: InMemoryChannel
     plural: inmemorychannels
@@ -43,31 +66,11 @@ spec:
     shortNames:
     - imc
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -35,6 +35,38 @@ metadata:
   name: apiserversources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1alpha2
+    served: true
+    storage: false
   names:
     categories:
     - all
@@ -44,40 +76,11 @@ spec:
     kind: ApiServerSource
     plural: apiserversources
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    - name: Sink
-      type: string
-      JSONPath: ".status.sinkUri"
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
@@ -22,17 +22,38 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: eventing.knative.dev
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time as well as ensure
-      # that different Broker Classes that might have different
-      # fields that are not in the Broker Spec will work.
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: Broker
     plural: brokers
@@ -42,31 +63,11 @@ spec:
     - knative
     - eventing
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
@@ -23,44 +23,13 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
-  preserveUnknownFields: false
-  names:
-    kind: Channel
-    plural: channels
-    singular: channel
-    categories:
-      - all
-      - knative
-      - messaging
-      - channel
-    shortNames:
-      - ch
-  scope: Namespaced
-  subresources:
-    status: {}
-  conversion:
-    strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
+  - &version
+    name: v1alpha1
     served: false
     storage: false
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         type: object
@@ -135,7 +104,21 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-  - name: v1beta1
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
     served: true
     storage: true
     schema:
@@ -148,3 +131,23 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Channel
+    plural: channels
+    singular: channel
+    categories:
+      - all
+      - knative
+      - messaging
+      - channel
+    shortNames:
+      - ch
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -23,6 +23,34 @@ metadata:
   name: containersources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
   names:
     categories:
     - all
@@ -32,31 +60,3 @@ spec:
     kind: ContainerSource
     plural: containersources
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    - name: Sink
-      type: string
-      JSONPath: ".status.sinkUri"
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
@@ -20,6 +20,48 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      jsonPath: ".spec.type"
+    - name: Source
+      type: string
+      jsonPath: ".spec.source"
+    - name: Schema
+      type: string
+      jsonPath: ".spec.schema"
+    - name: Broker
+      type: string
+      jsonPath: ".spec.broker"
+    - name: Description
+      type: string
+      jsonPath: ".spec.description"
+    # TODO remove Status https://github.com/knative/eventing/issues/2750
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: EventType
     plural: eventtypes
@@ -29,50 +71,11 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
-  additionalPrinterColumns:
-    - name: Type
-      type: string
-      JSONPath: ".spec.type"
-    - name: Source
-      type: string
-      JSONPath: ".spec.source"
-    - name: Schema
-      type: string
-      JSONPath: ".spec.schema"
-    - name: Broker
-      type: string
-      JSONPath: ".spec.broker"
-    - name: Description
-      type: string
-      JSONPath: ".spec.description"
-    # TODO remove Status https://github.com/knative/eventing/issues/2750
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
@@ -21,15 +21,38 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: flows.knative.dev
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: Parallel
     plural: parallels
@@ -40,32 +63,11 @@ spec:
     - eventing
     - flows
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
-
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -29,6 +29,38 @@ metadata:
   name: pingsources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1alpha2
+    served: true
+    storage: true
   names:
     categories:
     - all
@@ -38,40 +70,11 @@ spec:
     kind: PingSource
     plural: pingsources
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    - name: Sink
-      type: string
-      JSONPath: .status.sinkUri
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1alpha2
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
@@ -21,15 +21,38 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: flows.knative.dev
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: Sequence
     plural: sequences
@@ -40,31 +63,11 @@ spec:
     - eventing
     - flows
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -24,6 +24,37 @@ metadata:
   name: sinkbindings.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1alpha2
+    storage: false
   names:
     categories:
     - all
@@ -34,41 +65,11 @@ spec:
     kind: SinkBinding
     plural: sinkbindings
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-  - name: Sink
-    type: string
-    JSONPath: ".status.sinkUri"
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  - name: v1alpha2
-    served: true
-    storage: false
-
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
@@ -20,7 +20,35 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: messaging.knative.dev
-  preserveUnknownFields: false
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
+    served: true
+    storage: true
   names:
     kind: Subscription
     plural: subscriptions
@@ -32,117 +60,11 @@ spec:
     shortNames:
     - sub
   scope: Namespaced
-  subresources:
-    status: {}
-  conversion:
-    strategy: None
-#    strategy: Webhook
-#    webhookClientConfig:
-#      service:
-#        name: eventing-webhook
-#        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          required:
-            - channel
-          type: object
-          properties:
-            channel:
-              type: object
-              description: "Channel that forwards incoming events to the subscription."
-              required:
-                - apiVersion
-                - kind
-                - name
-              properties:
-                apiVersion:
-                  type: string
-                  minLength: 1
-                kind:
-                  type: string
-                name:
-                  type: string
-                  minLength: 1
-            subscriber:
-              type: object
-              description: "the subscriber that (optionally) processes events."
-              properties:
-                uri:
-                  type: string
-                  description: "the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI."
-                  minLength: 1
-                ref:
-                  type: object
-                  description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                  required:
-                    - apiVersion
-                    - kind
-                    - name
-                  properties:
-                    apiVersion:
-                      type: string
-                      minLength: 1
-                    kind:
-                      type: string
-                      minLength: 1
-                    name:
-                      type: string
-                      minLength: 1
-                    namespace:
-                      type: string
-                      minLength: 1
-            reply:
-              type: object
-              description: "the destination that (optionally) receive events."
-              properties:
-                uri:
-                  type: string
-                  description: "the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI."
-                  minLength: 1
-                ref:
-                  type: object
-                  description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                  required:
-                    - apiVersion
-                    - kind
-                    - name
-                  properties:
-                    apiVersion:
-                      type: string
-                      minLength: 1
-                    kind:
-                      type: string
-                      minLength: 1
-                    name:
-                      type: string
-                      minLength: 1
-                    namespace:
-                      type: string
-                      minLength: 1
-            delivery:
-              description: "Subscription delivery options. More information: https://knative.dev/docs/eventing/event-delivery."
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+  # conversion:
+  #   strategy: Webhook
+  #   webhook:
+  #     conversionReviewVersions: ["v1", "v1beta1"]
+  #     clientConfig:
+  #       service:
+  #         name: eventing-webhook
+  #         namespace: knative-eventing

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
@@ -21,44 +21,13 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: eventing.knative.dev
-  preserveUnknownFields: false
-  names:
-    kind: Trigger
-    plural: triggers
-    singular: trigger
-    categories:
-    - all
-    - knative
-    - eventing
-  scope: Namespaced
-  subresources:
-    status: {}
-  conversion:
-    strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: Broker
-      type: string
-      JSONPath: .spec.broker
-    - name: Subscriber_URI
-      type: string
-      JSONPath: .status.subscriberUri
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
+  - &version
+    name: v1alpha1
     served: false
     storage: false
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         type: object
@@ -116,7 +85,24 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-  - name: v1beta1
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Broker
+      type: string
+      jsonPath: .spec.broker
+    - name: Subscriber_URI
+      type: string
+      jsonPath: .status.subscriberUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1beta1
     served: true
     storage: true
     schema:
@@ -169,3 +155,20 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Trigger
+    plural: triggers
+    singular: trigger
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/pre-install/v0.16.0/broker.yaml
+++ b/config/pre-install/v0.16.0/broker.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
@@ -22,17 +22,38 @@ metadata:
     duck.knative.dev/addressable: "true"
 spec:
   group: eventing.knative.dev
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flush out the
-      # schema for each version at this time as well as ensure
-      # that different Broker Classes that might have different
-      # fields that are not in the Broker Spec will work.
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1alpha1
+    served: true
+    storage: false
   names:
     kind: Broker
     plural: brokers
@@ -42,31 +63,11 @@ spec:
     - knative
     - eventing
   scope: Namespaced
-  subresources:
-    status: {}
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-    - name: URL
-      type: string
-      JSONPath: .status.address.url
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-  - name: v1beta1
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/pre-install/v0.16.0/pingsource.yaml
+++ b/config/pre-install/v0.16.0/pingsource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -29,6 +29,38 @@ metadata:
   name: pingsources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+  - << : *version
+    name: v1alpha1
+    served: false
+    storage: false
   names:
     categories:
     - all
@@ -38,40 +70,11 @@ spec:
     kind: PingSource
     plural: pingsources
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      # this is a work around so we don't need to flesh out the
-      # schema for each version at this time
-      #
-      # see issue: https://github.com/knative/serving/issues/912
-      x-kubernetes-preserve-unknown-fields: true
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        name: eventing-webhook
-        namespace: knative-eventing
-  additionalPrinterColumns:
-    - name: Ready
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
-    - name: Sink
-      type: string
-      JSONPath: .status.sinkUri
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  versions:
-  - name: v1alpha1
-    served: false
-    storage: false
-  - name: v1alpha2
-    served: true
-    storage: true
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #3349

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- using `v1` of the CRD type

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Our CustomResourceDefinitions now use apiextensions.k8s.io/v1 APIs

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
