### PR TITLE
Add sources and bindings to edit view aggregation

### DIFF
--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -80,7 +80,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     eventing.knative.dev/release: devel
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "flows.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---

--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -80,7 +80,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     eventing.knative.dev/release: devel
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---


### PR DESCRIPTION

## Proposed Changes

- Adding `sources.knative.dev` back to the `edit` aggregation role. Looking here, it was removed: https://github.com/knative/eventing/commit/4d1c20b9c3a9c0d4987cba8ce8db4f6547bf631d#diff-bc901b9d7f4a101d28344eca9f094d84
- adding bindings to edit as well

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
