### PR TITLE
reconcile eventing with v1 resources, generate v1 dependent resources

### DIFF
--- a/pkg/apis/duck/v1/register.go
+++ b/pkg/apis/duck/v1/register.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{Group: "duck.knative.dev", Version: "v1"}
+
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+func Kind(kind string) schema.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Channelable{},
+		&ChannelableList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/pkg/apis/duck/v1/register_test.go
+++ b/pkg/apis/duck/v1/register_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Kind takes an unqualified resource and returns a Group qualified GroupKind
+func TestKind(t *testing.T) {
+	want := schema.GroupKind{
+		Group: "duck.knative.dev",
+		Kind:  "kind",
+	}
+
+	got := Kind("kind")
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected resource (-want, +got) = %v", diff)
+	}
+}
+
+// TestKnownTypes makes sure that expected types get added.
+func TestKnownTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	addKnownTypes(scheme)
+	types := scheme.KnownTypes(SchemeGroupVersion)
+
+	for _, name := range []string{
+		"Channelable",
+		"ChannelableList",
+	} {
+		if _, ok := types[name]; !ok {
+			t.Errorf("Did not find %q as registered type", name)
+		}
+	}
+}

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -29,14 +29,14 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	clientgotesting "k8s.io/client-go/testing"
-	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1beta1/channelable"
-	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/broker"
+	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler/mtbroker/resources"
 	"knative.dev/eventing/pkg/utils"
@@ -53,9 +53,9 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/resolver"
 
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/trigger/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	rtv1alpha1 "knative.dev/eventing/pkg/reconciler/testing"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	. "knative.dev/pkg/reconciler/testing"
 )
@@ -93,7 +93,7 @@ const (
 	finalizerName = "brokers.eventing.knative.dev"
 
 	imcSpec = `
-apiVersion: "messaging.knative.dev/v1beta1"
+apiVersion: "messaging.knative.dev/v1"
 kind: "InMemoryChannel"
 `
 )
@@ -123,7 +123,7 @@ var (
 		Ref: &duckv1.KReference{
 			Name:       sinkName,
 			Kind:       "Broker",
-			APIVersion: "eventing.knative.dev/v1beta1",
+			APIVersion: "eventing.knative.dev/v1",
 		},
 	}
 	sinkDNS               = "sink.mynamespace.svc." + utils.GetClusterDomainName()
@@ -139,7 +139,7 @@ var (
 
 func init() {
 	// Add types to scheme
-	_ = v1beta1.AddToScheme(scheme.Scheme)
+	_ = eventingv1.AddToScheme(scheme.Scheme)
 	_ = duckv1.AddToScheme(scheme.Scheme)
 }
 
@@ -1216,7 +1216,7 @@ func createChannel(namespace string, ready bool) *unstructured.Unstructured {
 	if ready {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": "messaging.knative.dev/v1beta1",
+				"apiVersion": "messaging.knative.dev/v1",
 				"kind":       "InMemoryChannel",
 				"metadata": map[string]interface{}{
 					"creationTimestamp": nil,
@@ -1224,7 +1224,7 @@ func createChannel(namespace string, ready bool) *unstructured.Unstructured {
 					"name":              name,
 					"ownerReferences": []interface{}{
 						map[string]interface{}{
-							"apiVersion":         "eventing.knative.dev/v1beta1",
+							"apiVersion":         "eventing.knative.dev/v1",
 							"blockOwnerDeletion": true,
 							"controller":         true,
 							"kind":               "Broker",
@@ -1246,7 +1246,7 @@ func createChannel(namespace string, ready bool) *unstructured.Unstructured {
 
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "messaging.knative.dev/v1beta1",
+			"apiVersion": "messaging.knative.dev/v1",
 			"kind":       "InMemoryChannel",
 			"metadata": map[string]interface{}{
 				"creationTimestamp": nil,
@@ -1254,7 +1254,7 @@ func createChannel(namespace string, ready bool) *unstructured.Unstructured {
 				"name":              name,
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "eventing.knative.dev/v1beta1",
+						"apiVersion":         "eventing.knative.dev/v1",
 						"blockOwnerDeletion": true,
 						"controller":         true,
 						"kind":               "Broker",
@@ -1281,7 +1281,7 @@ func createChannelNoHostInUrl(namespace string) *unstructured.Unstructured {
 
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "messaging.knative.dev/v1beta1",
+			"apiVersion": "messaging.knative.dev/v1",
 			"kind":       "InMemoryChannel",
 			"metadata": map[string]interface{}{
 				"creationTimestamp": nil,
@@ -1289,7 +1289,7 @@ func createChannelNoHostInUrl(namespace string) *unstructured.Unstructured {
 				"name":              name,
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "eventing.knative.dev/v1beta1",
+						"apiVersion":         "eventing.knative.dev/v1",
 						"blockOwnerDeletion": true,
 						"controller":         true,
 						"kind":               "Broker",
@@ -1311,7 +1311,7 @@ func createChannelNoHostInUrl(namespace string) *unstructured.Unstructured {
 
 func createTriggerChannelRef() *corev1.ObjectReference {
 	return &corev1.ObjectReference{
-		APIVersion: "messaging.knative.dev/v1beta1",
+		APIVersion: "messaging.knative.dev/v1",
 		Kind:       "InMemoryChannel",
 		Namespace:  testNS,
 		Name:       fmt.Sprintf("%s-kne-trigger", brokerName),
@@ -1325,14 +1325,14 @@ func makeServiceURI() *apis.URL {
 		Path:   fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID),
 	}
 }
-func makeFilterSubscription() *messagingv1beta1.Subscription {
+func makeFilterSubscription() *messagingv1.Subscription {
 	return resources.NewSubscription(makeTrigger(), createTriggerChannelRef(), makeBrokerRef(), makeServiceURI(), makeEmptyDelivery())
 }
 
-func makeTrigger() *v1beta1.Trigger {
-	return &v1beta1.Trigger{
+func makeTrigger() *eventingv1.Trigger {
+	return &eventingv1.Trigger{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "eventing.knative.dev/v1beta1",
+			APIVersion: "eventing.knative.dev/v1",
 			Kind:       "Trigger",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1340,9 +1340,9 @@ func makeTrigger() *v1beta1.Trigger {
 			Name:      triggerName,
 			UID:       triggerUID,
 		},
-		Spec: v1beta1.TriggerSpec{
+		Spec: eventingv1.TriggerSpec{
 			Broker: brokerName,
-			Filter: &v1beta1.TriggerFilter{
+			Filter: &eventingv1.TriggerFilter{
 				Attributes: map[string]string{"Source": "Any", "Type": "Any"},
 			},
 			Subscriber: duckv1.Destination{
@@ -1359,13 +1359,13 @@ func makeTrigger() *v1beta1.Trigger {
 
 func makeBrokerRef() *corev1.ObjectReference {
 	return &corev1.ObjectReference{
-		APIVersion: "eventing.knative.dev/v1beta1",
+		APIVersion: "eventing.knative.dev/v1",
 		Kind:       "Broker",
 		Namespace:  testNS,
 		Name:       brokerName,
 	}
 }
-func makeEmptyDelivery() *eventingduckv1beta1.DeliverySpec {
+func makeEmptyDelivery() *eventingduckv1.DeliverySpec {
 	return nil
 }
 
@@ -1392,35 +1392,35 @@ func allBrokerObjectsReadyPlus(objs ...runtime.Object) []runtime.Object {
 }
 
 // Just so we can test subscription updates
-func makeDifferentReadySubscription() *messagingv1beta1.Subscription {
+func makeDifferentReadySubscription() *messagingv1.Subscription {
 	s := makeFilterSubscription()
 	s.Spec.Subscriber.URI = apis.HTTP("different.example.com")
-	s.Status = *v1beta1.TestHelper.ReadySubscriptionStatus()
+	s.Status = *eventingv1.TestHelper.ReadySubscriptionStatus()
 	return s
 }
 
-func makeFilterSubscriptionNotOwnedByTrigger() *messagingv1beta1.Subscription {
+func makeFilterSubscriptionNotOwnedByTrigger() *messagingv1.Subscription {
 	sub := makeFilterSubscription()
 	sub.OwnerReferences = []metav1.OwnerReference{}
 	return sub
 }
 
-func makeReadySubscription() *messagingv1beta1.Subscription {
+func makeReadySubscription() *messagingv1.Subscription {
 	s := makeFilterSubscription()
-	s.Status = *v1beta1.TestHelper.ReadySubscriptionStatus()
+	s.Status = *eventingv1.TestHelper.ReadySubscriptionStatus()
 	return s
 }
 
-func makeReadySubscriptionDeprecatedName(triggerName, triggerUID string) *messagingv1beta1.Subscription {
+func makeReadySubscriptionDeprecatedName(triggerName, triggerUID string) *messagingv1.Subscription {
 	s := makeFilterSubscription()
 	t := NewTrigger(triggerName, testNS, brokerName)
 	t.UID = types.UID(triggerUID)
 	s.Name = utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", brokerName, triggerName))
-	s.Status = *v1beta1.TestHelper.ReadySubscriptionStatus()
+	s.Status = *eventingv1.TestHelper.ReadySubscriptionStatus()
 	return s
 }
 
-func makeReadySubscriptionWithCustomData(triggerName, triggerUID string) *messagingv1beta1.Subscription {
+func makeReadySubscriptionWithCustomData(triggerName, triggerUID string) *messagingv1.Subscription {
 	t := makeTrigger()
 	t.Name = triggerName
 	t.UID = types.UID(triggerUID)
@@ -1449,7 +1449,7 @@ func makeSubscriberAddressableAsUnstructured() *unstructured.Unstructured {
 	}
 }
 
-func makeFalseStatusSubscription() *messagingv1beta1.Subscription {
+func makeFalseStatusSubscription() *messagingv1.Subscription {
 	s := makeFilterSubscription()
 	s.Status.MarkReferencesNotResolved("testInducedError", "test induced error")
 	return s

--- a/pkg/reconciler/mtbroker/config.go
+++ b/pkg/reconciler/mtbroker/config.go
@@ -26,12 +26,12 @@ import (
 	"go.uber.org/zap"
 
 	corev1 "k8s.io/api/core/v1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/logging"
 )
 
 type Config struct {
-	DefaultChannelTemplate messagingv1beta1.ChannelTemplateSpec
+	DefaultChannelTemplate messagingv1.ChannelTemplateSpec
 }
 
 const (
@@ -41,7 +41,7 @@ const (
 func NewConfigFromConfigMapFunc(ctx context.Context) func(configMap *corev1.ConfigMap) (*Config, error) {
 	return func(configMap *corev1.ConfigMap) (*Config, error) {
 		config := &Config{
-			DefaultChannelTemplate: messagingv1beta1.ChannelTemplateSpec{},
+			DefaultChannelTemplate: messagingv1.ChannelTemplateSpec{},
 		}
 
 		temp, present := configMap.Data[channelTemplateSpec]

--- a/pkg/reconciler/mtbroker/config_test.go
+++ b/pkg/reconciler/mtbroker/config_test.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	logtesting "knative.dev/pkg/logging/testing"
 
 	. "knative.dev/pkg/configmap/testing"
@@ -47,7 +47,7 @@ func TestOurConfig(t *testing.T) {
 		name: "Example config",
 		fail: false,
 		want: &Config{
-			DefaultChannelTemplate: messagingv1beta1.ChannelTemplateSpec{
+			DefaultChannelTemplate: messagingv1.ChannelTemplateSpec{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "messaging.knative.dev/v1alpha1",
 					Kind:       "InMemoryChannel",
@@ -58,7 +58,7 @@ func TestOurConfig(t *testing.T) {
 	}, {
 		name: "With values",
 		want: &Config{
-			DefaultChannelTemplate: messagingv1beta1.ChannelTemplateSpec{
+			DefaultChannelTemplate: messagingv1.ChannelTemplateSpec{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "Foo/v1",
 					Kind:       "Bar",

--- a/pkg/reconciler/mtbroker/controller.go
+++ b/pkg/reconciler/mtbroker/controller.go
@@ -27,13 +27,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1beta1/channelable"
-	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
-	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/trigger"
-	subscriptioninformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/subscription"
-	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/broker"
+	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
+	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
+	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
+	subscriptioninformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
+	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/pkg/apis"
@@ -94,7 +94,7 @@ func NewController(
 		}()
 	}
 
-	v1beta1.RegisterAlternateBrokerConditionSet(apis.NewLivingConditionSet(
+	eventingv1.RegisterAlternateBrokerConditionSet(apis.NewLivingConditionSet(
 		BrokerConditionIngress,
 		BrokerConditionTriggerChannel,
 		BrokerConditionFilter,
@@ -130,7 +130,7 @@ func NewController(
 	// Reconcile Broker (which transitively reconciles the triggers), when Subscriptions
 	// that I own are changed.
 	subscriptionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1beta1.Kind("Broker")),
+		FilterFunc: controller.FilterControllerGK(eventingv1.Kind("Broker")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -143,7 +143,7 @@ func NewController(
 
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(
 		func(obj interface{}) {
-			if trigger, ok := obj.(*v1beta1.Trigger); ok {
+			if trigger, ok := obj.(*eventingv1.Trigger); ok {
 				impl.EnqueueKey(types.NamespacedName{Namespace: trigger.Namespace, Name: trigger.Spec.Broker})
 			}
 		},

--- a/pkg/reconciler/mtbroker/controller_test.go
+++ b/pkg/reconciler/mtbroker/controller_test.go
@@ -23,9 +23,9 @@ import (
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
-	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1beta1/channelable/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/subscription/fake"
+	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"

--- a/pkg/reconciler/mtbroker/resources/channel.go
+++ b/pkg/reconciler/mtbroker/resources/channel.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"knative.dev/eventing/pkg/apis/eventing"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -36,9 +36,9 @@ func BrokerChannelName(brokerName, channelType string) string {
 // test
 // NewChannel returns an unstructured.Unstructured based on the ChannelTemplateSpec
 // for a given Broker.
-func NewChannel(channelType string, owner kmeta.OwnerRefable, channelTemplate *messagingv1beta1.ChannelTemplateSpec, l map[string]string) (*unstructured.Unstructured, error) {
+func NewChannel(channelType string, owner kmeta.OwnerRefable, channelTemplate *messagingv1.ChannelTemplateSpec, l map[string]string) (*unstructured.Unstructured, error) {
 	// Set the name of the resource we're creating as well as the namespace, etc.
-	template := messagingv1beta1.ChannelTemplateSpecInternal{
+	template := messagingv1.ChannelTemplateSpecInternal{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       channelTemplate.Kind,
 			APIVersion: channelTemplate.APIVersion,

--- a/pkg/reconciler/mtbroker/resources/channel_test.go
+++ b/pkg/reconciler/mtbroker/resources/channel_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 )
 
 func TestBrokerChannelName(t *testing.T) {
@@ -37,11 +37,11 @@ func TestBrokerChannelName(t *testing.T) {
 
 func TestNewChannel(t *testing.T) {
 	testCases := map[string]struct {
-		channelTemplate messagingv1beta1.ChannelTemplateSpec
+		channelTemplate messagingv1.ChannelTemplateSpec
 		expectError     bool
 	}{
 		"InMemoryChannel": {
-			channelTemplate: messagingv1beta1.ChannelTemplateSpec{
+			channelTemplate: messagingv1.ChannelTemplateSpec{
 				TypeMeta: v1.TypeMeta{
 					APIVersion: "messaging.knative.dev/v1alpha1",
 					Kind:       "InMemoryChannel",
@@ -49,7 +49,7 @@ func TestNewChannel(t *testing.T) {
 			},
 		},
 		"KafkaChannel": {
-			channelTemplate: messagingv1beta1.ChannelTemplateSpec{
+			channelTemplate: messagingv1.ChannelTemplateSpec{
 				TypeMeta: v1.TypeMeta{
 					APIVersion: "messaging.knative.dev/v1alpha1",
 					Kind:       "KafkaChannel",
@@ -57,7 +57,7 @@ func TestNewChannel(t *testing.T) {
 			},
 		},
 		"Bad raw extension": {
-			channelTemplate: messagingv1beta1.ChannelTemplateSpec{
+			channelTemplate: messagingv1.ChannelTemplateSpec{
 				TypeMeta: v1.TypeMeta{
 					APIVersion: "messaging.knative.dev/v1alpha1",
 					Kind:       "InMemoryChannel",

--- a/pkg/reconciler/mtbroker/resources/subscription.go
+++ b/pkg/reconciler/mtbroker/resources/subscription.go
@@ -24,17 +24,17 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 
-	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // NewSubscription returns a placeholder subscription for trigger 't', from brokerTrigger to 'uri'
 // replying to brokerIngress.
-func NewSubscription(t *v1beta1.Trigger, brokerTrigger, brokerRef *corev1.ObjectReference, uri *apis.URL, delivery *duckv1beta1.DeliverySpec) *messagingv1beta1.Subscription {
-	return &messagingv1beta1.Subscription{
+func NewSubscription(t *eventingv1.Trigger, brokerTrigger, brokerRef *corev1.ObjectReference, uri *apis.URL, delivery *eventingduckv1.DeliverySpec) *messagingv1.Subscription {
+	return &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
 			Name:      kmeta.ChildName(fmt.Sprintf("%s-%s-", t.Spec.Broker, t.Name), string(t.GetUID())),
@@ -43,7 +43,7 @@ func NewSubscription(t *v1beta1.Trigger, brokerTrigger, brokerRef *corev1.Object
 			},
 			Labels: SubscriptionLabels(t),
 		},
-		Spec: messagingv1beta1.SubscriptionSpec{
+		Spec: messagingv1.SubscriptionSpec{
 			Channel: corev1.ObjectReference{
 				APIVersion: brokerTrigger.APIVersion,
 				Kind:       brokerTrigger.Kind,
@@ -67,7 +67,7 @@ func NewSubscription(t *v1beta1.Trigger, brokerTrigger, brokerRef *corev1.Object
 
 // SubscriptionLabels generates the labels present on the Subscription linking this Trigger to the
 // Broker's Channels.
-func SubscriptionLabels(t *v1beta1.Trigger) map[string]string {
+func SubscriptionLabels(t *eventingv1.Trigger) map[string]string {
 	return map[string]string{
 		eventing.BrokerLabelKey:        t.Spec.Broker,
 		"eventing.knative.dev/trigger": t.Name,

--- a/pkg/reconciler/mtbroker/resources/subscription_test.go
+++ b/pkg/reconciler/mtbroker/resources/subscription_test.go
@@ -22,22 +22,22 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestNewSubscription(t *testing.T) {
 	var TrueValue = true
-	trigger := &v1beta1.Trigger{
+	trigger := &eventingv1.Trigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "t-namespace",
 			Name:      "t-name",
 		},
-		Spec: v1beta1.TriggerSpec{
+		Spec: eventingv1.TriggerSpec{
 			Broker: "broker-name",
 		},
 	}
@@ -52,18 +52,18 @@ func TestNewSubscription(t *testing.T) {
 		Kind:       "broker-kind",
 		APIVersion: "broker-apiVersion",
 	}
-	delivery := &duckv1beta1.DeliverySpec{
+	delivery := &eventingduckv1.DeliverySpec{
 		DeadLetterSink: &duckv1.Destination{
 			URI: apis.HTTP("dlc.example.com"),
 		},
 	}
 	got := NewSubscription(trigger, triggerChannelRef, brokerRef, apis.HTTP("example.com"), delivery)
-	want := &messagingv1beta1.Subscription{
+	want := &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "t-namespace",
 			Name:      "broker-name-t-name-",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "eventing.knative.dev/v1beta1",
+				APIVersion:         "eventing.knative.dev/v1",
 				Kind:               "Trigger",
 				Name:               "t-name",
 				Controller:         &TrueValue,
@@ -74,7 +74,7 @@ func TestNewSubscription(t *testing.T) {
 				"eventing.knative.dev/trigger": "t-name",
 			},
 		},
-		Spec: messagingv1beta1.SubscriptionSpec{
+		Spec: messagingv1.SubscriptionSpec{
 			Channel: corev1.ObjectReference{
 				Name:       "tc-name",
 				Kind:       "tc-kind",
@@ -91,7 +91,7 @@ func TestNewSubscription(t *testing.T) {
 					APIVersion: "broker-apiVersion",
 				},
 			},
-			Delivery: &duckv1beta1.DeliverySpec{
+			Delivery: &eventingduckv1.DeliverySpec{
 				DeadLetterSink: &duckv1.Destination{
 					URI: apis.HTTP("dlc.example.com"),
 				},

--- a/pkg/reconciler/mtbroker/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger.go
@@ -28,8 +28,8 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/reconciler/mtbroker/resources"
 	"knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/eventing/pkg/reconciler/sugar/trigger/path"
@@ -52,7 +52,7 @@ const (
 	subscriptionDeleted       = "SubscriptionDeleted"
 )
 
-func (r *Reconciler) reconcileTrigger(ctx context.Context, b *v1beta1.Broker, t *v1beta1.Trigger, brokerTrigger *corev1.ObjectReference) error {
+func (r *Reconciler) reconcileTrigger(ctx context.Context, b *eventingv1.Broker, t *eventingv1.Trigger, brokerTrigger *corev1.ObjectReference) error {
 	t.Status.InitializeConditions()
 
 	if t.DeletionTimestamp != nil {
@@ -99,7 +99,7 @@ func (r *Reconciler) reconcileTrigger(ctx context.Context, b *v1beta1.Broker, t 
 }
 
 // subscribeToBrokerChannel subscribes service 'svc' to the Broker's channels.
-func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *v1beta1.Broker, t *v1beta1.Trigger, brokerTrigger *corev1.ObjectReference) (*messagingv1beta1.Subscription, error) {
+func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *eventingv1.Broker, t *eventingv1.Trigger, brokerTrigger *corev1.ObjectReference) (*messagingv1.Subscription, error) {
 	uri := &apis.URL{
 		Scheme: "http",
 		Host:   names.ServiceHostName("broker-filter", system.Namespace()),
@@ -122,14 +122,14 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *v1beta1.Br
 		// Issue #2842: Subscription name uses kmeta.ChildName. If a subscription by the previous name pattern is found, it should
 		// be deleted. This might cause temporary downtime.
 		if deprecatedName := utils.GenerateFixedName(t, fmt.Sprintf("%s-%s", t.Spec.Broker, t.Name)); deprecatedName != expected.Name {
-			if err := r.eventingClientSet.MessagingV1beta1().Subscriptions(t.Namespace).Delete(deprecatedName, &metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
+			if err := r.eventingClientSet.MessagingV1().Subscriptions(t.Namespace).Delete(deprecatedName, &metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
 				return nil, fmt.Errorf("error deleting deprecated named subscription: %v", err)
 			}
 			controller.GetEventRecorder(ctx).Eventf(t, corev1.EventTypeNormal, subscriptionDeleted, "Deprecated subscription removed: \"%s/%s\"", t.Namespace, deprecatedName)
 		}
 
 		logging.FromContext(ctx).Info("Creating subscription")
-		sub, err = r.eventingClientSet.MessagingV1beta1().Subscriptions(t.Namespace).Create(expected)
+		sub, err = r.eventingClientSet.MessagingV1().Subscriptions(t.Namespace).Create(expected)
 		if err != nil {
 			r.recorder.Eventf(t, corev1.EventTypeWarning, subscriptionCreateFailed, "Create Trigger's subscription failed: %v", err)
 			return nil, err
@@ -150,7 +150,7 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *v1beta1.Br
 	return sub, nil
 }
 
-func (r *Reconciler) reconcileSubscription(ctx context.Context, t *v1beta1.Trigger, expected, actual *messagingv1beta1.Subscription) (*messagingv1beta1.Subscription, error) {
+func (r *Reconciler) reconcileSubscription(ctx context.Context, t *eventingv1.Trigger, expected, actual *messagingv1.Subscription) (*messagingv1.Subscription, error) {
 	// Update Subscription if it has changed.
 	if equality.Semantic.DeepDerivative(expected.Spec, actual.Spec) {
 		return actual, nil
@@ -160,14 +160,14 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, t *v1beta1.Trigg
 	// Given that spec.channel is immutable, we cannot just update the Subscription. We delete
 	// it and re-create it instead.
 	logging.FromContext(ctx).Infow("Deleting subscription", zap.String("namespace", actual.Namespace), zap.String("name", actual.Name))
-	err := r.eventingClientSet.MessagingV1beta1().Subscriptions(t.Namespace).Delete(actual.Name, &metav1.DeleteOptions{})
+	err := r.eventingClientSet.MessagingV1().Subscriptions(t.Namespace).Delete(actual.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		logging.FromContext(ctx).Info("Cannot delete subscription", zap.Error(err))
 		r.recorder.Eventf(t, corev1.EventTypeWarning, subscriptionDeleteFailed, "Delete Trigger's subscription failed: %v", err)
 		return nil, err
 	}
 	logging.FromContext(ctx).Info("Creating subscription")
-	newSub, err := r.eventingClientSet.MessagingV1beta1().Subscriptions(t.Namespace).Create(expected)
+	newSub, err := r.eventingClientSet.MessagingV1().Subscriptions(t.Namespace).Create(expected)
 	if err != nil {
 		logging.FromContext(ctx).Infow("Cannot create subscription", zap.Error(err))
 		r.recorder.Eventf(t, corev1.EventTypeWarning, subscriptionCreateFailed, "Create Trigger's subscription failed: %v", err)
@@ -176,7 +176,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, t *v1beta1.Trigg
 	return newSub, nil
 }
 
-func (r *Reconciler) updateTriggerStatus(ctx context.Context, desired *v1beta1.Trigger) (*v1beta1.Trigger, error) {
+func (r *Reconciler) updateTriggerStatus(ctx context.Context, desired *eventingv1.Trigger) (*eventingv1.Trigger, error) {
 	trigger, err := r.triggerLister.Triggers(desired.Namespace).Get(desired.Name)
 	if err != nil {
 		return nil, err
@@ -190,12 +190,12 @@ func (r *Reconciler) updateTriggerStatus(ctx context.Context, desired *v1beta1.T
 	existing := trigger.DeepCopy()
 	existing.Status = desired.Status
 
-	return r.eventingClientSet.EventingV1beta1().Triggers(desired.Namespace).UpdateStatus(existing)
+	return r.eventingClientSet.EventingV1().Triggers(desired.Namespace).UpdateStatus(existing)
 }
 
-func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *v1beta1.Trigger, b *v1beta1.Broker) error {
-	if dependencyAnnotation, ok := t.GetAnnotations()[v1beta1.DependencyAnnotation]; ok {
-		dependencyObjRef, err := v1beta1.GetObjRefFromDependencyAnnotation(dependencyAnnotation)
+func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *eventingv1.Trigger, b *eventingv1.Broker) error {
+	if dependencyAnnotation, ok := t.GetAnnotations()[eventingv1.DependencyAnnotation]; ok {
+		dependencyObjRef, err := eventingv1.GetObjRefFromDependencyAnnotation(dependencyAnnotation)
 		if err != nil {
 			t.Status.MarkDependencyFailed("ReferenceError", "Unable to unmarshal objectReference from dependency annotation of trigger: %v", err)
 			return fmt.Errorf("getting object ref from dependency annotation %q: %v", dependencyAnnotation, err)
@@ -214,7 +214,7 @@ func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *v1beta1.T
 	return nil
 }
 
-func (r *Reconciler) propagateDependencyReadiness(ctx context.Context, t *v1beta1.Trigger, dependencyObjRef corev1.ObjectReference) error {
+func (r *Reconciler) propagateDependencyReadiness(ctx context.Context, t *eventingv1.Trigger, dependencyObjRef corev1.ObjectReference) error {
 	lister, err := r.kresourceTracker.ListerFor(dependencyObjRef)
 	if err != nil {
 		t.Status.MarkDependencyUnknown("ListerDoesNotExist", "Failed to retrieve lister: %v", err)

--- a/pkg/reconciler/sugar/trigger/path/path.go
+++ b/pkg/reconciler/sugar/trigger/path/path.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 )
 
 // Generate generates the Path portion of a URI to send events to the given Trigger.
-func Generate(t *v1beta1.Trigger) string {
+func Generate(t *v1.Trigger) string {
 	return fmt.Sprintf("/%s/%s/%s/%s", prefix, t.Namespace, t.Name, t.UID)
 }
 

--- a/pkg/reconciler/testing/v1/broker.go
+++ b/pkg/reconciler/testing/v1/broker.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// BrokerOption enables further configuration of a Broker.
+type BrokerOption func(*v1.Broker)
+
+// NewBroker creates a Broker with BrokerOptions.
+func NewBroker(name, namespace string, o ...BrokerOption) *v1.Broker {
+	b := &v1.Broker{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range o {
+		opt(b)
+	}
+	b.SetDefaults(context.Background())
+	return b
+}
+
+// WithInitBrokerConditions initializes the Broker's conditions.
+func WithInitBrokerConditions(b *v1.Broker) {
+	b.Status.InitializeConditions()
+}
+
+func WithBrokerFinalizers(finalizers ...string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Finalizers = finalizers
+	}
+}
+
+func WithBrokerResourceVersion(rv string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.ResourceVersion = rv
+	}
+}
+
+func WithBrokerGeneration(gen int64) BrokerOption {
+	return func(s *v1.Broker) {
+		s.Generation = gen
+	}
+}
+
+func WithBrokerStatusObservedGeneration(gen int64) BrokerOption {
+	return func(s *v1.Broker) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
+func WithBrokerDeletionTimestamp(b *v1.Broker) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	b.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+// WithBrokerChannel sets the Broker's ChannelTemplateSpec to the specified CRD.
+func WithBrokerConfig(config *duckv1.KReference) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Spec.Config = config
+	}
+}
+
+// WithBrokerAddress sets the Broker's address.
+func WithBrokerAddress(address string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.SetAddress(&apis.URL{
+			Scheme: "http",
+			Host:   address,
+		})
+	}
+}
+
+// WithBrokerAddressURI sets the Broker's address as URI.
+func WithBrokerAddressURI(uri *apis.URL) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.SetAddress(uri)
+	}
+}
+
+// WithBrokerReady sets .Status to ready.
+func WithBrokerReady(b *v1.Broker) {
+	b.Status = *v1.TestHelper.ReadyBrokerStatus()
+}
+
+func WithDeprecatedStatus(b *v1.Broker) {
+	dc := apis.Condition{
+		Type:     "Deprecated",
+		Reason:   "SingleTenantChannelBrokerDeprecated",
+		Status:   corev1.ConditionTrue,
+		Severity: apis.ConditionSeverityWarning,
+		Message:  "Single Tenant Channel Brokers are deprecated and will be removed in release 0.16. Use Multi Tenant Channel Brokers instead.",
+	}
+
+	for i, c := range b.Status.Status.Conditions {
+		if c.Type == dc.Type {
+			b.Status.Status.Conditions[i] = dc
+			return
+		}
+	}
+	b.Status.Status.Conditions = append(b.Status.Status.Conditions, dc)
+}
+
+// WithTriggerChannelFailed calls .Status.MarkTriggerChannelFailed on the Broker.
+func WithTriggerChannelFailed(reason, msg string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.MarkTriggerChannelFailed(reason, msg)
+	}
+}
+
+// WithFilterFailed calls .Status.MarkFilterFailed on the Broker.
+func WithFilterFailed(reason, msg string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.MarkFilterFailed(reason, msg)
+	}
+}
+
+// WithIngressFailed calls .Status.MarkIngressFailed on the Broker.
+func WithIngressFailed(reason, msg string) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.MarkIngressFailed(reason, msg)
+	}
+}
+
+// WithTriggerChannelReady calls .Status.PropagateTriggerChannelReadiness on the Broker.
+func WithTriggerChannelReady() BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.PropagateTriggerChannelReadiness(v1.TestHelper.ReadyChannelStatus())
+	}
+}
+
+func WithFilterAvailable() BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.PropagateFilterAvailability(v1.TestHelper.AvailableEndpoints())
+	}
+}
+
+func WithIngressAvailable() BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.PropagateIngressAvailability(v1.TestHelper.AvailableEndpoints())
+	}
+}
+
+func WithBrokerClass(bc string) BrokerOption {
+	return func(b *v1.Broker) {
+		annotations := b.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, 1)
+		}
+		annotations[broker.ClassAnnotationKey] = bc
+		b.SetAnnotations(annotations)
+	}
+}

--- a/pkg/reconciler/testing/v1/configmap.go
+++ b/pkg/reconciler/testing/v1/configmap.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConfigMapOption enables further configuration of a ConfigMap.
+type ConfigMapOption func(*v1.ConfigMap)
+
+// NewConfigMap creates a new ConfigMap.
+func NewConfigMap(name, namespace string, o ...ConfigMapOption) *v1.ConfigMap {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range o {
+		opt(cm)
+	}
+	return cm
+}
+
+func WithConfigMapLabels(labels metav1.LabelSelector) ConfigMapOption {
+	return func(cm *v1.ConfigMap) {
+		cm.ObjectMeta.Labels = labels.MatchLabels
+	}
+}
+
+func WithConfigMapData(data map[string]string) ConfigMapOption {
+	return func(cm *v1.ConfigMap) {
+		cm.Data = data
+	}
+}

--- a/pkg/reconciler/testing/v1/endpoints.go
+++ b/pkg/reconciler/testing/v1/endpoints.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EndpointsOption enables further configuration of a Endpoints.
+type EndpointsOption func(*corev1.Endpoints)
+
+// NewEndpoints creates a Endpoints with EndpointsOptions
+func NewEndpoints(name, namespace string, so ...EndpointsOption) *corev1.Endpoints {
+	s := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	return s
+}
+
+func WithEndpointsLabels(labels map[string]string) EndpointsOption {
+	return func(s *corev1.Endpoints) {
+		s.ObjectMeta.Labels = labels
+	}
+}
+
+func WithEndpointsAddresses(addrs ...corev1.EndpointAddress) EndpointsOption {
+	return func(s *corev1.Endpoints) {
+		s.Subsets = []corev1.EndpointSubset{{
+			Addresses: addrs,
+		}}
+	}
+}
+
+func WithEndpointsNotReadyAddresses(addrs ...corev1.EndpointAddress) EndpointsOption {
+	return func(s *corev1.Endpoints) {
+		s.Subsets = []corev1.EndpointSubset{{
+			NotReadyAddresses: addrs,
+		}}
+	}
+}
+
+func WithEndpointsAnnotations(annotations map[string]string) EndpointsOption {
+	return func(s *corev1.Endpoints) {
+		s.ObjectMeta.Annotations = annotations
+	}
+}

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/tools/record"
+
+	"go.uber.org/zap"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/controller"
+
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+
+	"knative.dev/pkg/reconciler"
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+const (
+	// maxEventBufferSize is the estimated max number of event notifications that
+	// can be buffered during reconciliation.
+	maxEventBufferSize = 10
+)
+
+// Ctor functions create a k8s controller with given params.
+type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
+
+// MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
+func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factory {
+	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList) {
+		ls := NewListers(r.Objects)
+
+		ctx := context.Background()
+		ctx = logging.WithLogger(ctx, logger)
+
+		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
+		ctx, client := fakeeventingclient.With(ctx, ls.GetEventingObjects()...)
+		ctx, dynamicClient := fakedynamicclient.With(ctx,
+			NewScheme(), ToUnstructured(t, r.Objects)...)
+
+		dynamicScheme := runtime.NewScheme()
+		for _, addTo := range clientSetSchemes {
+			addTo(dynamicScheme)
+		}
+
+		// The dynamic client's support for patching is BS.  Implement it
+		// here via PrependReactor (this can be overridden below by the
+		// provided reactors).
+		dynamicClient.PrependReactor("patch", "*",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
+		ctx = controller.WithEventRecorder(ctx, eventRecorder)
+
+		// Set up our Controller from the fakes.
+		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
+
+		// If the reconcilers is leader aware, then promote it.
+		if la, ok := c.(reconciler.LeaderAware); ok {
+			la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
+		}
+
+		for _, reactor := range r.WithReactors {
+			kubeClient.PrependReactor("*", "*", reactor)
+			client.PrependReactor("*", "*", reactor)
+			dynamicClient.PrependReactor("*", "*", reactor)
+		}
+
+		// Validate all Create operations through the eventing client.
+		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateCreates(ctx, action)
+		})
+		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateUpdates(ctx, action)
+		})
+
+		actionRecorderList := ActionRecorderList{dynamicClient, client, kubeClient}
+		eventList := EventList{Recorder: eventRecorder}
+
+		return c, actionRecorderList, eventList
+	}
+}
+
+// ToUnstructured takes a list of k8s resources and converts them to
+// Unstructured objects.
+// We must pass objects as Unstructured to the dynamic client fake, or it
+// won't handle them properly.
+func ToUnstructured(t *testing.T, objs []runtime.Object) (us []runtime.Object) {
+	sch := NewScheme()
+	for _, obj := range objs {
+		obj = obj.DeepCopyObject() // Don't mess with the primary copy
+		// Determine and set the TypeMeta for this object based on our test scheme.
+		gvks, _, err := sch.ObjectKinds(obj)
+		if err != nil {
+			t.Fatalf("Unable to determine kind for type: %v", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		ta, err := meta.TypeAccessor(obj)
+		if err != nil {
+			t.Fatalf("Unable to create type accessor: %v", err)
+		}
+		ta.SetAPIVersion(apiv)
+		ta.SetKind(k)
+
+		b, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("Unable to marshal: %v", err)
+		}
+		u := &unstructured.Unstructured{}
+		if err := json.Unmarshal(b, u); err != nil {
+			t.Fatalf("Unable to unmarshal: %v", err)
+		}
+		us = append(us, u)
+	}
+	return
+}

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	sourcesv1alpha1 "knative.dev/eventing/pkg/apis/sources/v1alpha1"
+	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
+	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
+	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
+	flowslisters "knative.dev/eventing/pkg/client/listers/flows/v1"
+	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
+	sourcelisters "knative.dev/eventing/pkg/client/listers/sources/v1alpha1"
+	sourcev1alpha2listers "knative.dev/eventing/pkg/client/listers/sources/v1alpha2"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/reconciler/testing"
+)
+
+var subscriberAddToScheme = func(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.eventing.knative.dev", Version: "v1alpha1", Kind: "Subscriber"}, &unstructured.Unstructured{})
+	return nil
+}
+
+var sourceAddToScheme = func(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.sources.knative.dev", Version: "v1alpha1", Kind: "TestSource"}, &duckv1.Source{})
+	return nil
+}
+
+var clientSetSchemes = []func(*runtime.Scheme) error{
+	fakekubeclientset.AddToScheme,
+	fakeeventingclientset.AddToScheme,
+	fakeapiextensionsclientset.AddToScheme,
+	subscriberAddToScheme,
+	sourceAddToScheme,
+	eventingduck.AddToScheme,
+}
+
+type Listers struct {
+	sorter testing.ObjectSorter
+}
+
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+	return scheme
+}
+
+func NewListers(objs []runtime.Object) Listers {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+
+	ls := Listers{
+		sorter: testing.NewObjectSorter(scheme),
+	}
+
+	ls.sorter.AddObjects(objs...)
+
+	return ls
+}
+
+func (l *Listers) indexerFor(obj runtime.Object) cache.Indexer {
+	return l.sorter.IndexerForObjectType(obj)
+}
+
+func (l *Listers) GetKubeObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
+}
+
+func (l *Listers) GetEventingObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeeventingclientset.AddToScheme)
+}
+
+func (l *Listers) GetSubscriberObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(subscriberAddToScheme)
+}
+
+func (l *Listers) GetAllObjects() []runtime.Object {
+	all := l.GetSubscriberObjects()
+	all = append(all, l.GetEventingObjects()...)
+	all = append(all, l.GetKubeObjects()...)
+	return all
+}
+
+func (l *Listers) GetSubscriptionLister() messaginglisters.SubscriptionLister {
+	return messaginglisters.NewSubscriptionLister(l.indexerFor(&messagingv1.Subscription{}))
+}
+
+func (l *Listers) GetSequenceLister() flowslisters.SequenceLister {
+	return flowslisters.NewSequenceLister(l.indexerFor(&flowsv1.Sequence{}))
+}
+
+func (l *Listers) GetTriggerLister() eventinglisters.TriggerLister {
+	return eventinglisters.NewTriggerLister(l.indexerFor(&eventingv1.Trigger{}))
+}
+
+func (l *Listers) GetBrokerLister() eventinglisters.BrokerLister {
+	return eventinglisters.NewBrokerLister(l.indexerFor(&eventingv1.Broker{}))
+}
+
+func (l *Listers) GetInMemoryChannelLister() messaginglisters.InMemoryChannelLister {
+	return messaginglisters.NewInMemoryChannelLister(l.indexerFor(&messagingv1.InMemoryChannel{}))
+}
+
+func (l *Listers) GetMessagingChannelLister() messaginglisters.ChannelLister {
+	return messaginglisters.NewChannelLister(l.indexerFor(&messagingv1.Channel{}))
+}
+
+func (l *Listers) GetParallelLister() flowslisters.ParallelLister {
+	return flowslisters.NewParallelLister(l.indexerFor(&flowsv1.Parallel{}))
+}
+
+func (l *Listers) GetApiServerSourceLister() sourcelisters.ApiServerSourceLister {
+	return sourcelisters.NewApiServerSourceLister(l.indexerFor(&sourcesv1alpha1.ApiServerSource{}))
+}
+
+func (l *Listers) GetPingSourceLister() sourcelisters.PingSourceLister {
+	return sourcelisters.NewPingSourceLister(l.indexerFor(&sourcesv1alpha1.PingSource{}))
+}
+
+func (l *Listers) GetSinkBindingLister() sourcelisters.SinkBindingLister {
+	return sourcelisters.NewSinkBindingLister(l.indexerFor(&sourcesv1alpha1.SinkBinding{}))
+}
+
+func (l *Listers) GetPingSourceV1alpha2Lister() sourcev1alpha2listers.PingSourceLister {
+	return sourcev1alpha2listers.NewPingSourceLister(l.indexerFor(&sourcesv1alpha2.PingSource{}))
+}
+
+func (l *Listers) GetContainerSourceLister() sourcev1alpha2listers.ContainerSourceLister {
+	return sourcev1alpha2listers.NewContainerSourceLister(l.indexerFor(&sourcesv1alpha2.ContainerSource{}))
+}
+
+func (l *Listers) GetSinkBindingV1alpha2Lister() sourcev1alpha2listers.SinkBindingLister {
+	return sourcev1alpha2listers.NewSinkBindingLister(l.indexerFor(&sourcesv1alpha2.SinkBinding{}))
+}
+
+func (l *Listers) GetApiServerSourceV1alpha2Lister() sourcev1alpha2listers.ApiServerSourceLister {
+	return sourcev1alpha2listers.NewApiServerSourceLister(l.indexerFor(&sourcesv1alpha2.ApiServerSource{}))
+}
+
+func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
+	return appsv1listers.NewDeploymentLister(l.indexerFor(&appsv1.Deployment{}))
+}
+
+func (l *Listers) GetK8sServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
+	return corev1listers.NewNamespaceLister(l.indexerFor(&corev1.Namespace{}))
+}
+
+func (l *Listers) GetServiceAccountLister() corev1listers.ServiceAccountLister {
+	return corev1listers.NewServiceAccountLister(l.indexerFor(&corev1.ServiceAccount{}))
+}
+
+func (l *Listers) GetServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetRoleBindingLister() rbacv1listers.RoleBindingLister {
+	return rbacv1listers.NewRoleBindingLister(l.indexerFor(&rbacv1.RoleBinding{}))
+}
+
+func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
+	return corev1listers.NewEndpointsLister(l.indexerFor(&corev1.Endpoints{}))
+}
+
+func (l *Listers) GetConfigMapLister() corev1listers.ConfigMapLister {
+	return corev1listers.NewConfigMapLister(l.indexerFor(&corev1.ConfigMap{}))
+}

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// TriggerOption enables further configuration of a Trigger.
+type TriggerOption func(*v1.Trigger)
+
+// NewTrigger creates a Trigger with TriggerOptions.
+func NewTrigger(name, namespace, broker string, to ...TriggerOption) *v1.Trigger {
+	t := &v1.Trigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.TriggerSpec{
+			Broker: broker,
+		},
+	}
+	for _, opt := range to {
+		opt(t)
+	}
+	t.SetDefaults(context.Background())
+	return t
+}
+
+func WithTriggerSubscriberURI(rawurl string) TriggerOption {
+	uri, _ := apis.ParseURL(rawurl)
+	return func(t *v1.Trigger) {
+		t.Spec.Subscriber = duckv1.Destination{URI: uri}
+	}
+}
+
+func WithTriggerSubscriberRef(gvk metav1.GroupVersionKind, name, namespace string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Spec.Subscriber = duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+				Namespace:  namespace,
+			},
+		}
+	}
+}
+
+func WithTriggerSubscriberRefAndURIReference(gvk metav1.GroupVersionKind, name, namespace string, rawuri string) TriggerOption {
+	uri, _ := apis.ParseURL(rawuri)
+	return func(t *v1.Trigger) {
+		t.Spec.Subscriber = duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+				Namespace:  namespace,
+			},
+			URI: uri,
+		}
+	}
+}
+
+// WithInitTriggerConditions initializes the Triggers's conditions.
+func WithInitTriggerConditions(t *v1.Trigger) {
+	t.Status.InitializeConditions()
+}
+
+func WithTriggerGeneration(gen int64) TriggerOption {
+	return func(s *v1.Trigger) {
+		s.Generation = gen
+	}
+}
+
+func WithTriggerStatusObservedGeneration(gen int64) TriggerOption {
+	return func(s *v1.Trigger) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
+// WithTriggerBrokerReady initializes the Triggers's conditions.
+func WithTriggerBrokerReady() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.PropagateBrokerCondition(v1.TestHelper.ReadyBrokerCondition())
+	}
+}
+
+// WithTriggerBrokerFailed marks the Broker as failed
+func WithTriggerBrokerFailed(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkBrokerFailed(reason, message)
+	}
+}
+
+// WithTriggerBrokerUnknown marks the Broker as unknown
+func WithTriggerBrokerUnknown(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkBrokerUnknown(reason, message)
+	}
+}
+
+func WithTriggerNotSubscribed(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkNotSubscribed(reason, message)
+	}
+}
+
+func WithTriggerSubscribedUnknown(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkSubscribedUnknown(reason, message)
+	}
+}
+
+func WithTriggerSubscriptionNotConfigured() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkSubscriptionNotConfigured()
+	}
+}
+
+func WithTriggerSubscribed() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.PropagateSubscriptionCondition(v1.TestHelper.ReadySubscriptionCondition())
+	}
+}
+
+func WithTriggerStatusSubscriberURI(uri string) TriggerOption {
+	return func(t *v1.Trigger) {
+		u, _ := apis.ParseURL(uri)
+		t.Status.SubscriberURI = u
+	}
+}
+
+func WithAnnotation(key, value string) TriggerOption {
+	return func(t *v1.Trigger) {
+		if t.Annotations == nil {
+			t.Annotations = make(map[string]string)
+		}
+		t.Annotations[key] = value
+	}
+}
+
+func WithDependencyAnnotation(dependencyAnnotation string) TriggerOption {
+	return func(t *v1.Trigger) {
+		if t.Annotations == nil {
+			t.Annotations = make(map[string]string)
+		}
+		t.Annotations[v1.DependencyAnnotation] = dependencyAnnotation
+	}
+}
+
+func WithTriggerDependencyReady() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkDependencySucceeded()
+	}
+}
+
+func WithTriggerDependencyFailed(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkDependencyFailed(reason, message)
+	}
+}
+
+func WithTriggerDependencyUnknown(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkDependencyUnknown(reason, message)
+	}
+}
+
+func WithTriggerSubscriberResolvedSucceeded() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkSubscriberResolvedSucceeded()
+	}
+}
+
+func WithTriggerSubscriberResolvedFailed(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkSubscriberResolvedFailed(reason, message)
+	}
+}
+
+func WithTriggerSubscriberResolvedUnknown(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkSubscriberResolvedUnknown(reason, message)
+	}
+}
+
+// TODO: this can be a runtime object
+func WithTriggerDeleted(t *v1.Trigger) {
+	deleteTime := metav1.NewTime(time.Unix(1e9, 0))
+	t.ObjectMeta.SetDeletionTimestamp(&deleteTime)
+}
+
+func WithTriggerUID(uid string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.UID = types.UID(uid)
+	}
+}

--- a/pkg/reconciler/testing/v1/unstructured.go
+++ b/pkg/reconciler/testing/v1/unstructured.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UnstructuredOption enables further configuration of a Unstructured.
+type UnstructuredOption func(*unstructured.Unstructured)
+
+// NewUnstructured creates a unstructured.Unstructured with UnstructuredOption
+func NewUnstructured(gvk metav1.GroupVersionKind, name, namespace string, uo ...UnstructuredOption) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion(gvk),
+			"kind":       gvk.Kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+	}
+	for _, opt := range uo {
+		opt(u)
+	}
+	return u
+}
+
+func WithUnstructuredAddressable(hostname string) UnstructuredOption {
+	return func(u *unstructured.Unstructured) {
+		status, ok := u.Object["status"].(map[string]interface{})
+		if ok {
+			status["address"] = map[string]interface{}{
+				"hostname": hostname,
+				"url":      fmt.Sprintf("http://%s", hostname),
+			}
+		}
+	}
+}
+
+func apiVersion(gvk metav1.GroupVersionKind) string {
+	groupVersion := gvk.Version
+	if gvk.Group != "" {
+		groupVersion = gvk.Group + "/" + gvk.Version
+	}
+	return groupVersion
+}


### PR DESCRIPTION
Fixes #3580

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reconcile eventing.{Broker, Trigger} with v1 shape
- Generate / operate on dependent resources using v1 shapes (Subscriptions, channels, etc.)
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
Reconcile eventing.{Broker,Trigger} using v1 api shape. Operate on dependent resources (Subscriptions, etc.) using their v1 shapes.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
