### PR TITLE
Remove channel-broker from tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -44,11 +44,6 @@ readonly MT_CHANNEL_BASED_BROKER_DEFAULT_CONFIG="config/core/configmaps/default-
 readonly SUGAR_CONTROLLER_CONFIG_DIR="config/sugar"
 readonly SUGAR_CONTROLLER_CONFIG="config/sugar/500-controller.yaml"
 
-# Channel Based Broker Controller.
-readonly CHANNEL_BASED_BROKER_CONTROLLER="config/brokers/channel-broker"
-# Channel Based Broker config.
-readonly CHANNEL_BASED_BROKER_DEFAULT_CONFIG="test/config/st-channel-broker.yaml"
-
 # Config tracing config.
 readonly CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
 

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -45,9 +45,9 @@ function update_knative() {
 
   echo ">> Update Broker"
   ko apply --selector knative.dev/crd-install=true \
-    -f config/brokers/channel-broker || abort "Failed to apply Broker CRD"
+    -f config/brokers/mt-channel-broker || abort "Failed to apply Broker CRD"
   ko apply \
-    -f config/brokers/channel-broker || abort "Failed to apply Broker resources"
+    -f config/brokers/mt-channel-broker || abort "Failed to apply Broker resources"
 }
 
 function update_benchmark() {


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Part of https://github.com/knative/eventing/pull/3547

`ChannelBasedBroker` doesn't exist anymore.

## Proposed Changes

- Remove channel-broker from tests

