### PR TITLE
Migrate channel reconciler to use messaging.* v1 resources

### DIFF
--- a/pkg/apis/duck/v1alpha1/channelable_combined_types.go
+++ b/pkg/apis/duck/v1alpha1/channelable_combined_types.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
@@ -33,7 +32,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of
-// v1alpha1, v1beta1 and v1 duck types. This is not to be used by resource writers and is
+// v1alpha1 and v1beta1 duck types. This is not to be used by resource writers and is
 // only used by Subscription Controller to synthesize patches and read the Status
 // of the Channelable Resources.
 // This is not a real resource.
@@ -56,17 +55,8 @@ type ChannelableCombinedSpec struct {
 	eventingduckv1beta1.SubscribableSpec `json:",inline"`
 
 	// DeliverySpec contains options controlling the event delivery
-	// for the v1beta1 spec compatibility.
 	// +optional
 	Delivery *eventingduckv1beta1.DeliverySpec `json:"delivery,omitempty"`
-
-	// SubscribableSpecv1 is for the v1 spec compatibility.
-	SubscribableSpecv1 eventingduckv1.SubscribableSpec `json:",inline"`
-
-	// DeliverySpecv1 contains options controlling the event delivery
-	// for the v1 spec compatibility.
-	// +optional
-	Deliveryv1 *eventingduckv1.DeliverySpec `json:"deliveryv1,omitempty"`
 }
 
 // ChannelableStatus contains the Status of a Channelable object.
@@ -81,8 +71,6 @@ type ChannelableCombinedStatus struct {
 	SubscribableTypeStatus `json:",inline"`
 	// SubscribableStatus is the v1beta1 part of the Subscribers status.
 	eventingduckv1beta1.SubscribableStatus `json:",inline"`
-	// SubscribableStatusv1 is the v1 part of the Subscribers status.
-	SubscribableStatusv1 eventingduckv1.SubscribableStatus `json:",inline"`
 	// ErrorChannel is set by the channel when it supports native error handling via a channel
 	// +optional
 	ErrorChannel *corev1.ObjectReference `json:"errorChannel,omitempty"`
@@ -125,23 +113,8 @@ func (c *ChannelableCombined) Populate() {
 			ReplyURI:      apis.HTTP("sink2"),
 		}},
 	}
-	c.Spec.SubscribableSpecv1 = eventingduckv1.SubscribableSpec{
-		// Populate ALL fields
-		Subscribers: []eventingduckv1.SubscriberSpec{{
-			UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-			Generation:    1,
-			SubscriberURI: apis.HTTP("call1"),
-			ReplyURI:      apis.HTTP("sink2"),
-		}, {
-			UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-			Generation:    2,
-			SubscriberURI: apis.HTTP("call2"),
-			ReplyURI:      apis.HTTP("sink2"),
-		}},
-	}
 	retry := int32(5)
 	linear := eventingduckv1beta1.BackoffPolicyLinear
-	linearv1 := eventingduckv1.BackoffPolicyLinear
 	delay := "5s"
 	deadLetterSink := duckv1.Destination{
 		Ref: &duckv1.KReference{
@@ -158,24 +131,7 @@ func (c *ChannelableCombined) Populate() {
 		BackoffPolicy:  &linear,
 		BackoffDelay:   &delay,
 	}
-	c.Spec.Deliveryv1 = &eventingduckv1.DeliverySpec{
-		DeadLetterSink: &deadLetterSink,
-		Retry:          &retry,
-		BackoffPolicy:  &linearv1,
-		BackoffDelay:   &delay,
-	}
 	subscribers := []eventingduckv1beta1.SubscriberStatus{{
-		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-		ObservedGeneration: 1,
-		Ready:              corev1.ConditionTrue,
-		Message:            "Some message",
-	}, {
-		UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-		ObservedGeneration: 2,
-		Ready:              corev1.ConditionFalse,
-		Message:            "Some message",
-	}}
-	subscribersv1 := []eventingduckv1.SubscriberStatus{{
 		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		ObservedGeneration: 1,
 		Ready:              corev1.ConditionTrue,
@@ -202,13 +158,9 @@ func (c *ChannelableCombined) Populate() {
 		SubscribableStatus: eventingduckv1beta1.SubscribableStatus{
 			Subscribers: subscribers,
 		},
-		SubscribableStatusv1: eventingduckv1.SubscribableStatus{
-			Subscribers: subscribersv1,
-		},
 		SubscribableTypeStatus: SubscribableTypeStatus{
 			SubscribableStatus: &SubscribableStatus{
-				Subscribers:   subscribers,
-				Subscribersv1: subscribersv1,
+				Subscribers: subscribers,
 			},
 		},
 	}

--- a/pkg/apis/duck/v1alpha1/channelable_combined_types_test.go
+++ b/pkg/apis/duck/v1alpha1/channelable_combined_types_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -45,27 +44,12 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 
 	retry := int32(5)
 	linear := eventingduckv1beta1.BackoffPolicyLinear
-	linearv1 := eventingduckv1.BackoffPolicyLinear
 	delay := "5s"
 	want := &ChannelableCombined{
 		Spec: ChannelableCombinedSpec{
 			SubscribableSpec: eventingduckv1beta1.SubscribableSpec{
 				// Populate ALL fields
 				Subscribers: []eventingduckv1beta1.SubscriberSpec{{
-					UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-					Generation:    1,
-					SubscriberURI: apis.HTTP("call1"),
-					ReplyURI:      apis.HTTP("sink2"),
-				}, {
-					UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-					Generation:    2,
-					SubscriberURI: apis.HTTP("call2"),
-					ReplyURI:      apis.HTTP("sink2"),
-				}},
-			},
-			SubscribableSpecv1: eventingduckv1.SubscribableSpec{
-				// Populate ALL fields
-				Subscribers: []eventingduckv1.SubscriberSpec{{
 					UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 					Generation:    1,
 					SubscriberURI: apis.HTTP("call1"),
@@ -106,20 +90,6 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 				BackoffPolicy: &linear,
 				BackoffDelay:  &delay,
 			},
-			Deliveryv1: &eventingduckv1.DeliverySpec{
-				DeadLetterSink: &duckv1.Destination{
-					Ref: &duckv1.KReference{
-						Name: "aname",
-					},
-					URI: &apis.URL{
-						Scheme: "http",
-						Host:   "test-error-domain",
-					},
-				},
-				Retry:         &retry,
-				BackoffPolicy: &linearv1,
-				BackoffDelay:  &delay,
-			},
 		},
 
 		Status: ChannelableCombinedStatus{
@@ -148,33 +118,9 @@ func TestChannelableCombinedPopulate(t *testing.T) {
 					Message:            "Some message",
 				}},
 			},
-			SubscribableStatusv1: eventingduckv1.SubscribableStatus{
-				Subscribers: []eventingduckv1.SubscriberStatus{{
-					UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-					ObservedGeneration: 1,
-					Ready:              corev1.ConditionTrue,
-					Message:            "Some message",
-				}, {
-					UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-					ObservedGeneration: 2,
-					Ready:              corev1.ConditionFalse,
-					Message:            "Some message",
-				}},
-			},
 			SubscribableTypeStatus: SubscribableTypeStatus{
 				SubscribableStatus: &SubscribableStatus{
 					Subscribers: []eventingduckv1beta1.SubscriberStatus{{
-						UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-						ObservedGeneration: 1,
-						Ready:              corev1.ConditionTrue,
-						Message:            "Some message",
-					}, {
-						UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-						ObservedGeneration: 2,
-						Ready:              corev1.ConditionFalse,
-						Message:            "Some message",
-					}},
-					Subscribersv1: []eventingduckv1.SubscriberStatus{{
 						UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 						ObservedGeneration: 1,
 						Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/subscribable_types.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 
-	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 )
 
@@ -62,8 +61,6 @@ type SubscriberSpec struct {
 	DeadLetterSinkURI *apis.URL `json:"deadLetterSink,omitempty"`
 	// +optional
 	Delivery *duckv1beta1.DeliverySpec `json:"delivery,omitempty"`
-	// +optional
-	Deliveryv1 *duckv1.DeliverySpec `json:"deliveryv1,omitempty"`
 }
 
 // SubscribableStatus is the schema for the subscribable's status portion of the status
@@ -73,11 +70,6 @@ type SubscribableStatus struct {
 	// +patchMergeKey=uid
 	// +patchStrategy=merge
 	Subscribers []duckv1beta1.SubscriberStatus `json:"subscribers,omitempty" patchStrategy:"merge" patchMergeKey:"uid"`
-
-	// This is the list of subscription's statuses for this channel.
-	// +patchMergeKey=uid
-	// +patchStrategy=merge
-	Subscribersv1 []duckv1.SubscriberStatus `json:"subscribersv1,omitempty" patchStrategy:"merge" patchMergeKey:"uid"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -144,14 +136,6 @@ func (s *SubscribableTypeStatus) AddSubscriberToSubscribableStatus(subscriberSta
 	s.SubscribableStatus.Subscribers = subscribers
 }
 
-// AddSubscriberToSubscribableStatus method is a Helper method for type SubscribableTypeStatus, if Subscribable Status needs to be appended
-// with Subscribers, use this function, so that the value is reflected in both the duplicate fields residing
-// in SubscribableTypeStatus
-func (s *SubscribableTypeStatus) AddSubscriberV1ToSubscribableStatus(subscriberStatus duckv1.SubscriberStatus) {
-	subscribersv1 := append(s.GetSubscribableTypeStatus().Subscribersv1, subscriberStatus)
-	s.SubscribableStatus.Subscribersv1 = subscribersv1
-}
-
 // GetFullType implements duck.Implementable
 func (s *Subscribable) GetFullType() duck.Populatable {
 	return &SubscribableType{}
@@ -176,17 +160,6 @@ func (c *SubscribableType) Populate() {
 	c.Status.SetSubscribableTypeStatus(SubscribableStatus{
 		// Populate ALL fields
 		Subscribers: []duckv1beta1.SubscriberStatus{{
-			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-			ObservedGeneration: 1,
-			Ready:              corev1.ConditionTrue,
-			Message:            "Some message",
-		}, {
-			UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-			ObservedGeneration: 2,
-			Ready:              corev1.ConditionFalse,
-			Message:            "Some message",
-		}},
-		Subscribersv1: []duckv1.SubscriberStatus{{
 			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			ObservedGeneration: 1,
 			Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_conversion_test.go
@@ -147,7 +147,7 @@ func TestSubscribableTypeConversionV1alphaV1(t *testing.T) {
 	// Just one for now, just adding the for loop for ease of future changes.
 	versions := []apis.Convertible{&v1.Subscribable{}}
 
-	linear := v1.BackoffPolicyLinear
+	linear := v1beta1.BackoffPolicyLinear
 
 	tests := []struct {
 		name string
@@ -180,7 +180,7 @@ func TestSubscribableTypeConversionV1alphaV1(t *testing.T) {
 							SubscriberURI:     apis.HTTP("subscriber.example.com"),
 							ReplyURI:          apis.HTTP("reply.example.com"),
 							DeadLetterSinkURI: apis.HTTP("subscriber.dls.example.com"),
-							Deliveryv1: &v1.DeliverySpec{
+							Delivery: &v1beta1.DeliverySpec{
 								DeadLetterSink: &pkgduckv1.Destination{
 									Ref: &pkgduckv1.KReference{
 										Kind:       "dlKind",
@@ -201,14 +201,14 @@ func TestSubscribableTypeConversionV1alphaV1(t *testing.T) {
 							SubscriberURI:     apis.HTTP("subscriber2.example.com"),
 							ReplyURI:          apis.HTTP("reply2.example.com"),
 							DeadLetterSinkURI: apis.HTTP("subscriber2.dls.example.com"),
-							Deliveryv1:        nil,
+							Delivery:          nil,
 						},
 					},
 				},
 			},
 			Status: SubscribableTypeStatus{
 				SubscribableStatus: &SubscribableStatus{
-					Subscribersv1: []v1.SubscriberStatus{
+					Subscribers: []v1beta1.SubscriberStatus{
 						{
 							UID:                "status-uid-1",
 							ObservedGeneration: 99,
@@ -232,7 +232,7 @@ func TestSubscribableTypeConversionV1alphaV1(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 
-				fixed := fixSubscribableTypeDeprecatedv1(test.in)
+				fixed := fixSubscribableTypeDeprecated(test.in)
 				if diff := cmp.Diff(fixed, got); diff != "" {
 					t.Errorf("roundtrip (-want, +got) = %v", diff)
 				}
@@ -451,23 +451,6 @@ func fixSubscribableTypeDeprecated(in *SubscribableType) *SubscribableType {
 		for i := range in.Spec.Subscribable.Subscribers {
 			if in.Spec.Subscribable.Subscribers[i].Delivery == nil {
 				in.Spec.Subscribable.Subscribers[i].Delivery = &v1beta1.DeliverySpec{
-					DeadLetterSink: &pkgduckv1.Destination{
-						URI: in.Spec.Subscribable.Subscribers[i].DeadLetterSinkURI,
-					},
-				}
-			}
-		}
-	}
-
-	return in
-}
-
-// Since v1 to v1alpha1 is lossy.
-func fixSubscribableTypeDeprecatedv1(in *SubscribableType) *SubscribableType {
-	if in.Spec.Subscribable != nil && len(in.Spec.Subscribable.Subscribers) > 0 {
-		for i := range in.Spec.Subscribable.Subscribers {
-			if in.Spec.Subscribable.Subscribers[i].Deliveryv1 == nil {
-				in.Spec.Subscribable.Subscribers[i].Deliveryv1 = &v1.DeliverySpec{
 					DeadLetterSink: &pkgduckv1.Destination{
 						URI: in.Spec.Subscribable.Subscribers[i].DeadLetterSinkURI,
 					},

--- a/pkg/apis/duck/v1alpha1/subscribable_types_test.go
+++ b/pkg/apis/duck/v1alpha1/subscribable_types_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis"
 )
@@ -79,17 +78,6 @@ func TestSubscribablePopulate(t *testing.T) {
 					Ready:              corev1.ConditionFalse,
 					Message:            "Some message",
 				}},
-				Subscribersv1: []eventingduckv1.SubscriberStatus{{
-					UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-					ObservedGeneration: 1,
-					Ready:              corev1.ConditionTrue,
-					Message:            "Some message",
-				}, {
-					UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-					ObservedGeneration: 2,
-					Ready:              corev1.ConditionFalse,
-					Message:            "Some message",
-				}},
 			},
 		},
 	}
@@ -106,17 +94,6 @@ func TestSubscribableTypeStatusHelperMethods(t *testing.T) {
 	s := &SubscribableStatus{
 		// Populate ALL fields
 		Subscribers: []eventingduckv1beta1.SubscriberStatus{{
-			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-			ObservedGeneration: 1,
-			Ready:              corev1.ConditionTrue,
-			Message:            "This is new field",
-		}, {
-			UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
-			ObservedGeneration: 2,
-			Ready:              corev1.ConditionFalse,
-			Message:            "This is new field",
-		}},
-		Subscribersv1: []eventingduckv1.SubscriberStatus{{
 			UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 			ObservedGeneration: 1,
 			Ready:              corev1.ConditionTrue,
@@ -151,14 +128,6 @@ func TestSubscribableTypeStatusHelperMethods(t *testing.T) {
 
 	/* Test AddSubscriberToSubscribableStatus */
 	subscribableTypeStatus.AddSubscriberToSubscribableStatus(eventingduckv1beta1.SubscriberStatus{
-		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
-		ObservedGeneration: 1,
-		Ready:              corev1.ConditionTrue,
-		Message:            "This is new field",
-	})
-
-	/* Test AddSubscriberV1ToSubscribableStatus */
-	subscribableTypeStatus.AddSubscriberV1ToSubscribableStatus(eventingduckv1.SubscriberStatus{
 		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		ObservedGeneration: 1,
 		Ready:              corev1.ConditionTrue,

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	v1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	apis "knative.dev/pkg/apis"
@@ -148,7 +148,7 @@ func (in *ChannelableCombinedStatus) DeepCopyInto(out *ChannelableCombinedStatus
 	in.SubscribableStatus.DeepCopyInto(&out.SubscribableStatus)
 	if in.ErrorChannel != nil {
 		in, out := &in.ErrorChannel, &out.ErrorChannel
-		*out = new(corev1.ObjectReference)
+		*out = new(v1.ObjectReference)
 		**out = **in
 	}
 	return
@@ -227,7 +227,7 @@ func (in *ChannelableStatus) DeepCopyInto(out *ChannelableStatus) {
 	in.SubscribableTypeStatus.DeepCopyInto(&out.SubscribableTypeStatus)
 	if in.ErrorChannel != nil {
 		in, out := &in.ErrorChannel, &out.ErrorChannel
-		*out = new(corev1.ObjectReference)
+		*out = new(v1.ObjectReference)
 		**out = **in
 	}
 	return

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	apis "knative.dev/pkg/apis"
 )
@@ -127,12 +126,6 @@ func (in *ChannelableCombinedSpec) DeepCopyInto(out *ChannelableCombinedSpec) {
 		*out = new(v1beta1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.SubscribableSpecv1.DeepCopyInto(&out.SubscribableSpecv1)
-	if in.Deliveryv1 != nil {
-		in, out := &in.Deliveryv1, &out.Deliveryv1
-		*out = new(v1.DeliverySpec)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 
@@ -153,7 +146,6 @@ func (in *ChannelableCombinedStatus) DeepCopyInto(out *ChannelableCombinedStatus
 	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	in.SubscribableTypeStatus.DeepCopyInto(&out.SubscribableTypeStatus)
 	in.SubscribableStatus.DeepCopyInto(&out.SubscribableStatus)
-	in.SubscribableStatusv1.DeepCopyInto(&out.SubscribableStatusv1)
 	if in.ErrorChannel != nil {
 		in, out := &in.ErrorChannel, &out.ErrorChannel
 		*out = new(corev1.ObjectReference)
@@ -341,11 +333,6 @@ func (in *SubscribableStatus) DeepCopyInto(out *SubscribableStatus) {
 		*out = make([]v1beta1.SubscriberStatus, len(*in))
 		copy(*out, *in)
 	}
-	if in.Subscribersv1 != nil {
-		in, out := &in.Subscribersv1, &out.Subscribersv1
-		*out = make([]v1.SubscriberStatus, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 
@@ -483,11 +470,6 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 	if in.Delivery != nil {
 		in, out := &in.Delivery, &out.Delivery
 		*out = new(v1beta1.DeliverySpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Deliveryv1 != nil {
-		in, out := &in.Deliveryv1, &out.Deliveryv1
-		*out = new(v1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -98,15 +98,19 @@ func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.
 	channelableStatus.Status = bc.Status
 	if cAnnotations != nil &&
 		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
+		subs := make([]eventingduckv1.SubscriberStatus, len(bc.SubscribableStatus.Subscribers))
+		for i, sub := range bc.SubscribableStatus.Subscribers {
+			sub.ConvertTo(ctx, &subs[i])
+		}
 		if len(bc.SubscribableStatus.Subscribers) > 0 {
-			channelableStatus.SubscribableStatus.Subscribers = bc.SubscribableStatus.Subscribers
+			channelableStatus.SubscribableStatus.Subscribers = subs
 		}
 	} else { //we assume v1alpha1 if no tag according to the spec
 		if bc.SubscribableTypeStatus.SubscribableStatus != nil &&
 			len(bc.SubscribableTypeStatus.SubscribableStatus.Subscribers) > 0 {
-			channelableStatus.SubscribableStatus.Subscribers = make([]duckv1beta1.SubscriberStatus, len(bc.SubscribableTypeStatus.SubscribableStatus.Subscribers))
+			channelableStatus.SubscribableStatus.Subscribers = make([]eventingduckv1.SubscriberStatus, len(bc.SubscribableTypeStatus.SubscribableStatus.Subscribers))
 			for i, ss := range bc.SubscribableTypeStatus.SubscribableStatus.Subscribers {
-				channelableStatus.SubscribableStatus.Subscribers[i] = duckv1beta1.SubscriberStatus{
+				channelableStatus.SubscribableStatus.Subscribers[i] = eventingduckv1.SubscriberStatus{
 					UID:                ss.UID,
 					ObservedGeneration: ss.ObservedGeneration,
 					Ready:              ss.Ready,

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/apis/messaging"
-	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
-	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/channel"
-	listers "knative.dev/eventing/pkg/client/listers/messaging/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/channel"
+	listers "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	eventingduck "knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/logging"
 	"knative.dev/eventing/pkg/reconciler/channel/resources"
@@ -52,7 +52,7 @@ type Reconciler struct {
 var _ channelreconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1beta1.Channel) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1.Channel) pkgreconciler.Event {
 	// 1. Create the backing Channel CRD, if it doesn't exist.
 	// 2. Propagate the backing Channel CRD Status, Address, and SubscribableStatus into this Channel.
 
@@ -88,16 +88,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1beta1.Channel) pkgr
 	return nil
 }
 
-func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.ChannelableCombinedStatus, cAnnotations map[string]string) *duckv1beta1.ChannelableStatus {
+func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.ChannelableCombinedStatus, cAnnotations map[string]string) *eventingduckv1.ChannelableStatus {
 
-	channelableStatus := &duckv1beta1.ChannelableStatus{}
+	channelableStatus := &eventingduckv1.ChannelableStatus{}
 	if bc.AddressStatus.Address != nil {
 		channelableStatus.AddressStatus.Address = &duckv1.Addressable{}
 		bc.AddressStatus.Address.ConvertTo(ctx, channelableStatus.AddressStatus.Address)
 	}
 	channelableStatus.Status = bc.Status
 	if cAnnotations != nil &&
-		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
+		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
 		if len(bc.SubscribableStatus.Subscribers) > 0 {
 			channelableStatus.SubscribableStatus.Subscribers = bc.SubscribableStatus.Subscribers
 		}
@@ -119,7 +119,7 @@ func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.
 }
 
 // reconcileBackingChannel reconciles Channel's 'c' underlying CRD channel.
-func (r *Reconciler) reconcileBackingChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, c *v1beta1.Channel, backingChannelObjRef duckv1.KReference) (*duckv1alpha1.ChannelableCombined, error) {
+func (r *Reconciler) reconcileBackingChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, c *v1.Channel, backingChannelObjRef duckv1.KReference) (*duckv1alpha1.ChannelableCombined, error) {
 	lister, err := r.channelableTracker.ListerForKReference(backingChannelObjRef)
 	if err != nil {
 		logging.FromContext(ctx).Error("Error getting lister for Channel", zap.Any("backingChannel", backingChannelObjRef), zap.Error(err))

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -97,7 +97,7 @@ func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.
 	}
 	channelableStatus.Status = bc.Status
 	if cAnnotations != nil &&
-		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
+		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" || cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
 		subs := make([]eventingduckv1.SubscriberStatus, len(bc.SubscribableStatus.Subscribers))
 		for i, sub := range bc.SubscribableStatus.Subscribers {
 			sub.ConvertTo(ctx, &subs[i])

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -238,31 +238,6 @@ func TestReconcile(t *testing.T) {
 				WithChannelAddress(backingChannelHostname),
 				WithChannelSubscriberStatuses(subscriberStatuses())),
 		}},
-	}, {
-		Name: "Updating v1alpha1 channelable subscribers statuses",
-		Key:  testKey,
-		Objects: []runtime.Object{
-			NewChannel(channelName, testNS,
-				WithChannelTemplate(channelableV1Alpha1CRD()),
-				WithInitChannelConditions,
-				WithBackingChannelObjRef(backingChannelObjRefV1Alpha1()),
-				WithBackingChannelReady,
-				WithChannelAddress(backingChannelHostname)),
-			NewChannelable(channelName, testNS,
-				WithChannelableReady(),
-				WithChannelableAddress(backingChannelHostname),
-				WithChannelableSubscribers(subscribersV1Alpha1()),
-				WithChannelableStatusSubscribers(subscriberStatuses())),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: NewChannel(channelName, testNS,
-				WithChannelTemplate(channelableV1Alpha1CRD()),
-				WithInitChannelConditions,
-				WithBackingChannelObjRef(backingChannelObjRefV1Alpha1()),
-				WithBackingChannelReady,
-				WithChannelAddress(backingChannelHostname),
-				WithChannelSubscriberStatuses(subscriberStatuses())),
-		}},
 	}}
 
 	logger := logtesting.TestLogger(t)

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 The Knative Authors
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,13 +25,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
-	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	v1 "knative.dev/eventing/pkg/apis/duck/v1"
+	v1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelablecombined"
-	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/channel"
+	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/channel"
 	"knative.dev/eventing/pkg/duck"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -59,8 +59,12 @@ var (
 
 func init() {
 	// Add types to scheme
-	_ = v1beta1.AddToScheme(scheme.Scheme)
-	_ = eventingduckv1alpha1.AddToScheme(scheme.Scheme)
+	// TODO(nlopezgi): figure out what is the right list to have here.
+	_ = messagingv1beta1.AddToScheme(scheme.Scheme)
+	_ = messagingv1.AddToScheme(scheme.Scheme)
+	_ = v1.AddToScheme(scheme.Scheme)
+	_ = v1alpha1.AddToScheme(scheme.Scheme)
+	_ = eventingduckv1.AddToScheme(scheme.Scheme)
 }
 
 func TestReconcile(t *testing.T) {
@@ -280,7 +284,7 @@ func TestReconcile(t *testing.T) {
 
 func channelCRD() metav1.TypeMeta {
 	return metav1.TypeMeta{
-		APIVersion: "messaging.knative.dev/v1beta1",
+		APIVersion: "messaging.knative.dev/v1",
 		Kind:       "InMemoryChannel",
 	}
 }
@@ -292,8 +296,8 @@ func channelableV1Alpha1CRD() metav1.TypeMeta {
 	}
 }
 
-func subscribers() []eventingduckv1beta1.SubscriberSpec {
-	return []eventingduckv1beta1.SubscriberSpec{{
+func subscribers() []eventingduckv1.SubscriberSpec {
+	return []eventingduckv1.SubscriberSpec{{
 		UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    1,
 		SubscriberURI: apis.HTTP("call1"),
@@ -306,8 +310,8 @@ func subscribers() []eventingduckv1beta1.SubscriberSpec {
 	}}
 }
 
-func subscribersV1Alpha1() []eventingduckv1alpha1.SubscriberSpec {
-	return []eventingduckv1alpha1.SubscriberSpec{{
+func subscribersV1Alpha1() []v1alpha1.SubscriberSpec {
+	return []v1alpha1.SubscriberSpec{{
 		UID:           "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		Generation:    1,
 		SubscriberURI: apis.HTTP("call1"),
@@ -320,7 +324,18 @@ func subscribersV1Alpha1() []eventingduckv1alpha1.SubscriberSpec {
 	}}
 }
 
-func subscriberStatuses() []eventingduckv1beta1.SubscriberStatus {
+func subscriberStatuses() []eventingduckv1.SubscriberStatus {
+	return []eventingduckv1.SubscriberStatus{{
+		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
+		ObservedGeneration: 1,
+		Ready:              "True",
+	}, {
+		UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+		ObservedGeneration: 2,
+		Ready:              "True",
+	}}
+}
+func subscriberStatusesV1beta1() []eventingduckv1beta1.SubscriberStatus {
 	return []eventingduckv1beta1.SubscriberStatus{{
 		UID:                "2f9b5e8e-deb6-11e8-9f32-f2801f1b9fd1",
 		ObservedGeneration: 1,
@@ -335,7 +350,7 @@ func subscriberStatuses() []eventingduckv1beta1.SubscriberStatus {
 func createChannelCRD(namespace, name string, ready bool) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "messaging.knative.dev/v1beta1",
+			"apiVersion": "messaging.knative.dev/v1",
 			"kind":       "InMemoryChannel",
 			"metadata": map[string]interface{}{
 				"creationTimestamp": nil,
@@ -343,7 +358,7 @@ func createChannelCRD(namespace, name string, ready bool) *unstructured.Unstruct
 				"name":              name,
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "messaging.knative.dev/v1beta1",
+						"apiVersion":         "messaging.knative.dev/v1",
 						"blockOwnerDeletion": true,
 						"controller":         true,
 						"kind":               "Channel",
@@ -367,7 +382,7 @@ func createChannelCRD(namespace, name string, ready bool) *unstructured.Unstruct
 
 func backingChannelObjRef() *duckv1.KReference {
 	return &duckv1.KReference{
-		APIVersion: "messaging.knative.dev/v1beta1",
+		APIVersion: "messaging.knative.dev/v1",
 		Kind:       "InMemoryChannel",
 		Namespace:  testNS,
 		Name:       channelName,
@@ -389,7 +404,7 @@ func createChannel(namespace, name string, ready bool) *unstructured.Unstructure
 	if ready {
 		return &unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"apiVersion": "messaging.knative.dev/v1beta1",
+				"apiVersion": "messaging.knative.dev/v1",
 				"kind":       "InMemoryChannel",
 				"metadata": map[string]interface{}{
 					"creationTimestamp": nil,
@@ -397,7 +412,7 @@ func createChannel(namespace, name string, ready bool) *unstructured.Unstructure
 					"name":              name,
 					"ownerReferences": []interface{}{
 						map[string]interface{}{
-							"apiVersion":         "messaging.knative.dev/v1beta1",
+							"apiVersion":         "messaging.knative.dev/v1",
 							"blockOwnerDeletion": true,
 							"controller":         true,
 							"kind":               "Channel",
@@ -418,7 +433,7 @@ func createChannel(namespace, name string, ready bool) *unstructured.Unstructure
 
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "messaging.knative.dev/v1beta1",
+			"apiVersion": "messaging.knative.dev/v1",
 			"kind":       "InMemoryChannel",
 			"metadata": map[string]interface{}{
 				"creationTimestamp": nil,
@@ -426,7 +441,7 @@ func createChannel(namespace, name string, ready bool) *unstructured.Unstructure
 				"name":              name,
 				"ownerReferences": []interface{}{
 					map[string]interface{}{
-						"apiVersion":         "messaging.knative.dev/v1beta1",
+						"apiVersion":         "messaging.knative.dev/v1",
 						"blockOwnerDeletion": true,
 						"controller":         true,
 						"kind":               "Channel",

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -25,8 +25,8 @@ import (
 	"knative.dev/pkg/logging"
 
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelablecombined"
-	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/channel"
-	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/channel"
+	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
+	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/channel"
 	"knative.dev/eventing/pkg/duck"
 )
 

--- a/pkg/reconciler/channel/controller_test.go
+++ b/pkg/reconciler/channel/controller_test.go
@@ -25,7 +25,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelablecombined/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/channel/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel/fake"
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )

--- a/pkg/reconciler/channel/resources/channel.go
+++ b/pkg/reconciler/channel/resources/channel.go
@@ -23,13 +23,13 @@ import (
 	"knative.dev/pkg/kmeta"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 )
 
 // NewChannel returns an unstructured.Unstructured based on the ChannelTemplateSpec for a given Channel.
-func NewChannel(c *v1beta1.Channel) (*unstructured.Unstructured, error) {
+func NewChannel(c *v1.Channel) (*unstructured.Unstructured, error) {
 	// Set the name of the resource we're creating as well as the namespace, etc.
-	template := v1beta1.ChannelTemplateSpecInternal{
+	template := v1.ChannelTemplateSpecInternal{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       c.Spec.ChannelTemplate.Kind,
 			APIVersion: c.Spec.ChannelTemplate.APIVersion,

--- a/pkg/reconciler/testing/v1/channel.go
+++ b/pkg/reconciler/testing/v1/channel.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// ChannelOption enables further configuration of a Channel.
+type ChannelOption func(*eventingv1.Channel)
+
+// NewChannel creates a Channel with ChannelOptions
+func NewChannel(name, namespace string, o ...ChannelOption) *eventingv1.Channel {
+	c := &eventingv1.Channel{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "messaging.knative.dev/v1",
+			Kind:       "Channel",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range o {
+		opt(c)
+	}
+	c.SetDefaults(context.Background())
+	return c
+}
+
+// WithInitChannelConditions initializes the Channel's conditions.
+func WithInitChannelConditions(c *eventingv1.Channel) {
+	c.Status.InitializeConditions()
+}
+
+func WithNoAnnotations(c *eventingv1.Channel) {
+	c.ObjectMeta.Annotations = nil
+}
+
+func WithChannelGeneration(gen int64) ChannelOption {
+	return func(s *eventingv1.Channel) {
+		s.Generation = gen
+	}
+}
+
+func WithChannelObservedGeneration(gen int64) ChannelOption {
+	return func(s *eventingv1.Channel) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
+func WithChannelDeleted(c *eventingv1.Channel) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	c.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+func WithChannelTemplate(typeMeta metav1.TypeMeta) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Spec.ChannelTemplate = &messagingv1.ChannelTemplateSpec{
+			TypeMeta: typeMeta,
+		}
+	}
+}
+
+func WithBackingChannelFailed(reason, msg string) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkBackingChannelFailed(reason, msg)
+	}
+}
+
+func WithBackingChannelUnknown(reason, msg string) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkBackingChannelUnknown(reason, msg)
+	}
+}
+
+func WithBackingChannelReady(c *eventingv1.Channel) {
+	c.Status.MarkBackingChannelReady()
+}
+
+func WithBackingChannelObjRef(objRef *duckv1.KReference) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.Channel = objRef
+	}
+}
+
+func WithChannelNoAddress() ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.SetAddress(nil)
+	}
+}
+
+func WithChannelAddress(hostname string) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.SetAddress(&duckv1.Addressable{URL: apis.HTTP(hostname)})
+	}
+}
+
+func WithChannelReadySubscriber(uid string) ChannelOption {
+	return WithChannelReadySubscriberAndGeneration(uid, 0)
+}
+
+func WithChannelReadySubscriberAndGeneration(uid string, observedGeneration int64) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.Subscribers = append(c.Status.Subscribers, eventingduckv1.SubscriberStatus{
+			UID:                types.UID(uid),
+			ObservedGeneration: observedGeneration,
+			Ready:              v1.ConditionTrue,
+		})
+	}
+}
+
+func WithChannelSubscriberStatuses(subscriberStatuses []eventingduckv1.SubscriberStatus) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.Subscribers = subscriberStatuses
+	}
+}

--- a/test/conformance/helpers/channel.go
+++ b/test/conformance/helpers/channel.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/eventing/test/lib/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 
@@ -58,6 +59,20 @@ func getChannelDuckTypeSupportVersion(channelName string, client *testlib.Client
 		return "", errors.Wrapf(err, "Unable to cast the channel %v", metaResource)
 	}
 	return channelable.ObjectMeta.Annotations[messaging.SubscribableDuckVersionAnnotation], nil
+}
+
+func getChannelAsV1Channelable(channelName string, client *testlib.Client, channel metav1.TypeMeta) (*eventingduckv1.Channelable, error) {
+	metaResource := resources.NewMetaResource(channelName, client.Namespace, &channel)
+	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1.Channelable{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to get the channel as v1 Channel duck type: %q", channel)
+	}
+	channelable, ok := obj.(*eventingduckv1.Channelable)
+	if !ok {
+		return nil, errors.Errorf("Unable to cast channel %q to v1 duck type", channel)
+	}
+
+	return channelable, nil
 }
 
 func getChannelAsV1Beta1Channelable(channelName string, client *testlib.Client, channel metav1.TypeMeta) (*eventingduckv1beta1.Channelable, error) {

--- a/test/conformance/helpers/channel_status_subscriber_test_helper.go
+++ b/test/conformance/helpers/channel_status_subscriber_test_helper.go
@@ -19,6 +19,7 @@ package helpers
 import (
 	"testing"
 
+	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
 	testlib "knative.dev/eventing/test/lib"
@@ -85,7 +86,7 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 		if channelable.Status.SubscribableStatus == nil || channelable.Status.SubscribableStatus.Subscribers == nil {
 			st.Fatalf("%q does not have status.subscribers", channel)
 		}
-		ss := findSubscriberStatus(channelable.Status.SubscribableStatus.Subscribers, subscription)
+		ss := findSubscriberStatusV1Beta1(channelable.Status.SubscribableStatus.Subscribers, subscription)
 		if ss == nil {
 			st.Fatalf("No subscription status found for channel %q and subscription %v", channel, subscription)
 		}
@@ -94,7 +95,7 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 		if ss.Ready != corev1.ConditionTrue {
 			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
 		}
-	} else if dtsv == "v1beta1" || dtsv == "v1" {
+	} else if dtsv == "v1beta1" {
 		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
 		if err != nil {
 			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)
@@ -104,7 +105,26 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 		if channelable.Status.Subscribers == nil {
 			st.Fatalf("%q does not have status.subscribers", channel)
 		}
-		ss := findSubscriberStatus(channelable.Status.Subscribers, subscription)
+		ss := findSubscriberStatusV1Beta1(channelable.Status.Subscribers, subscription)
+		if ss == nil {
+			st.Fatalf("No subscription status found for channel %q and subscription %v", channel, subscription)
+		}
+
+		// SPEC: The ready field of the subscriber identified by its uid MUST be set to True when the subscription is ready to be processed.
+		if ss.Ready != corev1.ConditionTrue {
+			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
+		}
+	} else if dtsv == "v1" {
+		channelable, err := getChannelAsV1Channelable(channelName, client, channel)
+		if err != nil {
+			st.Fatalf("Unable to get channel %q to v1 duck type: %q", channel, err)
+		}
+
+		// SPEC: Each subscription to a channel is added to the channel status.subscribers automatically.
+		if channelable.Status.Subscribers == nil {
+			st.Fatalf("%q does not have status.subscribers", channel)
+		}
+		ss := findSubscriberStatusV1(channelable.Status.Subscribers, subscription)
 		if ss == nil {
 			st.Fatalf("No subscription status found for channel %q and subscription %v", channel, subscription)
 		}
@@ -118,7 +138,16 @@ func channelHasRequiredSubscriberStatus(st *testing.T, client *testlib.Client, c
 	}
 }
 
-func findSubscriberStatus(statusArr []duckv1beta1.SubscriberStatus, subscription *eventingv1beta1.Subscription) *duckv1beta1.SubscriberStatus {
+func findSubscriberStatusV1Beta1(statusArr []duckv1beta1.SubscriberStatus, subscription *eventingv1beta1.Subscription) *duckv1beta1.SubscriberStatus {
+	for _, v := range statusArr {
+		if v.UID == subscription.UID {
+			return &v
+		}
+	}
+	return nil
+}
+
+func findSubscriberStatusV1(statusArr []duckv1.SubscriberStatus, subscription *eventingv1beta1.Subscription) *duckv1.SubscriberStatus {
 	for _, v := range statusArr {
 		if v.UID == subscription.UID {
 			return &v


### PR DESCRIPTION
Part of #3584

## Proposed Changes

- Migrate sequence reconciler to use messaging.* v1 resources
- New stab at https://github.com/knative/eventing/pull/3789

Implementing changes according to https://github.com/knative/eventing/pull/3789#discussion_r472280959