### PR TITLE
Return an error if the test client cannot getTracingConfig

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -91,6 +91,9 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 	client.Tracker = NewTracker(t, client.Dynamic)
 
 	client.tracingEnv, err = getTracingConfig(client.Kube.Kube)
+	if err != nil {
+		return nil, err
+	}
 
 	return client, nil
 }


### PR DESCRIPTION
Was leading to errors within the tests themselves of invalid pod
EnvVars (blank) when the config wasn't available.


----

#