### PR TITLE
remove event emit for normal trigger reconcile

### DIFF
--- a/pkg/reconciler/mtbroker/broker.go
+++ b/pkg/reconciler/mtbroker/broker.go
@@ -333,8 +333,6 @@ func (r *Reconciler) reconcileTriggers(ctx context.Context, b *eventingv1.Broker
 			if tErr != nil {
 				logging.FromContext(ctx).Errorw("Reconciling trigger failed:", zap.String("name", t.Name), zap.Error(err))
 				recorder.Eventf(trigger, corev1.EventTypeWarning, triggerReconcileFailed, "Trigger reconcile failed: %v", tErr)
-			} else {
-				recorder.Event(trigger, corev1.EventTypeNormal, triggerReconciled, "Trigger reconciled")
 			}
 			trigger.Status.ObservedGeneration = t.Generation
 			if _, updateStatusErr := r.updateTriggerStatus(ctx, trigger); updateStatusErr != nil {

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -509,7 +509,6 @@ func TestReconcile(t *testing.T) {
 			}},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(testNS, brokerName),
@@ -631,9 +630,6 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 					WithTriggerSubscriberURI(subscriberURI)),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 		}, {
 			Name: "Trigger subscription create fails",
 			Key:  testKey,
@@ -800,9 +796,6 @@ func TestReconcile(t *testing.T) {
 			WantCreates: []runtime.Object{
 				makeFilterSubscription(),
 			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 		}, {
 			Name: "Trigger has subscriber ref exists",
 			Key:  testKey,
@@ -813,9 +806,6 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberRef(subscriberGVK, subscriberName, testNS),
 					WithInitTriggerConditions)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -843,9 +833,6 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -873,9 +860,6 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -925,9 +909,6 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -952,9 +933,6 @@ func TestReconcile(t *testing.T) {
 					WithInitTriggerConditions,
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -1009,8 +987,6 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -1038,8 +1014,6 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -1068,8 +1042,6 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled")},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -1097,9 +1069,6 @@ func TestReconcile(t *testing.T) {
 					WithDependencyAnnotation(dependencyAnnotation),
 				)}...),
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerName, testNS, brokerName,
 					WithTriggerUID(triggerUID),
@@ -1131,7 +1100,6 @@ func TestReconcile(t *testing.T) {
 			WantErr: false,
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, subscriptionDeleted, `Deprecated subscription removed: "%s/%s"`, testNS, makeReadySubscriptionDeprecatedName(triggerNameLong, triggerUIDLong).Name),
-				Eventf(corev1.EventTypeNormal, "TriggerReconciled", "Trigger reconciled"),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewTrigger(triggerNameLong, testNS, brokerName,


### PR DESCRIPTION
Addresses #https://github.com/knative/pkg/issues/1520

While Matt and I were debugging things related to chaos, and in particular what happens to 'nop' controllers, we started looking at places were we are doing unnecessary api server calls. This is removing one of them.
Overarching issue tracking in /pkg
https://github.com/knative/pkg/issues/1520

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do no emit trigger reconciled successfully event 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
When Trigger is reconciled, do not emit an event for it
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
