### PR TITLE
add cluster role for bindings

### DIFF
--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -59,7 +59,18 @@ rules:
   - apiGroups: ["sources.knative.dev"]
     resources: ["*"]
     verbs: ["*"]
-
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-bindings-namespaced-admin
+  labels:
+    eventing.knative.dev/release: devel
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["bindings.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes #3464

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add cluster role which will give namespace admin to manage bindings.knative.dev
- As this is a common Cluster Role creating here instead of eventing contrib
