### PR TITLE
Add anti-affinity to our control plane deployments

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -30,6 +30,17 @@ spec:
         app: mt-broker-controller
         eventing.knative.dev/release: devel
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: mt-broker-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
       serviceAccountName: eventing-controller
 
       containers:

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -31,6 +31,17 @@ spec:
         app: eventing-controller
         eventing.knative.dev/release: devel
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: eventing-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
       serviceAccountName: eventing-controller
 
       containers:

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -29,6 +29,17 @@ spec:
     metadata:
       labels: *labels
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: eventing-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
       serviceAccountName: eventing-webhook
 
       containers:


### PR DESCRIPTION
Related: knative/pkg#1269

- 🧽 Update or clean up current behavior

```release-note
Control plane components now specify anti-affinity so that replicas will not be colocated.
```