### PR TITLE
Make SubscriberSpec implement apis.Convertible

### DIFF
--- a/pkg/apis/duck/v1/subscribable_types.go
+++ b/pkg/apis/duck/v1/subscribable_types.go
@@ -109,6 +109,8 @@ var (
 	_ apis.Convertible = (*Subscribable)(nil)
 	_ apis.Convertible = (*SubscribableSpec)(nil)
 	_ apis.Convertible = (*SubscribableStatus)(nil)
+
+	_ apis.Convertible = (*SubscriberSpec)(nil)
 )
 
 // GetFullType implements duck.Implementable

--- a/pkg/apis/duck/v1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion.go
@@ -52,3 +52,13 @@ func (source *SubscribableStatus) ConvertTo(ctx context.Context, sink apis.Conve
 func (sink *SubscribableStatus) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1 is the highest known version, got: %T", source)
 }
+
+// ConvertTo implements apis.Convertible
+func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/duck/v1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion_test.go
@@ -56,3 +56,15 @@ func TestSubscribableStatusConversionBadType(t *testing.T) {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
+
+func TestSubscriberSpecConversionBadType(t *testing.T) {
+	good, bad := &SubscriberSpec{}, &SubscriberSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -110,6 +110,8 @@ var (
 
 	_ apis.Convertible = (*SubscribableTypeSpec)(nil)
 	_ apis.Convertible = (*SubscribableTypeStatus)(nil)
+
+	_ apis.Convertible = (*SubscriberSpec)(nil)
 )
 
 // GetSubscribableTypeStatus method Returns the Default SubscribableStatus in this case it's SubscribableStatus

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
@@ -238,3 +238,15 @@ func TestSubscribableTypeStatusConversionBadType(t *testing.T) {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
+
+func TestSubscriberSpecStatusConversionBadType(t *testing.T) {
+	good, bad := &SubscriberSpec{}, &SubscriberSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/duck/v1beta1/subscribable_types.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types.go
@@ -109,6 +109,8 @@ var (
 	_ apis.Convertible = (*Subscribable)(nil)
 	_ apis.Convertible = (*SubscribableSpec)(nil)
 	_ apis.Convertible = (*SubscribableStatus)(nil)
+
+	_ apis.Convertible = (*SubscriberSpec)(nil)
 )
 
 // GetFullType implements duck.Implementable

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
@@ -289,3 +289,15 @@ func TestSubscribableStatusConversionBadType(t *testing.T) {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
+
+func TestSubscriberSpecConversionBadType(t *testing.T) {
+	good, bad := &SubscriberSpec{}, &SubscriberSpec{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/knative/eventing/issues/3474

Same story with https://github.com/knative/eventing/pull/3471 , but for `SubscriberSpec`