### PR TITLE
v1beta1 still defaults broker

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -67,7 +67,7 @@ spec:
             properties:
               broker:
                 type: string
-                description: "Broker that this trigger receives events from."
+                description: "Broker that this trigger receives events from. If not specified, will default to 'default'."
               filter:
                 type: object
                 properties:
@@ -122,7 +122,7 @@ spec:
             properties:
               broker:
                 type: string
-                description: "Broker that this trigger receives events from. If not specified, will default to 'default'."
+                description: "Broker that this trigger receives events from."
               filter:
                 type: object
                 properties:

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -117,6 +117,7 @@ spec:
           spec:
             required:
               - subscriber
+              - broker
             type: object
             properties:
               broker:

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -62,7 +62,6 @@ spec:
         properties:
           spec:
             required:
-              - broker
               - subscriber
             type: object
             properties:


### PR DESCRIPTION
Fixes #

I made a mistake making broker a required field in the v1beta1 schema making broker a required field when it is only required in the v1. 

## Proposed Changes

- v1beta1 version of trigger.spec.broker is not required.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
