### PR TITLE
reoder the api versions to enable downgrade from .16

### DIFF
--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -65,9 +65,9 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -64,9 +64,9 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
   - name: v1beta1
     served: true
     storage: false
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -58,6 +58,19 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
   - name: v1alpha1
     served: true
     storage: false
@@ -131,19 +144,6 @@ spec:
                           type: string
                           description: "Endpoint for the reply."
                           minLength: 1
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-  - name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -62,10 +62,10 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
 

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -62,9 +62,9 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
   - name: v1beta1
     served: true
     storage: true
+  - name: v1alpha1
+    served: true
+    storage: false

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -56,9 +56,9 @@ spec:
       type: date
       JSONPath: .metadata.creationTimestamp
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -74,13 +74,6 @@ spec:
               filter:
                 type: object
                 properties:
-                  sourceAndType:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      source:
-                        type: string
                   attributes:
                     type: object
                     description: "Map of CloudEvents attributes used for filtering events."
@@ -116,9 +109,9 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-  - name: v1beta1
+  - name: v1alpha1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object
@@ -134,6 +127,13 @@ spec:
               filter:
                 type: object
                 properties:
+                  sourceAndType:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      source:
+                        type: string
                   attributes:
                     type: object
                     description: "Map of CloudEvents attributes used for filtering events."


### PR DESCRIPTION
Addresses #3466

Without this change you can't downgrade properly after .16 because .16 has v1beta1 as the first api version (v1alpha1 removed).
vaikas-a01:eventing vaikas$ kubectl apply -f /tmp/broker.yaml
The CustomResourceDefinition "brokers.eventing.knative.dev" is invalid: spec.version: Invalid value: "v1beta1": must match the first version in spec.versions

With this change:
vaikas-a01:eventing vaikas$ kubectl apply -f /tmp/broker.yaml
customresourcedefinition.apiextensions.k8s.io/brokers.eventing.knative.dev configured

## Proposed Changes

- Reorder the API versions so that downgrading from .16 is possible. Without this when downgrading from .16 you will get an error.

-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Add new feature
If you are downgrading from .16 you have to downgrade to this version because the apiversions in the crd won't work without this.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
