### PR TITLE
fix subscription conversion for proper downgrade

### DIFF
--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -35,12 +35,11 @@ spec:
   subresources:
     status: {}
   conversion:
-    strategy: None
-#    strategy: Webhook
-#    webhookClientConfig:
-#      service:
-#        name: eventing-webhook
-#        namespace: knative-eventing
+   strategy: Webhook
+   webhookClientConfig:
+     service:
+       name: eventing-webhook
+       namespace: knative-eventing
   additionalPrinterColumns:
     - name: Ready
       type: string


### PR DESCRIPTION
Fixes #3466

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Change Subscription CRD conversion strategy from None to Webhook to support downgrade.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug Without this change you're not able to downgrade from .16 to .15 because the Subscription CRD won't work.
ACTION REQUIRED. If you are going to downgrade from .16, you must upgrade to this version.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
