### PR TITLE
remove reconciled normal event from mtbroker

### DIFF
--- a/pkg/reconciler/mtbroker/broker.go
+++ b/pkg/reconciler/mtbroker/broker.go
@@ -54,11 +54,6 @@ import (
 	"knative.dev/pkg/system"
 )
 
-const (
-	// Name of the corev1.Events emitted from the Broker reconciliation process.
-	brokerReconciled = "BrokerReconciled"
-)
-
 type Reconciler struct {
 	eventingClientSet clientset.Interface
 	dynamicClientSet  dynamic.Interface
@@ -94,10 +89,6 @@ type ReconcilerArgs struct {
 	IngressServiceAccountName string
 	FilterImage               string
 	FilterServiceAccountName  string
-}
-
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, brokerReconciled, "Broker reconciled: \"%s/%s\"", namespace, name)
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pkgreconciler.Event {
@@ -268,7 +259,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, b *eventingv1.Broker) pkg
 	if err := r.propagateBrokerStatusToTriggers(ctx, b.Namespace, b.Name, nil); err != nil {
 		return fmt.Errorf("Trigger reconcile failed: %v", err)
 	}
-	return newReconciledNormal(b.Namespace, b.Name)
+	return nil
 }
 
 // reconcileChannel reconciles Broker's 'b' underlying channel.

--- a/pkg/reconciler/mtbroker/broker_test.go
+++ b/pkg/reconciler/mtbroker/broker_test.go
@@ -167,9 +167,6 @@ func TestReconcile(t *testing.T) {
 					WithBrokerDeletionTimestamp),
 				imcConfigMap(),
 			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "BrokerReconciled", `Broker reconciled: "test-namespace/test-broker"`),
-			},
 		}, {
 			Name: "nil config",
 			Key:  testKey,
@@ -582,7 +579,6 @@ func TestReconcile(t *testing.T) {
 			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
-				Eventf(corev1.EventTypeNormal, "BrokerReconciled", `Broker reconciled: "test-namespace/test-broker"`),
 			},
 		}, {
 			Name: "Broker being deleted, marks trigger as not ready due to broker missing, fails",


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For MTBroker, the Kubernetes event "BrokerReconciled" is no longer produced for clean runs of the FinalizeKind method.
```

relates to https://github.com/knative/pkg/issues/1520