### PR TITLE
allow pingsource seconds in webhook. For testing only.

### DIFF
--- a/pkg/apis/sources/v1alpha2/ping_validation.go
+++ b/pkg/apis/sources/v1alpha2/ping_validation.go
@@ -18,6 +18,7 @@ package v1alpha2
 
 import (
 	"context"
+	"os"
 
 	"github.com/robfig/cron/v3"
 	"knative.dev/pkg/apis"
@@ -33,7 +34,15 @@ func (c *PingSource) Validate(ctx context.Context) *apis.FieldError {
 func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 
-	if _, err := cron.ParseStandard(cs.Schedule); err != nil {
+	// Standard parse options
+	parseOptions := cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow
+
+	if os.Getenv("PINGSOURCE_ENABLE_SECONDS") == "true" {
+		parseOptions |= cron.Second
+	}
+	parser := cron.NewParser(parseOptions)
+
+	if _, err := parser.Parse(cs.Schedule); err != nil {
 		fe := apis.ErrInvalidValue(cs.Schedule, "schedule")
 		errs = errs.Also(fe)
 	}

--- a/pkg/apis/sources/v1alpha2/ping_validation_test.go
+++ b/pkg/apis/sources/v1alpha2/ping_validation_test.go
@@ -111,6 +111,28 @@ func TestPingSourceValidation(t *testing.T) {
 			errs = errs.Also(fe)
 			return errs
 		}(),
+	}, {
+		name: "invalid spec with seconds",
+		source: PingSource{
+			Spec: PingSourceSpec{
+				Schedule: "* * * * * *",
+				SourceSpec: duckv1.SourceSpec{
+					Sink: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "v1alpha1",
+							Kind:       "broker",
+							Name:       "default",
+						},
+					},
+				},
+			},
+		},
+		want: func() *apis.FieldError {
+			var errs *apis.FieldError
+			fe := apis.ErrInvalidValue("* * * * * *", "spec.schedule")
+			errs = errs.Also(fe)
+			return errs
+		}(),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/sources/v1beta1/ping_validation_test.go
+++ b/pkg/apis/sources/v1beta1/ping_validation_test.go
@@ -121,6 +121,28 @@ func TestPingSourceValidation(t *testing.T) {
 			errs = errs.Also(fe)
 			return errs
 		}(),
+	}, {
+		name: "invalid spec with seconds",
+		source: PingSource{
+			Spec: PingSourceSpec{
+				Schedule: "* * * * * *",
+				SourceSpec: duckv1.SourceSpec{
+					Sink: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							APIVersion: "v1alpha1",
+							Kind:       "broker",
+							Name:       "default",
+						},
+					},
+				},
+			},
+		},
+		want: func() *apis.FieldError {
+			var errs *apis.FieldError
+			fe := apis.ErrInvalidValue("expected exactly 5 fields, found 6: [* * * * * *]", "spec.schedule")
+			errs = errs.Also(fe)
+			return errs
+		}(),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- enable pingsource second in webhook whe PINGSOURCE_ENABLE_SECONDS env var is set to true
- add test to make sure it's not enabled 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

