### PR TITLE
actually make subscription.spec.channel immutable

### DIFF
--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -27,7 +27,12 @@ import (
 )
 
 func (s *Subscription) Validate(ctx context.Context) *apis.FieldError {
-	return s.Spec.Validate(ctx).ViaField("spec")
+	errs := s.Spec.Validate(ctx).ViaField("spec")
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Subscription)
+		errs = errs.Also(s.CheckImmutableFields(ctx, original))
+	}
+	return errs
 }
 
 func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -248,12 +248,14 @@ func TestSubscriptionImmutable(t *testing.T) {
 		name: "valid",
 		c: &Subscription{
 			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
+				Channel:    getValidChannelRef(),
+				Subscriber: getValidDestination(),
 			},
 		},
 		og: &Subscription{
 			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
+				Channel:    getValidChannelRef(),
+				Subscriber: getValidDestination(),
 			},
 		},
 		want: nil,
@@ -331,12 +333,14 @@ func TestSubscriptionImmutable(t *testing.T) {
 		name: "Channel changed",
 		c: &Subscription{
 			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
+				Channel:    getValidChannelRef(),
+				Subscriber: getValidDestination(),
 			},
 		},
 		og: &Subscription{
 			Spec: SubscriptionSpec{
-				Channel: newChannel,
+				Channel:    newChannel,
+				Subscriber: getValidDestination(),
 			},
 		},
 		want: &apis.FieldError{
@@ -351,7 +355,9 @@ func TestSubscriptionImmutable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.c.CheckImmutableFields(context.TODO(), test.og)
+			ctx := context.Background()
+			ctx = apis.WithinUpdate(ctx, test.og)
+			got := test.c.Validate(ctx)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("CheckImmutableFields (-want, +got) = %v", diff)
 			}


### PR DESCRIPTION
Fixes #3521

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- subscription.spec.channel should be immutable, wire the checks through as they should be.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Subscription.spec.channel should be immutable, it's even being tested but not actually wired through.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
