### PR TITLE
add knobs for overriding qps / burst

### DIFF
--- a/cmd/mtchannel_broker/main.go
+++ b/cmd/mtchannel_broker/main.go
@@ -21,6 +21,7 @@ import (
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"flag"
 
+	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
 
@@ -29,8 +30,8 @@ import (
 
 func main() {
 	// TODO(https://github.com/knative/eventing/issues/3591): switch back to sharedmain.Main
-	clientQPS := flag.Float64("clientQPS", 5.0, "Overrides rest.Config.DefaultQPS.")
-	clientBurst := flag.Int("clientBurst", 10.0, "Overrides rest.Config.Burst.")
+	clientQPS := flag.Float64("clientQPS", float64(rest.DefaultQPS), "Overrides rest.Config.DefaultQPS.")
+	clientBurst := flag.Int("clientBurst", rest.DefaultBurst, "Overrides rest.Config.Burst.")
 
 	// This parses flags.
 	cfg := sharedmain.ParseAndGetConfigOrDie()

--- a/cmd/mtchannel_broker/main.go
+++ b/cmd/mtchannel_broker/main.go
@@ -28,6 +28,7 @@ import (
 )
 
 func main() {
+	// TODO(https://github.com/knative/eventing/issues/3591): switch back to sharedmain.Main
 	clientQPS := flag.Float64("clientQPS", 5.0, "Overrides rest.Config.DefaultQPS.")
 	clientBurst := flag.Int("clientBurst", 10.0, "Overrides rest.Config.Burst.")
 

--- a/cmd/mtchannel_broker/main.go
+++ b/cmd/mtchannel_broker/main.go
@@ -19,14 +19,21 @@ package main
 import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"flag"
 
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
 
 	"knative.dev/eventing/pkg/reconciler/mtbroker"
 )
 
 func main() {
-	sharedmain.Main("mt-broker-controller",
-		mtbroker.NewController,
-	)
+	clientQPS := flag.Float64("clientQPS", 5.0, "Overrides rest.Config.DefaultQPS.")
+	clientBurst := flag.Int("clientBurst", 10.0, "Overrides rest.Config.Burst.")
+
+	// This parses flags.
+	cfg := sharedmain.ParseAndGetConfigOrDie()
+	cfg.QPS = float32(*clientQPS)
+	cfg.Burst = *clientBurst
+	sharedmain.MainWithConfig(signals.NewContext(), "mt-broker-controller", cfg, mtbroker.NewController)
 }


### PR DESCRIPTION
Addresses #3591 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add flags for configuring the client qps / burst rates.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🎁 Add new feature
Add two flags to broker to control rest client QPS / Burst. Defaults to same as before.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
