### PR TITLE
Do not default trigger.spec.broker for v1.Trigger

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -62,12 +62,13 @@ spec:
         properties:
           spec:
             required:
+              - broker
               - subscriber
             type: object
             properties:
               broker:
                 type: string
-                description: "Broker that this trigger receives events from. If not specified, will default to 'default'."
+                description: "Broker that this trigger receives events from."
               filter:
                 type: object
                 properties:

--- a/pkg/apis/eventing/v1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1/trigger_defaults.go
@@ -33,9 +33,6 @@ func (t *Trigger) SetDefaults(ctx context.Context) {
 }
 
 func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
-	if ts.Broker == "" {
-		ts.Broker = "default"
-	}
 	// Make a default filter that allows anything.
 	if ts.Filter == nil {
 		ts.Filter = &TriggerFilter{}
@@ -45,8 +42,10 @@ func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
 }
 
 func setLabels(t *Trigger) {
-	if len(t.Labels) == 0 {
-		t.Labels = map[string]string{}
+	if t.Spec.Broker != "" {
+		if len(t.Labels) == 0 {
+			t.Labels = map[string]string{}
+		}
+		t.Labels[brokerLabel] = t.Spec.Broker
 	}
-	t.Labels[brokerLabel] = t.Spec.Broker
 }

--- a/pkg/apis/eventing/v1/trigger_defaults_test.go
+++ b/pkg/apis/eventing/v1/trigger_defaults_test.go
@@ -32,15 +32,7 @@ var (
 	otherBroker        = "other_broker"
 	namespace          = "testnamespace"
 	emptyTriggerFilter = &TriggerFilter{}
-	defaultTrigger     = Trigger{
-		ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{brokerLabel: defaultBroker},
-		},
-		Spec: TriggerSpec{
-			Broker: defaultBroker,
-			Filter: emptyTriggerFilter,
-		},
-	}
+	defaultTrigger     = Trigger{Spec: TriggerSpec{Filter: emptyTriggerFilter}}
 )
 
 func TestTriggerDefaults(t *testing.T) {
@@ -49,12 +41,8 @@ func TestTriggerDefaults(t *testing.T) {
 		expected Trigger
 	}{
 		"nil broker": {
-			initial: Trigger{Spec: TriggerSpec{Filter: emptyTriggerFilter}},
-			expected: Trigger{
-				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{brokerLabel: defaultBroker},
-				},
-				Spec: TriggerSpec{Broker: defaultBroker, Filter: emptyTriggerFilter}},
+			initial:  Trigger{Spec: TriggerSpec{Filter: emptyTriggerFilter}},
+			expected: defaultTrigger,
 		},
 		"nil filter": {
 			initial: Trigger{Spec: TriggerSpec{Broker: otherBroker}},


### PR DESCRIPTION
Addresses #3138 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do not default v1 Trigger.spec.broker anymore

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🗑️ Remove feature or internal logic
For v1 Trigger you must always specify a spec.broker, it is no longer defaulted to "default" 
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
