### PR TITLE
Fix ChannelableCombined and SubscribableTypes for v1 migration

### DIFF
--- a/pkg/apis/duck/v1alpha1/channelable_combined_types_test.go
+++ b/pkg/apis/duck/v1alpha1/channelable_combined_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -44,12 +45,27 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 
 	retry := int32(5)
 	linear := eventingduckv1beta1.BackoffPolicyLinear
+	linearv1 := eventingduckv1.BackoffPolicyLinear
 	delay := "5s"
 	want := &ChannelableCombined{
 		Spec: ChannelableCombinedSpec{
 			SubscribableSpec: eventingduckv1beta1.SubscribableSpec{
 				// Populate ALL fields
 				Subscribers: []eventingduckv1beta1.SubscriberSpec{{
+					UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+					Generation:    1,
+					SubscriberURI: apis.HTTP("call1"),
+					ReplyURI:      apis.HTTP("sink2"),
+				}, {
+					UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+					Generation:    2,
+					SubscriberURI: apis.HTTP("call2"),
+					ReplyURI:      apis.HTTP("sink2"),
+				}},
+			},
+			SubscribableSpecv1: eventingduckv1.SubscribableSpec{
+				// Populate ALL fields
+				Subscribers: []eventingduckv1.SubscriberSpec{{
 					UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 					Generation:    1,
 					SubscriberURI: apis.HTTP("call1"),
@@ -90,6 +106,20 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 				BackoffPolicy: &linear,
 				BackoffDelay:  &delay,
 			},
+			Deliveryv1: &eventingduckv1.DeliverySpec{
+				DeadLetterSink: &duckv1.Destination{
+					Ref: &duckv1.KReference{
+						Name: "aname",
+					},
+					URI: &apis.URL{
+						Scheme: "http",
+						Host:   "test-error-domain",
+					},
+				},
+				Retry:         &retry,
+				BackoffPolicy: &linearv1,
+				BackoffDelay:  &delay,
+			},
 		},
 
 		Status: ChannelableCombinedStatus{
@@ -118,9 +148,33 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 					Message:            "Some message",
 				}},
 			},
+			SubscribableStatusv1: eventingduckv1.SubscribableStatus{
+				Subscribers: []eventingduckv1.SubscriberStatus{{
+					UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+					ObservedGeneration: 1,
+					Ready:              corev1.ConditionTrue,
+					Message:            "Some message",
+				}, {
+					UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+					ObservedGeneration: 2,
+					Ready:              corev1.ConditionFalse,
+					Message:            "Some message",
+				}},
+			},
 			SubscribableTypeStatus: SubscribableTypeStatus{
 				SubscribableStatus: &SubscribableStatus{
 					Subscribers: []eventingduckv1beta1.SubscriberStatus{{
+						UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+						ObservedGeneration: 1,
+						Ready:              corev1.ConditionTrue,
+						Message:            "Some message",
+					}, {
+						UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+						ObservedGeneration: 2,
+						Ready:              corev1.ConditionFalse,
+						Message:            "Some message",
+					}},
+					Subscribersv1: []eventingduckv1.SubscriberStatus{{
 						UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 						ObservedGeneration: 1,
 						Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -24,8 +24,8 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 
+	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
-	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 )
 
 // +genduck
@@ -62,6 +62,8 @@ type SubscriberSpec struct {
 	DeadLetterSinkURI *apis.URL `json:"deadLetterSink,omitempty"`
 	// +optional
 	Delivery *duckv1beta1.DeliverySpec `json:"delivery,omitempty"`
+	// +optional
+	Deliveryv1 *duckv1.DeliverySpec `json:"deliveryv1,omitempty"`
 }
 
 // SubscribableStatus is the schema for the subscribable's status portion of the status
@@ -71,6 +73,11 @@ type SubscribableStatus struct {
 	// +patchMergeKey=uid
 	// +patchStrategy=merge
 	Subscribers []duckv1beta1.SubscriberStatus `json:"subscribers,omitempty" patchStrategy:"merge" patchMergeKey:"uid"`
+
+	// This is the list of subscription's statuses for this channel.
+	// +patchMergeKey=uid
+	// +patchStrategy=merge
+	Subscribersv1 []duckv1.SubscriberStatus `json:"subscribersv1,omitempty" patchStrategy:"merge" patchMergeKey:"uid"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -132,9 +139,17 @@ func (s *SubscribableTypeStatus) SetSubscribableTypeStatus(subscriberStatus Subs
 // AddSubscriberToSubscribableStatus method is a Helper method for type SubscribableTypeStatus, if Subscribable Status needs to be appended
 // with Subscribers, use this function, so that the value is reflected in both the duplicate fields residing
 // in SubscribableTypeStatus
-func (s *SubscribableTypeStatus) AddSubscriberToSubscribableStatus(subscriberStatus eventingduckv1beta1.SubscriberStatus) {
+func (s *SubscribableTypeStatus) AddSubscriberToSubscribableStatus(subscriberStatus duckv1beta1.SubscriberStatus) {
 	subscribers := append(s.GetSubscribableTypeStatus().Subscribers, subscriberStatus)
 	s.SubscribableStatus.Subscribers = subscribers
+}
+
+// AddSubscriberToSubscribableStatus method is a Helper method for type SubscribableTypeStatus, if Subscribable Status needs to be appended
+// with Subscribers, use this function, so that the value is reflected in both the duplicate fields residing
+// in SubscribableTypeStatus
+func (s *SubscribableTypeStatus) AddSubscriberV1ToSubscribableStatus(subscriberStatus duckv1.SubscriberStatus) {
+	subscribersv1 := append(s.GetSubscribableTypeStatus().Subscribersv1, subscriberStatus)
+	s.SubscribableStatus.Subscribersv1 = subscribersv1
 }
 
 // GetFullType implements duck.Implementable
@@ -160,7 +175,18 @@ func (c *SubscribableType) Populate() {
 	}
 	c.Status.SetSubscribableTypeStatus(SubscribableStatus{
 		// Populate ALL fields
-		Subscribers: []eventingduckv1beta1.SubscriberStatus{{
+		Subscribers: []duckv1beta1.SubscriberStatus{{
+			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+			ObservedGeneration: 1,
+			Ready:              corev1.ConditionTrue,
+			Message:            "Some message",
+		}, {
+			UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+			ObservedGeneration: 2,
+			Ready:              corev1.ConditionFalse,
+			Message:            "Some message",
+		}},
+		Subscribersv1: []duckv1.SubscriberStatus{{
 			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			ObservedGeneration: 1,
 			Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion.go
@@ -103,11 +103,8 @@ func (source *SubscriberSpec) ConvertTo(ctx context.Context, obj apis.Convertibl
 		sink.UID = source.UID
 		sink.Generation = source.Generation
 		sink.SubscriberURI = source.SubscriberURI
-		if source.Delivery != nil {
-			sink.Delivery = &eventingduckv1.DeliverySpec{}
-			if err := source.Delivery.ConvertTo(ctx, sink.Delivery); err != nil {
-				return err
-			}
+		if source.Deliveryv1 != nil {
+			sink.Delivery = source.Deliveryv1
 		} else {
 			// If however, there's a Deprecated DeadLetterSinkURI, convert that up
 			// to DeliverySpec.
@@ -142,12 +139,14 @@ func (source *SubscribableTypeStatus) ConvertTo(ctx context.Context, obj apis.Co
 		}
 	case *eventingduckv1.SubscribableStatus:
 		if source.SubscribableStatus != nil &&
-			len(source.SubscribableStatus.Subscribers) > 0 {
-			sink.Subscribers = make([]eventingduckv1.SubscriberStatus, len(source.SubscribableStatus.Subscribers))
-			for i, ss := range source.SubscribableStatus.Subscribers {
-				sink.Subscribers[i] = eventingduckv1.SubscriberStatus{}
-				if err := ss.ConvertTo(ctx, &sink.Subscribers[i]); err != nil {
-					return err
+			len(source.SubscribableStatus.Subscribersv1) > 0 {
+			sink.Subscribers = make([]eventingduckv1.SubscriberStatus, len(source.SubscribableStatus.Subscribersv1))
+			for i, ss := range source.SubscribableStatus.Subscribersv1 {
+				sink.Subscribers[i] = eventingduckv1.SubscriberStatus{
+					UID:                ss.UID,
+					ObservedGeneration: ss.ObservedGeneration,
+					Ready:              ss.Ready,
+					Message:            ss.Message,
 				}
 			}
 		}
@@ -229,17 +228,16 @@ func (sink *SubscriberSpec) ConvertFrom(ctx context.Context, obj apis.Convertibl
 		sink.Delivery = source.Delivery
 		sink.DeadLetterSinkURI = deadLetterSinkURI
 	case *eventingduckv1.SubscriberSpec:
+		var deadLetterSinkURI *apis.URL
+		if source.Delivery != nil && source.Delivery.DeadLetterSink != nil {
+			deadLetterSinkURI = source.Delivery.DeadLetterSink.URI
+		}
 		sink.UID = source.UID
 		sink.Generation = source.Generation
 		sink.SubscriberURI = source.SubscriberURI
 		sink.ReplyURI = source.ReplyURI
-		if source.Delivery != nil {
-			sink.Delivery = &eventingduckv1beta1.DeliverySpec{}
-			if err := sink.Delivery.ConvertFrom(ctx, source.Delivery); err != nil {
-				return err
-			}
-			sink.DeadLetterSinkURI = source.Delivery.DeadLetterSink.URI
-		}
+		sink.Deliveryv1 = source.Delivery
+		sink.DeadLetterSinkURI = deadLetterSinkURI
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
@@ -266,12 +264,14 @@ func (sink *SubscribableTypeStatus) ConvertFrom(ctx context.Context, obj apis.Co
 	case *eventingduckv1.SubscribableStatus:
 		if len(source.Subscribers) > 0 {
 			sink.SubscribableStatus = &SubscribableStatus{
-				Subscribers: make([]eventingduckv1beta1.SubscriberStatus, len(source.Subscribers)),
+				Subscribersv1: make([]eventingduckv1.SubscriberStatus, len(source.Subscribers)),
 			}
 			for i, ss := range source.Subscribers {
-				sink.SubscribableStatus.Subscribers[i] = eventingduckv1beta1.SubscriberStatus{}
-				if err := sink.SubscribableStatus.Subscribers[i].ConvertFrom(ctx, &ss); err != nil {
-					return err
+				sink.SubscribableStatus.Subscribersv1[i] = eventingduckv1.SubscriberStatus{
+					UID:                ss.UID,
+					ObservedGeneration: ss.ObservedGeneration,
+					Ready:              ss.Ready,
+					Message:            ss.Message,
 				}
 			}
 		}

--- a/pkg/apis/duck/v1alpha1/subscribable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis"
 )
@@ -78,6 +79,17 @@ func TestSubscribablePopulate(t *testing.T) {
 					Ready:              corev1.ConditionFalse,
 					Message:            "Some message",
 				}},
+				Subscribersv1: []eventingduckv1.SubscriberStatus{{
+					UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+					ObservedGeneration: 1,
+					Ready:              corev1.ConditionTrue,
+					Message:            "Some message",
+				}, {
+					UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+					ObservedGeneration: 2,
+					Ready:              corev1.ConditionFalse,
+					Message:            "Some message",
+				}},
 			},
 		},
 	}
@@ -94,6 +106,17 @@ func TestSubscribableTypeStatusHelperMethods(t *testing.T) {
 	s := &SubscribableStatus{
 		// Populate ALL fields
 		Subscribers: []eventingduckv1beta1.SubscriberStatus{{
+			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+			ObservedGeneration: 1,
+			Ready:              corev1.ConditionTrue,
+			Message:            "This is new field",
+		}, {
+			UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+			ObservedGeneration: 2,
+			Ready:              corev1.ConditionFalse,
+			Message:            "This is new field",
+		}},
+		Subscribersv1: []eventingduckv1.SubscriberStatus{{
 			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			ObservedGeneration: 1,
 			Ready:              corev1.ConditionTrue,
@@ -128,6 +151,14 @@ func TestSubscribableTypeStatusHelperMethods(t *testing.T) {
 
 	/* Test AddSubscriberToSubscribableStatus */
 	subscribableTypeStatus.AddSubscriberToSubscribableStatus(eventingduckv1beta1.SubscriberStatus{
+		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+		ObservedGeneration: 1,
+		Ready:              corev1.ConditionTrue,
+		Message:            "This is new field",
+	})
+
+	/* Test AddSubscriberV1ToSubscribableStatus */
+	subscribableTypeStatus.AddSubscriberV1ToSubscribableStatus(eventingduckv1.SubscriberStatus{
 		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		ObservedGeneration: 1,
 		Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -21,8 +21,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	apis "knative.dev/pkg/apis"
 )
@@ -126,6 +127,12 @@ func (in *ChannelableCombinedSpec) DeepCopyInto(out *ChannelableCombinedSpec) {
 		*out = new(v1beta1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	in.SubscribableSpecv1.DeepCopyInto(&out.SubscribableSpecv1)
+	if in.Deliveryv1 != nil {
+		in, out := &in.Deliveryv1, &out.Deliveryv1
+		*out = new(v1.DeliverySpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -146,9 +153,10 @@ func (in *ChannelableCombinedStatus) DeepCopyInto(out *ChannelableCombinedStatus
 	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	in.SubscribableTypeStatus.DeepCopyInto(&out.SubscribableTypeStatus)
 	in.SubscribableStatus.DeepCopyInto(&out.SubscribableStatus)
+	in.SubscribableStatusv1.DeepCopyInto(&out.SubscribableStatusv1)
 	if in.ErrorChannel != nil {
 		in, out := &in.ErrorChannel, &out.ErrorChannel
-		*out = new(v1.ObjectReference)
+		*out = new(corev1.ObjectReference)
 		**out = **in
 	}
 	return
@@ -227,7 +235,7 @@ func (in *ChannelableStatus) DeepCopyInto(out *ChannelableStatus) {
 	in.SubscribableTypeStatus.DeepCopyInto(&out.SubscribableTypeStatus)
 	if in.ErrorChannel != nil {
 		in, out := &in.ErrorChannel, &out.ErrorChannel
-		*out = new(v1.ObjectReference)
+		*out = new(corev1.ObjectReference)
 		**out = **in
 	}
 	return
@@ -331,6 +339,11 @@ func (in *SubscribableStatus) DeepCopyInto(out *SubscribableStatus) {
 	if in.Subscribers != nil {
 		in, out := &in.Subscribers, &out.Subscribers
 		*out = make([]v1beta1.SubscriberStatus, len(*in))
+		copy(*out, *in)
+	}
+	if in.Subscribersv1 != nil {
+		in, out := &in.Subscribersv1, &out.Subscribersv1
+		*out = make([]v1.SubscriberStatus, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -470,6 +483,11 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 	if in.Delivery != nil {
 		in, out := &in.Delivery, &out.Delivery
 		*out = new(v1beta1.DeliverySpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Deliveryv1 != nil {
+		in, out := &in.Deliveryv1, &out.Deliveryv1
+		*out = new(v1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
 	return


### PR DESCRIPTION
Fixes #3802 


## Proposed Changes

- ChannelableCombined: Add SubscribableSpec, DeliverySpecs and SubscribableStatus for v1 similar to existing ones for v1beta1
- SubscribableTypes: Add Delivery and Subscribers  for v1 similar to existing ones for v1beta1
-

fyi @n3wscott 
