### PR TITLE
Add Broker Metrics conformance tests

### DIFF
--- a/test/conformance/broker_data_plane_test.go
+++ b/test/conformance/broker_data_plane_test.go
@@ -39,3 +39,11 @@ func TestBrokerV1Beta1DataPlaneConsumer(t *testing.T) {
 	broker := helpers.BrokerDataPlaneSetupHelper(client, brokerName, brokerNamespace, brokerClass)
 	helpers.BrokerV1Beta1ConsumerDataPlaneTestHelper(t, client, broker)
 }
+func TestBrokerV1Beta1DataPlaneMetrics(t *testing.T) {
+	client := testlib.Setup(t, true, testlib.SetupClientOptionNoop)
+	defer testlib.TearDown(client)
+
+	broker := helpers.BrokerDataPlaneSetupHelper(client, brokerName, brokerNamespace, brokerClass)
+	helpers.BrokerV1Beta1MetricsDataPlaneTestHelper(t, client, broker)
+
+}

--- a/test/lib/recordevents/event_info_matchers.go
+++ b/test/lib/recordevents/event_info_matchers.go
@@ -69,6 +69,19 @@ func MatchEvent(evf ...cetest.EventMatcher) EventInfoMatcher {
 	}
 }
 
+// Convert a matcher to check that a Header exists
+func AdditionalHeaderExists(key string) EventInfoMatcher {
+	key = strings.ToLower(key)
+	return func(ei EventInfo) error {
+		for k := range ei.HTTPHeaders {
+			if strings.ToLower(k) == key {
+				return nil
+			}
+		}
+		return fmt.Errorf("cannot find header '%s'", key)
+	}
+}
+
 // Convert a matcher that checks valid messages to a function
 // that checks EventInfo structures, returning an error for any that don't
 // contain valid events.


### PR DESCRIPTION
related: #2705

/hold
It doesn't look like the headers remain the same -- any suggestions if this is something I'm constructing incorrectly in the tests or an actual bug? @slinkydeveloper