### PR TITLE
Do not produce reconciled-normal events always. - PingSource and Sequence

### DIFF
--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -67,12 +67,6 @@ const (
 	stadapterClusterRoleName = "knative-eventing-pingsource-adapter"
 )
 
-// newReconciledNormal makes a new reconciler event with event type Normal, and
-// reason PingSourceReconciled.
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "PingSourceReconciled", "PingSource reconciled: \"%s/%s\"", namespace, name)
-}
-
 func newWarningSinkNotFound(sink *duckv1.Destination) pkgreconciler.Event {
 	b, _ := json.Marshal(sink)
 	return pkgreconciler.NewEvent(corev1.EventTypeWarning, "SinkNotFound", "Sink not found: %s", string(b))
@@ -195,7 +189,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1alpha2.PingSou
 		Source: v1alpha2.PingSourceSource(source.Namespace, source.Name),
 	}}
 
-	return newReconciledNormal(source.Namespace, source.Name)
+	return nil
 }
 
 func (r *Reconciler) reconcileServiceAccount(ctx context.Context, source *v1alpha2.PingSource) (*corev1.ServiceAccount, error) {

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -164,7 +164,6 @@ func TestAllCases(t *testing.T) {
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "PingSourceServiceAccountCreated", `PingSource ServiceAccount created`),
 				Eventf(corev1.EventTypeNormal, "PingSourceRoleBindingCreated", `PingSource RoleBinding created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantCreates: []runtime.Object{
 				MakeServiceAccount(sourceName, sourceUID),
@@ -216,7 +215,6 @@ func TestAllCases(t *testing.T) {
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "PingSourceServiceAccountCreated", `PingSource ServiceAccount created`),
 				Eventf(corev1.EventTypeNormal, "PingSourceRoleBindingCreated", `PingSource RoleBinding created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantCreates: []runtime.Object{
 				MakeServiceAccount(sourceName, sourceUID),
@@ -268,7 +266,6 @@ func TestAllCases(t *testing.T) {
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "PingSourceServiceAccountCreated", `PingSource ServiceAccount created`),
 				Eventf(corev1.EventTypeNormal, "PingSourceRoleBindingCreated", `PingSource RoleBinding created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantCreates: []runtime.Object{
 				MakeServiceAccount(sourceName, sourceUID),
@@ -345,9 +342,6 @@ func TestAllCases(t *testing.T) {
 					WithPingSourceV1A2StatusObservedGeneration(generation),
 				),
 			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
-			},
 		}, {
 			Name: "valid",
 			Objects: []runtime.Object{
@@ -373,7 +367,6 @@ func TestAllCases(t *testing.T) {
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "PingSourceServiceAccountCreated", `PingSource ServiceAccount created`),
 				Eventf(corev1.EventTypeNormal, "PingSourceRoleBindingCreated", `PingSource RoleBinding created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantCreates: []runtime.Object{
 				MakeServiceAccount(sourceName, sourceUID),
@@ -422,9 +415,6 @@ func TestAllCases(t *testing.T) {
 				makeAvailableMTAdapter(),
 			},
 			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewPingSourceV1Alpha2(sourceName, testNS,
 					WithPingSourceV1A2Spec(sourcesv1alpha2.PingSourceSpec{
@@ -471,7 +461,6 @@ func TestAllCases(t *testing.T) {
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "PingSourceDeploymentCreated", `Cluster-scoped deployment created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceName),
 			},
 			WantCreates: []runtime.Object{
 				MakeMTAdapter(),
@@ -525,7 +514,6 @@ func TestAllCases(t *testing.T) {
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, pingSourceDeploymentDeleted, `Deprecated deployment removed: "%s/%s"`, testNS, makeAvailableReceiveAdapterDeprecatedName(sourceNameLong, sourceUIDLong, sinkDest).Name),
 				Eventf(corev1.EventTypeNormal, "PingSourceDeploymentCreated", `Deployment created`),
-				Eventf(corev1.EventTypeNormal, "PingSourceReconciled", `PingSource reconciled: "%s/%s"`, testNS, sourceNameLong),
 			},
 			WantCreates: []runtime.Object{
 				// makeJobRunner(),

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -43,10 +43,6 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
-func newReconciledNormal(namespace, name string) pkgreconciler.Event {
-	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "SequenceReconciled", "Sequence reconciled: \"%s/%s\"", namespace, name)
-}
-
 type Reconciler struct {
 	// listers index properties about resources
 	sequenceLister     listers.SequenceLister
@@ -114,7 +110,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, s *v1beta1.Sequence) pkg
 	}
 	s.Status.PropagateSubscriptionStatuses(subs)
 
-	return newReconciledNormal(s.Namespace, s.Name)
+	return nil
 }
 
 func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, s *v1beta1.Sequence, channelObjRef corev1.ObjectReference) (*eventingduckv1beta1.Channelable, error) {

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -174,9 +174,6 @@ func TestAllCases(t *testing.T) {
 				rt.WithSequenceChannelTemplateSpec(imc),
 				rt.WithSequenceSteps([]v1beta1.SequenceStep{{Destination: createDestination(0)}}))},
 		WantErr: false,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
 			resources.NewSubscription(0,
@@ -301,9 +298,6 @@ func TestAllCases(t *testing.T) {
 				rt.WithSequenceReply(createReplyChannel(replyChannelName)),
 				rt.WithSequenceSteps([]v1beta1.SequenceStep{{Destination: createDestination(0)}}))},
 		WantErr: false,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
 			resources.NewSubscription(0, rt.NewSequence(sequenceName, testNS,
@@ -360,9 +354,6 @@ func TestAllCases(t *testing.T) {
 					{Destination: createDestination(1)},
 					{Destination: createDestination(2)}}))},
 		WantErr: false,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
 			createChannel(sequenceName, 1),
@@ -481,9 +472,6 @@ func TestAllCases(t *testing.T) {
 					{Destination: createDestination(1), Delivery: createDelivery(subscriberGVK, "dlc1", testNS)},
 					{Destination: createDestination(2), Delivery: createDelivery(subscriberGVK, "dlc2", testNS)}}))},
 		WantErr: false,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
 			createChannel(sequenceName, 1),
@@ -602,9 +590,6 @@ func TestAllCases(t *testing.T) {
 					{Destination: createDestination(1)},
 					{Destination: createDestination(2)}}))},
 		WantErr: false,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
 			createChannel(sequenceName, 1),
@@ -728,9 +713,6 @@ func TestAllCases(t *testing.T) {
 					rt.WithSequenceSteps([]v1beta1.SequenceStep{{Destination: createDestination(0)}}))),
 			},
 			WantErr: false,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "SequenceReconciled", `Sequence reconciled: "test-namespace/test-sequence"`),
-			},
 			WantDeletes: []clientgotesting.DeleteActionImpl{
 				{Name: resources.SequenceChannelName(sequenceName, 0)},
 			},

--- a/pkg/reconciler/sugar/namespace/namespace.go
+++ b/pkg/reconciler/sugar/namespace/namespace.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/eventing/pkg/reconciler/sugar"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 	namespacereconciler "knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"
-	"knative.dev/pkg/controller"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
@@ -69,9 +68,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 		// wide object, if don't do this we'll end with the event created
 		// in the default namespace, which is a bad UX in our case.
 		ns.SetNamespace(ns.Name)
-		controller.GetEventRecorder(ctx).Event(ns, corev1.EventTypeNormal, brokerCreated,
+		return pkgreconciler.NewEvent(corev1.EventTypeNormal, brokerCreated,
 			"Default eventing.knative.dev Broker created.")
-		return nil
 	} else if err != nil {
 		return fmt.Errorf("Unable to list Brokers: %w", err)
 	}

--- a/pkg/reconciler/sugar/trigger/trigger.go
+++ b/pkg/reconciler/sugar/trigger/trigger.go
@@ -20,16 +20,14 @@ import (
 	"context"
 	"fmt"
 
-	"knative.dev/eventing/pkg/reconciler/sugar"
-	"knative.dev/eventing/pkg/reconciler/sugar/resources"
-	"knative.dev/pkg/controller"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/trigger"
 	listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	"knative.dev/eventing/pkg/reconciler/sugar"
+	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 )
@@ -64,9 +62,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1beta1.Trigger) reco
 		if err != nil {
 			return fmt.Errorf("Unable to create Broker: %w", err)
 		}
-		controller.GetEventRecorder(ctx).Event(t, corev1.EventTypeNormal, brokerCreated,
+		return reconciler.NewEvent(corev1.EventTypeNormal, brokerCreated,
 			fmt.Sprintf("Default eventing.knative.dev Broker %q created.", t.Spec.Broker))
-		return nil
 	} else if err != nil {
 		return fmt.Errorf("Unable to list Brokers: %w", err)
 	}


### PR DESCRIPTION
## Proposed Changes

- Do not produce reconciled-normal events always. This causes spam in the api server and results in n*deps for global resyncs, even for no-ops. 
- Use returned events in sugar controllers to produce events.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
For PingSource, the Kubernetes event "PingSourceReconciled" is no longer produced for clean runs of the ReconcileKind method.
For Sequence, the Kubernetes event "SequenceReconciled" is no longer produced for clean runs of the ReconcileKind method.
```

relates to https://github.com/knative/pkg/issues/1520