### PR TITLE
Flipping the SinkBinding storage bit to v1beta1

### DIFF
--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -26,7 +26,7 @@ spec:
   group: sources.knative.dev
   versions:
     - &version
-      name: v1alpha1
+      name: v1beta1
       served: true
       storage: true
       subresources:
@@ -53,11 +53,11 @@ spec:
           type: date
           jsonPath: .metadata.creationTimestamp
     - <<: *version
-      name: v1alpha2
+      name: v1alpha1
       served: true
       storage: false
     - <<: *version
-      name: v1beta1
+      name: v1alpha2
       served: true
       storage: false
   names:

--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -26,9 +26,9 @@ spec:
   group: sources.knative.dev
   versions:
     - &version
-      name: v1beta1
+      name: v1alpha1
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
       schema:
@@ -53,13 +53,13 @@ spec:
           type: date
           jsonPath: .metadata.creationTimestamp
     - <<: *version
-      name: v1alpha1
-      served: true
-      storage: false
-    - <<: *version
       name: v1alpha2
       served: true
       storage: false
+    - <<: *version
+      name: v1beta1
+      served: true
+      storage: true
   names:
     categories:
       - all


### PR DESCRIPTION
Helps with https://github.com/knative/eventing/issues/3544

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🎁  Storing SinkBindings in v1beta1 

Missing the storage migration job

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
SinkBinding is available in v1beta1
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
