### PR TITLE
remove reconciled normal event from parallel

### DIFF
--- a/pkg/reconciler/parallel/parallel.go
+++ b/pkg/reconciler/parallel/parallel.go
@@ -44,12 +44,6 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason ParallelReconciled.
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "ParallelReconciled", "Parallel reconciled: \"%s/%s\"", namespace, name)
-}
-
 type Reconciler struct {
 	// listers index properties about resources
 	parallelLister     listers.ParallelLister
@@ -130,7 +124,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, p *v1beta1.Parallel) pkg
 	}
 	p.Status.PropagateSubscriptionStatuses(filterSubs, subs)
 
-	return newReconciledNormal(p.Namespace, p.Name)
+	return nil
 }
 
 func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, p *v1beta1.Parallel, channelObjRef corev1.ObjectReference) (*duckv1beta1.Channelable, error) {

--- a/pkg/reconciler/parallel/parallel_test.go
+++ b/pkg/reconciler/parallel/parallel_test.go
@@ -124,9 +124,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(0)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -165,9 +162,6 @@ func TestAllBranches(t *testing.T) {
 						{Filter: createFilter(0), Subscriber: createSubscriber(0)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -204,9 +198,6 @@ func TestAllBranches(t *testing.T) {
 						{Filter: createFilter(0), Subscriber: createSubscriber(0), Delivery: createDelivery(subscriberGVK, "dlc", testNS)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -244,9 +235,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(0)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -287,9 +275,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(0), Reply: createBranchReplyChannel(0)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -330,9 +315,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(1)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -390,9 +372,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(1)},
 					}))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantCreates: []runtime.Object{
 				createChannel(parallelName),
 				createBranchChannel(parallelName, 0),
@@ -456,9 +435,6 @@ func TestAllBranches(t *testing.T) {
 						{Subscriber: createSubscriber(0)},
 					})))},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "ParallelReconciled", `Parallel reconciled: "test-namespace/test-parallel"`),
-			},
 			WantDeletes: []clientgotesting.DeleteActionImpl{
 				{Name: resources.ParallelBranchChannelName(parallelName, 0)},
 			},


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For Parallel, the Kubernetes event "ParallelReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520