### PR TITLE
deal with malformed events as errors

### DIFF
--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -118,6 +118,11 @@ Events contained in delivery responses SHOULD be published to the Broker ingress
 and processed as if the event had been produced to the Broker's addressable
 endpoint.
 
+Events contained in delivery responses that are malformed SHOULD be treated as
+if the event delivery had failed. Reasoning being that if the event was being
+transformed unsuccessfully (programming error for example) it should be treated
+as a failure.
+
 The subscriber MAY receive a confirmation that a reply event was accepted by the
 Broker. If the reply event was not accepted, the initial event SHOULD be
 redelivered to the subscriber.

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -220,10 +220,11 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 		h.logger.Error("failed to write response", zap.Error(err))
 		// Ok, so writeResponse will return the HttpStatus of the function. That may have
 		// succeeded (200), but it may have returned a malformed event, so if the
-		// function succeeded, convert this to an StatusInternalServerError instead to indicate
-		// error.
+		// function succeeded, convert this to an StatusBadGateway instead to indicate
+		// error. Note that we could just use StatusInternalServerError, but to distinguish
+		// between the two failure cases, we use a different code here.
 		if statusCode == 200 {
-			statusCode = http.StatusInternalServerError
+			statusCode = http.StatusBadGateway
 		}
 	}
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -272,6 +272,7 @@ func writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.R
 		// as delivery failure.
 		body := make([]byte, 1)
 		n, _ := response.BodyReader.Read(body)
+		response.BodyReader.Close()
 		if n != 0 {
 			return resp.StatusCode, errors.New("Received a malformed event in reply")
 		}

--- a/pkg/mtbroker/filter/filter_handler_test.go
+++ b/pkg/mtbroker/filter/filter_handler_test.go
@@ -284,7 +284,7 @@ func TestReceiver(t *testing.T) {
 			expectedDispatch:          true,
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
-			expectedStatus:            http.StatusInternalServerError,
+			expectedStatus:            http.StatusBadGateway,
 			response:                  makeMalformedEventResponse(),
 		},
 	}

--- a/pkg/mtbroker/filter/filter_handler_test.go
+++ b/pkg/mtbroker/filter/filter_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,6 +54,8 @@ const (
 
 	// Because it's a URL we're comparing to, without protocol it looks like this.
 	toBeReplaced = "//toBeReplaced"
+
+	invalidEvent = `{"id":"1234","knativebrokerttl":1,"source":"/mycontext","specversion":"0.1","type":"com.example.someevent"}`
 )
 
 var (
@@ -73,39 +76,39 @@ func TestReceiver(t *testing.T) {
 		failureStatus               int
 		returnedEvent               *cloudevents.Event
 		expectNewToFail             bool
-		expectedErr                 bool
 		expectedDispatch            bool
 		expectedStatus              int
 		expectedHeaders             http.Header
 		expectedEventCount          bool
 		expectedEventDispatchTime   bool
 		expectedEventProcessingTime bool
+		response                    *http.Response
 	}{
 		"Not POST": {
 			request:        httptest.NewRequest(http.MethodGet, validPath, nil),
 			expectedStatus: http.StatusMethodNotAllowed,
 		},
 		"Path too short": {
-			request:     httptest.NewRequest(http.MethodPost, "/test-namespace/test-trigger", nil),
-			expectedErr: true,
+			request:        httptest.NewRequest(http.MethodPost, "/test-namespace/test-trigger", nil),
+			expectedStatus: http.StatusBadRequest,
 		},
 		"Path too long": {
-			request:     httptest.NewRequest(http.MethodPost, "/triggers/test-namespace/test-trigger/extra", nil),
-			expectedErr: true,
+			request:        httptest.NewRequest(http.MethodPost, "/triggers/test-namespace/test-trigger/extra", nil),
+			expectedStatus: http.StatusBadRequest,
 		},
 		"Path without prefix": {
-			request:     httptest.NewRequest(http.MethodPost, "/something/test-namespace/test-trigger", nil),
-			expectedErr: true,
+			request:        httptest.NewRequest(http.MethodPost, "/something/test-namespace/test-trigger", nil),
+			expectedStatus: http.StatusBadRequest,
 		},
 		"Trigger.Get fails": {
 			// No trigger exists, so the Get will fail.
-			expectedErr: true,
+			expectedStatus: http.StatusBadRequest,
 		},
 		"Trigger doesn't have SubscriberURI": {
 			triggers: []*eventingv1beta1.Trigger{
 				makeTriggerWithoutSubscriberURI(),
 			},
-			expectedErr:        true,
+			expectedStatus:     http.StatusBadRequest,
 			expectedEventCount: true,
 		},
 		"Trigger without a Filter": {
@@ -157,7 +160,7 @@ func TestReceiver(t *testing.T) {
 				makeTrigger(makeTriggerFilterWithAttributes("", "")),
 			},
 			requestFails:              true,
-			expectedErr:               true,
+			expectedStatus:            http.StatusBadRequest,
 			expectedDispatch:          true,
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
@@ -239,7 +242,6 @@ func TestReceiver(t *testing.T) {
 			expectedDispatch:          true,
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
-			expectedErr:               true,
 			expectedStatus:            http.StatusTooManyRequests,
 		},
 		"Returned Cloud Event with custom headers": {
@@ -275,6 +277,16 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			returnedEvent:             makeDifferentEvent(),
 		},
+		"Returned malformed Cloud Event": {
+			triggers: []*eventingv1beta1.Trigger{
+				makeTrigger(makeTriggerFilterWithAttributes("", "")),
+			},
+			expectedDispatch:          true,
+			expectedEventCount:        true,
+			expectedEventDispatchTime: true,
+			expectedStatus:            http.StatusInternalServerError,
+			response:                  makeMalformedEventResponse(),
+		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
@@ -285,6 +297,7 @@ func TestReceiver(t *testing.T) {
 				returnedEvent: tc.returnedEvent,
 				headers:       tc.expectedHeaders,
 				t:             t,
+				response:      tc.response,
 			}
 			s := httptest.NewServer(&fh)
 			defer s.Close()
@@ -352,7 +365,7 @@ func TestReceiver(t *testing.T) {
 			}
 			if tc.returnedEvent != nil {
 				if tc.returnedEvent.SpecVersion() != event.CloudEventsVersionV1 {
-					t.Errorf("Incorrect event processing time reported metric. Expected %v, Actual %v", tc.expectedEventProcessingTime, reporter.eventProcessingTimeReported)
+					t.Errorf("Incorrect spec version. Expected %v, Actual %v", tc.returnedEvent.SpecVersion(), event.CloudEventsVersionV1)
 				}
 			}
 			// Compare the returned event.
@@ -420,9 +433,13 @@ type fakeHandler struct {
 	headers         http.Header
 	returnedEvent   *cloudevents.Event
 	t               *testing.T
+	response        *http.Response
 }
 
 func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	if h.returnedEvent != nil && h.response != nil {
+		h.t.Errorf("Can not specify both returnedEvent and response.")
+	}
 	h.requestReceived = true
 
 	for n, v := range h.headers {
@@ -442,16 +459,28 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
-	if h.returnedEvent == nil {
+	if h.returnedEvent == nil && h.response == nil {
 		resp.WriteHeader(http.StatusAccepted)
 		return
 	}
 
-	message := binding.ToMessage(h.returnedEvent)
-	defer message.Finish(nil)
-	err := cehttp.WriteResponseWriter(context.Background(), message, http.StatusAccepted, resp)
-	if err != nil {
-		h.t.Fatalf("Unable to write body: %v", err)
+	if h.returnedEvent != nil {
+		message := binding.ToMessage(h.returnedEvent)
+		defer message.Finish(nil)
+		err := cehttp.WriteResponseWriter(context.Background(), message, http.StatusAccepted, resp)
+		if err != nil {
+			h.t.Fatalf("Unable to write body: %v", err)
+		}
+	}
+	if h.response != nil {
+		defer h.response.Body.Close()
+		body, err := ioutil.ReadAll(h.response.Body)
+		if err != nil {
+			h.t.Fatalf("Unable to read body: %v", err)
+		}
+		resp.Header().Set("Content-Type", "garbage")
+		resp.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		resp.Write(body)
 	}
 }
 
@@ -537,4 +566,19 @@ func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
 	noTTL.SetExtension(extName, extValue)
 	e := addTTLToEvent(*noTTL)
 	return &e
+}
+
+func makeMalformedEventResponse() *http.Response {
+	r := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(invalidEvent)),
+		Header:     make(http.Header, 0),
+	}
+	r.Header.Set("Content-Type", "garbage")
+	r.Header.Set("Content-Length", fmt.Sprintf("%d", len(invalidEvent)))
+	return r
 }


### PR DESCRIPTION
Fixes #3438 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change the spec of what happens if event delivery succeeds but the function returns a malformed event.
- Do not silently ignore malformed events coming from the functions.
- Fix a bunch of tests that were not doing anything to actually do something.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug - If a function returns a malformed event, treat that the same as a failed event delivery.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
