### PR TITLE
add support for seconds in pingsource - for running tests only!

### DIFF
--- a/pkg/adapter/mtping/adapter.go
+++ b/pkg/adapter/mtping/adapter.go
@@ -18,6 +18,9 @@ package mtping
 
 import (
 	"context"
+	"flag"
+
+	"github.com/robfig/cron/v3"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -26,6 +29,15 @@ import (
 
 	"knative.dev/eventing/pkg/adapter/v2"
 )
+
+var (
+	// withSeconds enables schedules with seconds.
+	withSeconds bool
+)
+
+func init() {
+	flag.BoolVar(&withSeconds, "with-seconds", false, "Enables schedule with seconds")
+}
 
 // mtpingAdapter implements the PingSource mt adapter to sinks
 type mtpingAdapter struct {
@@ -38,13 +50,19 @@ func NewEnvConfig() adapter.EnvConfigAccessor {
 }
 
 func NewAdapter(ctx context.Context, _ adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
-	runner := NewCronJobsRunner(ceClient, kubeclient.Get(ctx), logging.FromContext(ctx))
+	logger := logging.FromContext(ctx)
+	var opts []cron.Option
+	if withSeconds {
+		logger.Info("enable schedule with a seconds field")
+		opts = append(opts, cron.WithSeconds())
+	}
+	runner := NewCronJobsRunner(ceClient, kubeclient.Get(ctx), logging.FromContext(ctx), opts...)
 
 	cmw := adapter.ConfigMapWatcherFromContext(ctx)
 	cmw.Watch("config-pingsource-mt-adapter", runner.updateFromConfigMap)
 
 	return &mtpingAdapter{
-		logger: logging.FromContext(ctx),
+		logger: logger,
 		runner: runner,
 	}
 }

--- a/pkg/adapter/mtping/runner.go
+++ b/pkg/adapter/mtping/runner.go
@@ -62,9 +62,9 @@ const (
 	resourceGroup = "pingsources.sources.knative.dev"
 )
 
-func NewCronJobsRunner(ceClient cloudevents.Client, kubeClient kubernetes.Interface, logger *zap.SugaredLogger) *cronJobsRunner {
+func NewCronJobsRunner(ceClient cloudevents.Client, kubeClient kubernetes.Interface, logger *zap.SugaredLogger, opts ...cron.Option) *cronJobsRunner {
 	return &cronJobsRunner{
-		cron:       *cron.New(),
+		cron:       *cron.New(opts...),
 		Client:     ceClient,
 		Logger:     logger,
 		entryids:   make(map[string]entryIdConfig),

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -337,18 +337,8 @@ func (r *Reconciler) reconcileMTReceiveAdapter(ctx context.Context, source *v1al
 }
 
 func podSpecChanged(oldPodSpec corev1.PodSpec, newPodSpec corev1.PodSpec) bool {
-	if !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) {
-		return true
-	}
-	if len(oldPodSpec.Containers) != len(newPodSpec.Containers) {
-		return true
-	}
-	for i := range newPodSpec.Containers {
-		if !equality.Semantic.DeepEqual(newPodSpec.Containers[i].Env, oldPodSpec.Containers[i].Env) {
-			return true
-		}
-	}
-	return false
+	// We really care about the fields we set and ignore the test.
+	return !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec)
 }
 
 // TODO determine how to push the updated logging config to existing data plane Pods.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add --with-seconds flags to mtping. When set it enables parsing schedule with an optional seconds field
- Only use deepDerivative when comparing old vs new adapter deployments
- To enable: patch the pingsource-mt-adapter deployment with `args: ["--with-seconds"]`
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
