### PR TITLE
use consistent version with tracker/lister

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -375,7 +375,7 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 		// to the cache we intend to use to pull the Channel from. This linkage
 		// is setup in NewController for r.tracker.
 		if err := r.tracker.TrackReference(tracker.Reference{
-			APIVersion: "messaging.knative.dev/" + gvk.Version,
+			APIVersion: "messaging.knative.dev/v1beta1",
 			Kind:       "Channel",
 			Namespace:  sub.Namespace,
 			Name:       sub.Spec.Channel.Name,


### PR DESCRIPTION
When tracking Channels, use consistent v1beta1 since that's the lister we use. Otherwise, there will be flakiness. 


## Proposed Changes

- We first saw this in: https://github.com/knative/eventing/issues/2641
- 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
