### PR TITLE
actually make channel.spec.channelspec immutable

### DIFF
--- a/pkg/apis/messaging/v1/channel_validation.go
+++ b/pkg/apis/messaging/v1/channel_validation.go
@@ -26,7 +26,12 @@ import (
 
 func (c *Channel) Validate(ctx context.Context) *apis.FieldError {
 	withNS := apis.WithinParent(ctx, c.ObjectMeta)
-	return c.Spec.Validate(withNS).ViaField("spec")
+	errs := c.Spec.Validate(withNS).ViaField("spec")
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Channel)
+		errs = errs.Also(c.CheckImmutableFields(ctx, original))
+	}
+	return errs
 }
 
 func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1/channel_validation_test.go
@@ -188,42 +188,13 @@ func TestChannelImmutableFields(t *testing.T) {
 	+: "OtherChannel"
 `,
 		},
-	}, {
-		name: "good (subscribable change)",
-		current: &Channel{
-			Spec: ChannelSpec{
-				ChannelTemplate: &ChannelTemplateSpec{
-					TypeMeta: v1.TypeMeta{
-						Kind:       "InMemoryChannel",
-						APIVersion: SchemeGroupVersion.String(),
-					},
-				},
-				ChannelableSpec: eventingduck.ChannelableSpec{
-					SubscribableSpec: eventingduck.SubscribableSpec{
-						Subscribers: []eventingduck.SubscriberSpec{{
-							SubscriberURI: apis.HTTP("subscriberendpoint"),
-							ReplyURI:      apis.HTTP("replyendpoint"),
-						}},
-					},
-				},
-			},
-		},
-		original: &Channel{
-			Spec: ChannelSpec{
-				ChannelTemplate: &ChannelTemplateSpec{
-					TypeMeta: v1.TypeMeta{
-						Kind:       "InMemoryChannel",
-						APIVersion: SchemeGroupVersion.String(),
-					},
-				},
-			},
-		},
-		want: nil,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.current.CheckImmutableFields(context.TODO(), test.original)
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.original)
+			got := test.current.Validate(ctx)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("CheckImmutableFields (-want, +got) = %v", diff)
 			}


### PR DESCRIPTION
Fixes #3518 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Actually wire through the immutable checks. 
- Remove the test which is invalid, because subscribers are not allowed to be set (changed a long time ago...)
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Make channel.spec.channeltemplate immutable as it should be.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
