### PR TITLE
remove the v1alpha1 api versions all together

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -24,9 +24,9 @@ spec:
   group: messaging.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
     schema:
@@ -50,10 +50,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
   - << : *version
     name: v1
     served: true

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -24,9 +24,9 @@ spec:
   group: eventing.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
     schema:
@@ -50,10 +50,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
   - << : *version
     name: v1
     served: true

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -25,85 +25,11 @@ spec:
   group: messaging.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              channelTemplate:
-                description: "Channel implementation which dictates the durability guarantees of events. If not specified then the default channel is used. More information: https://knative.dev/docs/eventing/channels/default-channels."
-                type: object
-                properties:
-                  apiVersion:
-                    type: string
-                    description: "API version of the channel implementation."
-                    minLength: 1
-                  kind:
-                    type: string
-                    description: "Kind of the channel implementation to use (InMemoryChannel, KafkaChannel, etc.)."
-                    minLength: 1
-                  spec:
-                    type: object
-                    description: "Spec defines the Spec to use for each channel created. Passed in verbatim to the Channel CRD as Spec section."
-                required:
-                  - apiVersion
-                  - kind
-              subscribable:
-                type: object
-                properties:
-                  subscribers:
-                    type: array
-                    description: "Events received on the channel are forwarded to its subscribers."
-                    items:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                      required:
-                        - uid
-                      properties:
-                        ref:
-                          type: object
-                          description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                          x-kubernetes-preserve-unknown-fields: true
-                          required:
-                            - namespace
-                            - name
-                            - uid
-                          properties:
-                            apiVersion:
-                              type: string
-                            kind:
-                              type: string
-                            name:
-                              type: string
-                              minLength: 1
-                            namespace:
-                              type: string
-                              minLength: 1
-                            uid:
-                              type: string
-                              minLength: 1
-                        uid:
-                          type: string
-                          description: "Used to understand the origin of the subscriber."
-                          minLength: 1
-                        subscriberURI:
-                          type: string
-                          description: "Endpoint for the subscriber."
-                          minLength: 1
-                        replyURI:
-                          type: string
-                          description: "Endpoint for the reply."
-                          minLength: 1
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
     additionalPrinterColumns:
     - name: Ready
       type: string
@@ -117,10 +43,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -135,16 +57,6 @@ spec:
     name: v1
     served: true
     storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Channel
     plural: channels

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -23,9 +23,9 @@ spec:
   group: flows.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
     schema:
@@ -49,10 +49,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
   - <<: *version
     name: v1
     served: true

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -23,9 +23,9 @@ spec:
   group: flows.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
     schema:
@@ -49,10 +49,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
   - <<: *version
     name: v1
     served: true

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -22,9 +22,9 @@ spec:
   group: messaging.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
     schema:
@@ -45,10 +45,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
   - <<: *version
     name: v1
     served: true

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -23,19 +23,11 @@ spec:
   group: eventing.knative.dev
   versions:
   - &version
-    name: v1alpha1
-    served: false
-    storage: false
+    name: v1beta1
+    served: true
+    storage: true
     subresources:
       status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        # this is a work around so we don't need to flush out the
-        # schema for each version at this time
-        #
-        # see issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
     additionalPrinterColumns:
     - name: Ready
       type: string
@@ -52,10 +44,6 @@ spec:
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp
-  - << : *version
-    name: v1beta1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
The presence of the fields is causing noise in the webhook logs for some reason.

## Proposed Changes

- Remove all the v1alpha1 versions from the CRD (was served=false, stored=false).
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
Remove the v1alpha1 CRD api versions.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
