### PR TITLE
Migrate Subscription reconciler to use messaging.* v1 resources

### DIFF
--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@ import (
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 
-	messagingv1beta1 "knative.dev/eventing/pkg/apis/messaging/v1beta1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelablecombined"
-	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/channel"
-	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/subscription"
-	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/subscription"
+	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
+	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
+	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/subscription"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 )
@@ -67,7 +67,7 @@ func NewController(
 		// populated.
 		controller.EnsureTypeMeta(
 			r.tracker.OnChanged,
-			messagingv1beta1.SchemeGroupVersion.WithKind("Channel"),
+			messagingv1.SchemeGroupVersion.WithKind("Channel"),
 		),
 	))
 

--- a/pkg/reconciler/subscription/controller_test.go
+++ b/pkg/reconciler/subscription/controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import (
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelable/fake"
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1alpha1/channelablecombined/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/channel/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1beta1/subscription/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 )
 

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -562,12 +562,11 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, ch
 			// Only set the deadletter sink if it's not nil. Otherwise we'll just end up patching
 			// empty delivery in there.
 			if sub.Status.PhysicalSubscription.DeadLetterSinkURI != nil {
-				deliveryv1 := eventingduckv1.DeliverySpec{
+				channel.Spec.Subscribers[i].Delivery = &eventingduckv1beta1.DeliverySpec{
 					DeadLetterSink: &duckv1.Destination{
 						URI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
 					},
 				}
-				deliveryv1.ConvertTo(ctx, channel.Spec.Subscribers[i].Delivery)
 			}
 			return
 		}

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -58,7 +58,6 @@ const (
 )
 
 var (
-	//v1ChannelGVK = v1.SchemeGroupVersion.WithKind("Channel")
 	v1ChannelGVK = v1.SchemeGroupVersion.WithKind("Channel")
 )
 
@@ -281,7 +280,7 @@ func (r *Reconciler) getSubStatus(ctx context.Context, subscription *v1.Subscrip
 	if channel.Annotations != nil {
 		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
 			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
-			return r.getSubStatusV1Beta1(subscription, channel)
+			return r.getSubStatusV1(subscription, channel)
 		}
 	}
 	return r.getSubStatusV1Alpha1(ctx, subscription, channel)
@@ -304,7 +303,7 @@ func (r *Reconciler) getSubStatusV1Alpha1(ctx context.Context, subscription *v1.
 	return eventingduckv1.SubscriberStatus{}, fmt.Errorf("subscription %q not present in channel %q subscriber's list", subscription.Name, channel.Name)
 }
 
-func (r *Reconciler) getSubStatusV1Beta1(subscription *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1.SubscriberStatus, error) {
+func (r *Reconciler) getSubStatusV1(subscription *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1.SubscriberStatus, error) {
 	for _, sub := range channel.Status.Subscribers {
 		if sub.UID == subscription.GetUID() &&
 			sub.ObservedGeneration == subscription.GetGeneration() {

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,13 +35,13 @@ import (
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	"knative.dev/eventing/pkg/apis/messaging"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	"knative.dev/eventing/pkg/apis/messaging/v1beta1"
-	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1beta1/subscription"
-	listers "knative.dev/eventing/pkg/client/listers/messaging/v1beta1"
+	subscriptionreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/subscription"
+	listers "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	eventingduck "knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/logging"
 )
@@ -58,8 +58,8 @@ const (
 )
 
 var (
-	v1beta1ChannelGVK = v1beta1.SchemeGroupVersion.WithKind("Channel")
-	v1ChannelGVK      = v1.SchemeGroupVersion.WithKind("Channel")
+	//v1ChannelGVK = v1.SchemeGroupVersion.WithKind("Channel")
+	v1ChannelGVK = v1.SchemeGroupVersion.WithKind("Channel")
 )
 
 func newChannelWarnEvent(messageFmt string, args ...interface{}) pkgreconciler.Event {
@@ -85,7 +85,7 @@ var _ subscriptionreconciler.Interface = (*Reconciler)(nil)
 var _ subscriptionreconciler.Finalizer = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (r *Reconciler) ReconcileKind(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	// Find the channel for this subscription.
 	channel, err := r.getChannel(ctx, subscription)
 	if err != nil {
@@ -116,7 +116,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, subscription *v1beta1.Su
 	return nil
 }
 
-func (r *Reconciler) FinalizeKind(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	channel, err := r.getChannel(ctx, subscription)
 	if err != nil {
 		// If the channel was deleted (i.e., error == notFound), just return nil so that
@@ -133,8 +133,8 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, subscription *v1beta1.Sub
 	return nil
 }
 
-func (r Reconciler) checkChannelStatusForSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) pkgreconciler.Event {
-	ss, err := r.getSubStatus(sub, channel)
+func (r Reconciler) checkChannelStatusForSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) pkgreconciler.Event {
+	ss, err := r.getSubStatus(ctx, sub, channel)
 	if err != nil {
 		logging.FromContext(ctx).Warn("Failed to get subscription status.", zap.Error(err))
 		sub.Status.MarkChannelUnknown(subscriptionNotMarkedReadyByChannel, "Failed to get subscription status: %s", err)
@@ -153,7 +153,7 @@ func (r Reconciler) checkChannelStatusForSubscription(ctx context.Context, chann
 	return nil
 }
 
-func (r Reconciler) syncChannel(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) pkgreconciler.Event {
+func (r Reconciler) syncChannel(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) pkgreconciler.Event {
 	// Ok, now that we have the Channel and at least one of the Call/Result, let's reconcile
 	// the Channel with this information.
 	if patched, err := r.syncPhysicalChannel(ctx, sub, channel, false); err != nil {
@@ -174,7 +174,7 @@ func (r Reconciler) syncChannel(ctx context.Context, channel *eventingduckv1alph
 	return nil
 }
 
-func (r *Reconciler) resolveSubscriptionURIs(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) resolveSubscriptionURIs(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	// Everything that was supposed to be resolved was, so flip the status bit on that.
 	subscription.Status.MarkReferencesResolvedUnknown("Resolving", "Subscription resolution interrupted.")
 
@@ -195,7 +195,7 @@ func (r *Reconciler) resolveSubscriptionURIs(ctx context.Context, subscription *
 	return nil
 }
 
-func (r *Reconciler) resolveSubscriber(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) resolveSubscriber(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	// Resolve Subscriber.
 	subscriber := subscription.Spec.Subscriber.DeepCopy()
 	if !isNilOrEmptyDestination(subscriber) {
@@ -222,7 +222,7 @@ func (r *Reconciler) resolveSubscriber(ctx context.Context, subscription *v1beta
 	return nil
 }
 
-func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	// Resolve Reply.
 	reply := subscription.Spec.Reply.DeepCopy()
 	if !isNilOrEmptyDestination(reply) {
@@ -249,7 +249,7 @@ func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1beta1.Sub
 	return nil
 }
 
-func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1beta1.Subscription) pkgreconciler.Event {
+func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1.Subscription) pkgreconciler.Event {
 	// Resolve DeadLetterSink.
 	delivery := subscription.Spec.Delivery.DeepCopy()
 	if !isNilOrEmptyDeliveryDeadLetterSink(delivery) {
@@ -277,36 +277,38 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1
 	return nil
 }
 
-func (r *Reconciler) getSubStatus(subscription *v1beta1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1beta1.SubscriberStatus, error) {
+func (r *Reconciler) getSubStatus(ctx context.Context, subscription *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1.SubscriberStatus, error) {
 	if channel.Annotations != nil {
 		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
 			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
 			return r.getSubStatusV1Beta1(subscription, channel)
 		}
 	}
-	return r.getSubStatusV1Alpha1(subscription, channel)
+	return r.getSubStatusV1Alpha1(ctx, subscription, channel)
 }
 
-func (r *Reconciler) getSubStatusV1Alpha1(subscription *v1beta1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1beta1.SubscriberStatus, error) {
+func (r *Reconciler) getSubStatusV1Alpha1(ctx context.Context, subscription *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1.SubscriberStatus, error) {
 	subscribableStatus := channel.Status.GetSubscribableTypeStatus()
 
 	if subscribableStatus == nil {
-		return eventingduckv1beta1.SubscriberStatus{}, fmt.Errorf("channel.Status.SubscribableStatus is nil")
+		return eventingduckv1.SubscriberStatus{}, fmt.Errorf("channel.Status.SubscribableStatus is nil")
 	}
 	for _, sub := range subscribableStatus.Subscribers {
 		if sub.UID == subscription.GetUID() &&
 			sub.ObservedGeneration == subscription.GetGeneration() {
-			return sub, nil
+			subv1 := eventingduckv1.SubscriberStatus{}
+			sub.ConvertTo(ctx, &subv1)
+			return subv1, nil
 		}
 	}
-	return eventingduckv1beta1.SubscriberStatus{}, fmt.Errorf("subscription %q not present in channel %q subscriber's list", subscription.Name, channel.Name)
+	return eventingduckv1.SubscriberStatus{}, fmt.Errorf("subscription %q not present in channel %q subscriber's list", subscription.Name, channel.Name)
 }
 
-func (r *Reconciler) getSubStatusV1Beta1(subscription *v1beta1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1beta1.SubscriberStatus, error) {
+func (r *Reconciler) getSubStatusV1Beta1(subscription *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined) (eventingduckv1.SubscriberStatus, error) {
 	for _, sub := range channel.Status.Subscribers {
 		if sub.UID == subscription.GetUID() &&
 			sub.ObservedGeneration == subscription.GetGeneration() {
-			return eventingduckv1beta1.SubscriberStatus{
+			return eventingduckv1.SubscriberStatus{
 				UID:                sub.UID,
 				ObservedGeneration: sub.ObservedGeneration,
 				Ready:              sub.Ready,
@@ -314,10 +316,10 @@ func (r *Reconciler) getSubStatusV1Beta1(subscription *v1beta1.Subscription, cha
 			}, nil
 		}
 	}
-	return eventingduckv1beta1.SubscriberStatus{}, fmt.Errorf("subscription %q not present in channel %q subscriber's list", subscription.Name, channel.Name)
+	return eventingduckv1.SubscriberStatus{}, fmt.Errorf("subscription %q not present in channel %q subscriber's list", subscription.Name, channel.Name)
 }
 
-func (r *Reconciler) trackAndFetchChannel(ctx context.Context, sub *v1beta1.Subscription, ref corev1.ObjectReference) (runtime.Object, pkgreconciler.Event) {
+func (r *Reconciler) trackAndFetchChannel(ctx context.Context, sub *v1.Subscription, ref corev1.ObjectReference) (runtime.Object, pkgreconciler.Event) {
 	// Track the channel using the channelableTracker.
 	// We don't need the explicitly set a channelInformer, as this will dynamically generate one for us.
 	// This code needs to be called before checking the existence of the `channel`, in order to make sure the
@@ -342,7 +344,7 @@ func (r *Reconciler) trackAndFetchChannel(ctx context.Context, sub *v1beta1.Subs
 // and verifies it's a channelable (so that we can operate on it via patches).
 // If the Channel is a channels.messaging type (hence, it's only a factory for
 // underlying channels), fetch and validate the "backing" channel.
-func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) (*eventingduckv1alpha1.ChannelableCombined, pkgreconciler.Event) {
+func (r *Reconciler) getChannel(ctx context.Context, sub *v1.Subscription) (*eventingduckv1alpha1.ChannelableCombined, pkgreconciler.Event) {
 	logging.FromContext(ctx).Info("Getting channel", zap.Any("channel", sub.Spec.Channel))
 
 	// 1. Track the channel pointed by subscription.
@@ -358,8 +360,7 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 	// Test to see if the channel is Channel.messaging because it is going
 	// to have a "backing" channel that is what we need to actually operate on
 	// as well as keep track of.
-	if (v1beta1ChannelGVK.Group == gvk.Group && v1beta1ChannelGVK.Kind == gvk.Kind) ||
-		(v1ChannelGVK.Group == gvk.Group && v1ChannelGVK.Kind == gvk.Kind) {
+	if v1ChannelGVK.Group == gvk.Group && v1ChannelGVK.Kind == gvk.Kind {
 		// Track changes on Channel.
 		// Ref: https://github.com/knative/eventing/issues/2641
 		// NOTE: There is a race condition with using the channelableTracker
@@ -371,7 +372,7 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 		// to the cache we intend to use to pull the Channel from. This linkage
 		// is setup in NewController for r.tracker.
 		if err := r.tracker.TrackReference(tracker.Reference{
-			APIVersion: "messaging.knative.dev/v1beta1",
+			APIVersion: "messaging.knative.dev/v1",
 			Kind:       "Channel",
 			Namespace:  sub.Namespace,
 			Name:       sub.Spec.Channel.Name,
@@ -412,8 +413,8 @@ func (r *Reconciler) getChannel(ctx context.Context, sub *v1beta1.Subscription) 
 	return ch.DeepCopy(), nil
 }
 
-func isNilOrEmptyDeliveryDeadLetterSink(delivery *eventingduckv1beta1.DeliverySpec) bool {
-	return delivery == nil || equality.Semantic.DeepEqual(delivery, &eventingduckv1beta1.DeliverySpec{}) ||
+func isNilOrEmptyDeliveryDeadLetterSink(delivery *eventingduckv1.DeliverySpec) bool {
+	return delivery == nil || equality.Semantic.DeepEqual(delivery, &eventingduckv1.DeliverySpec{}) ||
 		delivery.DeadLetterSink == nil
 }
 
@@ -421,7 +422,7 @@ func isNilOrEmptyDestination(destination *duckv1.Destination) bool {
 	return destination == nil || equality.Semantic.DeepEqual(destination, &duckv1.Destination{})
 }
 
-func (r *Reconciler) syncPhysicalChannel(ctx context.Context, sub *v1beta1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined, isDeleted bool) (bool, error) {
+func (r *Reconciler) syncPhysicalChannel(ctx context.Context, sub *v1.Subscription, channel *eventingduckv1alpha1.ChannelableCombined, isDeleted bool) (bool, error) {
 	logging.FromContext(ctx).Debug("Reconciling physical from Channel", zap.Any("sub", sub))
 	if patched, patchErr := r.patchSubscription(ctx, sub.Namespace, channel, sub); patchErr != nil {
 		if isDeleted && apierrors.IsNotFound(patchErr) {
@@ -434,7 +435,7 @@ func (r *Reconciler) syncPhysicalChannel(ctx context.Context, sub *v1beta1.Subsc
 	}
 }
 
-func (r *Reconciler) patchSubscription(ctx context.Context, namespace string, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) (bool, error) {
+func (r *Reconciler) patchSubscription(ctx context.Context, namespace string, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) (bool, error) {
 	after := channel.DeepCopy()
 
 	if sub.DeletionTimestamp.IsZero() {
@@ -467,10 +468,10 @@ func (r *Reconciler) patchSubscription(ctx context.Context, namespace string, ch
 	return true, nil
 }
 
-func (r *Reconciler) updateChannelRemoveSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelRemoveSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	if channel.Annotations != nil {
-		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
-			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
+		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" ||
+			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
 			r.updateChannelRemoveSubscriptionV1Beta1(ctx, channel, sub)
 			return
 		}
@@ -478,7 +479,7 @@ func (r *Reconciler) updateChannelRemoveSubscription(ctx context.Context, channe
 	r.updateChannelRemoveSubscriptionV1Alpha1(ctx, channel, sub)
 }
 
-func (r *Reconciler) updateChannelRemoveSubscriptionV1Beta1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelRemoveSubscriptionV1Beta1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	for i, v := range channel.Spec.Subscribers {
 		if v.UID == sub.UID {
 			channel.Spec.Subscribers = append(
@@ -489,7 +490,7 @@ func (r *Reconciler) updateChannelRemoveSubscriptionV1Beta1(ctx context.Context,
 	}
 }
 
-func (r *Reconciler) updateChannelRemoveSubscriptionV1Alpha1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelRemoveSubscriptionV1Alpha1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	if channel.Spec.Subscribable == nil {
 		return
 	}
@@ -504,7 +505,7 @@ func (r *Reconciler) updateChannelRemoveSubscriptionV1Alpha1(ctx context.Context
 	}
 }
 
-func (r *Reconciler) updateChannelAddSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelAddSubscription(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	if channel.Annotations != nil {
 		if channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" ||
 			channel.Annotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
@@ -515,7 +516,7 @@ func (r *Reconciler) updateChannelAddSubscription(ctx context.Context, channel *
 	r.updateChannelAddSubscriptionV1Alpha1(ctx, channel, sub)
 }
 
-func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	if channel.Spec.Subscribable == nil {
 		channel.Spec.Subscribable = &eventingduckv1alpha1.Subscribable{
 			Subscribers: []eventingduckv1alpha1.SubscriberSpec{{
@@ -551,7 +552,7 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, c
 		})
 }
 
-func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1beta1.Subscription) {
+func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, channel *eventingduckv1alpha1.ChannelableCombined, sub *v1.Subscription) {
 	// Look to update subscriber.
 	for i, v := range channel.Spec.Subscribers {
 		if v.UID == sub.UID {
@@ -561,11 +562,12 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, ch
 			// Only set the deadletter sink if it's not nil. Otherwise we'll just end up patching
 			// empty delivery in there.
 			if sub.Status.PhysicalSubscription.DeadLetterSinkURI != nil {
-				channel.Spec.Subscribers[i].Delivery = &eventingduckv1beta1.DeliverySpec{
+				deliveryv1 := eventingduckv1.DeliverySpec{
 					DeadLetterSink: &duckv1.Destination{
 						URI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
 					},
 				}
+				deliveryv1.ConvertTo(ctx, channel.Spec.Subscribers[i].Delivery)
 			}
 			return
 		}

--- a/pkg/reconciler/testing/v1/service.go
+++ b/pkg/reconciler/testing/v1/service.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ServiceOption enables further configuration of a Service.
+type ServiceOption func(*corev1.Service)
+
+// NewService creates a Service with ServiceOptions
+func NewService(name, namespace string, so ...ServiceOption) *corev1.Service {
+	s := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	return s
+}
+
+func WithServiceOwnerReferences(ownerReferences []metav1.OwnerReference) ServiceOption {
+	return func(s *corev1.Service) {
+		s.OwnerReferences = ownerReferences
+	}
+}
+
+func WithServiceLabels(labels map[string]string) ServiceOption {
+	return func(s *corev1.Service) {
+		s.ObjectMeta.Labels = labels
+		s.Spec.Selector = labels
+	}
+}
+
+func WithServicePorts(ports []corev1.ServicePort) ServiceOption {
+	return func(s *corev1.Service) {
+		s.Spec.Ports = ports
+	}
+}
+
+func WithServiceAnnotations(annotations map[string]string) ServiceOption {
+	return func(s *corev1.Service) {
+		s.ObjectMeta.Annotations = annotations
+	}
+}

--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// SubscriptionOption enables further configuration of a Subscription.
+type SubscriptionOption func(*v1.Subscription)
+
+// NewSubscription creates a Subscription with SubscriptionOptions
+func NewSubscription(name, namespace string, so ...SubscriptionOption) *v1.Subscription {
+	s := &v1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	s.SetDefaults(context.Background())
+	return s
+}
+
+// NewSubscriptionWithoutNamespace creates a Subscription with SubscriptionOptions but without a specific namespace
+func NewSubscriptionWithoutNamespace(name string, so ...SubscriptionOption) *v1.Subscription {
+	s := &v1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	for _, opt := range so {
+		opt(s)
+	}
+	s.SetDefaults(context.Background())
+	return s
+}
+
+func WithSubscriptionUID(uid types.UID) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.UID = uid
+	}
+}
+
+func WithSubscriptionGeneration(gen int64) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Generation = gen
+	}
+}
+
+func WithSubscriptionStatusObservedGeneration(gen int64) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.ObservedGeneration = gen
+	}
+}
+
+func WithSubscriptionGenerateName(generateName string) SubscriptionOption {
+	return func(c *v1.Subscription) {
+		c.ObjectMeta.GenerateName = generateName
+	}
+}
+
+// WithInitSubscriptionConditions initializes the Subscriptions's conditions.
+func WithInitSubscriptionConditions(s *v1.Subscription) {
+	s.Status.InitializeConditions()
+}
+
+func WithSubscriptionReady(s *v1.Subscription) {
+	s.Status = *eventingv1.TestHelper.ReadySubscriptionStatus()
+}
+
+// TODO: this can be a runtime object
+func WithSubscriptionDeleted(s *v1.Subscription) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	s.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+func WithSubscriptionOwnerReferences(ownerReferences []metav1.OwnerReference) SubscriptionOption {
+	return func(c *v1.Subscription) {
+		c.ObjectMeta.OwnerReferences = ownerReferences
+	}
+}
+
+func WithSubscriptionLabels(labels map[string]string) SubscriptionOption {
+	return func(c *v1.Subscription) {
+		c.ObjectMeta.Labels = labels
+	}
+}
+
+func WithSubscriptionChannel(gvk metav1.GroupVersionKind, name string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Spec.Channel = corev1.ObjectReference{
+			APIVersion: apiVersion(gvk),
+			Kind:       gvk.Kind,
+			Name:       name,
+		}
+	}
+}
+
+func WithSubscriptionSubscriberRef(gvk metav1.GroupVersionKind, name, namespace string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Spec.Subscriber = &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+				Namespace:  namespace,
+			},
+		}
+	}
+}
+
+func WithSubscriptionDeliveryRef(gvk metav1.GroupVersionKind, name, namespace string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Spec.Delivery = &eventingduckv1.DeliverySpec{
+			DeadLetterSink: &duckv1.Destination{
+				Ref: &duckv1.KReference{
+					APIVersion: apiVersion(gvk),
+					Kind:       gvk.Kind,
+					Name:       name,
+					Namespace:  namespace,
+				},
+			},
+		}
+	}
+}
+
+func WithSubscriptionPhysicalSubscriptionSubscriber(uri *apis.URL) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		if uri == nil {
+			panic(errors.New("nil URI"))
+		}
+		s.Status.PhysicalSubscription.SubscriberURI = uri
+	}
+}
+
+func WithSubscriptionPhysicalSubscriptionReply(uri *apis.URL) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		if uri == nil {
+			panic(errors.New("nil URI"))
+		}
+		s.Status.PhysicalSubscription.ReplyURI = uri
+	}
+}
+
+func WithSubscriptionDeadLetterSinkURI(uri *apis.URL) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		if uri == nil {
+			panic(errors.New("nil URI"))
+		}
+		s.Status.PhysicalSubscription.DeadLetterSinkURI = uri
+	}
+}
+
+func WithSubscriptionFinalizers(finalizers ...string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Finalizers = finalizers
+	}
+}
+
+func MarkSubscriptionReady(s *v1.Subscription) {
+	s.Status.MarkChannelReady()
+	s.Status.MarkReferencesResolved()
+	s.Status.MarkAddedToChannel()
+}
+
+func MarkAddedToChannel(s *v1.Subscription) {
+	s.Status.MarkAddedToChannel()
+}
+
+func MarkNotAddedToChannel(reason, msg string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.MarkNotAddedToChannel(reason, msg)
+	}
+}
+
+func MarkReferencesResolved(s *v1.Subscription) {
+	s.Status.MarkReferencesResolved()
+}
+
+func WithSubscriptionReferencesNotResolved(reason, msg string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.MarkReferencesNotResolved(reason, msg)
+	}
+}
+
+func WithSubscriptionReferencesResolvedUnknown(reason, msg string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.MarkReferencesResolvedUnknown(reason, msg)
+	}
+}
+
+func WithSubscriptionReply(gvk metav1.GroupVersionKind, name, namespace string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Spec.Reply = &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+				Namespace:  namespace,
+			},
+		}
+	}
+}


### PR DESCRIPTION
Part of #3584

## Proposed Changes

- Migrate Subscription reconciler to use messaging.* v1 resources

Removing tests that deal with v1alpha1 subscription (according to https://github.com/knative/eventing/pull/3789#discussion_r472280959 - see also https://github.com/knative/eventing/pull/3871) 
