### PR TITLE
add step for installing sugar for e2e

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,7 +136,7 @@ ko apply -f config/channels/in-memory-channel/
 Depending on your needs you might want to install other
 [channel implementations](https://github.com/knative/docs/blob/master/docs/eventing/channels/channels-crds.md).
 
-## Install Brokers
+## Install Broker
 
 Install the
 [MT Channel Broker](https://github.com/knative/eventing/tree/master/config/brokers/mt-channel-broker)
@@ -148,6 +148,15 @@ ko apply -f config/brokers/mt-channel-broker/
 
 Depending on your needs you might want to install other
 [Broker implementations](https://github.com/knative/eventing/tree/master/docs/broker).
+
+## (Optional) Install Sugar controller
+
+If you are running full set of e2e tests, you will need to install the
+[sugar controller](config/sugar/README.md). 
+
+```shell
+ko apply -f config/sugar/
+```
 
 ## Iterating
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,7 +152,7 @@ Depending on your needs you might want to install other
 ## (Optional) Install Sugar controller
 
 If you are running full set of e2e tests, you will need to install the
-[sugar controller](config/sugar/README.md). 
+[sugar controller](config/sugar/README.md).
 
 ```shell
 ko apply -f config/sugar/


### PR DESCRIPTION
Since E2E tests rely for some tests on sugar controller, we should document it in our development. One of our users ran into this.

## Proposed Changes

- Document that sugar is opttional component, but if you're running e2e tests you need to install it.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
