### PR TITLE
Add a job for migrating sinkbindings and containersource storage versions to v1beta1

### DIFF
--- a/config/pre-install/v0.18.0/clusterrole.yaml
+++ b/config/pre-install/v0.18.0/clusterrole.yaml
@@ -33,7 +33,6 @@ rules:
       - "watch"
   # Our own resources we care about.
   - apiGroups:
-      - "eventing.knative.dev"
       - "sources.knative.dev"
     resources:
       - "containersources"

--- a/config/pre-install/v0.18.0/clusterrole.yaml
+++ b/config/pre-install/v0.18.0/clusterrole.yaml
@@ -1,0 +1,48 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-pre-install-job-role
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  # Storage version upgrader needs to be able to patch CRDs.
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  # Our own resources we care about.
+  - apiGroups:
+      - "eventing.knative.dev"
+      - "sources.knative.dev"
+    resources:
+      - "containersources"
+      - "sinkbindings"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/config/pre-install/v0.18.0/containersource.yaml
+++ b/config/pre-install/v0.18.0/containersource.yaml
@@ -1,0 +1,73 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: devel
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  name: containersources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+    - &version
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flush out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Sink
+          type: string
+          jsonPath: ".status.sinkUri"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - <<: *version
+      name: v1alpha2
+      served: true
+      storage: false
+  names:
+    categories:
+      - all
+      - knative
+      - sources
+    kind: ContainerSource
+    plural: containersources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/pre-install/v0.18.0/dummy.go
+++ b/config/pre-install/v0.18.0/dummy.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package preinstall is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package preinstall

--- a/config/pre-install/v0.18.0/serviceaccount.yaml
+++ b/config/pre-install/v0.18.0/serviceaccount.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-eventing-pre-install-job
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-pre-install-job-role-binding
+  labels:
+    eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: knative-eventing-pre-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-pre-install-job-role
+  apiGroup: rbac.authorization.k8s.io
+

--- a/config/pre-install/v0.18.0/sinkbindings.yaml
+++ b/config/pre-install/v0.18.0/sinkbindings.yaml
@@ -1,0 +1,264 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: devel
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    duck.knative.dev/binding: "true"
+    knative.dev/crd-install: "true"
+  name: sinkbindings.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+    - &version
+      name: v1alpha1
+      served: true
+      storage: false
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flush out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Sink
+          type: string
+          jsonPath: ".status.sinkUri"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - <<: *version
+      name: v1alpha2
+      served: true
+      storage: false
+    - <<: *version
+      name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: 'SinkBinding describes a Binding that is also a Source.
+              The `sink` (from the Source duck) is resolved to a URL and
+              then projected into the `subject` by augmenting the runtime
+              contract of the referenced containers to have a `K_SINK`
+              environment variable holding the endpoint to which to send
+              cloud events.'
+          properties:
+            spec:
+              type: object
+              description: 'SinkBindingSpec holds the desired state of the SinkBinding (from the client).'
+              properties:
+                ceOverrides:
+                  description: 'CloudEventOverrides defines overrides to control the
+                      output format and modifications of the event sent to the sink.'
+                  type: object
+                  properties:
+                    extensions:
+                      description: 'Extensions specify what attribute are added or
+                          overridden on the outbound event. Each `Extensions` key-value
+                          pair are set on the event as an attribute extension independently.'
+                      type: object
+                      additionalProperties:
+                        type: string
+                sink:
+                  description: 'Sink is a reference to an object that will resolve to
+                      a uri to use as the sink.'
+                  type: object
+                  properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                This is optional field, it gets defaulted to the
+                                object holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty scheme and
+                            non-empty host) pointing to the target or a relative URI.
+                            Relative URIs will be resolved using the base URI retrieved
+                            from Ref.'
+                        type: string
+                subject:
+                  description: 'Subject references the resource(s) whose "runtime contract"
+                      should be augmented by Binding implementations.'
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'API version of the referent.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent.'
+                      type: string
+                    name:
+                      description: 'Name of the referent. Mutually exclusive with
+                          Selector.'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent.'
+                      type: string
+                    selector:
+                      description: 'Selector of the referents. Mutually exclusive
+                          with Name.'
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: 'matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.'
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                description: 'key is the label key that
+                                    the selector applies to.'
+                                type: string
+                              operator:
+                                description: 'operator represents a key''s
+                                    relationship to a set of values. Valid
+                                    operators are In, NotIn, Exists and
+                                    DoesNotExist.'
+                                type: string
+                              values:
+                                description: 'values is an array of string
+                                    values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This
+                                    array is replaced during a strategic
+                                    merge patch.'
+                                type: array
+                                items:
+                                    type: string
+                        matchLabels:
+                          description: 'matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is
+                              equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In",
+                              and the values array contains only "value". The
+                              requirements are ANDed.'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              description: 'SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).'
+              properties:
+                annotations:
+                    description: 'Annotations is additional Status fields for the Resource
+                        to save some additional State as well as convey more information
+                        to the user. This is roughly akin to Annotations on any k8s resource,
+                        just the reconciler conveying richer information outwards.'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                ceAttributes:
+                  description: 'CloudEventAttributes are the specific attributes that
+                      the Source uses as part of its CloudEvents.'
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      source:
+                        description: 'Source is the CloudEvents source attribute.'
+                        type: string
+                      type:
+                        description: 'Type refers to the CloudEvent type attribute.'
+                        type: string
+                conditions:
+                    description: 'Conditions the latest available observations of a resource''s
+                        current state.'
+                    type: array
+                    items:
+                        type: object
+                        required:
+                          - type
+                          - status
+                        properties:                        
+                          lastTransitionTime:
+                            description: 'LastTransitionTime is the last time the condition
+                                transitioned from one status to another. We use VolatileTime
+                                in place of metav1.Time to exclude this from creating
+                                equality.Semantic differences (all other things held
+                                constant).'
+                            type: string
+                          message:
+                            description: 'A human readable message indicating details
+                                about the transition.'
+                            type: string
+                          reason:
+                            description: 'The reason for the condition''s last transition.'
+                            type: string
+                          severity:
+                            description: 'Severity with which to treat failures of
+                                this type of condition. When this is not specified,
+                                it defaults to Error.'
+                            type: string
+                          status:
+                            description: 'Status of the condition, one of True, False,
+                                Unknown.'
+                            type: string
+                          type:
+                            description: 'Type of condition.'
+                            type: string
+                observedGeneration:
+                    description: 'ObservedGeneration is the ''Generation'' of the Service
+                        that was last processed by the controller.'
+                    type: integer
+                    format: int64
+                sinkUri:
+                    description: 'SinkURI is the current active sink URI that has been
+                        configured for the Source.'
+                    type: string
+  names:
+    categories:
+      - all
+      - knative
+      - sources
+      - bindings
+    kind: SinkBinding
+    plural: sinkbindings
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing

--- a/config/pre-install/v0.18.0/sinkbindings.yaml
+++ b/config/pre-install/v0.18.0/sinkbindings.yaml
@@ -209,7 +209,7 @@ spec:
                         required:
                           - type
                           - status
-                        properties:                        
+                        properties:
                           lastTransitionTime:
                             description: 'LastTransitionTime is the last time the condition
                                 transitioned from one status to another. We use VolatileTime

--- a/config/pre-install/v0.18.0/storage-version-migration.yaml
+++ b/config/pre-install/v0.18.0/storage-version-migration.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-version-migration-eventing
+  namespace: knative-eventing
+  labels:
+    app: "storage-version-migration-eventing"
+    eventing.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration-eventing"
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-eventing-pre-install-job
+      restartPolicy: OnFailure
+      containers:
+      - name: migrate
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+        args:
+          - "containersources.eventing.knative.dev"
+          - "sinkbindings.sources.knative.dev"


### PR DESCRIPTION
Fixes #3674, #3615

## Proposed Changes

- 
- Add a Preinstall job that migrates sinkbindings from v1alpha1 to v1beta1.
- Add a Preinstall job that migrates containersource from v1alpha1 to v1beta1.
- Similar to https://github.com/knative/eventing/pull/3262
-

**Release Note**

- 🗑️ Remove feature or internal logic
Eventing v1alpha1 API is removed.
action required: You must run pre-install job prior to upgrading to get sinkbindings and containersource to v1beta1 API.
