### PR TITLE
Remove reconciled normal event from channel

### DIFF
--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,12 +38,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
-
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason ChannelReconciled.
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: \"%s/%s\"", namespace, name)
-}
 
 type Reconciler struct {
 	// listers index properties about resources
@@ -92,7 +85,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1beta1.Channel) pkgr
 	bCS := r.getChannelableStatus(ctx, &backingChannel.Status, backingChannel.Annotations)
 	c.Status.PropagateStatuses(bCS)
 
-	return newReconciledNormal(c.Namespace, c.Name)
+	return nil
 }
 
 func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.ChannelableCombinedStatus, cAnnotations map[string]string) *duckv1beta1.ChannelableStatus {

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -132,9 +132,6 @@ func TestReconcile(t *testing.T) {
 				WithBackingChannelReady,
 				WithChannelAddress(backingChannelHostname)),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
-		},
 	}, {
 		Name: "Already reconciled",
 		Key:  testKey,
@@ -154,9 +151,6 @@ func TestReconcile(t *testing.T) {
 				WithInMemoryChannelSubscribers(subscribers()),
 				WithInMemoryChannelAddress(backingChannelHostname)),
 		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
-		},
 	}, {
 		Name: "Backing channel created",
 		Key:  testKey,
@@ -170,9 +164,6 @@ func TestReconcile(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			createChannel(testNS, channelName, false),
-		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewChannel(channelName, testNS,
@@ -213,9 +204,6 @@ func TestReconcile(t *testing.T) {
 				// Updates
 				WithChannelObservedGeneration(42)),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
-		},
 	}, {
 		Name: "Updating subscribers statuses",
 		Key:  testKey,
@@ -246,9 +234,6 @@ func TestReconcile(t *testing.T) {
 				WithChannelAddress(backingChannelHostname),
 				WithChannelSubscriberStatuses(subscriberStatuses())),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
-		},
 	}, {
 		Name: "Updating v1alpha1 channelable subscribers statuses",
 		Key:  testKey,
@@ -274,9 +259,6 @@ func TestReconcile(t *testing.T) {
 				WithChannelAddress(backingChannelHostname),
 				WithChannelSubscriberStatuses(subscriberStatuses())),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "ChannelReconciled", "Channel reconciled: %q", testKey),
-		},
 	}}
 
 	logger := logtesting.TestLogger(t)


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For Channel, the Kubernetes event "ChannelReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520