### PR TITLE
Skip the subtests in strict mode for ComponentsTestRunner

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	roleName            = "event-watcher-r"
-	serviceAccountName  = "event-watcher-sa"
-	recordEventsPodName = "api-server-source-logger-pod"
+	roleName                = "event-watcher-r"
+	serviceAccountName      = "event-watcher-sa"
+	recordEventsAPIPodName  = "api-server-source-logger-pod"
+	recordEventsPingPodName = "ping-source-logger-pod"
 )
 
 var channelTestRunner testlib.ComponentsTestRunner
@@ -78,11 +79,11 @@ func addSourcesInitializers() {
 		testlib.ApiServerSourceTypeMeta,
 		setupclientoptions.ApiServerSourceV1B1ClientSetupOption(apiSrcName,
 			"Reference",
-			recordEventsPodName, roleName, serviceAccountName),
+			recordEventsAPIPodName, roleName, serviceAccountName),
 	)
 	sourcesTestRunner.AddComponentSetupClientOption(
 		testlib.PingSourceTypeMeta,
 		setupclientoptions.PingSourceV1A2ClientSetupOption(pingSrcName,
-			recordEventsPodName),
+			recordEventsPingPodName),
 	)
 }

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -33,6 +33,6 @@ source "$(dirname "$0")/e2e-common.sh"
 initialize $@ --skip-istio-addon
 
 echo "Running tests with Multi Tenant Channel Based Broker"
-go_test_e2e -timeout=30m -parallel=12 ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
+go_test_e2e -timeout=30m -parallel=12 ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1beta1:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
 
 success

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -88,20 +88,20 @@ func (tr *ComponentsTestRunner) RunTestsWithComponentOptions(
 		options ...SetupClientOption),
 ) {
 	t.Parallel()
-	for _, component := range tr.ComponentsToTest {
-		// If in strict mode and a component is not present in the map, then
-		// don't run the tests
+	for _, c := range tr.ComponentsToTest {
+		component := c
 		features, present := tr.ComponentFeatureMap[component]
 		subTestName := fmt.Sprintf("%s-%s", component.Kind, component.APIVersion)
-		if !strict || (present && contains(features, feature)) {
-			t.Run(subTestName, func(st *testing.T) {
+		t.Run(subTestName, func(st *testing.T) {
+			// If in strict mode and a component is not present in the map, then
+			// don't run the tests
+			if !strict || (present && contains(features, feature)) {
 				testFunc(st, component, tr.componentOptions[component]...)
-			})
-		} else {
-			t.Skipf("Skipping %s for component %s since it did not "+
-				"match the feature %s and we are in strict mode", t.Name(),
-				subTestName, feature)
-		}
+			} else {
+				st.Skipf("Skipping component %s since it did not "+
+					"match the feature %s and we are in strict mode", subTestName, feature)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

- ComponentsTestRunner now creates a subtests for the component in all cases, then later decides on skipping it if the component doesn't match (better visibility)

