### PR TITLE
Reflect created sources API versions in setupclientoptions

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -76,13 +76,13 @@ func addSourcesInitializers() {
 		testlib.PingSourceTypeMeta.Kind))
 	sourcesTestRunner.AddComponentSetupClientOption(
 		testlib.ApiServerSourceTypeMeta,
-		setupclientoptions.ApiServerSourceClientSetupOption(apiSrcName,
+		setupclientoptions.ApiServerSourceV1B1ClientSetupOption(apiSrcName,
 			"Reference",
 			recordEventsPodName, roleName, serviceAccountName),
 	)
 	sourcesTestRunner.AddComponentSetupClientOption(
 		testlib.PingSourceTypeMeta,
-		setupclientoptions.PingSourceClientSetupOption(pingSrcName,
+		setupclientoptions.PingSourceV1A2ClientSetupOption(pingSrcName,
 			recordEventsPodName),
 	)
 }

--- a/test/lib/setupclientoptions/sources.go
+++ b/test/lib/setupclientoptions/sources.go
@@ -31,11 +31,11 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-// ApiServerSourceClientSetupOption returns a ClientSetupOption that can be used
+// ApiServerSourceV1B1ClientSetupOption returns a ClientSetupOption that can be used
 // to create a new ApiServerSource. It creates a ServiceAccount, a Role, a
 // RoleBinding, a RecordEvents pod and an ApiServerSource object with the event
 // mode and RecordEvent pod as its sink.
-func ApiServerSourceClientSetupOption(name string, mode string, recordEventsPodName string,
+func ApiServerSourceV1B1ClientSetupOption(name string, mode string, recordEventsPodName string,
 	roleName string, serviceAccountName string) testlib.SetupClientOption {
 	return func(client *testlib.Client) {
 		// create needed RBAC SA, Role & RoleBinding
@@ -68,10 +68,10 @@ func ApiServerSourceClientSetupOption(name string, mode string, recordEventsPodN
 	}
 }
 
-// PingSourceClientSetupOption returns a ClientSetupOption that can be used
+// PingSourceV1A2ClientSetupOption returns a ClientSetupOption that can be used
 // to create a new PingSource. It creates a RecordEvents pod and a
 // PingSource object with the RecordEvent pod as its sink.
-func PingSourceClientSetupOption(name string, recordEventsPodName string) testlib.SetupClientOption {
+func PingSourceV1A2ClientSetupOption(name string, recordEventsPodName string) testlib.SetupClientOption {
 	return func(client *testlib.Client) {
 
 		// create event logger pod and service


### PR DESCRIPTION
We only currently have setupclientoption functions for latest
sources API versions to run the conformance tests against.

It should be visible in the test that we are initializing
a specific API version of the source

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Reflect created sources API versions in setupclientoptions