### PR TITLE
[master] Updated Development.md to include installing mt-channel-broker

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,6 +147,7 @@ ko apply -f config/brokers/channel-broker/
 ```
 
 You may also need to install the MT Channel Based Broker
+
 ```shell
 ko apply -f config/brokers/mt-channel-broker/
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,14 +139,8 @@ Depending on your needs you might want to install other
 ## Install Brokers
 
 Install the
-[Channel Broker](https://github.com/knative/eventing/tree/master/config/brokers/channel-broker)
+[MT Channel Broker](https://github.com/knative/eventing/tree/master/config/brokers/mt-channel-broker)
 or any of the other Brokers available inside the `config/brokers/` directory.
-
-```shell
-ko apply -f config/brokers/channel-broker/
-```
-
-You may also need to install the MT Channel Based Broker
 
 ```shell
 ko apply -f config/brokers/mt-channel-broker/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,6 +146,11 @@ or any of the other Brokers available inside the `config/brokers/` directory.
 ko apply -f config/brokers/channel-broker/
 ```
 
+You may also need to install the MT Channel Based Broker
+```shell
+ko apply -f config/brokers/mt-channel-broker/
+```
+
 Depending on your needs you might want to install other
 [Broker implementations](https://github.com/knative/eventing/tree/master/docs/broker).
 


### PR DESCRIPTION
Fixes

<!-- Please include the 'why' behind your changes if no issue exists -->
E2E tests fail without the installation of the MT Channel Based Broker. Development.md is a bit vague and says the user might want to install other brokers, instead of specifying which brokers need to be installed other than the default.

## Proposed Changes
- Modify DEVELOPMENT.md to include the instruction for installing the mt-channel-broker
