### PR TITLE
Test Client now has a Cleanup method

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -54,6 +54,8 @@ type Client struct {
 	podsCreated []string
 
 	tracingEnv corev1.EnvVar
+
+	cleanup func()
 }
 
 // NewClient instantiates and returns several clientsets required for making request to the
@@ -96,6 +98,31 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 	}
 
 	return client, nil
+}
+
+// Cleanup acts similarly to testing.T, but it's tied to the client lifecycle
+func (c *Client) Cleanup(f func()) {
+	oldCleanup := c.cleanup
+	c.cleanup = func() {
+		if oldCleanup != nil {
+			defer oldCleanup()
+		}
+		f()
+	}
+}
+
+func (c *Client) runCleanup() (err error) {
+	if c.cleanup == nil {
+		return nil
+	}
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			err = fmt.Errorf("panic in cleanup function: %+v", panicVal)
+		}
+	}()
+
+	c.cleanup()
+	return nil
 }
 
 func getTracingConfig(c *kubernetes.Clientset) (corev1.EnvVar, error) {

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -93,7 +93,7 @@ func NewEventInfoStore(client *testlib.Client, podName string) (*EventInfoStore,
 	ei := newTestableEventInfoStore(egi, -1, -1)
 	ei.podName = podName
 	ei.tb = client.T
-	client.T.Cleanup(ei.cleanup)
+	client.Cleanup(ei.cleanup)
 	return ei, nil
 }
 

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -28,10 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	"knative.dev/eventing/pkg/utils"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/prow"
+
+	"knative.dev/eventing/pkg/utils"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
@@ -179,6 +180,10 @@ func makeK8sNamespace(baseFuncName string) string {
 
 // TearDown will delete created names using clients.
 func TearDown(client *Client) {
+	if err := client.runCleanup(); err != nil {
+		client.T.Logf("Cleanup error: %+v", err)
+	}
+
 	// Dump the events in the namespace
 	el, err := client.Kube.Kube.CoreV1().Events(client.Namespace).List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #

## Proposed Changes

- Client now has a Cleanup method to hook the lifecycle of the event tracker to the client. This should avoid the tracker to continue working after the test is finished (and hopefully fix related flakyness)