### PR TITLE
[master] golang format tools

### DIFF
--- a/pkg/apis/messaging/v1beta1/in_memory_channel_conversion_test.go
+++ b/pkg/apis/messaging/v1beta1/in_memory_channel_conversion_test.go
@@ -259,25 +259,25 @@ func TestInMemoryChannelConversion(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				ver := &v1.InMemoryChannel{}
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
-					t.Errorf("ConvertTo() = %v", err)
-				}
-				got := &InMemoryChannel{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
-					t.Errorf("ConvertFrom() = %v", err)
-				}
-				// Make sure the annotation specifies the correct duck.
-				if test.in.Annotations == nil {
-					test.in.Annotations = make(map[string]string)
-				}
-				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
+		t.Run(test.name, func(t *testing.T) {
+			ver := &v1.InMemoryChannel{}
+			if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				t.Errorf("ConvertTo() = %v", err)
+			}
+			got := &InMemoryChannel{}
+			if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				t.Errorf("ConvertFrom() = %v", err)
+			}
+			// Make sure the annotation specifies the correct duck.
+			if test.in.Annotations == nil {
+				test.in.Annotations = make(map[string]string)
+			}
+			test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 
-				if diff := cmp.Diff(test.in, got); diff != "" {
-					t.Errorf("roundtrip (-want, +got) = %v", diff)
-				}
-			})
+			if diff := cmp.Diff(test.in, got); diff != "" {
+				t.Errorf("roundtrip (-want, +got) = %v", diff)
+			}
+		})
 	}
 }
 
@@ -496,25 +496,25 @@ func TestInMemoryChannelConversionWithV1Beta1(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				version := &InMemoryChannel{}
-				if err := version.ConvertFrom(context.Background(), test.in); err != nil {
-					t.Errorf("ConvertTo() = %v", err)
-				}
-				got := &v1.InMemoryChannel{}
-				if err := version.ConvertTo(context.Background(), got); err != nil {
-					t.Errorf("ConvertFrom() = %v", err)
-				}
-				// Make sure the annotation specifies the correct duck.
-				if test.in.Annotations == nil {
-					test.in.Annotations = make(map[string]string)
-				}
-				test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+		t.Run(test.name, func(t *testing.T) {
+			version := &InMemoryChannel{}
+			if err := version.ConvertFrom(context.Background(), test.in); err != nil {
+				t.Errorf("ConvertTo() = %v", err)
+			}
+			got := &v1.InMemoryChannel{}
+			if err := version.ConvertTo(context.Background(), got); err != nil {
+				t.Errorf("ConvertFrom() = %v", err)
+			}
+			// Make sure the annotation specifies the correct duck.
+			if test.in.Annotations == nil {
+				test.in.Annotations = make(map[string]string)
+			}
+			test.in.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
 
-				if diff := cmp.Diff(test.in, got); diff != "" {
-					t.Errorf("roundtrip (-want, +got) = %v", diff)
-				}
-			})
+			if diff := cmp.Diff(test.in, got); diff != "" {
+				t.Errorf("roundtrip (-want, +got) = %v", diff)
+			}
+		})
 
 	}
 }


### PR DESCRIPTION
<!--[master] golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)`
/assign grantr n3wscott
/cc grantr n3wscott
