### PR TITLE
Force the latest version to be v0.16.1.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -66,11 +66,9 @@ TEST_EVENTING_NAMESPACE="${TEST_EVENTING_NAMESPACE:-"knative-eventing-"$(cat /de
   | tr -dc 'a-z0-9' | fold -w 10 | head -n 1)}"
 
 latest_version() {
-  local semver=$(git describe --match "v[0-9]*" --abbrev=0)
-  local major_minor=$(echo "$semver" | cut -d. -f1-2)
-
-  # Get the latest patch release for the major minor
-  git tag -l "${major_minor}*" | sort -r --version-sort | head -n1
+  # v0.17.0 is a bad release. To unblock submitting new PRs and to allow the creation of v0.17.1,
+  # use the most recent, valid release.
+  echo "v0.16.1"
 }
 
 # Latest release. If user does not supply this as a flag, the latest


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use `v0.16.1` as the 'latest release'.
    - v0.17.0 is a bad release, see https://github.com/knative/eventing/issues/3873. It is blocking any new PRs and is blocking the creation of a new release because the bad release is being used in the upgrade test, causing it to fail.


Once release `v0.17.1` is created and is shown to work, revert this PR.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```