### PR TITLE
kubectl explain for sequence

### DIFF
--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -29,13 +29,361 @@ spec:
     subresources:
       status: {}
     schema:
-      openAPIV3Schema:
+      openAPIV3Schema: &openAPIV3Schema
+       
         type: object
-        # this is a work around so we don't need to flush out the
-        # schema for each version at this time
-        #
-        # see issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
+        properties:
+          spec:
+            description: Spec defines the desired state of the Sequence.
+            type: object
+            properties:
+              channelTemplate:
+                description: ChannelTemplate specifies which Channel CRD to use. If
+                    left unspecified, it is set to the default Channel CRD for the
+                    namespace (or cluster, in case there are no defaults for the namespace).
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST
+                        resource this object represents. Servers may infer this
+                        from the endpoint the client submits requests to. Cannot
+                        be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  spec:
+                    description: Spec defines the Spec to use for each channel
+                        created. Passed in verbatim to the Channel CRD as Spec
+                        section.
+                    type: string
+              reply:
+                description: Reply is a Reference to where the result of the last
+                    Subscriber gets sent to.
+                type: object
+                properties:
+                    ref:
+                      description: Ref points to an Addressable.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted to the
+                              object holding it if left out.'
+                          type: string
+                    uri:
+                      description: URI can be an absolute URL(non-empty scheme and
+                          non-empty host) pointing to the target or a relative URI.
+                          Relative URIs will be resolved using the base URI retrieved
+                          from Ref.
+                      type: string
+              steps:
+                description: Steps is the list of Destinations (processors / functions)
+                    that will be called in the order provided. Each step has its own
+                    delivery options
+                type: array
+                items:
+                  type: object
+                  properties:
+                    delivery:
+                      description: Delivery is the delivery specification for
+                          events to the subscriber This includes things like
+                          retries, DLQ, etc.
+                      type: object
+                      properties:
+                        backoffDelay:
+                          description: 'BackoffDelay is the delay before
+                              retrying. More information on Duration format:
+                              - https://www.iso.org/iso-8601-date-and-time-format.html
+                              - https://en.wikipedia.org/wiki/ISO_8601  For
+                              linear policy, backoff delay is the time interval
+                              between retries. For exponential policy ,
+                              backoff delay is backoffDelay*2^<numberOfRetries>.'
+                          type: string
+                        backoffPolicy:
+                          description: BackoffPolicy is the retry backoff
+                              policy (linear, exponential).
+                          type: string
+                        deadLetterSink:
+                          description: DeadLetterSink is the sink receiving
+                              event that could not be sent to a destination.
+                          type: object
+                          properties:
+                            ref:
+                              description: Ref points to an Addressable.
+                              type: object
+                              properties:
+                                apiVersion:
+                                  description: API version of the
+                                      referent.
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the
+                                      referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      This is optional field, it
+                                      gets defaulted to the object
+                                      holding it if left out.'
+                                  type: string
+                            uri:
+                              description: URI can be an absolute URL(non-empty
+                                  scheme and non-empty host) pointing
+                                  to the target or a relative URI. Relative
+                                  URIs will be resolved using the base
+                                  URI retrieved from Ref.
+                              type: string
+                        retry:
+                          description: Retry is the minimum number of retries
+                              the sender should attempt when sending an
+                              event before moving it to the dead letter
+                              sink.
+                          type: integer
+                          format: int32
+                    ref:
+                      description: Ref points to an Addressable.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More
+                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted
+                              to the object holding it if left out.'
+                          type: string
+                    uri:
+                      description: URI can be an absolute URL(non-empty scheme
+                          and non-empty host) pointing to the target or a relative
+                          URI. Relative URIs will be resolved using the base
+                          URI retrieved from Ref.
+                      type: string
+          status:
+            description: Status represents the current state of the Sequence. This data
+                may be out of date.
+            type: object
+            required:
+              - address
+            properties:
+              address:
+                type: object
+                required:
+                  - url
+                properties:
+                    url:
+                        type: string
+              annotations:
+                description: Annotations is additional Status fields for the Resource
+                    to save some additional State as well as convey more information
+                    to the user. This is roughly akin to Annotations on any k8s resource,
+                    just the reconciler conveying richer information outwards.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              channelStatuses:
+                description: ChannelStatuses is an array of corresponding Channel
+                    statuses. Matches the Spec.Steps array in the order.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    channel:
+                      description: Channel is the reference to the underlying
+                          channel.
+                      type: object
+                      properties: &referentProperties
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object
+                              instead of an entire object, this string should
+                              contain a valid JSON/Go field access statement,
+                              such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to
+                              a container within a pod, this would take
+                              on a value like: "spec.containers{name}" (where
+                              "name" refers to the name of the container
+                              that triggered the event) or if no container
+                              name is specified "spec.containers[2]" (container
+                              with index 2 in this pod). This syntax is
+                              chosen only to have some well-defined way
+                              of referencing a part of an object.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More
+                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which
+                              this reference is made, if any. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info:
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                    ready:
+                      description: ReadyCondition indicates whether the Channel
+                          is ready or not.
+                      type: object
+                      required:
+                        - type
+                        - status
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time
+                              the condition transitioned from one status
+                              to another. We use VolatileTime in place of
+                              metav1.Time to exclude this from creating
+                              equality.Semantic differences (all other things
+                              held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating
+                              details about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last
+                              transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures
+                              of this type of condition. When this is not
+                              specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True,
+                              False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+              conditions:
+                description: Conditions the latest available observations of a resource's
+                    current state.
+                type: array
+                items:
+                  type: object
+                  required:
+                    - type
+                    - status
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another. We use VolatileTime
+                          in place of metav1.Time to exclude this from creating
+                          equality.Semantic differences (all other things held
+                          constant).
+                      type: string
+                    message:
+                      description: A human readable message indicating details
+                          about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    severity:
+                      description: Severity with which to treat failures of
+                          this type of condition. When this is not specified,
+                          it defaults to Error.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False,
+                          Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the Service
+                    that was last processed by the controller.
+                type: integer
+                format: int64
+              subscriptionStatuses:
+                description: SubscriptionStatuses is an array of corresponding Subscription
+                    statuses. Matches the Spec.Steps array in the order.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    ready:
+                      description: ReadyCondition indicates whether the Subscription
+                          is ready or not.
+                      type: object
+                      required:
+                        - type
+                        - status
+                      properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time
+                              the condition transitioned from one status
+                              to another. We use VolatileTime in place of
+                              metav1.Time to exclude this from creating
+                              equality.Semantic differences (all other things
+                              held constant).
+                          type: string
+                        message:
+                          description: A human readable message indicating
+                              details about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last
+                              transition.
+                          type: string
+                        severity:
+                          description: Severity with which to treat failures
+                              of this type of condition. When this is not
+                              specified, it defaults to Error.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True,
+                              False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition.
+                          type: string
+                    subscription:
+                      description: Subscription is the reference to the underlying
+                          Subscription.
+                      type: object
+                      properties:
+                        <<: *referentProperties
     additionalPrinterColumns:
     - name: URL
       type: string
@@ -53,6 +401,10 @@ spec:
     name: v1
     served: true
     storage: false
+    # the schema of v1 is exactly the same as v1beta1 schema
+    schema:
+      openAPIV3Schema:
+        << : *openAPIV3Schema
   names:
     kind: Sequence
     plural: sequences

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -190,13 +190,9 @@ spec:
             description: Status represents the current state of the Sequence. This data
                 may be out of date.
             type: object
-            required:
-              - address
             properties:
               address:
                 type: object
-                required:
-                  - url
                 properties:
                     url:
                         type: string
@@ -262,9 +258,6 @@ spec:
                       description: ReadyCondition indicates whether the Channel
                           is ready or not.
                       type: object
-                      required:
-                        - type
-                        - status
                       properties:
                         lastTransitionTime:
                           description: LastTransitionTime is the last time
@@ -300,9 +293,6 @@ spec:
                 type: array
                 items:
                   type: object
-                  required:
-                    - type
-                    - status
                   properties:
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
@@ -346,9 +336,6 @@ spec:
                       description: ReadyCondition indicates whether the Subscription
                           is ready or not.
                       type: object
-                      required:
-                        - type
-                        - status
                       properties:
                         lastTransitionTime:
                           description: LastTransitionTime is the last time

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -64,7 +64,7 @@ spec:
                 description: Reply is a Reference to where the result of the last
                     Subscriber gets sent to.
                 type: object
-                properties:
+                properties: &addressableProperties
                     ref:
                       description: Ref points to an Addressable.
                       type: object
@@ -122,36 +122,7 @@ spec:
                               event that could not be sent to a destination.
                           type: object
                           properties:
-                            ref:
-                              description: Ref points to an Addressable.
-                              type: object
-                              properties:
-                                apiVersion:
-                                  description: API version of the
-                                      referent.
-                                  type: string
-                                kind:
-                                  description: 'Kind of the referent.
-                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                  type: string
-                                name:
-                                  description: 'Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                namespace:
-                                  description: 'Namespace of the
-                                      referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                                      This is optional field, it
-                                      gets defaulted to the object
-                                      holding it if left out.'
-                                  type: string
-                            uri:
-                              description: URI can be an absolute URL(non-empty
-                                  scheme and non-empty host) pointing
-                                  to the target or a relative URI. Relative
-                                  URIs will be resolved using the base
-                                  URI retrieved from Ref.
-                              type: string
+                            << : *addressableProperties
                         retry:
                           description: Retry is the minimum number of retries
                               the sender should attempt when sending an
@@ -163,23 +134,7 @@ spec:
                       description: Ref points to an Addressable.
                       type: object
                       properties:
-                        apiVersion:
-                          description: API version of the referent.
-                          type: string
-                        kind:
-                          description: 'Kind of the referent. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info:
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        namespace:
-                          description: 'Namespace of the referent. More
-                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                              This is optional field, it gets defaulted
-                              to the object holding it if left out.'
-                          type: string
+                        << : *addressableProperties
                     uri:
                       description: URI can be an absolute URL(non-empty scheme
                           and non-empty host) pointing to the target or a relative
@@ -190,13 +145,9 @@ spec:
             description: Status represents the current state of the Sequence. This data
                 may be out of date.
             type: object
-            required:
-              - address
             properties:
               address:
                 type: object
-                required:
-                  - url
                 properties:
                     url:
                         type: string
@@ -262,10 +213,7 @@ spec:
                       description: ReadyCondition indicates whether the Channel
                           is ready or not.
                       type: object
-                      required:
-                        - type
-                        - status
-                      properties:
+                      properties: &readyConditionProperties
                         lastTransitionTime:
                           description: LastTransitionTime is the last time
                               the condition transitioned from one status
@@ -300,36 +248,8 @@ spec:
                 type: array
                 items:
                   type: object
-                  required:
-                    - type
-                    - status
                   properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use VolatileTime
-                          in place of metav1.Time to exclude this from creating
-                          equality.Semantic differences (all other things held
-                          constant).
-                      type: string
-                    message:
-                      description: A human readable message indicating details
-                          about the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    severity:
-                      description: Severity with which to treat failures of
-                          this type of condition. When this is not specified,
-                          it defaults to Error.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False,
-                          Unknown.
-                      type: string
-                    type:
-                      description: Type of condition.
-                      type: string
+                    <<: *readyConditionProperties
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service
                     that was last processed by the controller.
@@ -346,38 +266,8 @@ spec:
                       description: ReadyCondition indicates whether the Subscription
                           is ready or not.
                       type: object
-                      required:
-                        - type
-                        - status
                       properties:
-                        lastTransitionTime:
-                          description: LastTransitionTime is the last time
-                              the condition transitioned from one status
-                              to another. We use VolatileTime in place of
-                              metav1.Time to exclude this from creating
-                              equality.Semantic differences (all other things
-                              held constant).
-                          type: string
-                        message:
-                          description: A human readable message indicating
-                              details about the transition.
-                          type: string
-                        reason:
-                          description: The reason for the condition's last
-                              transition.
-                          type: string
-                        severity:
-                          description: Severity with which to treat failures
-                              of this type of condition. When this is not
-                              specified, it defaults to Error.
-                          type: string
-                        status:
-                          description: Status of the condition, one of True,
-                              False, Unknown.
-                          type: string
-                        type:
-                          description: Type of condition.
-                          type: string
+                        <<: *readyConditionProperties
                     subscription:
                       description: Subscription is the reference to the underlying
                           Subscription.

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -130,17 +130,7 @@ spec:
                               sink.
                           type: integer
                           format: int32
-                    ref:
-                      description: Ref points to an Addressable.
-                      type: object
-                      properties:
-                        << : *addressableProperties
-                    uri:
-                      description: URI can be an absolute URL(non-empty scheme
-                          and non-empty host) pointing to the target or a relative
-                          URI. Relative URIs will be resolved using the base
-                          URI retrieved from Ref.
-                      type: string
+                    << : *addressableProperties
           status:
             description: Status represents the current state of the Sequence. This data
                 may be out of date.
@@ -157,7 +147,6 @@ spec:
                     to the user. This is roughly akin to Annotations on any k8s resource,
                     just the reconciler conveying richer information outwards.
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
               channelStatuses:
                 description: ChannelStatuses is an array of corresponding Channel
                     statuses. Matches the Spec.Steps array in the order.

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -98,6 +98,7 @@ spec:
                 items:
                   type: object
                   properties:
+                    << : *addressableProperties
                     delivery:
                       description: Delivery is the delivery specification for
                           events to the subscriber This includes things like
@@ -130,7 +131,6 @@ spec:
                               sink.
                           type: integer
                           format: int32
-                    << : *addressableProperties
           status:
             description: Status represents the current state of the Sequence. This data
                 may be out of date.
@@ -202,15 +202,8 @@ spec:
                       description: ReadyCondition indicates whether the Channel
                           is ready or not.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                       properties: &readyConditionProperties
-                        lastTransitionTime:
-                          description: LastTransitionTime is the last time
-                              the condition transitioned from one status
-                              to another. We use VolatileTime in place of
-                              metav1.Time to exclude this from creating
-                              equality.Semantic differences (all other things
-                              held constant).
-                          type: string
                         message:
                           description: A human readable message indicating
                               details about the transition.

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -30,7 +30,6 @@ spec:
       status: {}
     schema:
       openAPIV3Schema: &openAPIV3Schema
-       
         type: object
         properties:
           spec:

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -58,7 +58,8 @@ spec:
                     description: Spec defines the Spec to use for each channel
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
-                    type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
               reply:
                 description: Reply is a Reference to where the result of the last
                     Subscriber gets sent to.
@@ -189,9 +190,13 @@ spec:
             description: Status represents the current state of the Sequence. This data
                 may be out of date.
             type: object
+            required:
+              - address
             properties:
               address:
                 type: object
+                required:
+                  - url
                 properties:
                     url:
                         type: string
@@ -257,6 +262,9 @@ spec:
                       description: ReadyCondition indicates whether the Channel
                           is ready or not.
                       type: object
+                      required:
+                        - type
+                        - status
                       properties:
                         lastTransitionTime:
                           description: LastTransitionTime is the last time
@@ -292,6 +300,9 @@ spec:
                 type: array
                 items:
                   type: object
+                  required:
+                    - type
+                    - status
                   properties:
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
@@ -335,6 +346,9 @@ spec:
                       description: ReadyCondition indicates whether the Subscription
                           is ready or not.
                       type: object
+                      required:
+                        - type
+                        - status
                       properties:
                         lastTransitionTime:
                           description: LastTransitionTime is the last time


### PR DESCRIPTION
Part of #3054

## Proposed Changes

- Add content in CRDs to generate kubectl explain content for Sequence
- 🐛 partial fix for bug #3054
- Note use of placeholders to avoid duplication of content via &referentProperties (fyi @aavarghese )
