### PR TITLE
receive adapters can now run in leader elected mode

### DIFF
--- a/pkg/adapter/v2/config_test.go
+++ b/pkg/adapter/v2/config_test.go
@@ -34,6 +34,7 @@ func TestEnvConfig(t *testing.T) {
 	os.Setenv("K_METRICS_CONFIG", "metrics")
 	os.Setenv("K_LOGGING_CONFIG", "logging")
 	os.Setenv("K_TRACING_CONFIG", "tracing")
+	os.Setenv("K_LEADER_ELECTION_CONFIG", "leaderelection")
 	os.Setenv("MODE", "mymode") // note: custom to this test impl
 
 	var env myEnvConfig
@@ -48,5 +49,9 @@ func TestEnvConfig(t *testing.T) {
 
 	if env.Sink != "http://sink" {
 		t.Errorf("Expected sinkURI http://sink, got: %s", env.Sink)
+	}
+
+	if env.LeaderElectionConfigJson != "leaderelection" {
+		t.Errorf("Expected LeaderElectionConfigJson leaderelection, got: %s", env.LeaderElectionConfigJson)
 	}
 }

--- a/pkg/adapter/v2/main_message.go
+++ b/pkg/adapter/v2/main_message.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"time"
 
+	"knative.dev/pkg/injection/sharedmain"
+
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
@@ -114,9 +116,23 @@ func MainMessageAdapterWithContext(ctx context.Context, component string, ector 
 	// Configuring the adapter
 	adapter := ctor(ctx, env, httpBindingsSender, reporter)
 
-	logger.Info("Starting Receive MessageAdapter", zap.Any("adapter", adapter))
+	run := func(ctx context.Context) {
+		logger.Info("Starting Receive MessageAdapter", zap.Any("adapter", adapter))
 
-	if err := adapter.Start(ctx); err != nil {
-		logger.Warn("start returned an error", zap.Error(err))
+		if err := adapter.Start(ctx); err != nil {
+			logger.Warn("start returned an error", zap.Error(err))
+		}
+	}
+
+	leConfig, err := env.GetLeaderElectionConfig()
+	if err != nil {
+		logger.Error("Error loading the leader election configuration", zap.Error(err))
+	}
+
+	if leConfig.LeaderElect {
+		sharedmain.RunLeaderElected(ctx, logger, run, *leConfig)
+	} else {
+		logger.Infof("%v will not run in leader-elected mode", component)
+		run(ctx)
 	}
 }

--- a/pkg/adapter/v2/main_message_test.go
+++ b/pkg/adapter/v2/main_message_test.go
@@ -36,6 +36,7 @@ func TestMainMessageAdapter(t *testing.T) {
 	os.Setenv("K_METRICS_CONFIG", "metrics")
 	os.Setenv("K_LOGGING_CONFIG", "logging")
 	os.Setenv("MODE", "mymode")
+	os.Setenv("K_LEADER_ELECTION_CONFIG", "")
 
 	ctx, cancel := context.WithCancel(context.TODO())
 
@@ -50,6 +51,14 @@ func TestMainMessageAdapter(t *testing.T) {
 
 			if env.Sink != "http://sink" {
 				t.Errorf("Expected sinkURI http://sink, got: %s", env.Sink)
+			}
+
+			leConfig, err := env.GetLeaderElectionConfig()
+			if err != nil {
+				t.Errorf("Expected no error: %v", err)
+			}
+			if leConfig.LeaderElect {
+				t.Errorf("Expected LeaderElect to be false, got: %t", leConfig.LeaderElect)
 			}
 			return &myAdapterBindings{}
 		})

--- a/pkg/adapter/v2/main_test.go
+++ b/pkg/adapter/v2/main_test.go
@@ -34,6 +34,7 @@ func TestMainWithContext(t *testing.T) {
 	os.Setenv("K_METRICS_CONFIG", "metrics")
 	os.Setenv("K_LOGGING_CONFIG", "logging")
 	os.Setenv("MODE", "mymode")
+	os.Setenv("K_LEADER_ELECTION_CONFIG", "")
 
 	ctx, cancel := context.WithCancel(context.TODO())
 
@@ -48,6 +49,14 @@ func TestMainWithContext(t *testing.T) {
 
 			if env.Sink != "http://sink" {
 				t.Errorf("Expected sinkURI http://sink, got: %s", env.Sink)
+			}
+
+			leConfig, err := env.GetLeaderElectionConfig()
+			if err != nil {
+				t.Errorf("Expected no error: %v", err)
+			}
+			if leConfig.LeaderElect {
+				t.Errorf("Expected LeaderElect to be false, got: %t", leConfig.LeaderElect)
 			}
 			return &myAdapter{}
 		})


### PR DESCRIPTION
For #3157

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Receive adapter can now run in leader elected mode
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
