### PR TITLE
Adapter main now inject standard elector builder 

### DIFF
--- a/pkg/adapter/v2/config_test.go
+++ b/pkg/adapter/v2/config_test.go
@@ -37,6 +37,16 @@ func TestEnvConfig(t *testing.T) {
 	os.Setenv("K_LEADER_ELECTION_CONFIG", "leaderelection")
 	os.Setenv("MODE", "mymode") // note: custom to this test impl
 
+	defer func() {
+		os.Unsetenv("K_SINK")
+		os.Unsetenv("NAMESPACE")
+		os.Unsetenv("K_METRICS_CONFIG")
+		os.Unsetenv("K_LOGGING_CONFIG")
+		os.Unsetenv("K_TRACING_CONFIG")
+		os.Unsetenv("K_LEADER_ELECTION_CONFIG")
+		os.Unsetenv("MODE")
+	}()
+
 	var env myEnvConfig
 	err := envconfig.Process("", &env)
 	if err != nil {
@@ -54,4 +64,5 @@ func TestEnvConfig(t *testing.T) {
 	if env.LeaderElectionConfigJson != "leaderelection" {
 		t.Errorf("Expected LeaderElectionConfigJson leaderelection, got: %s", env.LeaderElectionConfigJson)
 	}
+
 }

--- a/pkg/adapter/v2/main_message.go
+++ b/pkg/adapter/v2/main_message.go
@@ -23,11 +23,11 @@ import (
 	"net/http"
 	"time"
 
-	"knative.dev/eventing/pkg/leaderelection"
-
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
+	"knative.dev/eventing/pkg/leaderelection"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/profiling"
@@ -117,6 +117,16 @@ func MainMessageAdapterWithContext(ctx context.Context, component string, ector 
 	adapter := ctor(ctx, env, httpBindingsSender, reporter)
 
 	// Build the leader elector
+	leConfig, err := env.GetLeaderElectionConfig()
+	if err != nil {
+		logger.Error("Error loading the leader election configuration", zap.Error(err))
+	}
+
+	if leConfig.LeaderElect {
+		// Signal that we are executing in a context with leader election.
+		ctx = leaderelection.WithStandardLeaderElectorBuilder(ctx, kubeclient.Get(ctx), *leConfig)
+	}
+
 	elector, err := leaderelection.BuildAdapterElector(ctx, adapter)
 	if err != nil {
 		logger.Fatal("Error creating the adapter elector", zap.Error(err))

--- a/pkg/adapter/v2/main_message_test.go
+++ b/pkg/adapter/v2/main_message_test.go
@@ -31,12 +31,19 @@ import (
 type myAdapterBindings struct{}
 
 func TestMainMessageAdapter(t *testing.T) {
-	os.Setenv("SINK_URI", "http://sink")
+	os.Setenv("K_SINK", "http://sink")
 	os.Setenv("NAMESPACE", "ns")
 	os.Setenv("K_METRICS_CONFIG", "metrics")
 	os.Setenv("K_LOGGING_CONFIG", "logging")
 	os.Setenv("MODE", "mymode")
-	os.Setenv("K_LEADER_ELECTION_CONFIG", "")
+
+	defer func() {
+		os.Unsetenv("SINK_URI")
+		os.Unsetenv("NAMESPACE")
+		os.Unsetenv("K_METRICS_CONFIG")
+		os.Unsetenv("K_LOGGING_CONFIG")
+		os.Unsetenv("MODE")
+	}()
 
 	ctx, cancel := context.WithCancel(context.TODO())
 

--- a/pkg/adapter/v2/main_message_test.go
+++ b/pkg/adapter/v2/main_message_test.go
@@ -38,7 +38,7 @@ func TestMainMessageAdapter(t *testing.T) {
 	os.Setenv("MODE", "mymode")
 
 	defer func() {
-		os.Unsetenv("SINK_URI")
+		os.Unsetenv("K_SINK")
 		os.Unsetenv("NAMESPACE")
 		os.Unsetenv("K_METRICS_CONFIG")
 		os.Unsetenv("K_LOGGING_CONFIG")

--- a/pkg/adapter/v2/main_test.go
+++ b/pkg/adapter/v2/main_test.go
@@ -34,7 +34,14 @@ func TestMainWithContext(t *testing.T) {
 	os.Setenv("K_METRICS_CONFIG", "metrics")
 	os.Setenv("K_LOGGING_CONFIG", "logging")
 	os.Setenv("MODE", "mymode")
-	os.Setenv("K_LEADER_ELECTION_CONFIG", "")
+
+	defer func() {
+		os.Unsetenv("K_SINK")
+		os.Unsetenv("NAMESPACE")
+		os.Unsetenv("K_METRICS_CONFIG")
+		os.Unsetenv("K_LOGGING_CONFIG")
+		os.Unsetenv("MODE")
+	}()
 
 	ctx, cancel := context.WithCancel(context.TODO())
 
@@ -43,6 +50,7 @@ func TestMainWithContext(t *testing.T) {
 		func() EnvConfigAccessor { return &myEnvConfig{} },
 		func(ctx context.Context, processed EnvConfigAccessor, client cloudevents.Client) Adapter {
 			env := processed.(*myEnvConfig)
+
 			if env.Mode != "mymode" {
 				t.Errorf("Expected mode mymode, got: %s", env.Mode)
 			}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adapter main now inject standard elector builder when leader election is turned on 
  for the given component
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
