### PR TITLE
Drop vestigial kubeclient.

### DIFF
--- a/pkg/reconciler/mtbroker/broker.go
+++ b/pkg/reconciler/mtbroker/broker.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -63,7 +62,6 @@ const (
 type Reconciler struct {
 	eventingClientSet clientset.Interface
 	dynamicClientSet  dynamic.Interface
-	kubeClientSet     kubernetes.Interface
 
 	// listers index properties about resources
 	endpointsLister    corev1listers.EndpointsLister

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -46,7 +46,6 @@ import (
 	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
 	v1a1addr "knative.dev/pkg/client/injection/ducks/duck/v1alpha1/addressable"
 	v1b1addr "knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
-	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
@@ -1162,7 +1161,6 @@ func TestReconcile(t *testing.T) {
 		r := &Reconciler{
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
-			kubeClientSet:      fakekubeclient.Get(ctx),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			triggerLister:      listers.GetTriggerLister(),
 

--- a/pkg/reconciler/mtbroker/controller.go
+++ b/pkg/reconciler/mtbroker/controller.go
@@ -34,7 +34,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	"knative.dev/pkg/configmap"
@@ -81,7 +80,6 @@ func NewController(
 	r := &Reconciler{
 		eventingClientSet:  eventingclient.Get(ctx),
 		dynamicClientSet:   dynamicclient.Get(ctx),
-		kubeClientSet:      kubeclient.Get(ctx),
 		endpointsLister:    endpointsInformer.Lister(),
 		subscriptionLister: subscriptionInformer.Lister(),
 		triggerLister:      triggerInformer.Lister(),


### PR DESCRIPTION
After vaikas switched to the configmap lister, this is no longer needed.

- 🧽 Update or clean up current behavior
