### PR TITLE
pass leader election config to mtping

### DIFF
--- a/cmd/mtping/main.go
+++ b/cmd/mtping/main.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"knative.dev/eventing/pkg/adapter/mtping"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
 
+	"knative.dev/eventing/pkg/adapter/mtping"
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -21,7 +21,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/example-checksum: "43edfe90"
   annotations:
-    knative.dev/example-checksum: a2104fac
+    knative.dev/example-checksum: 0694ae46
 data:
   _example: |
     ################################
@@ -63,4 +63,4 @@ data:
     # - broker-controller
     # - inmemorychannel-dispatcher
     # - inmemorychannel-controller
-    enabledComponents: "controller,broker-controller,inmemorychannel-dispatcher,inmemorychannel-controller,webhook"
+    enabledComponents: "controller,broker-controller,inmemorychannel-dispatcher,inmemorychannel-controller,webhook,pingsource-mt-adapter"

--- a/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
+++ b/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
@@ -50,3 +50,15 @@ rules:
     verbs:
       - "create"
       - "patch"
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+

--- a/pkg/adapter/mtping/adapter.go
+++ b/pkg/adapter/mtping/adapter.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 )
 
-// mtpingAdapter implements the PingSource mt adapter to
+// mtpingAdapter implements the PingSource mt adapter to sinks
 type mtpingAdapter struct {
 	logger *zap.SugaredLogger
 	client cloudevents.Client

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -32,6 +32,7 @@ var (
 		"inmemorychannel-dispatcher",
 		"inmemorychannel-controller",
 		"webhook",
+		"pingsource-mt-adapter",
 	)
 )
 

--- a/pkg/leaderelection/leader_election_test.go
+++ b/pkg/leaderelection/leader_election_test.go
@@ -37,7 +37,7 @@ func okConfig() *kle.Config {
 		LeaseDuration:     15 * time.Second,
 		RenewDeadline:     10 * time.Second,
 		RetryPeriod:       2 * time.Second,
-		EnabledComponents: sets.NewString("controller", "inmemorychannel-dispatcher", "inmemorychannel-controller", "broker-controller", "webhook"),
+		EnabledComponents: sets.NewString("controller", "inmemorychannel-dispatcher", "inmemorychannel-controller", "broker-controller", "webhook", "pingsource-mt-adapter"),
 	}
 }
 
@@ -50,7 +50,7 @@ func okData() map[string]string {
 		"leaseDuration":     "15s",
 		"renewDeadline":     "10s",
 		"retryPeriod":       "2s",
-		"enabledComponents": "controller,inmemorychannel-dispatcher,inmemorychannel-controller,broker-controller,webhook",
+		"enabledComponents": "controller,inmemorychannel-dispatcher,inmemorychannel-controller,broker-controller,webhook,pingsource-mt-adapter",
 	}
 }
 
@@ -69,7 +69,7 @@ func TestValidateConfig(t *testing.T) {
 		data: kmeta.UnionMaps(okData(), map[string]string{
 			"enabledComponents": "controller,frobulator",
 		}),
-		err: errors.New(`invalid enabledComponent "frobulator": valid values are ["broker-controller" "controller" "inmemorychannel-controller" "inmemorychannel-dispatcher" "webhook"]`),
+		err: errors.New(`invalid enabledComponent "frobulator": valid values are ["broker-controller" "controller" "inmemorychannel-controller" "inmemorychannel-dispatcher" "pingsource-mt-adapter" "webhook"]`),
 	}, {
 		name: "invalid config",
 		data: kmeta.UnionMaps(okData(), map[string]string{

--- a/pkg/reconciler/pingsource/resources/mt_receive_adapter.go
+++ b/pkg/reconciler/pingsource/resources/mt_receive_adapter.go
@@ -38,6 +38,7 @@ type MTArgs struct {
 	Image              string
 	MetricsConfig      string
 	LoggingConfig      string
+	LeConfig           string
 }
 
 // MakeMTReceiveAdapter generates the mtping deployment for pingsources
@@ -111,5 +112,8 @@ func makeEnv(args MTArgs) []corev1.EnvVar {
 	}, {
 		Name:  adapter.EnvConfigLoggingConfig,
 		Value: args.LoggingConfig,
+	}, {
+		Name:  adapter.EnvConfigLeaderElectionConfig,
+		Value: args.LeConfig,
 	}}
 }

--- a/pkg/reconciler/pingsource/resources/mt_receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/mt_receive_adapter_test.go
@@ -79,6 +79,9 @@ func TestMakeMTPingAdapter(t *testing.T) {
 							}, {
 								Name:  "K_LOGGING_CONFIG",
 								Value: "logging",
+							}, {
+								Name:  "K_LEADER_ELECTION_CONFIG",
+								Value: "",
 							}},
 							// Set low resource requests and limits.
 							// This should be configurable.


### PR DESCRIPTION
For #3157

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- PingSource controller passes the leader election config down to the mtping adapter
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Depends on https://github.com/knative/eventing/pull/3371