### PR TITLE
Make SubscriberStatus implement apis.Convertible

### DIFF
--- a/pkg/apis/duck/v1/subscribable_types.go
+++ b/pkg/apis/duck/v1/subscribable_types.go
@@ -111,6 +111,7 @@ var (
 	_ apis.Convertible = (*SubscribableStatus)(nil)
 
 	_ apis.Convertible = (*SubscriberSpec)(nil)
+	_ apis.Convertible = (*SubscriberStatus)(nil)
 )
 
 // GetFullType implements duck.Implementable

--- a/pkg/apis/duck/v1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion.go
@@ -62,3 +62,13 @@ func (source *SubscriberSpec) ConvertTo(ctx context.Context, sink apis.Convertib
 func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1 is the highest known version, got: %T", source)
 }
+
+// ConvertTo implements apis.Convertible
+func (source *SubscriberStatus) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (sink *SubscriberStatus) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/duck/v1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1/subscribable_types_conversion_test.go
@@ -68,3 +68,15 @@ func TestSubscriberSpecConversionBadType(t *testing.T) {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
+
+func TestSubscriberStatusConversionBadType(t *testing.T) {
+	good, bad := &SubscriberStatus{}, &SubscriberStatus{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
@@ -215,7 +215,7 @@ func TestSubscribableTypeConversionWithV1Beta1(t *testing.T) {
 	}
 }
 
-func TestSubscribableTypeSpecStatusConversionBadType(t *testing.T) {
+func TestSubscribableTypeSpecConversionBadType(t *testing.T) {
 	good, bad := &SubscribableTypeSpec{}, &SubscribableTypeSpec{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {
@@ -239,7 +239,7 @@ func TestSubscribableTypeStatusConversionBadType(t *testing.T) {
 	}
 }
 
-func TestSubscriberSpecStatusConversionBadType(t *testing.T) {
+func TestSubscriberSpecConversionBadType(t *testing.T) {
 	good, bad := &SubscriberSpec{}, &SubscriberSpec{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {

--- a/pkg/apis/duck/v1beta1/subscribable_types.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types.go
@@ -111,6 +111,7 @@ var (
 	_ apis.Convertible = (*SubscribableStatus)(nil)
 
 	_ apis.Convertible = (*SubscriberSpec)(nil)
+	_ apis.Convertible = (*SubscriberStatus)(nil)
 )
 
 // GetFullType implements duck.Implementable

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion.go
@@ -81,14 +81,26 @@ func (source *SubscribableStatus) ConvertTo(ctx context.Context, obj apis.Conver
 		if len(source.Subscribers) > 0 {
 			sink.Subscribers = make([]eventingduckv1.SubscriberStatus, len(source.Subscribers))
 			for i, ss := range source.Subscribers {
-				sink.Subscribers[i] = eventingduckv1.SubscriberStatus{
-					UID:                ss.UID,
-					ObservedGeneration: ss.ObservedGeneration,
-					Ready:              ss.Ready,
-					Message:            ss.Message,
+				sink.Subscribers[i] = eventingduckv1.SubscriberStatus{}
+				if err := ss.ConvertTo(ctx, &sink.Subscribers[i]); err != nil {
+					return err
 				}
 			}
 		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
+	}
+	return nil
+}
+
+// ConvertTo implements apis.Convertible
+func (source *SubscriberStatus) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *eventingduckv1.SubscriberStatus:
+		sink.UID = source.UID
+		sink.ObservedGeneration = source.ObservedGeneration
+		sink.Ready = source.Ready
+		sink.Message = source.Message
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
@@ -150,14 +162,26 @@ func (sink *SubscribableStatus) ConvertFrom(ctx context.Context, obj apis.Conver
 		if len(source.Subscribers) > 0 {
 			sink.Subscribers = make([]SubscriberStatus, len(source.Subscribers))
 			for i, ss := range source.Subscribers {
-				sink.Subscribers[i] = SubscriberStatus{
-					UID:                ss.UID,
-					ObservedGeneration: ss.ObservedGeneration,
-					Ready:              ss.Ready,
-					Message:            ss.Message,
+				sink.Subscribers[i] = SubscriberStatus{}
+				if err := sink.Subscribers[i].ConvertFrom(ctx, &ss); err != nil {
+					return err
 				}
 			}
 		}
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
+	}
+	return nil
+}
+
+// ConvertFrom implements apis.Convertible
+func (sink *SubscriberStatus) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *eventingduckv1.SubscriberStatus:
+		sink.UID = source.UID
+		sink.ObservedGeneration = source.ObservedGeneration
+		sink.Ready = source.Ready
+		sink.Message = source.Message
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}

--- a/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1beta1/subscribable_types_conversion_test.go
@@ -301,3 +301,15 @@ func TestSubscriberSpecConversionBadType(t *testing.T) {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
 	}
 }
+
+func TestSubscriberStatusConversionBadType(t *testing.T) {
+	good, bad := &SubscriberStatus{}, &SubscriberStatus{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/knative/eventing/issues/3474

Same story with https://github.com/knative/eventing/pull/3471, but for `SubscriberStatus`