### PR TITLE
add broker developers as system integrator personas

### DIFF
--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,7 +1,7 @@
 # Knative Personas
 
 When discussing user actions, it is often helpful to
-[define specific user roles](<https://en.wikipedia.org/wiki/Persona_(user_experience)>)
+[define specific user roles](https://en.wikipedia.org/wiki/Persona_(user_experience))
 who might want to do the action.
 
 ## Knative Events
@@ -35,7 +35,7 @@ User stories:
 
 System Integrators are typically of three varieties. They are producing new
 Channel implementations, or new Event Source implementations, or new Broker
-implementations .
+implementations.
 
 User stories:
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -33,14 +33,16 @@ User stories:
 
 ### System Integrator
 
-System Integrators are typically of two varieties. They are producing new
-Channel implementations or new Event Source implementations.
+System Integrators are typically of three varieties. They are producing new
+Channel implementations, or new Event Source implementations, or new Broker
+implementations .
 
 User stories:
 
 - Create a new Event Source (creating a bridge between an existing system and
   Knative Eventing)
 - Create a new Channel implementation
+- Create a new Broker implementation
 
 ## Contributors
 

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,7 +1,7 @@
 # Knative Personas
 
 When discussing user actions, it is often helpful to
-[define specific user roles](<https://en.wikipedia.org/wiki/Persona_(user_experience)>)
+[define specific user roles](<https://en.wikipedia.org/wiki/Persona_\(user_experience\)>)
 who might want to do the action.
 
 ## Knative Events

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,7 +1,7 @@
 # Knative Personas
 
 When discussing user actions, it is often helpful to
-[define specific user roles](https://en.wikipedia.org/wiki/Persona_(user_experience))
+[define specific user roles](<https://en.wikipedia.org/wiki/Persona_(user_experience)>)
 who might want to do the action.
 
 ## Knative Events


### PR DESCRIPTION
Add Broker developer as an example of a System Integrator. We currently list only new Event Source, Channel implementors as System Integrators, with the addition of Broker Classes, we should add a Broker implementor as this type as well.

## Proposed Changes

- Add Broker implementor as System Integrator persona.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 Update or clean up current behavior
Add Broker implementor as a System Integrator persona.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
