### PR TITLE
Decoupled fanout config from ducktypes

### DIFF
--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -23,7 +23,6 @@ package fanout
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	nethttp "net/http"
 	"net/url"
@@ -44,59 +43,10 @@ const (
 )
 
 type Subscription struct {
-	Subscriber  *url.URL `json:"subscriber,omitempty"`
-	Reply       *url.URL `json:"reply,omitempty"`
-	DeadLetter  *url.URL `json:"deadLetter,omitempty"`
+	Subscriber  *url.URL
+	Reply       *url.URL
+	DeadLetter  *url.URL
 	RetryConfig *kncloudevents.RetryConfig
-}
-
-func (s Subscription) MarshalJSON() ([]byte, error) {
-	rawStrings := make(map[string]string)
-
-	if s.Subscriber != nil {
-		rawStrings["subscriber"] = s.Subscriber.String()
-	}
-	if s.Reply != nil {
-		rawStrings["reply"] = s.Reply.String()
-	}
-	if s.DeadLetter != nil {
-		rawStrings["deadLetter"] = s.DeadLetter.String()
-	}
-
-	return json.Marshal(rawStrings)
-}
-
-func (s *Subscription) UnmarshalJSON(j []byte) error {
-	var rawStrings map[string]string
-	if err := json.Unmarshal(j, &rawStrings); err != nil {
-		return err
-	}
-
-	if subscriberStr, ok := rawStrings["subscriber"]; ok {
-		if subscriberUrl, err := url.Parse(subscriberStr); err == nil {
-			s.Subscriber = subscriberUrl
-		} else {
-			return err
-		}
-	}
-
-	if replyStr, ok := rawStrings["reply"]; ok {
-		if replyUrl, err := url.Parse(replyStr); err == nil {
-			s.Reply = replyUrl
-		} else {
-			return err
-		}
-	}
-
-	if deadLetterStr, ok := rawStrings["deadLetter"]; ok {
-		if deadLetterUrl, err := url.Parse(deadLetterStr); err == nil {
-			s.DeadLetter = deadLetterUrl
-		} else {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // Config for a fanout.MessageHandler.

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -23,6 +23,7 @@ package fanout
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	nethttp "net/http"
 	"net/url"
@@ -43,10 +44,59 @@ const (
 )
 
 type Subscription struct {
-	Subscriber  *url.URL
-	Reply       *url.URL
-	DeadLetter  *url.URL
+	Subscriber  *url.URL `json:"subscriber,omitempty"`
+	Reply       *url.URL `json:"reply,omitempty"`
+	DeadLetter  *url.URL `json:"deadLetter,omitempty"`
 	RetryConfig *kncloudevents.RetryConfig
+}
+
+func (s Subscription) MarshalJSON() ([]byte, error) {
+	rawStrings := make(map[string]string)
+
+	if s.Subscriber != nil {
+		rawStrings["subscriber"] = s.Subscriber.String()
+	}
+	if s.Reply != nil {
+		rawStrings["reply"] = s.Reply.String()
+	}
+	if s.DeadLetter != nil {
+		rawStrings["deadLetter"] = s.DeadLetter.String()
+	}
+
+	return json.Marshal(rawStrings)
+}
+
+func (s *Subscription) UnmarshalJSON(j []byte) error {
+	var rawStrings map[string]string
+	if err := json.Unmarshal(j, &rawStrings); err != nil {
+		return err
+	}
+
+	if subscriberStr, ok := rawStrings["subscriber"]; ok {
+		if subscriberUrl, err := url.Parse(subscriberStr); err == nil {
+			s.Subscriber = subscriberUrl
+		} else {
+			return err
+		}
+	}
+
+	if replyStr, ok := rawStrings["reply"]; ok {
+		if replyUrl, err := url.Parse(replyStr); err == nil {
+			s.Reply = replyUrl
+		} else {
+			return err
+		}
+	}
+
+	if deadLetterStr, ok := rawStrings["deadLetter"]; ok {
+		if deadLetterUrl, err := url.Parse(deadLetterStr); err == nil {
+			s.DeadLetter = deadLetterUrl
+		} else {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Config for a fanout.MessageHandler.

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -33,15 +33,14 @@ import (
 	"go.uber.org/zap"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 )
 
 // Domains used in subscriptions, which will be replaced by the real domains of the started HTTP
 // servers.
 var (
-	replaceSubscriber = apis.HTTP("replaceSubscriber")
-	replaceReplier    = apis.HTTP("replaceReplier")
+	replaceSubscriber = apis.HTTP("replaceSubscriber").URL()
+	replaceReplier    = apis.HTTP("replaceReplier").URL()
 )
 
 func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
@@ -77,9 +76,7 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 			timeout: time.Millisecond,
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-					},
+					Subscriber: replaceSubscriber,
 				},
 			},
 			subscriber: func(writer http.ResponseWriter, _ *http.Request) {
@@ -105,9 +102,7 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"reply fails": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						ReplyURI: replaceReplier,
-					},
+					Reply: replaceReplier,
 				},
 			},
 			replier: func(writer http.ResponseWriter, _ *http.Request) {
@@ -120,9 +115,7 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"subscriber fails": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-					},
+					Subscriber: replaceSubscriber,
 				},
 			},
 			subscriber: func(writer http.ResponseWriter, _ *http.Request) {
@@ -135,10 +128,8 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"subscriber succeeds, result fails": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -153,10 +144,8 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"one sub succeeds": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -171,16 +160,12 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"one sub succeeds, one sub fails": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 			},
 			subscriber:          callableSucceed,
@@ -193,22 +178,16 @@ func TestFanoutMessageHandler_ServeHTTP(t *testing.T) {
 		"all subs succeed": {
 			subs: []Subscription{
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 				{
-					SubscriberSpec: eventingduck.SubscriberSpec{
-						SubscriberURI: replaceSubscriber,
-						ReplyURI:      replaceReplier,
-					},
+					Subscriber: replaceSubscriber,
+					Reply:      replaceReplier,
 				},
 			},
 			subscriber: callableSucceed,
@@ -257,11 +236,11 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 	// Rewrite the subs to use the servers we just started.
 	subs := make([]Subscription, 0)
 	for _, sub := range inSubs {
-		if sub.SubscriberURI == replaceSubscriber {
-			sub.SubscriberURI = apis.HTTP(subscriberServer.URL[7:]) // strip the leading 'http://'
+		if sub.Subscriber == replaceSubscriber {
+			sub.Subscriber = apis.HTTP(subscriberServer.URL[7:]).URL() // strip the leading 'http://'
 		}
-		if sub.ReplyURI == replaceReplier {
-			sub.ReplyURI = apis.HTTP(replyServer.URL[7:]) // strip the leading 'http://'
+		if sub.Reply == replaceReplier {
+			sub.Reply = apis.HTTP(replyServer.URL[7:]).URL() // strip the leading 'http://'
 		}
 		subs = append(subs, sub)
 	}

--- a/pkg/channel/multichannelfanout/config.go
+++ b/pkg/channel/multichannelfanout/config.go
@@ -23,13 +23,13 @@ import (
 // Config for a multichannelfanout.Handler.
 type Config struct {
 	// The configuration of each channel in this handler.
-	ChannelConfigs []ChannelConfig `json:"channelConfigs"`
+	ChannelConfigs []ChannelConfig
 }
 
 // ChannelConfig is the configuration for a single Channel.
 type ChannelConfig struct {
-	Namespace    string        `json:"namespace"`
-	Name         string        `json:"name"`
-	HostName     string        `json:"hostname"`
-	FanoutConfig fanout.Config `json:"fanoutConfig"`
+	Namespace    string
+	Name         string
+	HostName     string
+	FanoutConfig fanout.Config
 }

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -30,14 +30,13 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 )
 
 var (
 	// The httptest.Server's host name will replace this value in all ChannelConfigs.
-	replaceDomain = apis.HTTP("replaceDomain")
+	replaceDomain = apis.HTTP("replaceDomain").URL()
 )
 
 func TestNewMessageHandler(t *testing.T) {
@@ -94,9 +93,7 @@ func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []fanout.Subscription{
 						{
-							SubscriberSpec: eventingduck.SubscriberSpec{
-								SubscriberURI: apis.HTTP("subscriberdomain"),
-							},
+							Subscriber: apis.HTTP("subscriberdomain").URL(),
 						},
 					},
 				},
@@ -111,9 +108,7 @@ func TestCopyMessageHandlerWithNewConfig(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []fanout.Subscription{
 						{
-							SubscriberSpec: eventingduck.SubscriberSpec{
-								ReplyURI: apis.HTTP("replydomain"),
-							},
+							Reply: apis.HTTP("replydomain").URL(),
 						},
 					},
 				},
@@ -162,9 +157,7 @@ func TestConfigDiffMessageHandler(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					Subscriptions: []fanout.Subscription{
 						{
-							SubscriberSpec: eventingduck.SubscriberSpec{
-								SubscriberURI: apis.HTTP("subscriberdomain"),
-							},
+							Subscriber: apis.HTTP("subscriberdomain").URL(),
 						},
 					},
 				},
@@ -194,9 +187,7 @@ func TestConfigDiffMessageHandler(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []fanout.Subscription{
 								{
-									SubscriberSpec: eventingduck.SubscriberSpec{
-										SubscriberURI: apis.HTTP("different"),
-									},
+									Subscriber: apis.HTTP("different").URL(),
 								},
 							},
 						},
@@ -250,9 +241,7 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []fanout.Subscription{
 								{
-									SubscriberSpec: eventingduck.SubscriberSpec{
-										ReplyURI: replaceDomain,
-									},
+									Reply: replaceDomain,
 								},
 							},
 						},
@@ -274,9 +263,7 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []fanout.Subscription{
 								{
-									SubscriberSpec: eventingduck.SubscriberSpec{
-										ReplyURI: apis.HTTP("first-to-domain"),
-									},
+									Reply: apis.HTTP("first-to-domain").URL(),
 								},
 							},
 						},
@@ -288,9 +275,7 @@ func TestServeHTTPMessageHandler(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []fanout.Subscription{
 								{
-									SubscriberSpec: eventingduck.SubscriberSpec{
-										SubscriberURI: replaceDomain,
-									},
+									Subscriber: replaceDomain,
 								},
 							},
 						},
@@ -360,11 +345,11 @@ func fakeHandler(statusCode int) http.HandlerFunc {
 func replaceDomains(config Config, replacement string) {
 	for i, cc := range config.ChannelConfigs {
 		for j, sub := range cc.FanoutConfig.Subscriptions {
-			if sub.SubscriberURI == replaceDomain {
-				sub.SubscriberURI = apis.HTTP(replacement)
+			if sub.Subscriber == replaceDomain {
+				sub.Subscriber = apis.HTTP(replacement).URL()
 			}
-			if sub.ReplyURI == replaceDomain {
-				sub.ReplyURI = apis.HTTP(replacement)
+			if sub.Reply == replaceDomain {
+				sub.Reply = apis.HTTP(replacement).URL()
 			}
 			cc.FanoutConfig.Subscriptions[j] = sub
 		}

--- a/pkg/channel/swappable/swappable_message_handler_test.go
+++ b/pkg/channel/swappable/swappable_message_handler_test.go
@@ -29,13 +29,12 @@ import (
 	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/apis"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
 )
 
-var replaceDomain = apis.HTTP("replaceDomain")
+var replaceDomain = apis.HTTP("replaceDomain").URL()
 
 const (
 	hostName = "a.b.c.d"
@@ -54,9 +53,7 @@ func TestMessageHandler(t *testing.T) {
 							FanoutConfig: fanout.Config{
 								Subscriptions: []fanout.Subscription{
 									{
-										SubscriberSpec: eventingduck.SubscriberSpec{
-											SubscriberURI: replaceDomain,
-										},
+										Subscriber: replaceDomain,
 									},
 								},
 							},
@@ -70,9 +67,7 @@ func TestMessageHandler(t *testing.T) {
 							FanoutConfig: fanout.Config{
 								Subscriptions: []fanout.Subscription{
 									{
-										SubscriberSpec: eventingduck.SubscriberSpec{
-											ReplyURI: replaceDomain,
-										},
+										Reply: replaceDomain,
 									},
 								},
 							},
@@ -109,9 +104,7 @@ func TestMessageHandler_InvalidConfigChange(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []fanout.Subscription{
 								{
-									SubscriberSpec: eventingduck.SubscriberSpec{
-										SubscriberURI: replaceDomain,
-									},
+									Subscriber: replaceDomain,
 								},
 							},
 						},
@@ -222,11 +215,11 @@ func successHandler(w http.ResponseWriter, r *http.Request) {
 func replaceDomains(c multichannelfanout.Config, replacement string) multichannelfanout.Config {
 	for i, cc := range c.ChannelConfigs {
 		for j, sub := range cc.FanoutConfig.Subscriptions {
-			if sub.ReplyURI == replaceDomain {
-				sub.ReplyURI = apis.HTTP(replacement)
+			if sub.Subscriber == replaceDomain {
+				sub.Subscriber = apis.HTTP(replacement).URL()
 			}
-			if sub.SubscriberURI == replaceDomain {
-				sub.SubscriberURI = apis.HTTP(replacement)
+			if sub.Reply == replaceDomain {
+				sub.Reply = apis.HTTP(replacement).URL()
 			}
 			cc.FanoutConfig.Subscriptions[j] = sub
 		}

--- a/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloudevents/sdk-go/v2/test"
 	"go.uber.org/zap"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
@@ -73,12 +72,8 @@ func BenchmarkDispatcher_dispatch_ok_through_2_channels(b *testing.B) {
 				FanoutConfig: fanout.Config{
 					AsyncHandler: false,
 					Subscriptions: []fanout.Subscription{{
-						SubscriberSpec: eventingduck.SubscriberSpec{
-							UID:           "aaaa",
-							Generation:    1,
-							SubscriberURI: transformationsUrl,
-							ReplyURI:      channelBUrl,
-						},
+						Subscriber: transformationsUrl.URL(),
+						Reply:      channelBUrl.URL(),
 					}},
 				},
 			},
@@ -89,11 +84,7 @@ func BenchmarkDispatcher_dispatch_ok_through_2_channels(b *testing.B) {
 				FanoutConfig: fanout.Config{
 					AsyncHandler: false,
 					Subscriptions: []fanout.Subscription{{
-						SubscriberSpec: eventingduck.SubscriberSpec{
-							UID:           "bbbb",
-							Generation:    1,
-							SubscriberURI: receiverUrl,
-						},
+						Subscriber: receiverUrl.URL(),
 					}},
 				},
 			},

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -34,9 +34,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
@@ -232,22 +230,12 @@ func TestDispatcher_dispatch(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					AsyncHandler: false,
 					Subscriptions: []fanout.Subscription{{
-						SubscriberSpec: eventingduck.SubscriberSpec{
-							UID:           "aaaa",
-							Generation:    1,
-							SubscriberURI: mustParseUrl(t, transformationsServer.URL),
-							ReplyURI:      mustParseUrl(t, channelBProxy.URL),
-						},
+						Subscriber: mustParseUrl(t, transformationsServer.URL).URL(),
+						Reply:      mustParseUrl(t, channelBProxy.URL).URL(),
 					}, {
-						SubscriberSpec: eventingduck.SubscriberSpec{
-							UID:           "cccc",
-							Generation:    1,
-							SubscriberURI: mustParseUrl(t, transformationsFailureServer.URL),
-							ReplyURI:      mustParseUrl(t, channelBProxy.URL),
-							Delivery: &eventingduck.DeliverySpec{
-								DeadLetterSink: &duckv1.Destination{URI: mustParseUrl(t, deadLetterServer.URL)},
-							},
-						},
+						Subscriber: mustParseUrl(t, transformationsFailureServer.URL).URL(),
+						Reply:      mustParseUrl(t, channelBProxy.URL).URL(),
+						DeadLetter: mustParseUrl(t, deadLetterServer.URL).URL(),
 					}},
 				},
 			},
@@ -258,11 +246,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 				FanoutConfig: fanout.Config{
 					AsyncHandler: false,
 					Subscriptions: []fanout.Subscription{{
-						SubscriberSpec: eventingduck.SubscriberSpec{
-							UID:           "bbbb",
-							Generation:    1,
-							SubscriberURI: mustParseUrl(t, receiverServer.URL),
-						},
+						Subscriber: mustParseUrl(t, receiverServer.URL).URL(),
 					}},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #3702

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Decoupled fanout config from ducktypes, so now that code doesn't need to be aware of type conversions and so on
- Provided a function to easily convert a `duckv1.SubscriberSpec` to `fanout.Config`
- Pruned remaining config json conversion code after https://github.com/knative/eventing/pull/3713
