### PR TITLE
Added conformance tests for failing status code in channel data plane

### DIFF
--- a/test/conformance/channel_data_plane_test.go
+++ b/test/conformance/channel_data_plane_test.go
@@ -25,6 +25,10 @@ import (
 	testlib "knative.dev/eventing/test/lib"
 )
 
-func TestChannelEventModesAndSpecVersions(t *testing.T) {
-	helpers.ChannelMessageModesAndSpecVersionsTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+func TestChannelDataPlaneSuccess(t *testing.T) {
+	helpers.ChannelDataPlaneSuccessTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}
+
+func TestChannelDataPlaneFailure(t *testing.T) {
+	helpers.ChannelDataPlaneFailureTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
 }

--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -34,7 +34,7 @@ import (
 	configtracing "knative.dev/pkg/tracing/config"
 
 	eventing "knative.dev/eventing/pkg/client/clientset/versioned"
-	"knative.dev/eventing/test/lib/tracing"
+	"knative.dev/eventing/test/test_images"
 )
 
 // Client holds instances of interfaces for making requests to Knative.
@@ -109,5 +109,5 @@ func getTracingConfig(c *kubernetes.Clientset) (corev1.EnvVar, error) {
 		return corev1.EnvVar{}, fmt.Errorf("error while serializing the config-tracing config map: %+v", errors.WithStack(err))
 	}
 
-	return corev1.EnvVar{Name: tracing.ConfigTracingEnv, Value: configSerialized}, nil
+	return corev1.EnvVar{Name: test_images.ConfigTracingEnv, Value: configSerialized}, nil
 }

--- a/test/lib/sender/events.go
+++ b/test/lib/sender/events.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sender
 
 import (
+	"net/http"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -43,6 +44,18 @@ func NewSenderEvent(id string, source string, event *cloudevents.Event, result *
 	if event != nil {
 		_ = ev.SetData("application/json", event)
 	}
+
+	return ev
+}
+
+func NewSenderEventFromRaw(id string, source string, response *http.Response) cloudevents.Event {
+	ev := cloudevents.NewEvent()
+	ev.SetID(id)
+	ev.SetSource(source)
+	ev.SetType(EventType)
+	ev.SetTime(time.Now())
+
+	ev.SetExtension(ResponseStatusCodeExtension, response.StatusCode)
 
 	return ev
 }

--- a/test/lib/sender/resources.go
+++ b/test/lib/sender/resources.go
@@ -26,10 +26,8 @@ import (
 	pkgTest "knative.dev/pkg/test"
 )
 
-type EventSenderOption func(*corev1.Pod)
-
 // EnableTracing enables tracing in sender pod
-func EnableTracing() EventSenderOption {
+func EnableTracing() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
 			pod.Spec.Containers[0].Args,
@@ -39,8 +37,8 @@ func EnableTracing() EventSenderOption {
 	}
 }
 
-// EnableIncrementalId creates a new incremental id for each event sent from the sender pod
-func EnableIncrementalId() EventSenderOption {
+// EnableIncrementalId creates a new incremental id for each event sent from the sender pod. Supported only by event-sender
+func EnableIncrementalId() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
 			pod.Spec.Containers[0].Args,
@@ -50,8 +48,8 @@ func EnableIncrementalId() EventSenderOption {
 	}
 }
 
-// WithEncoding forces the encoding of the event to send from the sender pod
-func WithEncoding(encoding cloudevents.Encoding) EventSenderOption {
+// WithEncoding forces the encoding of the event to send from the sender pod. Supported only by event-sender
+func WithEncoding(encoding cloudevents.Encoding) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
 			pod.Spec.Containers[0].Args,
@@ -62,7 +60,7 @@ func WithEncoding(encoding cloudevents.Encoding) EventSenderOption {
 }
 
 // WithResponseSink sends the response information as CloudEvent to another sink
-func WithResponseSink(responseSink string) EventSenderOption {
+func WithResponseSink(responseSink string) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
 			pod.Spec.Containers[0].Args,
@@ -72,24 +70,19 @@ func WithResponseSink(responseSink string) EventSenderOption {
 	}
 }
 
-// WithEncoding forces the encoding of the event to send from the sender pod
-func WithAdditionalHeaders(headers map[string]string) EventSenderOption {
-	var kv []string
-	for k, v := range headers {
-		kv = append(kv, k+"="+v)
-	}
-	serializedHeaders := strings.Join(kv, ",")
+// WithEncoding forces the encoding of the event to send from the sender pod. Supported only by event-sender
+func WithAdditionalHeaders(headers map[string]string) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
 			pod.Spec.Containers[0].Args,
 			"-additional-headers",
-			serializedHeaders,
+			serializeHeaders(headers),
 		)
 	}
 }
 
 // EventSenderPod creates a Pod that sends events to the given address.
-func EventSenderPod(imageName string, name string, sink string, event cloudevents.Event, options ...EventSenderOption) (*corev1.Pod, error) {
+func EventSenderPod(imageName string, name string, sink string, event cloudevents.Event, options ...func(*corev1.Pod)) (*corev1.Pod, error) {
 	encodedEvent, err := json.Marshal(event)
 	if err != nil {
 		return nil, err
@@ -123,4 +116,57 @@ func EventSenderPod(imageName string, name string, sink string, event cloudevent
 	}
 
 	return p, nil
+}
+
+// WithMethod configures the method used to send the http request. Supported only by request-sender
+func WithMethod(method string) func(*corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		pod.Spec.Containers[0].Args = append(
+			pod.Spec.Containers[0].Args,
+			"-method",
+			method,
+		)
+	}
+}
+
+// EventSenderPod creates a Pod that sends http requests to the given address.
+func RequestSenderPod(imageName string, name string, sink string, headers map[string]string, body string, options ...func(*corev1.Pod)) (*corev1.Pod, error) {
+	args := []string{
+		"-sink",
+		sink,
+		"-headers",
+		serializeHeaders(headers),
+		"-body",
+		body,
+	}
+
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            imageName,
+				Image:           pkgTest.ImagePath(imageName),
+				ImagePullPolicy: corev1.PullAlways,
+				Args:            args,
+			}},
+			// Never restart the event sender Pod.
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	for _, opt := range options {
+		opt(p)
+	}
+
+	return p, nil
+}
+
+func serializeHeaders(headers map[string]string) string {
+	var kv []string
+	for k, v := range headers {
+		kv = append(kv, k+"="+v)
+	}
+	return strings.Join(kv, ",")
 }

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"log"
 	nethttp "net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -34,7 +32,7 @@ import (
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 
 	"knative.dev/eventing/test/lib/sender"
-	"knative.dev/eventing/test/lib/tracing"
+	"knative.dev/eventing/test/test_images"
 )
 
 var (
@@ -44,7 +42,7 @@ var (
 	eventEncoding     string
 	periodStr         string
 	delayStr          string
-	maxMsgStr         string
+	maxMsg            int
 	addTracing        bool
 	addSequence       bool
 	incrementalId     bool
@@ -58,32 +56,17 @@ func init() {
 	flag.StringVar(&eventEncoding, "event-encoding", "binary", "The encoding of the cloud event: [binary, structured].")
 	flag.StringVar(&periodStr, "period", "5", "The number of seconds between messages.")
 	flag.StringVar(&delayStr, "delay", "5", "The number of seconds to wait before sending messages.")
-	flag.StringVar(&maxMsgStr, "max-messages", "1", "The number of messages to attempt to send. 0 for unlimited.")
+	flag.IntVar(&maxMsg, "max-messages", 1, "The number of messages to attempt to send. 0 for unlimited.")
 	flag.BoolVar(&addTracing, "add-tracing", false, "Should tracing be added to events sent.")
 	flag.BoolVar(&addSequence, "add-sequence-extension", false, "Should add extension 'sequence' identifying the sequence number.")
 	flag.BoolVar(&incrementalId, "incremental-id", false, "Override the event id with an incremental id.")
 	flag.StringVar(&additionalHeaders, "additional-headers", "", "Additional non-CloudEvents headers to send")
 }
 
-func parseDurationStr(durationStr string, defaultDuration int) time.Duration {
-	var duration time.Duration
-	if d, err := strconv.Atoi(durationStr); err != nil {
-		duration = time.Duration(defaultDuration) * time.Second
-	} else {
-		duration = time.Duration(d) * time.Second
-	}
-	return duration
-}
-
 func main() {
 	flag.Parse()
-	period := parseDurationStr(periodStr, 5)
-	delay := parseDurationStr(delayStr, 5)
-
-	maxMsg := 1
-	if m, err := strconv.Atoi(maxMsgStr); err == nil {
-		maxMsg = m
-	}
+	period := test_images.ParseDurationStr(periodStr, 5)
+	delay := test_images.ParseDurationStr(delayStr, 5)
 
 	if delay > 0 {
 		log.Printf("will sleep for %s", delay)
@@ -115,9 +98,8 @@ func main() {
 		)
 	}
 	if additionalHeaders != "" {
-		for _, kv := range strings.Split(additionalHeaders, ",") {
-			splitted := strings.Split(kv, "=")
-			httpOpts = append(httpOpts, cloudevents.WithHeader(splitted[0], splitted[1]))
+		for k, v := range test_images.ParseHeaders(additionalHeaders) {
+			httpOpts = append(httpOpts, cloudevents.WithHeader(k, v[0]))
 		}
 	}
 
@@ -130,7 +112,7 @@ func main() {
 	if addTracing {
 		log.Println("Adding tracing")
 		logger, _ := zap.NewDevelopment()
-		if err := tracing.ConfigureTracing(logger.Sugar(), ""); err != nil {
+		if err := test_images.ConfigureTracing(logger.Sugar(), ""); err != nil {
 			log.Fatalf("Unable to setup trace publishing: %v", err)
 		}
 

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -32,7 +32,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
-	"knative.dev/eventing/test/lib/tracing"
+	"knative.dev/eventing/test/test_images"
 )
 
 type eventRecorder struct {
@@ -150,7 +150,7 @@ func main() {
 	er.StartServer(recordevents.RecordEventsPort)
 
 	logger, _ := zap.NewDevelopment()
-	if err := tracing.ConfigureTracing(logger.Sugar(), ""); err != nil {
+	if err := test_images.ConfigureTracing(logger.Sugar(), ""); err != nil {
 		log.Fatalf("Unable to setup trace publishing: %v", err)
 	}
 

--- a/test/test_images/request-sender/main.go
+++ b/test/test_images/request-sender/main.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"log"
+	nethttp "net/http"
+	"strings"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"go.opencensus.io/plugin/ochttp"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
+
+	"knative.dev/eventing/test/lib/sender"
+	"knative.dev/eventing/test/test_images"
+)
+
+var (
+	sink         string
+	method       string
+	responseSink string
+	inputHeaders string
+	inputBody    string
+	periodStr    string
+	delayStr     string
+	maxMsg       int
+	addTracing   bool
+)
+
+func init() {
+	flag.StringVar(&sink, "sink", "", "The sink url for the message destination.")
+	flag.StringVar(&method, "method", "POST", "HTTP Method to send.")
+	flag.StringVar(&responseSink, "response-sink", "", "The response sink url to send the response.")
+	flag.StringVar(&inputHeaders, "headers", "", "HTTP Headers to send.")
+	flag.StringVar(&inputBody, "body", "", "HTTP body to send.")
+	flag.StringVar(&periodStr, "period", "5", "The number of seconds between messages.")
+	flag.StringVar(&delayStr, "delay", "5", "The number of seconds to wait before sending messages.")
+	flag.IntVar(&maxMsg, "max-messages", 1, "The number of messages to attempt to send. 0 for unlimited.")
+	flag.BoolVar(&addTracing, "add-tracing", false, "Should tracing be added to events sent.")
+}
+
+func main() {
+	flag.Parse()
+	period := test_images.ParseDurationStr(periodStr, 5)
+	delay := test_images.ParseDurationStr(delayStr, 5)
+
+	if delay > 0 {
+		log.Printf("will sleep for %s", delay)
+		time.Sleep(delay)
+		log.Printf("awake, continuing")
+	}
+
+	// I need the httpClient to report to responseSink
+	ceClient, err := cloudevents.NewDefaultClient()
+	if err != nil {
+		log.Fatalf("failed to create httpClient, %v", err)
+	}
+
+	httpClient := &nethttp.Client{
+		Transport: &ochttp.Transport{
+			Base:        nethttp.DefaultTransport,
+			Propagation: tracecontextb3.TraceContextEgress,
+		},
+	}
+
+	sequence := 0
+
+	ticker := time.NewTicker(period)
+	for {
+		sequence++
+
+		var body io.Reader
+		if inputBody != "" {
+			body = strings.NewReader(inputBody)
+			log.Printf("Using body: '%s'", inputBody)
+		}
+
+		request, err := nethttp.NewRequest(method, sink, body)
+		if err != nil {
+			log.Fatalf("Cannot create request: %s", err.Error())
+		}
+
+		if inputHeaders != "" {
+			for k, v := range test_images.ParseHeaders(inputHeaders) {
+				request.Header.Set(k, v[0])
+				log.Printf("Using header %s: %s", k, v[0])
+			}
+		}
+
+		response, err := httpClient.Do(request)
+		if err != nil {
+			log.Fatalf("Error while executing HTTP request: %v", err.Error())
+		}
+
+		responseEvent := sender.NewSenderEventFromRaw(
+			uuid.New().String(),
+			"https://knative.dev/eventing/test/event-sender",
+			response,
+		)
+
+		if responseSink != "" {
+			res := ceClient.Send(cloudevents.ContextWithTarget(context.Background(), responseSink), responseEvent)
+			if cloudevents.IsUndelivered(res) {
+				log.Printf("send to response sink returned an error: %v\n", res)
+			} else {
+				log.Printf("Got response from %s\n%s\n", responseSink, res)
+			}
+		}
+
+		// Wait for next tick
+		<-ticker.C
+		// Only send a limited number of messages.
+		if maxMsg != 0 && maxMsg == sequence {
+			return
+		}
+	}
+}

--- a/test/test_images/request-sender/pod.yaml
+++ b/test/test_images/request-sender/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: request-sender
+spec:
+  containers:
+    - name: request-sender
+      image: ko://knative.dev/eventing/test/test_images/request-sender
+

--- a/test/test_images/transformevents/main.go
+++ b/test/test_images/transformevents/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 
 	"knative.dev/eventing/pkg/kncloudevents"
-	"knative.dev/eventing/test/lib/tracing"
+	"knative.dev/eventing/test/test_images"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -69,7 +69,7 @@ func main() {
 	flag.Parse()
 
 	logger, _ := zap.NewDevelopment()
-	if err := tracing.ConfigureTracing(logger.Sugar(), ""); err != nil {
+	if err := test_images.ConfigureTracing(logger.Sugar(), ""); err != nil {
 		log.Fatalf("Unable to setup trace publishing: %v", err)
 	}
 

--- a/test/test_images/utils.go
+++ b/test/test_images/utils.go
@@ -14,16 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tracing
+package test_images
 
 import (
+	"net/http"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"go.uber.org/zap"
-	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracing/config"
 
 	"knative.dev/eventing/pkg/tracing"
 )
+
+func ParseHeaders(serializedHeaders string) http.Header {
+	h := make(http.Header)
+	for _, kv := range strings.Split(serializedHeaders, ",") {
+		splitted := strings.Split(kv, "=")
+		h.Set(splitted[0], splitted[1])
+	}
+	return h
+}
+
+func ParseDurationStr(durationStr string, defaultDuration int) time.Duration {
+	var duration time.Duration
+	if d, err := strconv.Atoi(durationStr); err != nil {
+		duration = time.Duration(defaultDuration) * time.Second
+	} else {
+		duration = time.Duration(d) * time.Second
+	}
+	return duration
+}
 
 const ConfigTracingEnv = "K_CONFIG_TRACING"
 
@@ -35,7 +58,7 @@ func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 		return tracing.SetupStaticPublishing(logger, serviceName, tracing.AlwaysSample)
 	}
 
-	conf, err := tracingconfig.JsonToTracingConfig(tracingEnv)
+	conf, err := config.JsonToTracingConfig(tracingEnv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #1845

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Added a new test image to send raw http requests (mainly useful to send bad event requests)
- Added status code checks for 405 and 400 to channel data plane conformance tests
- Rename TestChannelEventModesAndSpecVersions to TestChannelDataPlaneSuccess
