### PR TITLE
Improve eventing v1beta1 conversion tests

### DIFF
--- a/pkg/apis/eventing/v1/broker_conversion_test.go
+++ b/pkg/apis/eventing/v1/broker_conversion_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestBrokerConversionBadType(t *testing.T) {
+func TestBrokerConversionHighestVersion(t *testing.T) {
 	good, bad := &Broker{}, &Broker{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {

--- a/pkg/apis/eventing/v1/trigger_conversion_test.go
+++ b/pkg/apis/eventing/v1/trigger_conversion_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestTriggerConversionBadType(t *testing.T) {
+func TestTriggerConversionHighestVersion(t *testing.T) {
 	good, bad := &Trigger{}, &Trigger{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {

--- a/pkg/apis/eventing/v1beta1/broker_conversion.go
+++ b/pkg/apis/eventing/v1beta1/broker_conversion.go
@@ -29,8 +29,10 @@ func (source *Broker) ConvertTo(ctx context.Context, to apis.Convertible) error 
 	switch sink := to.(type) {
 	case *v1.Broker:
 		sink.Spec.Config = source.Spec.Config
-		if err := source.Spec.Delivery.ConvertTo(ctx, sink.Spec.Delivery); err != nil {
-			return err
+		if source.Spec.Delivery != nil {
+			if err := source.Spec.Delivery.ConvertTo(ctx, sink.Spec.Delivery); err != nil {
+				return err
+			}
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.Address = source.Status.Address
@@ -45,8 +47,10 @@ func (sink *Broker) ConvertFrom(ctx context.Context, from apis.Convertible) erro
 	switch source := from.(type) {
 	case *v1.Broker:
 		sink.Spec.Config = source.Spec.Config
-		if err := source.Spec.Delivery.ConvertFrom(ctx, sink.Spec.Delivery); err != nil {
-			return err
+		if source.Spec.Delivery != nil {
+			if err := source.Spec.Delivery.ConvertFrom(ctx, sink.Spec.Delivery); err != nil {
+				return err
+			}
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.Address = source.Status.Address

--- a/pkg/apis/eventing/v1beta1/broker_conversion_test.go
+++ b/pkg/apis/eventing/v1beta1/broker_conversion_test.go
@@ -19,10 +19,36 @@ package v1beta1
 import (
 	"context"
 	"testing"
+
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
+
+func TestBrokerConversion(t *testing.T) {
+	objv1betav1, objv1 := &Broker{}, &v1.Broker{}
+
+	if err := objv1betav1.ConvertTo(context.Background(), objv1); err != nil {
+		t.Errorf("ConvertTo() = %#v, unexpected error", objv1betav1)
+	}
+
+	if err := objv1betav1.ConvertFrom(context.Background(), objv1); err != nil {
+		t.Errorf("ConvertFrom() = %#v, unexpected error", objv1)
+	}
+}
 
 func TestBrokerConversionBadType(t *testing.T) {
 	good, bad := &Broker{}, &Trigger{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
+func TestBrokerConversionBadVersion(t *testing.T) {
+	good, bad := &Broker{}, &Broker{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)

--- a/pkg/apis/eventing/v1beta1/eventtype_conversion_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_conversion_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestEventTypeConversionBadType(t *testing.T) {
+func TestEventTypeConversionHighestVersion(t *testing.T) {
 	good, bad := &EventType{}, &EventType{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {

--- a/pkg/apis/eventing/v1beta1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion.go
@@ -25,16 +25,16 @@ import (
 )
 
 // ConvertTo implements apis.Convertible
-func (source *Trigger) ConvertTo(ctx context.Context, to apis.Convertible) error {
+func (source *Trigger) ConvertTo(_ context.Context, to apis.Convertible) error {
 	switch sink := to.(type) {
 	case *v1.Trigger:
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
 			sink.Spec.Filter = &v1.TriggerFilter{}
-		}
-		for k, v := range source.Spec.Filter.Attributes {
-			sink.Spec.Filter.Attributes[k] = v
+			for k, v := range source.Spec.Filter.Attributes {
+				sink.Spec.Filter.Attributes[k] = v
+			}
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.SubscriberURI = source.Status.SubscriberURI
@@ -45,16 +45,16 @@ func (source *Trigger) ConvertTo(ctx context.Context, to apis.Convertible) error
 }
 
 // ConvertFrom implements apis.Convertible
-func (sink *Trigger) ConvertFrom(ctx context.Context, from apis.Convertible) error {
+func (sink *Trigger) ConvertFrom(_ context.Context, from apis.Convertible) error {
 	switch source := from.(type) {
 	case *v1.Trigger:
 		sink.Spec.Broker = source.Spec.Broker
 		sink.Spec.Subscriber = source.Spec.Subscriber
 		if source.Spec.Filter != nil {
 			sink.Spec.Filter = &TriggerFilter{}
-		}
-		for k, v := range source.Spec.Filter.Attributes {
-			sink.Spec.Filter.Attributes[k] = v
+			for k, v := range source.Spec.Filter.Attributes {
+				sink.Spec.Filter.Attributes[k] = v
+			}
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.SubscriberURI = source.Status.SubscriberURI

--- a/pkg/apis/eventing/v1beta1/trigger_conversion_test.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion_test.go
@@ -19,10 +19,36 @@ package v1beta1
 import (
 	"context"
 	"testing"
+
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
+
+func TestTriggerConversion(t *testing.T) {
+	objv1betav1, objv1 := &Trigger{}, &v1.Trigger{}
+
+	if err := objv1betav1.ConvertTo(context.Background(), objv1); err != nil {
+		t.Errorf("ConvertTo() = %#v, unexpected error", objv1betav1)
+	}
+
+	if err := objv1betav1.ConvertFrom(context.Background(), objv1); err != nil {
+		t.Errorf("ConvertFrom() = %#v, unexpected error", objv1)
+	}
+}
 
 func TestTriggerConversionBadType(t *testing.T) {
 	good, bad := &Trigger{}, &Broker{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
+func TestTriggerConversionBadVersion(t *testing.T) {
+	good, bad := &Trigger{}, &Trigger{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)


### PR DESCRIPTION
## Proposed Changes

- Improve eventing v1beta1 conversion tests as noted in https://github.com/knative/eventing/pull/3372#discussion_r444028257

I can improve conversion tests for other types after seeing how this PR goes.

UPDATE:  I now realize in other conversion tests there was a test like v1->v1beta1->v1. (nothing on the current state of the source tree, but saw some stuff from Git history)
I will do that in a separate PR. let's merge this one anyway
