### PR TITLE
add a hack to work around knative-monitoring ns missing

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -102,6 +102,9 @@ function install_knative_eventing() {
     --field-selector status.phase=Running 2> /dev/null | tail -n +2 | wc -l)
   if ! [[ ${knative_monitoring_pods} -gt 0 ]]; then
     echo ">> Installing Knative Monitoring"
+    # Hack hack hack. Why is this namespace not created as part of monitoring release.
+    # https://github.com/knative/eventing/issues/3469
+    kubectl create ns knative-monitoring
     start_knative_monitoring "${KNATIVE_MONITORING_RELEASE}" || fail_test "Knative Monitoring did not come up"
     UNINSTALL_LIST+=( "${KNATIVE_MONITORING_RELEASE}" )
   else


### PR DESCRIPTION
Fixes #3469 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- create knative-monitoring namespace in the tests because somehow it's gone missing from the release.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
