### PR TITLE
Expanded the Channel data plane conformance test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1 // indirect
-	github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200608152019-2ab697c8fc0b
+	github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200625144206-4e4657232c9e
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudevents/sdk-go v0.0.0-20190509003705-56931988abe3/go.mod h1:j1nZWMLGg3om8SswStBoY6/SHvcLM19MuZqwDtMtmzs=
 github.com/cloudevents/sdk-go v1.0.0 h1:gS5I0s2qPmdc4GBPlUmzZU7RH30BaiOdcRJ1RkXnPrc=
 github.com/cloudevents/sdk-go v1.0.0/go.mod h1:3TkmM0cFqkhCHOq5JzzRU/RxRkwzoS8TZ+G448qVTog=
-github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200608152019-2ab697c8fc0b h1:JuajVVvOdNSXhVlI5Aks9m4+y5i4rM8EOaLhIytotYc=
-github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200608152019-2ab697c8fc0b/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
+github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200625144206-4e4657232c9e h1:LNIb8Nznd/Ytac0x2atm4MKV4ryOj07VJGpkMWa26pE=
+github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200625144206-4e4657232c9e/go.mod h1:3CTrpB4+u7Iaj6fd7E2Xvm5IxMdRoaAhqaRVnOr2rCU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/channel/message_receiver.go
+++ b/pkg/channel/message_receiver.go
@@ -24,18 +24,14 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.uber.org/zap"
 
+	"knative.dev/pkg/network"
+
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/utils"
-	"knative.dev/pkg/network"
 )
-
-var defaultTransformers = []binding.Transformer{
-	transformer.AddTimeNow,
-}
 
 // UnknownChannelError represents the error when an event is received by a channel dispatcher for a
 // channel that does not exist.
@@ -176,9 +172,7 @@ func (r *MessageReceiver) ServeHTTP(response nethttp.ResponseWriter, request *ne
 		return
 	}
 
-	transformers := append(defaultTransformers, AddHistory(host))
-
-	err = r.receiverFunc(request.Context(), channel, message, transformers, utils.PassThroughHeaders(request.Header))
+	err = r.receiverFunc(request.Context(), channel, message, []binding.Transformer{AddHistory(host)}, utils.PassThroughHeaders(request.Header))
 	if err != nil {
 		if _, ok := err.(*UnknownChannelError); ok {
 			response.WriteHeader(nethttp.StatusNotFound)

--- a/test/conformance/helpers/broker_tracing_test_helper.go
+++ b/test/conformance/helpers/broker_tracing_test_helper.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/eventing/pkg/utils"
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 	testlib "knative.dev/eventing/test/lib"
-	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
 )
@@ -205,7 +204,7 @@ func setupBrokerTracing(brokerClass string) SetupTracingTestInfrastructureFunc {
 		return expected, cetest.AllOf(
 			cetest.HasSource(senderName),
 			cetest.HasId(eventID),
-			recordevents.DataContains(eventBody),
+			cetest.DataContains(eventBody),
 		)
 	}
 }

--- a/test/conformance/helpers/channel_message_modes_specversion_helper.go
+++ b/test/conformance/helpers/channel_message_modes_specversion_helper.go
@@ -48,7 +48,7 @@ func ChannelMessageModesAndSpecVersionsTestRunner(
 	for _, event := range []cloudevents.Event{MinEvent(), FullEvent()} {
 		for _, enc := range []cloudevents.Encoding{cloudevents.EncodingBinary, cloudevents.EncodingStructured} {
 			for _, version := range []string{cloudevents.VersionV03, cloudevents.VersionV1} {
-				testCases = append(testCases, testCase{event, enc, version})
+				testCases = append(testCases, testCase{ConvertEventExtensionsToString(t, event), enc, version})
 			}
 		}
 	}

--- a/test/conformance/helpers/channel_message_modes_specversion_helper.go
+++ b/test/conformance/helpers/channel_message_modes_specversion_helper.go
@@ -108,7 +108,7 @@ func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, event clo
 	// The extension matcher needs to match an eventual extension containing knativehistory extension
 	// (which is not mandatory by the spec)
 	var extKeys []string
-	for k, _ := range event.Extensions() {
+	for k := range event.Extensions() {
 		extKeys = append(extKeys, k)
 	}
 	extKeys = append(extKeys, eventingchannel.EventHistory)

--- a/test/conformance/helpers/channel_message_modes_specversion_helper.go
+++ b/test/conformance/helpers/channel_message_modes_specversion_helper.go
@@ -22,9 +22,9 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	. "github.com/cloudevents/sdk-go/v2/test"
-	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	eventingchannel "knative.dev/eventing/pkg/channel"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
@@ -37,40 +37,37 @@ func ChannelMessageModesAndSpecVersionsTestRunner(
 	channelTestRunner testlib.ComponentsTestRunner,
 	options ...testlib.SetupClientOption,
 ) {
-	testCases := []struct {
+	type testCase struct {
+		event    cloudevents.Event
 		encoding cloudevents.Encoding
 		version  string
-	}{
-		{
-			encoding: cloudevents.EncodingBinary,
-			version:  cloudevents.VersionV03,
-		}, {
-			encoding: cloudevents.EncodingStructured,
-			version:  cloudevents.VersionV03,
-		}, {
-			encoding: cloudevents.EncodingBinary,
-			version:  cloudevents.VersionV1,
-		}, {
-			encoding: cloudevents.EncodingStructured,
-			version:  cloudevents.VersionV1,
-		},
+	}
+
+	var testCases []testCase
+
+	for _, event := range []cloudevents.Event{MinEvent(), FullEvent()} {
+		for _, enc := range []cloudevents.Encoding{cloudevents.EncodingBinary, cloudevents.EncodingStructured} {
+			for _, version := range []string{cloudevents.VersionV03, cloudevents.VersionV1} {
+				testCases = append(testCases, testCase{event, enc, version})
+			}
+		}
 	}
 
 	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 		for _, tc := range testCases {
-			t.Run("encoding_"+tc.encoding.String()+"_version_"+tc.version, func(t *testing.T) {
-				messageModeSpecVersionTest(t, channel, tc.encoding, tc.version, options...)
+			t.Run(tc.event.ID()+"_encoding_"+tc.encoding.String()+"_version_"+tc.version, func(t *testing.T) {
+				messageModeSpecVersionTest(t, channel, tc.event, tc.encoding, tc.version, options...)
 			})
 		}
 	})
 }
 
 // Sender -> Channel -> Subscriber -> Record Events
-func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, encoding cloudevents.Encoding, version string, options ...testlib.SetupClientOption) {
+func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, event cloudevents.Event, encoding cloudevents.Encoding, version string, options ...testlib.SetupClientOption) {
 	client := testlib.Setup(t, true, options...)
 	defer testlib.TearDown(client)
 
-	resourcesNamePrefix := strings.ReplaceAll(strings.ToLower(encoding.String()+"-"+version), ".", "")
+	resourcesNamePrefix := strings.ReplaceAll(strings.ToLower(event.ID()+"-"+encoding.String()+"-"+version), ".", "")
 
 	channelName := resourcesNamePrefix + "-ch"
 	client.CreateChannelOrFail(channelName, &channel)
@@ -87,9 +84,6 @@ func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, encoding 
 
 	client.WaitForAllTestResourcesReadyOrFail()
 
-	event := FullEvent()
-	event.SetID(uuid.New().String())
-
 	switch version {
 	case cloudevents.VersionV1:
 		event.Context = event.Context.AsV1()
@@ -105,9 +99,30 @@ func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, encoding 
 		sender.WithEncoding(encoding),
 	)
 
-	eventTracker.AssertExact(1, recordevents.NoError(), recordevents.MatchEvent(
-		HasSpecVersion(version),
-		HasId(event.ID()),
-		IsValid(),
+	matchers := []EventMatcher{IsContextEqualTo(event.Context)}
+	if event.Data() != nil {
+		matchers = append(matchers, HasData(event.Data()))
+	} else {
+		matchers = append(matchers, HasNoData())
+	}
+	// The extension matcher needs to match an eventual extension containing knativehistory extension
+	// (which is not mandatory by the spec)
+	var extKeys []string
+	for k, _ := range event.Extensions() {
+		extKeys = append(extKeys, k)
+	}
+	extKeys = append(extKeys, eventingchannel.EventHistory)
+	matchers = append(matchers, recordevents.AnyOf(
+		HasExactlyExtensions(event.Extensions()),
+		AllOf(
+			recordevents.ContainsExactlyExtensions(extKeys...),
+			HasExtensions(event.Extensions()),
+		),
 	))
+
+	eventTracker.AssertExact(
+		1,
+		recordevents.NoError(),
+		recordevents.MatchEvent(matchers...),
+	)
 }

--- a/test/conformance/helpers/channel_message_modes_specversion_helper.go
+++ b/test/conformance/helpers/channel_message_modes_specversion_helper.go
@@ -99,7 +99,7 @@ func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, event clo
 		sender.WithEncoding(encoding),
 	)
 
-	matchers := []EventMatcher{IsContextEqualTo(event.Context)}
+	matchers := []EventMatcher{HasExactlyAttributesEqualTo(event.Context)}
 	if event.Data() != nil {
 		matchers = append(matchers, HasData(event.Data()))
 	} else {
@@ -112,10 +112,10 @@ func messageModeSpecVersionTest(t *testing.T, channel metav1.TypeMeta, event clo
 		extKeys = append(extKeys, k)
 	}
 	extKeys = append(extKeys, eventingchannel.EventHistory)
-	matchers = append(matchers, recordevents.AnyOf(
+	matchers = append(matchers, AnyOf(
 		HasExactlyExtensions(event.Extensions()),
 		AllOf(
-			recordevents.ContainsExactlyExtensions(extKeys...),
+			ContainsExactlyExtensions(extKeys...),
 			HasExtensions(event.Extensions()),
 		),
 	))

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -28,7 +28,6 @@ import (
 
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 	testlib "knative.dev/eventing/test/lib"
-	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/lib/resources/sender"
 )
@@ -228,6 +227,6 @@ func setupChannelTracingWithReply(
 	return expected, cetest.AllOf(
 		cetest.HasSource(senderName),
 		cetest.HasId(eventID),
-		recordevents.DataContains(body),
+		cetest.DataContains(body),
 	)
 }

--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -133,7 +133,7 @@ func BrokerChannelFlowWithTransformation(t *testing.T,
 		// create trigger3 to receive the transformed event, and send it to the channel
 		channelURL, err := client.GetAddressableURI(channelName, &channel)
 		if err != nil {
-			st.Fatalf("Failed to get the url for the channel %q: %v", channelName, err)
+			st.Fatalf("Failed to get the url for the channel %q: %+v", channelName, err)
 		}
 		client.CreateTriggerOrFailV1Beta1(
 			triggerName3,

--- a/test/e2e/helpers/parallel_test_helper.go
+++ b/test/e2e/helpers/parallel_test_helper.go
@@ -18,6 +18,7 @@ package helpers
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
@@ -122,6 +123,7 @@ func ParallelTestHelper(t *testing.T,
 			eventSource := fmt.Sprintf("http://%s.svc/", senderPodName)
 			event.SetSource(eventSource)
 			event.SetType(testlib.DefaultEventType)
+			event.SetTime(time.Now())
 			body := fmt.Sprintf(`{"msg":"TestFlowParallel %s"}`, uuid.New().String())
 			if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
 				st.Fatalf("Cannot set the payload of the event: %s", err.Error())

--- a/test/e2e/helpers/parallel_test_helper.go
+++ b/test/e2e/helpers/parallel_test_helper.go
@@ -24,13 +24,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
 	"knative.dev/eventing/pkg/apis/flows/v1beta1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 type branchConfig struct {
@@ -136,7 +137,7 @@ func ParallelTestHelper(t *testing.T,
 			// verify the logger service receives the correct transformed event
 			eventTracker.AssertExact(1, recordevents.MatchEvent(
 				HasSource(eventSource),
-				recordevents.DataContains(tc.expected),
+				DataContains(tc.expected),
 			))
 
 			eventTracker.Cleanup()

--- a/test/e2e/helpers/sequence_test_helper.go
+++ b/test/e2e/helpers/sequence_test_helper.go
@@ -24,13 +24,14 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
 	"knative.dev/eventing/pkg/apis/flows/v1beta1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func SequenceTestHelper(t *testing.T,
@@ -142,7 +143,7 @@ func SequenceTestHelper(t *testing.T,
 		}
 		eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
 			cetest.HasSource(eventSource),
-			recordevents.DataContains(expectedMsg),
+			cetest.DataContains(expectedMsg),
 		))
 	})
 }

--- a/test/e2e/source_api_server_test.go
+++ b/test/e2e/source_api_server_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	cetest "github.com/cloudevents/sdk-go/v2/test"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -172,7 +173,7 @@ func TestApiServerSource(t *testing.T) {
 				eventTracker.AssertNot(recordevents.Any())
 			} else {
 				eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
-					recordevents.DataContains(tc.expected),
+					cetest.DataContains(tc.expected),
 				))
 			}
 		})

--- a/test/lib/operation.go
+++ b/test/lib/operation.go
@@ -63,7 +63,7 @@ func (c *Client) WaitForResourceReadyOrFail(name string, typemeta *metav1.TypeMe
 	namespace := c.Namespace
 	metaResource := resources.NewMetaResource(name, namespace, typemeta)
 	if err := duck.WaitForResourceReady(c.Dynamic, metaResource); err != nil {
-		c.T.Fatalf("Failed to get %v-%s ready: %v", *typemeta, name, errors.WithStack(err))
+		c.T.Fatalf("Failed to get %v-%s ready: %+v", *typemeta, name, errors.WithStack(err))
 	}
 }
 
@@ -73,7 +73,7 @@ func (c *Client) WaitForResourcesReadyOrFail(typemeta *metav1.TypeMeta) {
 	namespace := c.Namespace
 	metaResourceList := resources.NewMetaResourceList(namespace, typemeta)
 	if err := duck.WaitForResourcesReady(c.Dynamic, metaResourceList); err != nil {
-		c.T.Fatalf("Failed to get all %v resources ready: %v", *typemeta, errors.WithStack(err))
+		c.T.Fatalf("Failed to get all %v resources ready: %+v", *typemeta, errors.WithStack(err))
 	}
 }
 
@@ -86,7 +86,7 @@ func (c *Client) WaitForAllTestResourcesReady() error {
 	// Explicitly wait for all pods that were created directly by this test to become ready.
 	for _, n := range c.podsCreated {
 		if err := pkgTest.WaitForPodRunning(c.Kube, n, c.Namespace); err != nil {
-			return fmt.Errorf("created Pod %q did not become ready: %v", n, errors.WithStack(err))
+			return fmt.Errorf("created Pod %q did not become ready: %+v", n, errors.WithStack(err))
 		}
 	}
 	// FIXME(chizhg): This hacky sleep is added to try mitigating the test flakiness.
@@ -97,13 +97,13 @@ func (c *Client) WaitForAllTestResourcesReady() error {
 
 func (c *Client) WaitForAllTestResourcesReadyOrFail() {
 	if err := c.WaitForAllTestResourcesReady(); err != nil {
-		c.T.Fatalf("Failed to get all test resources ready: %v", errors.WithStack(err))
+		c.T.Fatalf("Failed to get all test resources ready: %+v", errors.WithStack(err))
 	}
 }
 
 func (c *Client) WaitForServiceEndpointsOrFail(svcName string, numberOfExpectedEndpoints int) {
 	c.T.Logf("Waiting for %d endpoints in service %s", numberOfExpectedEndpoints, svcName)
 	if err := pkgTest.WaitForServiceEndpoints(c.Kube, svcName, c.Namespace, numberOfExpectedEndpoints); err != nil {
-		c.T.Fatalf("Failed while waiting for %d endpoints in service %s: %v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
+		c.T.Fatalf("Failed while waiting for %d endpoints in service %s: %+v", numberOfExpectedEndpoints, svcName, errors.WithStack(err))
 	}
 }

--- a/test/lib/recordevents/event_info_matchers.go
+++ b/test/lib/recordevents/event_info_matchers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package recordevents
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -108,6 +109,54 @@ func DataContains(expectedContainedString string) cetest.EventMatcher {
 		dataAsString := string(have.Data())
 		if !strings.Contains(dataAsString, expectedContainedString) {
 			return fmt.Errorf("data '%s' doesn't contain '%s'", dataAsString, expectedContainedString)
+		}
+		return nil
+	}
+}
+
+// AnyOf returns a matcher which match if at least one of the provided matchers matches
+func AnyOf(matchers ...cetest.EventMatcher) cetest.EventMatcher {
+	return func(have cloudevents.Event) error {
+		var errs []error
+		for _, m := range matchers {
+			if err := m(have); err == nil {
+				return nil
+			} else {
+				errs = append(errs, err)
+			}
+		}
+		var sb strings.Builder
+		sb.WriteString("Cannot match any of the provided matchers\n")
+		for i, err := range errs {
+			sb.WriteString(fmt.Sprintf("%d: %s\n", i+1, err))
+		}
+		return errors.New(sb.String())
+	}
+}
+
+// ContainsExactlyExtensions checks if the event contains only the provided extension names and no more
+func ContainsExactlyExtensions(exts ...string) cetest.EventMatcher {
+	return func(have cloudevents.Event) error {
+		// Copy in a temporary set first
+		extsInEvent := map[string]struct{}{}
+		for k, _ := range have.Extensions() {
+			extsInEvent[k] = struct{}{}
+		}
+
+		for _, ext := range exts {
+			if _, ok := have.Extensions()[ext]; !ok {
+				return fmt.Errorf("expecting extension '%s'", ext)
+			} else {
+				delete(extsInEvent, ext)
+			}
+		}
+
+		if len(extsInEvent) != 0 {
+			var unexpectedKeys []string
+			for k, _ := range extsInEvent {
+				unexpectedKeys = append(unexpectedKeys, k)
+			}
+			return fmt.Errorf("not expecting extensions '%v'", unexpectedKeys)
 		}
 		return nil
 	}

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -234,7 +234,7 @@ func (ei *EventInfoStore) Find(matchers ...EventInfoMatcher) ([]EventInfo, Searc
 func (ei *EventInfoStore) AssertAtLeast(min int, matchers ...EventInfoMatcher) []EventInfo {
 	events, err := ei.waitAtLeastNMatch(AllOf(matchers...), min)
 	if err != nil {
-		ei.tb.Fatalf("Timeout waiting for at least %d matches.\nError: %v", min, errors.WithStack(err))
+		ei.tb.Fatalf("Timeout waiting for at least %d matches.\nError: %+v", min, errors.WithStack(err))
 	}
 	return events
 }
@@ -244,7 +244,7 @@ func (ei *EventInfoStore) AssertAtLeast(min int, matchers ...EventInfoMatcher) [
 func (ei *EventInfoStore) AssertInRange(min int, max int, matchers ...EventInfoMatcher) []EventInfo {
 	events := ei.AssertAtLeast(min, matchers...)
 	if max > 0 && len(events) > max {
-		ei.tb.Fatalf("Assert in range failed: %v", errors.WithStack(fmt.Errorf("expected <= %d events, saw %d", max, len(events))))
+		ei.tb.Fatalf("Assert in range failed: %+v", errors.WithStack(fmt.Errorf("expected <= %d events, saw %d", max, len(events))))
 	}
 
 	return events
@@ -255,11 +255,11 @@ func (ei *EventInfoStore) AssertInRange(min int, max int, matchers ...EventInfoM
 func (ei *EventInfoStore) AssertNot(matchers ...EventInfoMatcher) []EventInfo {
 	res, recentEvents, _, err := ei.Find(matchers...)
 	if err != nil {
-		ei.tb.Fatalf("Unexpected error during find on recordevents '%s': %v", ei.podName, errors.WithStack(err))
+		ei.tb.Fatalf("Unexpected error during find on recordevents '%s': %+v", ei.podName, errors.WithStack(err))
 	}
 
 	if len(res) != 0 {
-		ei.tb.Fatalf("Assert not failed: %v", errors.WithStack(
+		ei.tb.Fatalf("Assert not failed: %+v", errors.WithStack(
 			fmt.Errorf("Unexpected matches on recordevents '%s', found: %v. %s", ei.podName, res, &recentEvents)),
 		)
 	}

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -43,6 +43,7 @@ var (
 	delayStr          string
 	maxMsgStr         string
 	addTracing        bool
+	addSequence       bool
 	incrementalId     bool
 	additionalHeaders string
 )
@@ -55,6 +56,7 @@ func init() {
 	flag.StringVar(&delayStr, "delay", "5", "The number of seconds to wait before sending messages.")
 	flag.StringVar(&maxMsgStr, "max-messages", "1", "The number of messages to attempt to send. 0 for unlimited.")
 	flag.BoolVar(&addTracing, "add-tracing", false, "Should tracing be added to events sent.")
+	flag.BoolVar(&addSequence, "add-sequence-extension", false, "Should add extension 'sequence' identifying the sequence number.")
 	flag.BoolVar(&incrementalId, "incremental-id", false, "Override the event id with an incremental id.")
 	flag.StringVar(&additionalHeaders, "additional-headers", "", "Additional non-CloudEvents headers to send")
 }
@@ -165,8 +167,9 @@ func main() {
 		event := baseEvent.Clone()
 
 		sequence++
-		event.SetExtension("sequence", sequence)
-
+		if addSequence {
+			event.SetExtension("sequence", sequence)
+		}
 		if incrementalId {
 			event.SetID(fmt.Sprintf("%d", sequence))
 		}

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -31,8 +31,9 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.opencensus.io/plugin/ochttp"
 	"go.uber.org/zap"
-	"knative.dev/eventing/pkg/tracing"
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
+
+	"knative.dev/eventing/pkg/tracing"
 )
 
 var (
@@ -140,8 +141,6 @@ func main() {
 		}
 
 		c, err = cloudevents.NewClientObserved(t,
-			cloudevents.WithTimeNow(),
-			cloudevents.WithUUIDs(),
 			cloudevents.WithTracePropagation,
 		)
 	} else {

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -144,10 +144,7 @@ func main() {
 			cloudevents.WithTracePropagation,
 		)
 	} else {
-		c, err = cloudevents.NewClient(t,
-			cloudevents.WithTimeNow(),
-			cloudevents.WithUUIDs(),
-		)
+		c, err = cloudevents.NewClient(t)
 	}
 
 	if err != nil {

--- a/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/v2/client/http_receiver.go
@@ -29,7 +29,7 @@ func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		r.p.ServeHTTP(rw, req)
 	}()
 
-	ctx := context.Background()
+	ctx := req.Context()
 	msg, respFn, err := r.p.Respond(ctx)
 	if err != nil {
 		//lint:ignore SA9003 TODO: Branch left empty

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
-# github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200608152019-2ab697c8fc0b
+# github.com/cloudevents/sdk-go/v2 v2.0.1-0.20200625144206-4e4657232c9e
 ## explicit
 github.com/cloudevents/sdk-go/v2
 github.com/cloudevents/sdk-go/v2/binding


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Part of #1845

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Now it tests the equality of the events received
- Removed some assertions from recordevents because https://github.com/cloudevents/sdk-go/pull/538 adds them to sdk-go 
- Increase verbosity in test failures (now it prints the stack)

Let's wait https://github.com/cloudevents/sdk-go/pull/538 first.