### PR TITLE
Make SubscribableSpec implement apis.Convertible

### DIFF
--- a/pkg/apis/duck/v1/subscribable_types.go
+++ b/pkg/apis/duck/v1/subscribable_types.go
@@ -107,6 +107,7 @@ var (
 	_ apis.Listable    = (*Subscribable)(nil)
 
 	_ apis.Convertible = (*Subscribable)(nil)
+	_ apis.Convertible = (*SubscribableSpec)(nil)
 	_ apis.Convertible = (*SubscribableStatus)(nil)
 )
 

--- a/pkg/apis/duck/v1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion.go
@@ -34,6 +34,16 @@ func (sink *Subscribable) ConvertFrom(ctx context.Context, source apis.Convertib
 }
 
 // ConvertTo implements apis.Convertible
+func (source *SubscribableSpec) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (sink *SubscribableSpec) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}
+
+// ConvertTo implements apis.Convertible
 func (source *SubscribableStatus) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
 }

--- a/pkg/apis/duck/v1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion_test.go
@@ -33,6 +33,18 @@ func TestSubscribableConversionBadType(t *testing.T) {
 	}
 }
 
+func TestSubscribableSpecConversionBadType(t *testing.T) {
+	good, bad := &SubscribableSpec{}, &SubscribableSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
 func TestSubscribableStatusConversionBadType(t *testing.T) {
 	good, bad := &SubscribableStatus{}, &SubscribableStatus{}
 

--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -108,6 +108,7 @@ var (
 
 	_ apis.Convertible = (*SubscribableType)(nil)
 
+	_ apis.Convertible = (*SubscribableTypeSpec)(nil)
 	_ apis.Convertible = (*SubscribableTypeStatus)(nil)
 )
 

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
@@ -39,13 +39,18 @@ func (source *SubscribableType) ConvertTo(ctx context.Context, obj apis.Converti
 	}
 }
 
-// ConvertTo helps implement apis.Convertible
-func (source *SubscribableTypeSpec) ConvertTo(ctx context.Context, sink *duckv1beta1.SubscribableSpec) error {
-	if source.Subscribable != nil {
-		sink.Subscribers = make([]duckv1beta1.SubscriberSpec, len(source.Subscribable.Subscribers))
-		for i, s := range source.Subscribable.Subscribers {
-			s.ConvertTo(ctx, &sink.Subscribers[i])
+// ConvertTo implements apis.Convertible
+func (source *SubscribableTypeSpec) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *duckv1beta1.SubscribableSpec:
+		if source.Subscribable != nil {
+			sink.Subscribers = make([]duckv1beta1.SubscriberSpec, len(source.Subscribable.Subscribers))
+			for i, s := range source.Subscribable.Subscribers {
+				s.ConvertTo(ctx, &sink.Subscribers[i])
+			}
 		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 	return nil
 }
@@ -105,16 +110,22 @@ func (sink *SubscribableType) ConvertFrom(ctx context.Context, obj apis.Converti
 	}
 }
 
-// ConvertFrom helps implement apis.Convertible
-func (sink *SubscribableTypeSpec) ConvertFrom(ctx context.Context, source duckv1beta1.SubscribableSpec) {
-	if len(source.Subscribers) > 0 {
-		sink.Subscribable = &Subscribable{
-			Subscribers: make([]SubscriberSpec, len(source.Subscribers)),
+// ConvertFrom implements apis.Convertible
+func (sink *SubscribableTypeSpec) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *duckv1beta1.SubscribableSpec:
+		if len(source.Subscribers) > 0 {
+			sink.Subscribable = &Subscribable{
+				Subscribers: make([]SubscriberSpec, len(source.Subscribers)),
+			}
+			for i, s := range source.Subscribers {
+				sink.Subscribable.Subscribers[i].ConvertFrom(ctx, s)
+			}
 		}
-		for i, s := range source.Subscribers {
-			sink.Subscribable.Subscribers[i].ConvertFrom(ctx, s)
-		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", source)
 	}
+	return nil
 }
 
 // ConvertFrom helps implement apis.Convertible

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
@@ -103,7 +103,7 @@ func (sink *SubscribableType) ConvertFrom(ctx context.Context, obj apis.Converti
 	case *duckv1beta1.Subscribable:
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, &source.Status)
-		sink.Spec.ConvertFrom(ctx, source.Spec)
+		sink.Spec.ConvertFrom(ctx, &source.Spec)
 		return nil
 	default:
 		return fmt.Errorf("unknown version, got: %T", source)

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
@@ -215,6 +215,18 @@ func TestSubscribableTypeConversionWithV1Beta1(t *testing.T) {
 	}
 }
 
+func TestSubscribableTypeSpecStatusConversionBadType(t *testing.T) {
+	good, bad := &SubscribableTypeSpec{}, &SubscribableTypeSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
 func TestSubscribableTypeStatusConversionBadType(t *testing.T) {
 	good, bad := &SubscribableTypeStatus{}, &SubscribableTypeStatus{}
 

--- a/pkg/apis/duck/v1beta1/subscribable_types.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types.go
@@ -107,6 +107,7 @@ var (
 	_ apis.Listable    = (*Subscribable)(nil)
 
 	_ apis.Convertible = (*Subscribable)(nil)
+	_ apis.Convertible = (*SubscribableSpec)(nil)
 	_ apis.Convertible = (*SubscribableStatus)(nil)
 )
 

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -39,14 +39,19 @@ func (source *Subscribable) ConvertTo(ctx context.Context, to apis.Convertible) 
 }
 
 // ConvertTo helps implement apis.Convertible
-func (source *SubscribableSpec) ConvertTo(ctx context.Context, sink *eventingduckv1.SubscribableSpec) {
-	if len(source.Subscribers) > 0 {
-		sink.Subscribers = make([]eventingduckv1.SubscriberSpec, len(source.Subscribers))
-		for i, s := range source.Subscribers {
-			s.ConvertTo(ctx, &sink.Subscribers[i])
+func (source *SubscribableSpec) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *eventingduckv1.SubscribableSpec:
+		if len(source.Subscribers) > 0 {
+			sink.Subscribers = make([]eventingduckv1.SubscriberSpec, len(source.Subscribers))
+			for i, s := range source.Subscribers {
+				s.ConvertTo(ctx, &sink.Subscribers[i])
+			}
 		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
 	}
-
+	return nil
 }
 
 // ConvertTo helps implement apis.Convertible
@@ -98,14 +103,19 @@ func (sink *Subscribable) ConvertFrom(ctx context.Context, from apis.Convertible
 }
 
 // ConvertFrom helps implement apis.Convertible
-func (sink *SubscribableSpec) ConvertFrom(ctx context.Context, source eventingduckv1.SubscribableSpec) error {
-	if len(source.Subscribers) > 0 {
-		sink.Subscribers = make([]SubscriberSpec, len(source.Subscribers))
-		for i, s := range source.Subscribers {
-			if err := sink.Subscribers[i].ConvertFrom(ctx, s); err != nil {
-				return err
+func (sink *SubscribableSpec) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *eventingduckv1.SubscribableSpec:
+		if len(source.Subscribers) > 0 {
+			sink.Subscribers = make([]SubscriberSpec, len(source.Subscribers))
+			for i, s := range source.Subscribers {
+				if err := sink.Subscribers[i].ConvertFrom(ctx, s); err != nil {
+					return err
+				}
 			}
 		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", source)
 	}
 	return nil
 }

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -96,7 +96,7 @@ func (sink *Subscribable) ConvertFrom(ctx context.Context, from apis.Convertible
 	case *eventingduckv1.Subscribable:
 		sink.ObjectMeta = source.ObjectMeta
 		sink.Status.ConvertFrom(ctx, &source.Status)
-		return sink.Spec.ConvertFrom(ctx, source.Spec)
+		return sink.Spec.ConvertFrom(ctx, &source.Spec)
 	default:
 		return fmt.Errorf("unknown version, got: %T", source)
 	}

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
@@ -266,6 +266,18 @@ func TestSubscribableTypeConversionWithV1(t *testing.T) {
 	}
 }
 
+func TestSubscribableSpecConversionBadType(t *testing.T) {
+	good, bad := &SubscribableSpec{}, &SubscribableSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
 func TestSubscribableStatusConversionBadType(t *testing.T) {
 	good, bad := &SubscribableStatus{}, &SubscribableStatus{}
 

--- a/pkg/apis/messaging/v1beta1/channel_conversion.go
+++ b/pkg/apis/messaging/v1beta1/channel_conversion.go
@@ -96,7 +96,7 @@ func (sink *ChannelSpec) ConvertFrom(ctx context.Context, source v1.ChannelSpec)
 		sink.Delivery = &v1beta1.DeliverySpec{}
 		sink.Delivery.ConvertFrom(ctx, source.Delivery)
 	}
-	sink.ChannelableSpec.SubscribableSpec.ConvertFrom(ctx, source.ChannelableSpec.SubscribableSpec)
+	sink.ChannelableSpec.SubscribableSpec.ConvertFrom(ctx, &source.ChannelableSpec.SubscribableSpec)
 }
 
 // ConvertFrom helps implement apis.Convertible

--- a/pkg/apis/messaging/v1beta1/in_memory_channel_conversion.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_conversion.go
@@ -91,7 +91,7 @@ func (sink *InMemoryChannelSpec) ConvertFrom(ctx context.Context, source v1.InMe
 		}
 	}
 	sink.SubscribableSpec = eventingduckv1beta1.SubscribableSpec{}
-	sink.SubscribableSpec.ConvertFrom(ctx, source.SubscribableSpec)
+	sink.SubscribableSpec.ConvertFrom(ctx, &source.SubscribableSpec)
 	return nil
 }
 


### PR DESCRIPTION
Part of https://github.com/knative/eventing/issues/3474

Same story with that https://github.com/knative/eventing/pull/3471, but for `SubscribableSpec`