### PR TITLE
remove reconciled normal event from eventtypes

### DIFF
--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/eventtype"
@@ -29,12 +28,6 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
 )
-
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason EventTypeReconciled.
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "EventTypeReconciled", "EventType reconciled: \"%s/%s\"", namespace, name)
-}
 
 type Reconciler struct {
 	// listers index properties about resources
@@ -81,7 +74,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta1.EventType) p
 
 	et.Status.PropagateBrokerStatus(&b.Status)
 
-	return newReconciledNormal(et.Namespace, et.Name)
+	return nil
 }
 
 // getBroker returns the Broker for EventType 'et' if it exists, otherwise it returns an error.

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -124,9 +124,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeBrokerFailed("DeploymentFailure", "inducing failure for create deployments"),
 			),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "EventTypeReconciled", `EventType reconciled: "test-namespace/test-eventtype"`),
-		},
 	}, {
 		Name: "The status of Broker is Unknown",
 		Key:  testKey,
@@ -149,9 +146,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeBrokerUnknown("", ""),
 			),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "EventTypeReconciled", `EventType reconciled: "test-namespace/test-eventtype"`),
-		},
 	}, {
 		Name: "Successful reconcile, became ready",
 		Key:  testKey,
@@ -174,9 +168,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeBrokerReady,
 			),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "EventTypeReconciled", `EventType reconciled: "test-namespace/test-eventtype"`),
-		},
 	}}
 
 	logger := logtesting.TestLogger(t)


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For EventType, the Kubernetes event "EventTypeReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520