### PR TITLE
Add explicit content encoding to event-senders in broker conf test

### DIFF
--- a/test/conformance/helpers/broker_data_plane_test_helper.go
+++ b/test/conformance/helpers/broker_data_plane_test_helper.go
@@ -100,7 +100,7 @@ func BrokerV1Beta1IngressDataPlaneTestHelper(
 		}
 		event.Context.AsV03()
 		event.SetSpecVersion("0.3")
-		client.SendEventToAddressable("v03-test-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable("v03-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
 			cetest.HasId(eventID),
 			cetest.HasSpecVersion("0.3"),
@@ -119,7 +119,7 @@ func BrokerV1Beta1IngressDataPlaneTestHelper(
 			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}
 
-		client.SendEventToAddressable("v10-test-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable("v10-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
 			cetest.HasId(eventID),
 			cetest.HasSpecVersion("1.0"),
@@ -294,7 +294,7 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		event := baseEvent
 		id := "identical-attibutes"
 		event.SetID(id)
-		client.SendEventToAddressable(id+"-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable(id+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		originalEventMatcher := recordevents.MatchEvent(
 			cetest.HasId(id),
 			cetest.HasType(testlib.DefaultEventType),
@@ -310,8 +310,8 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		event.SetSource(source)
 		secondEvent := baseEvent
 
-		client.SendEventToAddressable("first-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, event)
-		client.SendEventToAddressable("second-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, secondEvent)
+		client.SendEventToAddressable("first-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+		client.SendEventToAddressable("second-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, secondEvent, sender.WithEncoding(ce.EncodingStructured))
 		filteredEventMatcher := recordevents.MatchEvent(
 			cetest.HasSource(source),
 		)
@@ -326,7 +326,7 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		event := baseEvent
 		source := "filtered-event"
 		event.SetSource(source)
-		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		filteredEventMatcher := recordevents.MatchEvent(
 			cetest.HasSource(source),
 		)
@@ -338,7 +338,7 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		event := baseEvent
 		source := "delivery-check"
 		event.SetSource(source)
-		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		originalEventMatcher := recordevents.MatchEvent(
 			cetest.HasSource(source),
 		)
@@ -354,7 +354,7 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		client.WaitForResourceReadyOrFail(transformTrigger.Name, testlib.TriggerTypeMeta)
 
 		client.WaitForResourceReadyOrFail(replyTrigger.Name, testlib.TriggerTypeMeta)
-		client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event)
+		client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured)))
 		transformedEventMatcher := recordevents.MatchEvent(
 			cetest.HasSource("reply-check-source"),
 			cetest.HasType("reply-check-type"),

--- a/test/conformance/helpers/broker_data_plane_test_helper.go
+++ b/test/conformance/helpers/broker_data_plane_test_helper.go
@@ -354,7 +354,7 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		client.WaitForResourceReadyOrFail(transformTrigger.Name, testlib.TriggerTypeMeta)
 
 		client.WaitForResourceReadyOrFail(replyTrigger.Name, testlib.TriggerTypeMeta)
-		client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured)))
+		client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
 		transformedEventMatcher := recordevents.MatchEvent(
 			cetest.HasSource("reply-check-source"),
 			cetest.HasType("reply-check-type"),


### PR DESCRIPTION
Realted: #3791

For broker data plane conformance tests, when observing some of the
errors in pod sender logs, the following message was seen:

"Got response from http://broker-ingress.knative-eventing-28b9ei2f23.svc.cluster.local/test-broker-v1-beta1-data-plane-consumer-wzjjv/br
failed to convert response into event: unknown Message encoding"

Add a `sender.WithEncoding(ce.EncodingStructured)` option to the event
sender in an attempt to make the conformance tests more robust.

---

# Make broker conformance tests more robust