### PR TITLE
[master] golang format tools

### DIFF
--- a/test/conformance/helpers/sources/source_crd_metadata_test_helper.go
+++ b/test/conformance/helpers/sources/source_crd_metadata_test_helper.go
@@ -17,8 +17,9 @@ limitations under the License.
 package sources
 
 import (
-	"knative.dev/eventing/test/conformance/helpers"
 	"testing"
+
+	"knative.dev/eventing/test/conformance/helpers"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testlib "knative.dev/eventing/test/lib"

--- a/test/lib/config.go
+++ b/test/lib/config.go
@@ -48,17 +48,17 @@ var ChannelFeatureMap = map[metav1.TypeMeta][]Feature{
 
 var ApiServerSourceTypeMeta = metav1.TypeMeta{
 	APIVersion: resources.SourcesV1B1APIVersion,
-	Kind: 		resources.ApiServerSourceKind,
+	Kind:       resources.ApiServerSourceKind,
 }
 
 var PingSourceTypeMeta = metav1.TypeMeta{
 	APIVersion: resources.SourcesV1A2APIVersion,
-	Kind: 		resources.PingSourceKind,
+	Kind:       resources.PingSourceKind,
 }
 
 var SourceFeatureMap = map[metav1.TypeMeta][]Feature{
 	ApiServerSourceTypeMeta: {FeatureBasic, FeatureLongLiving},
-	PingSourceTypeMeta: {FeatureBasic, FeatureLongLiving},
+	PingSourceTypeMeta:      {FeatureBasic, FeatureLongLiving},
 }
 
 // Feature is the feature supported by the channel.

--- a/test/lib/resources/constants.go
+++ b/test/lib/resources/constants.go
@@ -80,7 +80,7 @@ const (
 )
 
 //Kind for sources resources that exist in Eventing core
-const(
+const (
 	ApiServerSourceKind string = "ApiServerSource"
-	PingSourceKind 		string = "PingSource"
+	PingSourceKind      string = "PingSource"
 )


### PR DESCRIPTION
<!--[master] golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party | grep -v .pb.go | grep -v wire_gen.go)`
/assign grantr n3wscott
/cc grantr n3wscott
