### PR TITLE
configmaplister, reduce trigger status churn

### DIFF
--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -232,11 +232,11 @@ func TestReconcile(t *testing.T) {
 					WithBrokerClass(eventing.MTChannelBrokerClassValue),
 					WithInitBrokerConditions,
 					WithBrokerConfig(config()),
-					WithTriggerChannelFailed("ChannelTemplateFailed", `Error on setting up the ChannelTemplate: configmaps "test-configmap" not found`)),
+					WithTriggerChannelFailed("ChannelTemplateFailed", `Error on setting up the ChannelTemplate: configmap "test-configmap" not found`)),
 			}},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
-				Eventf(corev1.EventTypeWarning, "InternalError", `configmaps "test-configmap" not found`),
+				Eventf(corev1.EventTypeWarning, "InternalError", `configmap "test-configmap" not found`),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(testNS, brokerName),
@@ -1167,6 +1167,7 @@ func TestReconcile(t *testing.T) {
 			triggerLister:      listers.GetTriggerLister(),
 
 			endpointsLister:    listers.GetEndpointsLister(),
+			configmapLister:    listers.GetConfigMapLister(),
 			kresourceTracker:   duck.NewListableTracker(ctx, conditions.Get, func(types.NamespacedName) {}, 0),
 			channelableTracker: duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
 			addressableTracker: duck.NewListableTracker(ctx, v1a1addr.Get, func(types.NamespacedName) {}, 0),

--- a/pkg/reconciler/mtbroker/controller.go
+++ b/pkg/reconciler/mtbroker/controller.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -68,6 +69,7 @@ func NewController(
 	triggerInformer := triggerinformer.Get(ctx)
 	subscriptionInformer := subscriptioninformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
+	configmapInformer := configmapinformer.Get(ctx)
 
 	eventingv1.RegisterAlternateBrokerConditionSet(apis.NewLivingConditionSet(
 		BrokerConditionIngress,
@@ -84,6 +86,7 @@ func NewController(
 		subscriptionLister: subscriptionInformer.Lister(),
 		triggerLister:      triggerInformer.Lister(),
 		brokerClass:        eventing.MTChannelBrokerClassValue,
+		configmapLister:    configmapInformer.Lister(),
 	}
 	impl := brokerreconciler.NewImpl(ctx, r, eventing.MTChannelBrokerClassValue)
 

--- a/pkg/reconciler/mtbroker/controller_test.go
+++ b/pkg/reconciler/mtbroker/controller_test.go
@@ -29,6 +29,7 @@ import (
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 )

--- a/pkg/reconciler/mtbroker/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -184,7 +183,10 @@ func (r *Reconciler) updateTriggerStatus(ctx context.Context, desired *eventingv
 		return nil, err
 	}
 
-	if reflect.DeepEqual(trigger.Status, desired.Status) {
+	// Do the postprocessing for unnecessary trigger status changes.
+	groomConditionsTransitionTime(desired, trigger)
+
+	if equality.Semantic.DeepEqual(trigger.Status, desired.Status) {
 		return trigger, nil
 	}
 


### PR DESCRIPTION
Addresses #3591

As part of debugging the #3591 there were couple of things we could do better to reduce the churn on the API server, namely use configmap lister instead of hitting the API server. Also use the same logic for deciding whether to update Trigger Status just like we would do if we were using genreconciler. 

## Proposed Changes

- use configmap lister
- reduce trigger status churn
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
