### PR TITLE
Channel spec clarification about Channel not found behaviour

### DIFF
--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -335,10 +335,8 @@ Channel at any given moment in time. This MAY be done via the host, path, query
 string, or any combination of these. This mapping is handled exclusively by the
 Channel implementation, exposed via the Channel's `status.address`.
 
-If an HTTP event queueing request's URL does not correspond to an existing
-Channel, then the failure behaviour is undefined. For example, the Channel MAY
-respond with `404 Not Found` or the DNS MAY fail to resolve the hostname of the
-request.
+If a channel implementation receives a request that does not correspond to a
+known channel, then it MUST reply with a `404 Not Found`.
 
 The Channel MUST respond with `202 Accepted` if the event queueing request is
 accepted by the server.

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -335,8 +335,8 @@ Channel at any given moment in time. This MAY be done via the host, path, query
 string, or any combination of these. This mapping is handled exclusively by the
 Channel implementation, exposed via the Channel's `status.address`.
 
-If a channel implementation receives a request that does not correspond to a
-known channel, then it MUST reply with a `404 Not Found`.
+If a Channel receives a request that does not correspond to a known channel,
+then it MUST respond with a `404 Not Found`.
 
 The Channel MUST respond with `202 Accepted` if the event queueing request is
 accepted by the server.

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -335,9 +335,10 @@ Channel at any given moment in time. This MAY be done via the host, path, query
 string, or any combination of these. This mapping is handled exclusively by the
 Channel implementation, exposed via the Channel's `status.address`.
 
-If an HTTP event queueing request's URL does not correspond to an existing Channel, then
-the failure behaviour is undefined. For example, the Channel MAY respond with `404 Not Found`
-or the DNS MAY fail to resolve the hostname of the request.
+If an HTTP event queueing request's URL does not correspond to an existing
+Channel, then the failure behaviour is undefined. For example, the Channel MAY
+respond with `404 Not Found` or the DNS MAY fail to resolve the hostname of the
+request.
 
 The Channel MUST respond with `202 Accepted` if the event queueing request is
 accepted by the server.

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -333,9 +333,11 @@ queueing requests (e.g. health checks) are not constrained.
 The HTTP event queueing request's URL MUST correspond to a single, unique
 Channel at any given moment in time. This MAY be done via the host, path, query
 string, or any combination of these. This mapping is handled exclusively by the
-Channel implementation, exposed via the Channel's `status.address`. If an HTTP
-event queueing request's URL does not correspond to an existing Channel, then
-the Channel MUST respond with `404 Not Found`.
+Channel implementation, exposed via the Channel's `status.address`.
+
+If an HTTP event queueing request's URL does not correspond to an existing Channel, then
+the failure behaviour is undefined. For example, the Channel MAY respond with `404 Not Found`
+or the DNS MAY fail to resolve the hostname of the request.
 
 The Channel MUST respond with `202 Accepted` if the event queueing request is
 accepted by the server.


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This came out while i was working on #1845.

The _Channel not found_ behaviour is implementation dependant, so the sentence 

> the Channel MUST respond with `404 Not Found`.

may be incorrect. E.g. if you have a channel implementation that spawns one deployment per channel, then there is no endpoint to send the event, so you'll probably get a DNS or an i/o timeout error, nor a 404 response. With IMC channel, if the channel does not exists, then the `ExternalName` service does not exists. The user could invoke directly the imc-dispatcher svc and configure the `Host` header and in that case he will get a 404 back, but that's a behaviour depending on the specific IMC dispatcher implementation.

My proposal here is to make that sentence a little bit more generic, specifying that the behaviour is implementation dependant and could result in a 404 or a DNS failure