### PR TITLE
Retry on conflict in TestChannelSpec

### DIFF
--- a/test/conformance/helpers/channel_spec_test_helper.go
+++ b/test/conformance/helpers/channel_spec_test_helper.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/util/retry"
 
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
@@ -54,70 +55,73 @@ func ChannelSpecTestHelperWithChannelTestRunner(
 func channelSpecAllowsSubscribersArray(st *testing.T, client *testlib.Client, channel metav1.TypeMeta, options ...testlib.SetupClientOption) {
 	st.Logf("Running channel spec conformance test with channel %s", channel)
 
-	dtsv, err := getChannelDuckTypeSupportVersionFromTypeMeta(client, channel)
-	if err != nil {
-		st.Fatalf("Unable to check Channel duck type support version for %s: %s", channel, err)
-	}
-
-	channelName := names.SimpleNameGenerator.GenerateName("channel-spec-subscribers-")
-	client.T.Logf("Creating channel %+v-%s", channel, channelName)
-	client.CreateChannelOrFail(channelName, &channel)
-	client.WaitForResourceReadyOrFail(channelName, &channel)
-
-	sampleUrl, _ := apis.ParseURL("http://example.com")
-	gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
-
-	var ch interface{}
-
-	if dtsv == "" || dtsv == "v1alpha1" {
-		// treat missing annotation value as v1alpha1, as written in the spec
-		channelable, err := getChannelAsV1Alpha1Channelable(channelName, client, channel)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		dtsv, err := getChannelDuckTypeSupportVersionFromTypeMeta(client, channel)
 		if err != nil {
-			st.Fatalf("Unable to get channel %s to v1alpha1 duck type: %s", channel, err)
+			st.Fatalf("Unable to check Channel duck type support version for %s: %s", channel, err)
 		}
 
-		// SPEC: each channel CRD MUST contain an array of subscribers: spec.subscribable.subscribers
-		channelable.Spec.Subscribable = &eventingduckv1alpha1.Subscribable{
-			Subscribers: []eventingduckv1alpha1.SubscriberSpec{
+		channelName := names.SimpleNameGenerator.GenerateName("channel-spec-subscribers-")
+		client.T.Logf("Creating channel %+v-%s", channel, channelName)
+		client.CreateChannelOrFail(channelName, &channel)
+		client.WaitForResourceReadyOrFail(channelName, &channel)
+
+		sampleUrl, _ := apis.ParseURL("http://example.com")
+		gvr, _ := meta.UnsafeGuessKindToResource(channel.GroupVersionKind())
+
+		var ch interface{}
+
+		if dtsv == "" || dtsv == "v1alpha1" {
+			// treat missing annotation value as v1alpha1, as written in the spec
+			channelable, err := getChannelAsV1Alpha1Channelable(channelName, client, channel)
+			if err != nil {
+				st.Fatalf("Unable to get channel %s to v1alpha1 duck type: %s", channel, err)
+			}
+
+			// SPEC: each channel CRD MUST contain an array of subscribers: spec.subscribable.subscribers
+			channelable.Spec.Subscribable = &eventingduckv1alpha1.Subscribable{
+				Subscribers: []eventingduckv1alpha1.SubscriberSpec{
+					{
+						UID:      "1234",
+						ReplyURI: sampleUrl,
+					},
+				},
+			}
+
+			ch = channelable
+
+		} else if dtsv == "v1beta1" || dtsv == "v1" {
+			channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
+			if err != nil {
+				st.Fatalf("Unable to get channel %s to v1beta1 duck type: %s", channel, err)
+			}
+
+			// SPEC: each channel CRD MUST contain an array of subscribers: spec.subscribers
+			channelable.Spec.Subscribers = []eventingduckv1beta1.SubscriberSpec{
 				{
 					UID:      "1234",
 					ReplyURI: sampleUrl,
 				},
-			},
+			}
+
+			ch = channelable
+		} else {
+			st.Fatalf("Channel doesn't support v1alpha1 nor v1beta1 Channel duck types: %s", channel)
 		}
 
-		ch = channelable
-
-	} else if dtsv == "v1beta1" || dtsv == "v1" {
-		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
+		raw, err := json.Marshal(ch)
 		if err != nil {
-			st.Fatalf("Unable to get channel %s to v1beta1 duck type: %s", channel, err)
+			st.Fatalf("Error marshaling %s: %s", channel, err)
+		}
+		u := &unstructured.Unstructured{}
+		err = json.Unmarshal(raw, u)
+		if err != nil {
+			st.Fatalf("Error unmarshaling %s: %s", u, err)
 		}
 
-		// SPEC: each channel CRD MUST contain an array of subscribers: spec.subscribers
-		channelable.Spec.Subscribers = []eventingduckv1beta1.SubscriberSpec{
-			{
-				UID:      "1234",
-				ReplyURI: sampleUrl,
-			},
-		}
-
-		ch = channelable
-	} else {
-		st.Fatalf("Channel doesn't support v1alpha1 nor v1beta1 Channel duck types: %s", channel)
-	}
-
-	raw, err := json.Marshal(ch)
-	if err != nil {
-		st.Fatalf("Error marshaling %s: %s", channel, err)
-	}
-	u := &unstructured.Unstructured{}
-	err = json.Unmarshal(raw, u)
-	if err != nil {
-		st.Fatalf("Error unmarshaling %s: %s", u, err)
-	}
-
-	_, err = client.Dynamic.Resource(gvr).Namespace(client.Namespace).Update(u, metav1.UpdateOptions{})
+		_, err = client.Dynamic.Resource(gvr).Namespace(client.Namespace).Update(u, metav1.UpdateOptions{})
+		return err
+	})
 	if err != nil {
 		st.Fatalf("Error updating %s with subscribers in spec: %s", channel, err)
 	}


### PR DESCRIPTION
Recent flaky tests show errors like this:
```
Error updating <Channel> with subscribers in spec: Operation cannot
be fulfilled on <Channel> "channel-spec-subscribers-n7zb8": the
object has been modified;
please apply your changes to the latest version and try again.
```
So, retrying on conflict might mitigate the issue.

Addresses #3766

## Proposed Changes

- Retry on conflict in TestChannelSpec
