### PR TITLE
do not use resp if it fails, use 0 instead

### DIFF
--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -255,7 +255,14 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 		err = fmt.Errorf("failed to dispatch message: %w", err)
 	}
 
-	_ = h.reporter.ReportEventDispatchTime(reporterArgs, resp.StatusCode, dispatchTime)
+	var sc int
+	if resp == nil {
+		sc = 0
+	} else {
+		sc = resp.StatusCode
+	}
+
+	_ = h.reporter.ReportEventDispatchTime(reporterArgs, sc, dispatchTime)
 
 	return resp, err
 }

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -255,10 +255,8 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 		err = fmt.Errorf("failed to dispatch message: %w", err)
 	}
 
-	var sc int
-	if resp == nil {
-		sc = 0
-	} else {
+	sc := 0
+	if resp != nil {
 		sc = resp.StatusCode
 	}
 


### PR DESCRIPTION
Addresses #3791

When send fails or response is nil, set the response code to 0.

## Proposed Changes

- Seen while debugging 3791, does not fix the flakiness though.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
In cases where Filter sends a message and it fails or response is nil, it will panic because it uses it.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
