### PR TITLE
bump channel,imc,subscription to v1, add e2e tests

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -54,6 +54,10 @@ spec:
     name: v1beta1
     served: true
     storage: true
+  - << : *version
+    name: v1
+    served: true
+    storage: false
   names:
     kind: InMemoryChannel
     plural: inmemorychannels

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -131,6 +131,20 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+  - << : *version
+    name: v1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Channel
     plural: channels

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -49,6 +49,10 @@ spec:
     name: v1beta1
     served: true
     storage: true
+  - <<: *version
+    name: v1
+    served: true
+    storage: false
   names:
     kind: Subscription
     plural: subscriptions
@@ -60,11 +64,11 @@ spec:
     shortNames:
     - sub
   scope: Namespaced
-  # conversion:
-  #   strategy: Webhook
-  #   webhook:
-  #     conversionReviewVersions: ["v1", "v1beta1"]
-  #     clientConfig:
-  #       service:
-  #         name: eventing-webhook
-  #         namespace: knative-eventing
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -55,10 +55,10 @@ func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink *eventingduckv
 	sink.UID = source.UID
 	sink.Generation = source.Generation
 	sink.SubscriberURI = source.SubscriberURI
-	sink.Delivery = &eventingduckv1.DeliverySpec{
-		DeadLetterSink: &duckv1.Destination{},
+	if source.Delivery != nil {
+		sink.Delivery = &eventingduckv1.DeliverySpec{}
+		source.Delivery.ConvertTo(ctx, sink.Delivery)
 	}
-	source.Delivery.ConvertTo(ctx, sink.Delivery)
 	sink.ReplyURI = source.ReplyURI
 }
 

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
@@ -51,15 +50,18 @@ func (source *SubscribableSpec) ConvertTo(ctx context.Context, sink *eventingduc
 }
 
 // ConvertTo helps implement apis.Convertible
-func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink *eventingduckv1.SubscriberSpec) {
+func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink *eventingduckv1.SubscriberSpec) error {
 	sink.UID = source.UID
 	sink.Generation = source.Generation
 	sink.SubscriberURI = source.SubscriberURI
 	if source.Delivery != nil {
 		sink.Delivery = &eventingduckv1.DeliverySpec{}
-		source.Delivery.ConvertTo(ctx, sink.Delivery)
+		if err := source.Delivery.ConvertTo(ctx, sink.Delivery); err != nil {
+			return err
+		}
 	}
 	sink.ReplyURI = source.ReplyURI
+	return nil
 }
 
 // ConvertTo helps implement apis.Convertible
@@ -83,33 +85,36 @@ func (sink *Subscribable) ConvertFrom(ctx context.Context, from apis.Convertible
 	case *eventingduckv1.Subscribable:
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, source.Status)
-		sink.Spec.ConvertFrom(ctx, source.Spec)
-		return nil
+		return sink.Spec.ConvertFrom(ctx, source.Spec)
 	default:
 		return fmt.Errorf("unknown version, got: %T", source)
 	}
 }
 
 // ConvertFrom helps implement apis.Convertible
-func (sink *SubscribableSpec) ConvertFrom(ctx context.Context, source eventingduckv1.SubscribableSpec) {
+func (sink *SubscribableSpec) ConvertFrom(ctx context.Context, source eventingduckv1.SubscribableSpec) error {
 	if len(source.Subscribers) > 0 {
 		sink.Subscribers = make([]SubscriberSpec, len(source.Subscribers))
 		for i, s := range source.Subscribers {
-			sink.Subscribers[i].ConvertFrom(ctx, s)
+			if err := sink.Subscribers[i].ConvertFrom(ctx, s); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // ConvertFrom helps implement apis.Convertible
-func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, source eventingduckv1.SubscriberSpec) {
+func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, source eventingduckv1.SubscriberSpec) error {
 	sink.UID = source.UID
 	sink.Generation = source.Generation
 	sink.SubscriberURI = source.SubscriberURI
 	sink.ReplyURI = source.ReplyURI
-	sink.Delivery = &DeliverySpec{
-		DeadLetterSink: &duckv1.Destination{},
+	if source.Delivery != nil {
+		sink.Delivery = &DeliverySpec{}
+		return sink.Delivery.ConvertFrom(ctx, source.Delivery)
 	}
-	sink.Delivery.ConvertFrom(ctx, source.Delivery)
+	return nil
 }
 
 // ConvertFrom helps implement apis.Convertible

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
@@ -63,6 +63,35 @@ func TestSubscribableTypeConversion(t *testing.T) {
 			Status: SubscribableStatus{},
 		},
 	}, {
+		name: "full configuration no delivery on subscriber",
+		in: &Subscribable{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec: SubscribableSpec{
+				Subscribers: []SubscriberSpec{
+					{
+						UID:           "uid-1",
+						Generation:    7,
+						SubscriberURI: apis.HTTP("subscriber.example.com"),
+						ReplyURI:      apis.HTTP("reply.example.com"),
+					},
+				},
+			},
+			Status: SubscribableStatus{
+				Subscribers: []SubscriberStatus{
+					{
+						UID:                "status-uid-1",
+						ObservedGeneration: 99,
+						Ready:              corev1.ConditionTrue,
+						Message:            "msg",
+					},
+				},
+			},
+		},
+	}, {
 		name: "full configuration",
 		in: &Subscribable{
 			ObjectMeta: metav1.ObjectMeta{
@@ -144,6 +173,35 @@ func TestSubscribableTypeConversionWithV1(t *testing.T) {
 			},
 			Spec:   eventingv1.SubscribableSpec{},
 			Status: eventingv1.SubscribableStatus{},
+		},
+	}, {
+		name: "full configuration - no delivery on subscriber",
+		in: &eventingv1.Subscribable{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "subscribable-name",
+				Namespace:  "subscribable-ns",
+				Generation: 17,
+			},
+			Spec: eventingv1.SubscribableSpec{
+				Subscribers: []eventingv1.SubscriberSpec{
+					{
+						UID:           "uid-1",
+						Generation:    7,
+						SubscriberURI: apis.HTTP("subscriber.example.com"),
+						ReplyURI:      apis.HTTP("reply.example.com"),
+					},
+				},
+			},
+			Status: eventingv1.SubscribableStatus{
+				Subscribers: []eventingv1.SubscriberStatus{
+					{
+						UID:                "status-uid-1",
+						ObservedGeneration: 99,
+						Ready:              corev1.ConditionTrue,
+						Message:            "msg",
+					},
+				},
+			},
 		},
 	}, {
 		name: "full configuration",

--- a/pkg/apis/messaging/v1/channel_types.go
+++ b/pkg/apis/messaging/v1/channel_types.go
@@ -29,7 +29,7 @@ import (
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Channel represents a geneeric Channel. It is normally used when we want a Channel, but don't need a specific Channel implementation.
+// Channel represents a generic Channel. It is normally used when we want a Channel, but don't need a specific Channel implementation.
 type Channel struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/messaging/v1beta1/channel_conversion.go
+++ b/pkg/apis/messaging/v1beta1/channel_conversion.go
@@ -35,15 +35,14 @@ func (source *Channel) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 		}
 		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
 		source.Status.ConvertTo(ctx, &sink.Status)
-		source.Spec.ConvertTo(ctx, &sink.Spec)
-		return nil
+		return source.Spec.ConvertTo(ctx, &sink.Spec)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
 // ConvertTo helps implement apis.Convertible
-func (source *ChannelSpec) ConvertTo(ctx context.Context, sink *v1.ChannelSpec) {
+func (source *ChannelSpec) ConvertTo(ctx context.Context, sink *v1.ChannelSpec) error {
 	if source.ChannelTemplate != nil {
 		sink.ChannelTemplate = &v1.ChannelTemplateSpec{
 			TypeMeta: source.ChannelTemplate.TypeMeta,
@@ -51,11 +50,12 @@ func (source *ChannelSpec) ConvertTo(ctx context.Context, sink *v1.ChannelSpec) 
 		}
 	}
 	sink.ChannelableSpec = eventingduckv1.ChannelableSpec{}
+	source.SubscribableSpec.ConvertTo(ctx, &sink.SubscribableSpec)
 	if source.Delivery != nil {
 		sink.Delivery = &eventingduckv1.DeliverySpec{}
-		source.Delivery.ConvertTo(ctx, sink.Delivery)
+		return source.Delivery.ConvertTo(ctx, sink.Delivery)
 	}
-	source.SubscribableSpec.ConvertTo(ctx, &sink.SubscribableSpec)
+	return nil
 }
 
 // ConvertTo helps implement apis.Convertible
@@ -74,6 +74,10 @@ func (sink *Channel) ConvertFrom(ctx context.Context, obj apis.Convertible) erro
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, source.Status)
 		sink.Spec.ConvertFrom(ctx, source.Spec)
+		if sink.Annotations == nil {
+			sink.Annotations = make(map[string]string)
+		}
+		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 		return nil
 	default:
 		return fmt.Errorf("unknown version, got: %T", source)

--- a/pkg/apis/messaging/v1beta1/channel_conversion.go
+++ b/pkg/apis/messaging/v1beta1/channel_conversion.go
@@ -19,6 +19,7 @@ import (
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/apis/messaging"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 )
@@ -29,6 +30,10 @@ func (source *Channel) ConvertTo(ctx context.Context, obj apis.Convertible) erro
 	switch sink := obj.(type) {
 	case *v1.Channel:
 		sink.ObjectMeta = source.ObjectMeta
+		if sink.Annotations == nil {
+			sink.Annotations = make(map[string]string)
+		}
+		sink.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
 		source.Status.ConvertTo(ctx, &sink.Status)
 		source.Spec.ConvertTo(ctx, &sink.Spec)
 		return nil

--- a/pkg/apis/messaging/v1beta1/channel_conversion_test.go
+++ b/pkg/apis/messaging/v1beta1/channel_conversion_test.go
@@ -24,6 +24,7 @@ import (
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/duck/v1beta1"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	"knative.dev/eventing/pkg/apis/messaging"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 
 	"knative.dev/pkg/apis"
@@ -157,6 +158,11 @@ func TestChannelConversion(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+				// Make sure the annotation specifies the correct duck.
+				if test.in.Annotations == nil {
+					test.in.Annotations = make(map[string]string)
+				}
+				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 				if diff := cmp.Diff(test.in, got); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}
@@ -295,6 +301,11 @@ func TestChannelConversionWithV1(t *testing.T) {
 				if err := ver.ConvertTo(context.Background(), got); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
+				// Make sure the annotation specifies the correct duck.
+				if test.in.Annotations == nil {
+					test.in.Annotations = make(map[string]string)
+				}
+				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
 				if diff := cmp.Diff(test.in, got); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_conversion.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_conversion.go
@@ -47,14 +47,12 @@ func (source *InMemoryChannel) ConvertTo(ctx context.Context, obj apis.Convertib
 
 // ConvertTo helps implement apis.Convertible
 func (source *InMemoryChannelSpec) ConvertTo(ctx context.Context, sink *v1.InMemoryChannelSpec) error {
-	if source.Delivery != nil {
-		sink.Delivery = &eventingduckv1.DeliverySpec{}
-		if err := source.Delivery.ConvertTo(ctx, sink.Delivery); err != nil {
-			return err
-		}
-	}
 	sink.SubscribableSpec = eventingduckv1.SubscribableSpec{}
 	source.SubscribableSpec.ConvertTo(ctx, &sink.SubscribableSpec)
+	if source.Delivery != nil {
+		sink.Delivery = &eventingduckv1.DeliverySpec{}
+		return source.Delivery.ConvertTo(ctx, sink.Delivery)
+	}
 	return nil
 }
 

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -281,7 +281,8 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1
 
 func (r *Reconciler) getSubStatus(subscription *v1beta1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1beta1.SubscriberStatus, error) {
 	if channel.Annotations != nil {
-		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
+		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
+			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
 			return r.getSubStatusV1Beta1(subscription, channel)
 		}
 	}
@@ -469,7 +470,8 @@ func (r *Reconciler) patchSubscription(ctx context.Context, namespace string, ch
 
 func (r *Reconciler) updateChannelRemoveSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
 	if channel.Annotations != nil {
-		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
+		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
+			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
 			r.updateChannelRemoveSubscriptionV1Beta1(ctx, channel, sub)
 			return
 		}
@@ -505,7 +507,8 @@ func (r *Reconciler) updateChannelRemoveSubscriptionV1Alpha1(ctx context.Context
 
 func (r *Reconciler) updateChannelAddSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
 	if channel.Annotations != nil {
-		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
+		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
+			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
 			r.updateChannelAddSubscriptionV1Beta1(ctx, channel, sub)
 			return
 		}

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -38,6 +38,7 @@ import (
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/apis/messaging"
+	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/subscription"
 	listers "knative.dev/eventing/pkg/client/listers/messaging/v1beta1"
@@ -58,6 +59,7 @@ const (
 
 var (
 	v1beta1ChannelGVK = v1beta1.SchemeGroupVersion.WithKind("Channel")
+	v1ChannelGVK      = v1.SchemeGroupVersion.WithKind("Channel")
 )
 
 func newReconciledNormal(namespace, name string) pkgreconciler.Event {
@@ -360,7 +362,8 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 	// Test to see if the channel is Channel.messaging because it is going
 	// to have a "backing" channel that is what we need to actually operate on
 	// as well as keep track of.
-	if v1beta1ChannelGVK.Group == gvk.Group && v1beta1ChannelGVK.Kind == gvk.Kind {
+	if (v1beta1ChannelGVK.Group == gvk.Group && v1beta1ChannelGVK.Kind == gvk.Kind) ||
+		(v1ChannelGVK.Group == gvk.Group && v1ChannelGVK.Kind == gvk.Kind) {
 		// Track changes on Channel.
 		// Ref: https://github.com/knative/eventing/issues/2641
 		// NOTE: There is a race condition with using the channelableTracker
@@ -372,7 +375,7 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 		// to the cache we intend to use to pull the Channel from. This linkage
 		// is setup in NewController for r.tracker.
 		if err := r.tracker.TrackReference(tracker.Reference{
-			APIVersion: "messaging.knative.dev/v1beta1",
+			APIVersion: "messaging.knative.dev/" + gvk.Version,
 			Kind:       "Channel",
 			Namespace:  sub.Namespace,
 			Name:       sub.Spec.Channel.Name,

--- a/test/conformance/helpers/channel.go
+++ b/test/conformance/helpers/channel.go
@@ -27,6 +27,7 @@ import (
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 
 	"knative.dev/eventing/pkg/apis/messaging"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 )
 
@@ -36,6 +37,13 @@ var (
 	channelv1beta1 = metav1.TypeMeta{
 		Kind:       channelv1beta1GVK.Kind,
 		APIVersion: channelv1beta1GVK.GroupVersion().String(),
+	}
+
+	channelv1GVK = (&messagingv1.Channel{}).GetGroupVersionKind()
+
+	channelv1 = metav1.TypeMeta{
+		Kind:       channelv1GVK.Kind,
+		APIVersion: channelv1GVK.GroupVersion().String(),
 	}
 )
 

--- a/test/conformance/helpers/channel_spec_test_helper.go
+++ b/test/conformance/helpers/channel_spec_test_helper.go
@@ -43,7 +43,7 @@ func ChannelSpecTestHelperWithChannelTestRunner(
 		defer testlib.TearDown(client)
 
 		t.Run("Channel spec allows subscribers", func(t *testing.T) {
-			if channel == channelv1beta1 {
+			if channel == channelv1beta1 || channel == channelv1 {
 				t.Skip("Not running spec.subscribers array test for generic Channel")
 			}
 			channelSpecAllowsSubscribersArray(st, client, channel)
@@ -88,7 +88,7 @@ func channelSpecAllowsSubscribersArray(st *testing.T, client *testlib.Client, ch
 
 		ch = channelable
 
-	} else if dtsv == "v1beta1" {
+	} else if dtsv == "v1beta1" || dtsv == "v1" {
 		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
 		if err != nil {
 			st.Fatalf("Unable to get channel %s to v1beta1 duck type: %s", channel, err)

--- a/test/conformance/helpers/channel_status_subscriber_test_helper.go
+++ b/test/conformance/helpers/channel_status_subscriber_test_helper.go
@@ -94,7 +94,7 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 		if ss.Ready != corev1.ConditionTrue {
 			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
 		}
-	} else if dtsv == "v1beta1" {
+	} else if dtsv == "v1beta1" || dtsv == "v1" {
 		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
 		if err != nil {
 			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)
@@ -114,7 +114,7 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
 		}
 	} else {
-		st.Fatalf("Channel doesn't support v1alpha1 nor v1beta1 Channel duck types: %v", channel)
+		st.Fatalf("Channel doesn't support v1alpha1, v1beta1 or v1 Channel duck types: %v", channel)
 	}
 }
 

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -76,7 +76,7 @@ func channelHasRequiredStatus(st *testing.T, client *testlib.Client, channel met
 		if channelable.Status.AddressStatus.Address.URL.IsEmpty() {
 			st.Fatalf("No hostname found for %q", channel)
 		}
-	} else if dtsv == "v1beta1" dtsv == "v1" {
+	} else if dtsv == "v1beta1" || dtsv == "v1" {
 		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
 		if err != nil {
 			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)

--- a/test/conformance/helpers/channel_status_test_helper.go
+++ b/test/conformance/helpers/channel_status_test_helper.go
@@ -76,7 +76,7 @@ func channelHasRequiredStatus(st *testing.T, client *testlib.Client, channel met
 		if channelable.Status.AddressStatus.Address.URL.IsEmpty() {
 			st.Fatalf("No hostname found for %q", channel)
 		}
-	} else if dtsv == "v1beta1" {
+	} else if dtsv == "v1beta1" dtsv == "v1" {
 		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
 		if err != nil {
 			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,6 +35,6 @@ initialize $@ --skip-istio-addon
 install_mt_broker || fail_test "Could not install MT Channel Based Broker"
 
 echo "Running tests with Multi Tenant Channel Based Broker"
-go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
+go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
 
 success

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -35,6 +35,6 @@ initialize $@ --skip-istio-addon
 install_mt_broker || fail_test "Could not install MT Channel Based Broker"
 
 echo "Running tests with Multi Tenant Channel Based Broker"
-go_test_e2e -timeout=20m -parallel=12 ./test/e2e ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
+go_test_e2e -timeout=30m -parallel=12 ./test/e2e ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
 
 success

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -66,6 +66,11 @@ install_mt_broker || fail_test 'Installing HEAD Broker failed'
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout="${TIMEOUT}" ./test/upgrade || fail_test
 
+# We need to manually patch the Subscription because the newer version has webhook
+# and the older one doesn't have it and simply applying it will not work.
+# https://github.com/knative/eventing/issues/3466
+kubectl patch crd subscriptions.messaging.knative.dev --type='json' -p '[{"op" : "remove", "path" : "/spec/conversion/webhook"},{"op":"replace", "path":"/spec/conversion/strategy","value" : "None"}]'
+
 header "Performing downgrade to latest release"
 install_latest_release || fail_test 'Installing latest release of Knative Eventing failed'
 

--- a/test/e2e/channel_chain_test.go
+++ b/test/e2e/channel_chain_test.go
@@ -31,5 +31,9 @@ EventSource ---> Channel ---> Subscriptions ---> Channel ---> Subscriptions --->
 
 */
 func TestChannelChain(t *testing.T) {
-	helpers.ChannelChainTestHelper(t, channelTestRunner)
+	helpers.ChannelChainTestHelper(t, helpers.SubscriptionV1beta1, channelTestRunner)
+}
+
+func TestChannelChainV1(t *testing.T) {
+	helpers.ChannelChainTestHelper(t, helpers.SubscriptionV1, channelTestRunner)
 }

--- a/test/e2e/channel_dls_test.go
+++ b/test/e2e/channel_dls_test.go
@@ -26,5 +26,9 @@ import (
 
 // TestChannelDeadLetterSink tests DeadLetterSink
 func TestChannelDeadLetterSink(t *testing.T) {
-	helpers.ChannelDeadLetterSinkTestHelper(t, channelTestRunner)
+	helpers.ChannelDeadLetterSinkTestHelper(t, helpers.SubscriptionV1beta1, channelTestRunner)
+}
+
+func TestChannelDeadLetterSinkV1(t *testing.T) {
+	helpers.ChannelDeadLetterSinkTestHelper(t, helpers.SubscriptionV1beta1, channelTestRunner)
 }

--- a/test/e2e/channel_event_transformation_test.go
+++ b/test/e2e/channel_event_transformation_test.go
@@ -36,5 +36,9 @@ EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> 
                                    -----------> Service(Transformation)
 */
 func TestEventTransformationForSubscription(t *testing.T) {
-	helpers.EventTransformationForSubscriptionTestHelper(t, channelTestRunner)
+	helpers.EventTransformationForSubscriptionTestHelper(t, helpers.SubscriptionV1beta1, channelTestRunner)
+}
+
+func TestEventTransformationForSubscriptionV1(t *testing.T) {
+	helpers.EventTransformationForSubscriptionTestHelper(t, helpers.SubscriptionV1, channelTestRunner)
 }

--- a/test/e2e/channel_single_event_test.go
+++ b/test/e2e/channel_single_event_test.go
@@ -52,3 +52,23 @@ func TestSingleStructuredEventForChannelV1Beta1(t *testing.T) {
 		channelTestRunner,
 	)
 }
+
+func TestSingleBinaryEventForChannelV1(t *testing.T) {
+	helpers.SingleEventForChannelTestHelper(
+		t,
+		cloudevents.EncodingBinary,
+		helpers.SubscriptionV1,
+		"",
+		channelTestRunner,
+	)
+}
+
+func TestSingleStructuredEventForChannelV1(t *testing.T) {
+	helpers.SingleEventForChannelTestHelper(
+		t,
+		cloudevents.EncodingStructured,
+		helpers.SubscriptionV1,
+		"",
+		channelTestRunner,
+	)
+}

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -36,6 +36,7 @@ type SubscriptionVersion string
 
 const (
 	SubscriptionV1beta1 SubscriptionVersion = "v1beta1"
+	SubscriptionV1      SubscriptionVersion = "v1"
 )
 
 // SingleEventForChannelTestHelper is the helper function for channel_single_event_test
@@ -73,6 +74,13 @@ func SingleEventForChannelTestHelper(t *testing.T, encoding cloudevents.Encoding
 		}
 		// create subscription to subscribe the channel, and forward the received events to the logger service
 		switch subscriptionVersion {
+		case SubscriptionV1:
+			client.CreateSubscriptionV1OrFail(
+				subscriptionName,
+				channelName,
+				&channel,
+				resources.WithSubscriberForSubscriptionV1(eventRecorder),
+			)
 		case SubscriptionV1beta1:
 			client.CreateSubscriptionOrFail(
 				subscriptionName,

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	flowsv1beta1 "knative.dev/eventing/pkg/apis/flows/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing/pkg/utils"
@@ -71,7 +72,7 @@ func (c *Client) CreateChannelsOrFail(names []string, channelTypeMeta *metav1.Ty
 
 // CreateChannelWithDefaultOrFail will create a default Channel Resource in Eventing or fail the test if there is an error.
 func (c *Client) CreateChannelWithDefaultOrFail(channel *messagingv1beta1.Channel) {
-	c.T.Logf("Creating default channel %+v", channel)
+	c.T.Logf("Creating default v1beta1 channel %+v", channel)
 	channels := c.Eventing.MessagingV1beta1().Channels(c.Namespace)
 	_, err := channels.Create(channel)
 	if err != nil {
@@ -80,7 +81,18 @@ func (c *Client) CreateChannelWithDefaultOrFail(channel *messagingv1beta1.Channe
 	c.Tracker.AddObj(channel)
 }
 
-// CreateSubscriptionOrFail will create a Subscription or fail the test if there is an error.
+// CreateChannelV1WithDefaultOrFail will create a default Channel Resource in Eventing or fail the test if there is an error.
+func (c *Client) CreateChannelV1WithDefaultOrFail(channel *messagingv1.Channel) {
+	c.T.Logf("Creating default v1 channel %+v", channel)
+	channels := c.Eventing.MessagingV1().Channels(c.Namespace)
+	_, err := channels.Create(channel)
+	if err != nil {
+		c.T.Fatalf("Failed to create channel %q: %v", channel.Name, err)
+	}
+	c.Tracker.AddObj(channel)
+}
+
+// CreateSubscriptionOrFail will create a v1beta1 Subscription or fail the test if there is an error.
 func (c *Client) CreateSubscriptionOrFail(
 	name, channelName string,
 	channelTypeMeta *metav1.TypeMeta,
@@ -99,7 +111,26 @@ func (c *Client) CreateSubscriptionOrFail(
 	return subscription
 }
 
-// CreateSubscriptionsOrFail will create a list of Subscriptions with the same configuration except the name.
+// CreateSubscriptionV1OrFail will create a v1 Subscription or fail the test if there is an error.
+func (c *Client) CreateSubscriptionV1OrFail(
+	name, channelName string,
+	channelTypeMeta *metav1.TypeMeta,
+	options ...resources.SubscriptionOptionV1,
+) *messagingv1.Subscription {
+	namespace := c.Namespace
+	subscription := resources.SubscriptionV1(name, channelName, channelTypeMeta, options...)
+	subscriptions := c.Eventing.MessagingV1().Subscriptions(namespace)
+	c.T.Logf("Creating v1 subscription %s for channel %+v-%s", name, channelTypeMeta, channelName)
+	// update subscription with the new reference
+	subscription, err := subscriptions.Create(subscription)
+	if err != nil {
+		c.T.Fatalf("Failed to create subscription %q: %v", name, err)
+	}
+	c.Tracker.AddObj(subscription)
+	return subscription
+}
+
+// CreateSubscriptionsOrFail will create a list of v1beta1 Subscriptions with the same configuration except the name.
 func (c *Client) CreateSubscriptionsOrFail(
 	names []string,
 	channelName string,
@@ -109,6 +140,19 @@ func (c *Client) CreateSubscriptionsOrFail(
 	c.T.Logf("Creating subscriptions %v for channel %+v-%s", names, channelTypeMeta, channelName)
 	for _, name := range names {
 		c.CreateSubscriptionOrFail(name, channelName, channelTypeMeta, options...)
+	}
+}
+
+// CreateSubscriptionsV1OrFail will create a list of v1 Subscriptions with the same configuration except the name.
+func (c *Client) CreateSubscriptionsV1OrFail(
+	names []string,
+	channelName string,
+	channelTypeMeta *metav1.TypeMeta,
+	options ...resources.SubscriptionOptionV1,
+) {
+	c.T.Logf("Creating subscriptions %v for channel %+v-%s", names, channelTypeMeta, channelName)
+	for _, name := range names {
+		c.CreateSubscriptionV1OrFail(name, channelName, channelTypeMeta, options...)
 	}
 }
 


### PR DESCRIPTION
Addresses #3446 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add v1 types for crds: channel,inmemorychannel,subscription
- add e2e tests
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Add new feature bump channel, subscription, inmemorychannel to v1.
After upgrading to this version if you downgrade to .15 you must first manually patch (or edit) subscriptions.messaging.knative.dev CRD like so:
kubectl patch crd subscriptions.messaging.knative.dev --type='json' -p '[{"op" : "remove", "path" : "/spec/conversion/webhook"},{"op":"replace", "path":"/spec/conversion/strategy","value" : "None"}]'

# https://github.com/knative/eventing/issues/3466
```

**Docs**
https://github.com/knative/docs/pull/2630

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
