### PR TITLE
Drop the event emission on every reconcile

### DIFF
--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -143,9 +143,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelChannelServiceReady(),
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		}, {
 			Name: "the status of deployment is unknown",
 			Key:  imcKey,
@@ -168,9 +165,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelChannelServiceReady(),
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		}, {
 			Name: "Service does not exist",
 			Key:  imcKey,
@@ -254,9 +248,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress),
 				),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		}, {
 			Name: "Works, channel exists",
 			Key:  imcKey,
@@ -278,9 +269,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress),
 				),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		}, {
 			Name: "channel exists, not owned by us",
 			Key:  imcKey,
@@ -328,9 +316,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress),
 				),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		}, {
 			Name: "channel does not exist, fails to create",
 			Key:  imcKey,
@@ -417,7 +402,6 @@ func TestInNamespace(t *testing.T) {
 				Eventf(corev1.EventTypeNormal, "DispatcherRoleBindingCreated", "Dispatcher RoleBinding created"),
 				Eventf(corev1.EventTypeNormal, "DispatcherDeploymentCreated", "Dispatcher Deployment created"),
 				Eventf(corev1.EventTypeNormal, "DispatcherServiceCreated", "Dispatcher Service created"),
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
 			},
 		},
 		{
@@ -446,9 +430,6 @@ func TestInNamespace(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress),
 				),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "InMemoryChannelReconciled", `InMemoryChannel reconciled: "test-namespace/test-imc"`),
-			},
 		},
 	}
 


### PR DESCRIPTION
Addresses #https://github.com/knative/pkg/issues/1520

Do not emit events for every reconcile. Add logging

## Proposed Changes

- Do not emit normal events for every reconcile
- Add logging
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🗑️ Remove feature or internal logic

Do not emit k8s events for every successful reconcile of IMC
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
