### PR TITLE
actually make trigger.spec.broker immutable

### DIFF
--- a/pkg/apis/eventing/v1/trigger_validation.go
+++ b/pkg/apis/eventing/v1/trigger_validation.go
@@ -39,6 +39,10 @@ func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs = t.validateAnnotation(errs, DependencyAnnotation, t.validateDependencyAnnotation)
 	errs = t.validateAnnotation(errs, DeprecatedInjectionAnnotation, t.validateInjectionAnnotation)
 	errs = t.validateAnnotation(errs, InjectionAnnotation, t.validateInjectionAnnotation)
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Trigger)
+		errs = errs.Also(t.CheckImmutableFields(ctx, original))
+	}
 	return errs
 }
 

--- a/pkg/apis/eventing/v1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1/trigger_validation_test.go
@@ -233,7 +233,31 @@ func TestTriggerValidation(t *testing.T) {
 				Paths:   []string{injectionAnnotationPath},
 				Message: "The provided injection annotation value can only be \"enabled\" or \"disabled\", not \"wut\"",
 			},
-		}, {
+		},
+		{
+			name: "invalid trigger spec, invalid dependency annotation(missing kind, name, apiVersion) and invalid injection",
+			t: &Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						DependencyAnnotation: "{}",
+						InjectionAnnotation:  invalidInjectionAnnotation,
+					}},
+				Spec: TriggerSpec{Broker: "default", Subscriber: validSubscriber}},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				errs = errs.Also(&apis.FieldError{
+					Message: fmt.Sprintf(`The provided injection annotation value can only be "enabled", not "disabled"`),
+					Paths:   []string{"metadata.annotations[knative-eventing-injection]"},
+				})
+
+				errs = errs.Also(apis.ErrMissingField("metadata.annotations[knative.dev/dependency].apiVersion"))
+				errs = errs.Also(apis.ErrMissingField("metadata.annotations[knative.dev/dependency].kind"))
+				errs = errs.Also(apis.ErrMissingField("metadata.annotations[knative.dev/dependency].name"))
+				return errs
+			}(),
+		},
+		{
 			name: "valid injection annotation value, non-default broker specified",
 			t: &Trigger{
 				ObjectMeta: v1.ObjectMeta{
@@ -400,12 +424,14 @@ func TestTriggerImmutableFields(t *testing.T) {
 		name: "good (no change)",
 		current: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
+				Broker:     "broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		original: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
+				Broker:     "broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		want: nil,
@@ -413,7 +439,8 @@ func TestTriggerImmutableFields(t *testing.T) {
 		name: "new nil is ok",
 		current: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
+				Broker:     "broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		original: nil,
@@ -422,13 +449,15 @@ func TestTriggerImmutableFields(t *testing.T) {
 		name: "good (filter change)",
 		current: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
+				Broker:     "broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		original: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
-				Filter: validAttributesFilter,
+				Broker:     "broker",
+				Filter:     validAttributesFilter,
+				Subscriber: validSubscriber,
 			},
 		},
 		want: nil,
@@ -436,12 +465,14 @@ func TestTriggerImmutableFields(t *testing.T) {
 		name: "bad (broker change)",
 		current: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "broker",
+				Broker:     "broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		original: &Trigger{
 			Spec: TriggerSpec{
-				Broker: "original_broker",
+				Broker:     "original_broker",
+				Subscriber: validSubscriber,
 			},
 		},
 		want: &apis.FieldError{
@@ -456,7 +487,9 @@ func TestTriggerImmutableFields(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.current.CheckImmutableFields(context.TODO(), test.original)
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.original)
+			got := test.current.Validate(ctx)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("CheckImmutableFields (-want, +got) = %v", diff)
 			}

--- a/pkg/apis/eventing/v1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1/trigger_validation_test.go
@@ -247,8 +247,8 @@ func TestTriggerValidation(t *testing.T) {
 			want: func() *apis.FieldError {
 				var errs *apis.FieldError
 				errs = errs.Also(&apis.FieldError{
-					Message: fmt.Sprintf(`The provided injection annotation value can only be "enabled", not "disabled"`),
-					Paths:   []string{"metadata.annotations[knative-eventing-injection]"},
+					Message: fmt.Sprintf(`The provided injection annotation value can only be "enabled" or "disabled", not "wut"`),
+					Paths:   []string{"metadata.annotations[eventing.knative.dev/injection]"},
 				})
 
 				errs = errs.Also(apis.ErrMissingField("metadata.annotations[knative.dev/dependency].apiVersion"))


### PR DESCRIPTION
Fixes #3515  

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Actually wire the CheckImmutableFields to be called for Trigger.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
The code that was ensuring that trigger.spec.broker field was immutable was never called. Well, except in the unit tests...
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
