### PR TITLE
Use preinstall 0.18 in upgrade tests

### DIFF
--- a/config/pre-install/v0.18.0/storage-version-migration.yaml
+++ b/config/pre-install/v0.18.0/storage-version-migration.yaml
@@ -38,7 +38,7 @@ spec:
         # and substituted here.
         image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
         args:
-          - "containersources.eventing.knative.dev"
+          - "containersources.sources.knative.dev"
           - "sinkbindings.sources.knative.dev"
           - "brokers.sources.knative.dev"
           - "triggers.sources.knative.dev"

--- a/config/pre-install/v0.18.0/storage-version-migration.yaml
+++ b/config/pre-install/v0.18.0/storage-version-migration.yaml
@@ -40,7 +40,7 @@ spec:
         args:
           - "containersources.sources.knative.dev"
           - "sinkbindings.sources.knative.dev"
-          - "brokers.sources.knative.dev"
-          - "triggers.sources.knative.dev"
+          - "brokers.eventing.knative.dev"
+          - "triggers.eventing.knative.dev"
           - "channels.messaging.knative.dev"
           - "inmemorychannels.messaging.knative.dev"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -47,8 +47,8 @@ readonly SUGAR_CONTROLLER_CONFIG="config/sugar/500-controller.yaml"
 # Config tracing config.
 readonly CONFIG_TRACING_CONFIG="test/config/config-tracing.yaml"
 
-# PreInstall script for v0.16
-readonly PRE_INSTALL_V016="config/pre-install/v0.16.0"
+# PreInstall script for v0.18
+readonly PRE_INSTALL_V018="config/pre-install/v0.18.0"
 
 # The number of controlplane replicas to run.
 readonly REPLICAS=3
@@ -176,12 +176,12 @@ function install_latest_release() {
     fail_test "Knative latest release installation failed"
 }
 
-function run_preinstall_V016() {
-  local TMP_PRE_INSTALL_V016=${TMP_DIR}/pre_install
-  mkdir -p ${TMP_PRE_INSTALL_V016}
-  cp -r ${PRE_INSTALL_V016}/* ${TMP_PRE_INSTALL_V016}
-  find ${TMP_PRE_INSTALL_V016} -type f -name "*.yaml" -exec sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" {} +
-  ko apply --strict -f "${TMP_PRE_INSTALL_V016}" || return 1
+function run_preinstall_V018() {
+  local TMP_PRE_INSTALL_V018=${TMP_DIR}/pre_install
+  mkdir -p ${TMP_PRE_INSTALL_V018}
+  cp -r ${PRE_INSTALL_V018}/* ${TMP_PRE_INSTALL_V018}
+  find ${TMP_PRE_INSTALL_V018} -type f -name "*.yaml" -exec sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" {} +
+  ko apply --strict -f "${TMP_PRE_INSTALL_V018}" || return 1
   wait_until_batch_job_complete ${TEST_EVENTING_NAMESPACE} || return 1
 }
 

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -58,7 +58,7 @@ echo "Prober PID is ${PROBER_PID}"
 wait_for_file ${PROBER_READY_FILE} || fail_test
 
 header "Performing upgrade to HEAD"
-run_preinstall_V016 || fail_test 'Running preinstall 0.16 failed'
+run_preinstall_V018 || fail_test 'Running preinstall 0.18 failed'
 install_head || fail_test 'Installing HEAD version of eventing failed'
 install_channel_crds || fail_test 'Installing HEAD channel CRDs failed'
 install_mt_broker || fail_test 'Installing HEAD Broker failed'


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use preinstall 0.18 script in upgrade tests
- So, the migration job actually runs (from 0.17 to 0.18) for resources that have a storage version change
- Some storage version change PRs are already merged without testing
- Some are still open (like https://github.com/knative/eventing/pull/3936) and merging this PR will make sure the storage change PRs are tested properly
