### PR TITLE
Export logs from knative-eventing namespace

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +26,7 @@ import (
 
 	"knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
 )
 
 var channelTestRunner testlib.ComponentsTestRunner
@@ -50,6 +53,7 @@ func TestMain(m *testing.M) {
 		// place that cleans it up. If an individual test calls this instead, then it will break other
 		// tests that need the tracing in place.
 		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+		defer testlib.ExportLogs(testlib.SystemLogsDir, resources.SystemNamespace)
 
 		return m.Run()
 	}())

--- a/test/conformance/source_crd_metadata_test.go
+++ b/test/conformance/source_crd_metadata_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +23,7 @@ import (
 
 	"knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
 )
 
 var setup = testlib.Setup
@@ -35,5 +38,10 @@ func TestMain(m *testing.M) {
 		ComponentsToTest:    test.EventingFlags.Channels,
 	}
 	brokerClass = test.EventingFlags.BrokerClass
-	os.Exit(m.Run())
+
+	exit := m.Run()
+
+	testlib.ExportLogs(testlib.SystemLogsDir, resources.SystemNamespace)
+
+	os.Exit(exit)
 }

--- a/test/lib/config.go
+++ b/test/lib/config.go
@@ -66,6 +66,8 @@ const (
 	// The interval and timeout used for polling pod logs.
 	interval = 1 * time.Second
 	timeout  = 4 * time.Minute
+
+	SystemLogsDir = "knative-eventing-logs"
 )
 
 // InterestingHeaders is used by logging pods to decide interesting HTTP headers to log

--- a/test/lib/logexporter.go
+++ b/test/lib/logexporter.go
@@ -18,35 +18,44 @@ package lib
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/test"
+	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
+	"knative.dev/pkg/test/prow"
 )
 
 func (c *Client) ExportLogs(dir string) error {
+	return exportLogs(c.Kube, c.Namespace, dir, c.T.Logf)
+}
+
+func exportLogs(kubeClient *test.KubeClient, namespace, dir string, logFunc func(format string, args ...interface{})) error {
+
 	// Create a directory for the namespace.
-	logPath := filepath.Join(dir, c.Namespace)
+	logPath := filepath.Join(dir, namespace)
 	if err := helpers.CreateDir(logPath); err != nil {
-		return fmt.Errorf("error creating directory %q: %w", c.Namespace, err)
+		return fmt.Errorf("error creating directory %q: %w", namespace, err)
 	}
 
-	pods, err := c.Kube.Kube.CoreV1().Pods(c.Namespace).List(metav1.ListOptions{})
+	pods, err := kubeClient.Kube.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("error listing pods in namespace %q: %w", c.Namespace, err)
+		return fmt.Errorf("error listing pods in namespace %q: %w", namespace, err)
 	}
 
 	var errs []error
 	for _, pod := range pods.Items {
 		for _, ct := range pod.Spec.Containers {
 			fn := filepath.Join(logPath, fmt.Sprintf("%s-%s.log", pod.Name, ct.Name))
-			c.T.Logf("Exporting logs in pod %q container %q to %q", pod.Name, ct.Name, fn)
+			logFunc("Exporting logs in pod %q container %q to %q", pod.Name, ct.Name, fn)
 			f, err := os.Create(fn)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error creating file %q: %w", fn, err))
 			}
-			log, err := c.Kube.PodLogs(pod.Name, ct.Name, c.Namespace)
+			log, err := kubeClient.PodLogs(pod.Name, ct.Name, pod.Namespace)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error getting logs for pod %q container %q: %w", pod.Name, ct.Name, err))
 			}
@@ -60,4 +69,21 @@ func (c *Client) ExportLogs(dir string) error {
 	}
 
 	return helpers.CombineErrors(errs)
+}
+
+func ExportLogs(systemLogsDir, systemNamespace string) {
+
+	// If the test is run by CI, export the pod logs in the namespace to the artifacts directory,
+	// which will then be uploaded to GCS after the test job finishes.
+	if prow.IsCI() {
+		kubeClient, err := pkgtest.NewKubeClient(pkgtest.Flags.Kubeconfig, pkgtest.Flags.Cluster)
+		if err != nil {
+			log.Printf("Failed to create Kube client: %v\n", err)
+		}
+
+		dir := filepath.Join(prow.GetLocalArtifactsDir(), systemLogsDir)
+		if err := exportLogs(kubeClient, systemNamespace, dir, log.Printf); err != nil {
+			log.Printf("Error in exporting logs: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
Exporting logs from `knative-eventing` namespace at the end of `e2e` and `conformance` test suites can help to debug failed test runs.

## Proposed Changes

- Export logs from `knative-eventing` namespace at the end of `e2e` and `conformance` test suites.