### PR TITLE
mtping now uses shared main adapter

### DIFF
--- a/cmd/mtping/main.go
+++ b/cmd/mtping/main.go
@@ -17,10 +17,30 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"fmt"
+
 	"knative.dev/eventing/pkg/adapter/mtping"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+
+	"knative.dev/eventing/pkg/adapter/v2"
 )
 
 func main() {
-	sharedmain.Main("pingsource-mt-adapter", mtping.NewController)
+	ctx := signals.NewContext()
+	cfg := sharedmain.ParseAndGetConfigOrDie()
+	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
+
+	// Start the injection clients and informers.
+	go func(ctx context.Context) {
+		if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+			panic(fmt.Sprintf("Failed to start informers - %s", err))
+		}
+		<-ctx.Done()
+	}(ctx)
+
+	adapter.MainWithContext(ctx, "pingsource-mt-adapter", mtping.NewEnvConfig, mtping.NewAdapter)
 }

--- a/pkg/adapter/mtping/adapter.go
+++ b/pkg/adapter/mtping/adapter.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+
+	"knative.dev/eventing/pkg/adapter/v2"
+)
+
+// mtpingAdapter implements the PingSource mt adapter to
+type mtpingAdapter struct {
+	logger *zap.SugaredLogger
+	client cloudevents.Client
+}
+
+func NewEnvConfig() adapter.EnvConfigAccessor {
+	return &adapter.EnvConfig{}
+}
+
+func NewAdapter(ctx context.Context, _ adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
+	return &mtpingAdapter{
+		logger: logging.FromContext(ctx),
+		client: ceClient,
+	}
+}
+
+// Start implements adapter.Adapter
+func (a *mtpingAdapter) Start(ctx context.Context) error {
+	runner := NewCronJobsRunner(a.client, a.logger)
+
+	ctrl := NewController(ctx, runner)
+
+	a.logger.Info("Starting controllers...")
+	go controller.StartAll(ctx, ctrl)
+
+	a.logger.Info("Starting job runner...")
+	runner.Start(ctx.Done())
+
+	a.logger.Infof("controller and runner stopped")
+	return nil
+}

--- a/pkg/adapter/mtping/adapter_test.go
+++ b/pkg/adapter/mtping/adapter_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	adaptertest "knative.dev/eventing/pkg/adapter/v2/test"
+	rectesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestStartStopAdapter(t *testing.T) {
+	ctx, _ := rectesting.SetupFakeContext(t)
+	envCfg := NewEnvConfig()
+	ce := adaptertest.NewTestClient()
+	adapter := NewAdapter(ctx, envCfg, ce)
+
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan bool)
+	go func(ctx context.Context) {
+		err := adapter.Start(ctx)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		done <- true
+	}(ctx)
+
+	cancel()
+
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected adapter to be stopped after 2 seconds")
+	case <-done:
+	}
+}

--- a/pkg/adapter/mtping/controller_test.go
+++ b/pkg/adapter/mtping/controller_test.go
@@ -19,7 +19,6 @@ package mtping
 import (
 	"testing"
 
-	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
@@ -29,7 +28,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, &configmap.InformedWatcher{})
+	c := NewController(ctx, nil)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -293,10 +293,22 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1alpha2.Pin
 }
 
 func (r *Reconciler) reconcileMTReceiveAdapter(ctx context.Context, source *v1alpha2.PingSource) (*appsv1.Deployment, error) {
+	loggingConfig, err := pkgLogging.LoggingConfigToJson(r.loggingConfig)
+	if err != nil {
+		logging.FromContext(ctx).Error("error while converting logging config to JSON", zap.Any("receiveAdapter", err))
+	}
+
+	metricsConfig, err := metrics.MetricsOptionsToJson(r.metricsConfig)
+	if err != nil {
+		logging.FromContext(ctx).Error("error while converting metrics config to JSON", zap.Any("receiveAdapter", err))
+	}
+
 	args := resources.MTArgs{
 		ServiceAccountName: mtadapterName,
 		MTAdapterName:      mtadapterName,
 		Image:              r.receiveMTAdapterImage,
+		LoggingConfig:      loggingConfig,
+		MetricsConfig:      metricsConfig,
 	}
 	expected := resources.MakeMTReceiveAdapter(args)
 

--- a/pkg/reconciler/pingsource/resources/mt_receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/mt_receive_adapter_test.go
@@ -35,6 +35,8 @@ func TestMakeMTPingAdapter(t *testing.T) {
 		ServiceAccountName: "test-sa",
 		MTAdapterName:      "test-name",
 		Image:              "test-image",
+		MetricsConfig:      "metrics",
+		LoggingConfig:      "logging",
 	}
 
 	want := &v1.Deployment{
@@ -65,21 +67,18 @@ func TestMakeMTPingAdapter(t *testing.T) {
 								Name:  system.NamespaceEnvKey,
 								Value: system.Namespace(),
 							}, {
-								Name:  "METRICS_DOMAIN",
-								Value: "knative.dev/eventing",
-							}, {
-								Name:  "CONFIG_OBSERVABILITY_NAME",
-								Value: "config-observability",
-							}, {
-								Name:  "CONFIG_LOGGING_NAME",
-								Value: "config-logging",
-							}, {
 								Name: "NAMESPACE",
 								ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "metadata.namespace",
 									},
 								},
+							}, {
+								Name:  "K_METRICS_CONFIG",
+								Value: "metrics",
+							}, {
+								Name:  "K_LOGGING_CONFIG",
+								Value: "logging",
 							}},
 							// Set low resource requests and limits.
 							// This should be configurable.


### PR DESCRIPTION
For #3157

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Top-level cmd uses shared main adapter instead of shared main controller
- No more hot config files reloading
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Depends on https://github.com/knative/eventing/pull/3370. 
