### PR TITLE
[WIP] trigger and broker to have a description via 'kubectl explain'

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -54,6 +54,93 @@ spec:
     name: v1
     served: true
     storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: "Broker collects a pool of events that are consumable using Triggers. Brokers provide a well-known endpoint for event delivery that senders can use with minimal knowledge of the event routing strategy. Receivers use Triggers to request delivery of events from a Broker's pool to a specific URL or Addressable endpoint."
+        properties:
+          spec:
+             description: "Spec defines the desired state of the Broker."
+             type: object
+             properties:
+              config:
+                description: "Config is a KReference to the configuration that specifies
+                      configuration options for this Broker. For example, this could
+                      be a pointer to a ConfigMap."
+                type: object
+                properties:
+                  apiVersion:
+                    description: "API version of the referent."
+                    type: string
+                  kind:
+                    description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                    type: string
+                  name:
+                    description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                    type: string
+                  namespace:
+                    description: "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        This is optional field, it gets defaulted to the object
+                        holding it if left out."
+                    type: string
+              delivery:
+                description: "Delivery is the delivery specification for Events within
+                    the Broker mesh. This includes things like retries, DLQ, etc."
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                        information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                        - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                        backoff delay is the time interval between retries. For
+                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: BackoffPolicy is the retry backoff policy (linear,
+                        exponential).
+                    type: string
+                  deadLetterSink:
+                    description: "DeadLetterSink is the sink receiving event that
+                        could not be sent to a destination."
+                    type: object
+                    properties:
+                      ref:
+                        description: "Ref points to an Addressable."
+                        type: object
+                        properties:
+                            apiVersion:
+                                description: API version of the referent.
+                                type: string
+                            kind:
+                                description: 'Kind of the referent. More info:
+                                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                            name:
+                                description: 'Name of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            namespace:
+                                description: 'Namespace of the referent. More
+                                    info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    This is optional field, it gets defaulted
+                                    to the object holding it if left out.'
+                                type: string
+                      uri:
+                        description: URI can be an absolute URL(non-empty
+                            scheme and non-empty host) pointing to the target
+                            or a relative URI. Relative URIs will be resolved
+                            using the base URI retrieved from Ref.
+                        type: string
+                  retry:
+                    description: Retry is the minimum number of retries the sender
+                        should attempt when sending an event before moving it
+                        to the dead letter sink.
+                    type: integer
+                    format: int32
+          status:
+            description: "Status represents the current state of the Broker. This data
+                may be out of date."
+            type: object
   names:
     kind: Broker
     plural: brokers

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -57,35 +57,42 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        description: "Broker collects a pool of events that are consumable using Triggers. Brokers provide a well-known endpoint for event delivery that senders can use with minimal knowledge of the event routing strategy. Receivers use Triggers to request delivery of events from a Broker's pool to a specific URL or Addressable endpoint."
+        description: 'Broker collects a pool of events that are consumable using Triggers.
+           Brokers provide a well-known endpoint for event delivery that senders can
+           use with minimal knowledge of the event routing strategy. Subscribers use
+           Triggers to request delivery of events from a Broker''s pool to a specific
+           URL or Addressable endpoint.'
         properties:
           spec:
-             description: "Spec defines the desired state of the Broker."
+             description: 'Spec defines the desired state of the Broker.'
              type: object
              properties:
               config:
-                description: "Config is a KReference to the configuration that specifies
+                description: 'Config is a KReference to the configuration that specifies
                       configuration options for this Broker. For example, this could
-                      be a pointer to a ConfigMap."
+                      be a pointer to a ConfigMap.'
                 type: object
                 properties:
                   apiVersion:
-                    description: "API version of the referent."
+                    description: 'API version of the referent.'
                     type: string
                   kind:
-                    description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                    description: 'Kind of the referent. More info:
+                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
-                    description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                    description: 'Name of the referent. More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                   namespace:
-                    description: "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    description: 'Namespace of the referent. More info:
+                        https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                         This is optional field, it gets defaulted to the object
-                        holding it if left out."
+                        holding it if left out.'
                     type: string
               delivery:
-                description: "Delivery is the delivery specification for Events within
-                    the Broker mesh. This includes things like retries, DLQ, etc."
+                description: 'Delivery is the delivery specification for Events within
+                    the Broker mesh. This includes things like retries, DLQ, etc.'
                 type: object
                 properties:
                   backoffDelay:
@@ -96,20 +103,20 @@ spec:
                         exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
-                    description: BackoffPolicy is the retry backoff policy (linear,
-                        exponential).
+                    description: ' BackoffPolicy is the retry backoff policy (linear,
+                        exponential).'
                     type: string
                   deadLetterSink:
-                    description: "DeadLetterSink is the sink receiving event that
-                        could not be sent to a destination."
+                    description: 'DeadLetterSink is the sink receiving event that
+                        could not be sent to a destination.'
                     type: object
                     properties:
                       ref:
-                        description: "Ref points to an Addressable."
+                        description: 'Ref points to an Addressable.'
                         type: object
                         properties:
                             apiVersion:
-                                description: API version of the referent.
+                                description: 'API version of the referent.'
                                 type: string
                             kind:
                                 description: 'Kind of the referent. More info:
@@ -126,20 +133,20 @@ spec:
                                     to the object holding it if left out.'
                                 type: string
                       uri:
-                        description: URI can be an absolute URL(non-empty
+                        description: 'URI can be an absolute URL(non-empty
                             scheme and non-empty host) pointing to the target
                             or a relative URI. Relative URIs will be resolved
-                            using the base URI retrieved from Ref.
+                            using the base URI retrieved from Ref.'
                         type: string
                   retry:
-                    description: Retry is the minimum number of retries the sender
+                    description: 'Retry is the minimum number of retries the sender
                         should attempt when sending an event before moving it
-                        to the dead letter sink.
+                        to the dead letter sink.'
                     type: integer
                     format: int32
           status:
-            description: "Status represents the current state of the Broker. This data
-                may be out of date."
+            description: 'Status represents the current state of the Broker. This data
+                may be out of date.'
             type: object
   names:
     kind: Broker

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -55,22 +55,22 @@ spec:
             properties:
               broker:
                 type: string
-                description: "Broker that this trigger receives events from. If not specified, will default to 'default'."
+                description: 'Broker that this trigger receives events from. If not specified, will default to "default".'
               filter:
                 type: object
                 properties:
                   attributes:
                     type: object
-                    description: "Map of CloudEvents attributes used for filtering events. If not specified, will default to all events"
+                    description: 'Map of CloudEvents attributes used for filtering events. If not specified, will default to all events'
                     additionalProperties:
                       type: string
               subscriber:
                 type: object
-                description: "the destination that should receive events."
+                description: 'the destination that should receive events.'
                 properties:
                   ref:
                     type: object
-                    description: "a reference to a Kubernetes object from which to retrieve the target URI."
+                    description: 'a reference to a Kubernetes object from which to retrieve the target URI.'
                     required:
                     - apiVersion
                     - kind
@@ -90,7 +90,7 @@ spec:
                         minLength: 1
                   uri:
                     type: string
-                    description: "the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI."
+                    description: 'the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI.'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
@@ -101,10 +101,10 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        description: "Trigger represents a request to have events delivered to a consumer from a Broker's event pool."
+        description: 'Trigger represents a request to have events delivered to a subscriber from a Broker''s event pool.'
         properties:
           spec:
-            description: "Spec defines the desired state of the Trigger."
+            description: 'Spec defines the desired state of the Trigger.'
             required:
               - subscriber
               - broker
@@ -112,26 +112,26 @@ spec:
             properties:
               broker:
                 type: string
-                description: "Broker that this trigger receives events from."
+                description: 'Broker that this trigger receives events from.'
               filter:
                 type: object
-                description: "Filter is the filter to apply against all events from
+                description: 'Filter is the filter to apply against all events from
                     the Broker. Only events that pass this filter will be sent to
                     the Subscriber. If not specified, will default to allowing all
-                    events."
+                    events.'
                 properties:
                   attributes:
                     type: object
-                    description: "Map of CloudEvents attributes used for filtering events. If not specified, will default to all events"
+                    description: 'Map of CloudEvents attributes used for filtering events. If not specified, will default to all events'
                     additionalProperties:
                       type: string
               subscriber:
                 type: object
-                description: "the destination that should receive events."
+                description: 'the destination that should receive events.'
                 properties:
                   ref:
                     type: object
-                    description: "a reference to a Kubernetes object from which to retrieve the target URI."
+                    description: 'a reference to a Kubernetes object from which to retrieve the target URI.'
                     required:
                     - apiVersion
                     - kind
@@ -151,9 +151,9 @@ spec:
                         minLength: 1
                   uri:
                     type: string
-                    description: "the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI."
+                    description: 'the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI.'
           status:
-            description: "Status represents the current state of the Trigger. This data may be out of date."
+            description: 'Status represents the current state of the Trigger. This data may be out of date.'
             type: object
             x-kubernetes-preserve-unknown-fields: true
   names:

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -101,8 +101,10 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
+        description: "Trigger represents a request to have events delivered to a consumer from a Broker's event pool."
         properties:
           spec:
+            description: "Spec defines the desired state of the Trigger."
             required:
               - subscriber
               - broker
@@ -113,6 +115,10 @@ spec:
                 description: "Broker that this trigger receives events from."
               filter:
                 type: object
+                description: "Filter is the filter to apply against all events from
+                    the Broker. Only events that pass this filter will be sent to
+                    the Subscriber. If not specified, will default to allowing all
+                    events."
                 properties:
                   attributes:
                     type: object
@@ -147,6 +153,7 @@ spec:
                     type: string
                     description: "the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI."
           status:
+            description: "Status represents the current state of the Trigger. This data may be out of date."
             type: object
             x-kubernetes-preserve-unknown-fields: true
   names:

--- a/pkg/apis/eventing/v1/broker_types.go
+++ b/pkg/apis/eventing/v1/broker_types.go
@@ -33,7 +33,7 @@ import (
 
 // Broker collects a pool of events that are consumable using Triggers. Brokers
 // provide a well-known endpoint for event delivery that senders can use with
-// minimal knowledge of the event routing strategy. Receivers use Triggers to
+// minimal knowledge of the event routing strategy. Subscribers use Triggers to
 // request delivery of events from a Broker's pool to a specific URL or
 // Addressable endpoint.
 type Broker struct {

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -41,7 +41,7 @@ const (
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Trigger represents a request to have events delivered to a consumer from a
+// Trigger represents a request to have events delivered to a subscriber from a
 // Broker's event pool.
 type Trigger struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
Part of #3054

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add content in CRDs to generate kubectl explain content for trigger and broker
- 🐛 partial fix for bug #3054
-
-

Sample output of kubectl explain
Trigger: 
```
>kubectl explain trigger
KIND:     Trigger
VERSION:  eventing.knative.dev/v1

DESCRIPTION:
     Trigger represents a request to have events delivered to a consumer from a
     Broker's event pool.

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec	<Object>
     Spec defines the desired state of the Trigger.

   status	<map[string]>
     Status represents the current state of the Trigger. This data may be out of
     date.
```

Broker:

```
kubectl explain Broker
KIND:     Broker
VERSION:  eventing.knative.dev/v1

DESCRIPTION:
     Broker collects a pool of events that are consumable using Triggers.
     Brokers provide a well-known endpoint for event delivery that senders can
     use with minimal knowledge of the event routing strategy. Receivers use
     Triggers to request delivery of events from a Broker's pool to a specific
     URL or Addressable endpoint.

FIELDS:
   apiVersion	<string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind	<string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata	<Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec	<Object>
     Spec defines the desired state of the Broker.

   status	<map[string]>
     Status represents the current state of the Broker. This data may be out of
     date.
```

Content was partially generated using https://github.com/Harwayne/knative-gcp/tree/reflective-schema/hack/schema
fyi @lionelvillard 