### PR TITLE
remove reconciled normal event from subscriptions

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -62,10 +62,6 @@ var (
 	v1ChannelGVK      = v1.SchemeGroupVersion.WithKind("Channel")
 )
 
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "SubscriptionReconciled", "Subscription reconciled: \"%s/%s\"", namespace, name)
-}
-
 func newChannelWarnEvent(messageFmt string, args ...interface{}) pkgreconciler.Event {
 	return pkgreconciler.NewEvent(corev1.EventTypeWarning, channelReferenceFailed, messageFmt, args...)
 }
@@ -117,7 +113,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, subscription *v1beta1.Su
 		return event
 	}
 
-	return newReconciledNormal(subscription.Namespace, subscription.Name)
+	return nil
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -208,9 +208,6 @@ func TestAllCases(t *testing.T) {
 			},
 			Key:     testNS + "/" + subscriptionName,
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "SubscriptionReconciled", `Subscription reconciled: "testnamespace/testsubscription"`),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewSubscription(subscriptionName, testNS,
 					WithSubscriptionUID(subscriptionUID),


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For Subscription, the Kubernetes event "SubscriptionReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520