### PR TITLE
revert change to get PingSource specs from ConfigMaps

### DIFF
--- a/cmd/mtping/main.go
+++ b/cmd/mtping/main.go
@@ -37,7 +37,6 @@ func main() {
 	// which under the cover delays the release of the lease.
 	ctx := mtping.NewDelayingContext(sctx, mtping.GetNoShutDownAfterValue())
 
-	ctx = adapter.WithConfigMapWatcherEnabled(ctx)
 	ctx = adapter.WithInjectorEnabled(ctx)
 	ctx = adapter.WithHAEnabled(ctx)
 	adapter.MainWithContext(ctx, component, mtping.NewEnvConfig, mtping.NewAdapter)

--- a/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
+++ b/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
@@ -28,6 +28,22 @@ rules:
       - "list"
       - "watch"
   - apiGroups:
+      - sources.knative.dev
+    resources:
+      - pingsources
+      - pingsources/status
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - sources.knative.dev
+    resources:
+      - pingsources/finalizers
+    verbs:
+      - "patch"
+  - apiGroups:
       - ""
     resources:
       - events

--- a/pkg/adapter/mtping/controller.go
+++ b/pkg/adapter/mtping/controller.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"context"
+	"sync"
+
+	"github.com/robfig/cron/v3"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	pingsourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha2/pingsource"
+	pingsourcereconciler "knative.dev/eventing/pkg/client/injection/reconciler/sources/v1alpha2/pingsource"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+)
+
+// NewController initializes the controller and is called by the generated code.
+// Registers event handlers to enqueue events.
+func NewController(ctx context.Context, cronRunner *cronJobsRunner) *controller.Impl {
+	logger := logging.FromContext(ctx)
+
+	pingsourceInformer := pingsourceinformer.Get(ctx)
+
+	r := &Reconciler{
+		eventingClientSet: eventingclient.Get(ctx),
+		kubeClient:        kubeclient.Get(ctx),
+		pingsourceLister:  pingsourceInformer.Lister(),
+		entryidMu:         sync.RWMutex{},
+		entryids:          make(map[string]cron.EntryID),
+		cronRunner:        cronRunner,
+	}
+
+	impl := pingsourcereconciler.NewImpl(ctx, r)
+
+	logger.Info("Setting up event handlers")
+
+	// Watch for pingsource objects
+	pingsourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	return impl
+}

--- a/pkg/adapter/mtping/controller_test.go
+++ b/pkg/adapter/mtping/controller_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"testing"
+
+	. "knative.dev/pkg/reconciler/testing"
+
+	// Fake injection informers
+	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha2/pingsource/fake"
+)
+
+func TestNew(t *testing.T) {
+	ctx, _ := SetupFakeContext(t)
+
+	c := NewController(ctx, nil)
+
+	if c == nil {
+		t.Fatal("Expected NewController to return a non-nil value")
+	}
+}

--- a/pkg/adapter/mtping/pingsource.go
+++ b/pkg/adapter/mtping/pingsource.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	pkgreconciler "knative.dev/pkg/reconciler"
+
+	"knative.dev/eventing/pkg/apis/eventing"
+	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
+	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
+	pingsourcereconciler "knative.dev/eventing/pkg/client/injection/reconciler/sources/v1alpha2/pingsource"
+	sourceslisters "knative.dev/eventing/pkg/client/listers/sources/v1alpha2"
+	"knative.dev/eventing/pkg/logging"
+)
+
+// Reconciler reconciles PingSources
+type Reconciler struct {
+	cronRunner        *cronJobsRunner
+	eventingClientSet clientset.Interface
+	pingsourceLister  sourceslisters.PingSourceLister
+	kubeClient        kubernetes.Interface
+
+	entryidMu sync.RWMutex
+	entryids  map[string]cron.EntryID // key: resource namespace/name
+}
+
+// Check that our Reconciler implements ReconcileKind.
+var _ pingsourcereconciler.Interface = (*Reconciler)(nil)
+
+// Check that our Reconciler implements FinalizeKind.
+var _ pingsourcereconciler.Finalizer = (*Reconciler)(nil)
+
+func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1alpha2.PingSource) pkgreconciler.Event {
+	scope, ok := source.Annotations[eventing.ScopeAnnotationKey]
+	if ok && scope != eventing.ScopeCluster {
+		// Not our responsibility
+		logging.FromContext(ctx).Info("Skipping non-cluster-scoped PingSource", zap.Any("namespace", source.Namespace), zap.Any("name", source.Name))
+		return nil
+	}
+
+	if !source.Status.IsReady() {
+		return fmt.Errorf("PingSource is not ready. Cannot configure the cron jobs runner")
+	}
+
+	reconcileErr := r.reconcile(ctx, source)
+	if reconcileErr != nil {
+		logging.FromContext(ctx).Error("Error reconciling PingSource", zap.Error(reconcileErr))
+	} else {
+		logging.FromContext(ctx).Debug("PingSource reconciled")
+	}
+	return reconcileErr
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, source *v1alpha2.PingSource) error {
+	logging.FromContext(ctx).Info("synchronizing schedule")
+
+	key := fmt.Sprintf("%s/%s", source.Namespace, source.Name)
+	// Is the schedule already cached?
+	r.entryidMu.RLock()
+	id, ok := r.entryids[key]
+	r.entryidMu.RUnlock()
+
+	if ok {
+		r.cronRunner.RemoveSchedule(id)
+	}
+
+	config := PingConfig{
+		ObjectReference: corev1.ObjectReference{
+			Namespace: source.Namespace,
+			Name:      source.Name,
+		},
+		Schedule: source.Spec.Schedule,
+		JsonData: source.Spec.JsonData,
+
+		SinkURI: source.Status.SinkURI.String(),
+	}
+	if source.Spec.CloudEventOverrides != nil {
+		config.Extensions = source.Spec.CloudEventOverrides.Extensions
+	}
+
+	id = r.cronRunner.AddSchedule(config)
+
+	r.entryidMu.Lock()
+	r.entryids[key] = id
+	r.entryidMu.Unlock()
+
+	return nil
+}
+
+func (r *Reconciler) FinalizeKind(ctx context.Context, source *v1alpha2.PingSource) pkgreconciler.Event {
+	key := fmt.Sprintf("%s/%s", source.Namespace, source.Name)
+
+	r.entryidMu.RLock()
+	id, ok := r.entryids[key]
+	r.entryidMu.RUnlock()
+
+	if ok {
+		r.cronRunner.RemoveSchedule(id)
+
+		r.entryidMu.Lock()
+		delete(r.entryids, key)
+		r.entryidMu.Unlock()
+	}
+
+	return nil
+}

--- a/pkg/adapter/mtping/pingsource_test.go
+++ b/pkg/adapter/mtping/pingsource_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mtping
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/robfig/cron/v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	adaptertesting "knative.dev/eventing/pkg/adapter/v2/test"
+	sourcesv1alpha2 "knative.dev/eventing/pkg/apis/sources/v1alpha2"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	"knative.dev/eventing/pkg/client/injection/reconciler/sources/v1alpha2/pingsource"
+	. "knative.dev/eventing/pkg/reconciler/testing"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+const (
+	testNS               = "test-namespace"
+	pingSourceName       = "test-pingsource"
+	testSchedule         = "*/2 * * * *"
+	testData             = "data"
+	sinkName             = "mysink"
+	defaultFinalizerName = "pingsources.sources.knative.dev"
+)
+
+var (
+	sinkDest = duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Name:       sinkName,
+			Namespace:  testNS,
+			Kind:       "Channel",
+			APIVersion: "messaging.knative.dev/v1beta1",
+		},
+	}
+
+	sinkURI, _ = apis.ParseURL("https://" + sinkName)
+)
+
+func TestAllCases(t *testing.T) {
+	pingsourceKey := testNS + "/" + pingSourceName
+	table := TableTest{
+		{
+			Name: "bad workqueue key",
+			// Make sure Reconcile handles bad keys.
+			Key: "too/many/parts",
+		}, {
+			Name: "valid schedule",
+			Key:  pingsourceKey,
+			Objects: []runtime.Object{
+				NewPingSourceV1Alpha2(pingSourceName, testNS,
+					WithPingSourceV1A2Spec(sourcesv1alpha2.PingSourceSpec{
+						Schedule: testSchedule,
+						JsonData: testData,
+						SourceSpec: duckv1.SourceSpec{
+							Sink:                sinkDest,
+							CloudEventOverrides: nil,
+						},
+					}),
+					WithInitPingSourceV1A2Conditions,
+					WithValidPingSourceV1A2Schedule,
+					WithPingSourceV1A2Deployed,
+					WithPingSourceV1A2Sink(sinkURI),
+					WithPingSourceV1A2CloudEventAttributes,
+				),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "%s" finalizers`, pingSourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(testNS, pingSourceName, defaultFinalizerName),
+			},
+			WantErr: false,
+		}, {
+			Name: "valid schedule, with finalizer",
+			Key:  pingsourceKey,
+			Objects: []runtime.Object{
+				NewPingSourceV1Alpha2(pingSourceName, testNS,
+					WithPingSourceV1A2Spec(sourcesv1alpha2.PingSourceSpec{
+						Schedule: testSchedule,
+						JsonData: testData,
+						SourceSpec: duckv1.SourceSpec{
+							Sink:                sinkDest,
+							CloudEventOverrides: nil,
+						},
+					}),
+					WithInitPingSourceV1A2Conditions,
+					WithValidPingSourceV1A2Schedule,
+					WithPingSourceV1A2Deployed,
+					WithPingSourceV1A2Sink(sinkURI),
+					WithPingSourceV1A2CloudEventAttributes,
+					WithPingSourceV1A2Finalizers(defaultFinalizerName),
+				),
+			},
+			WantErr: false,
+		}, {
+			Name: "valid schedule, deleted with finalizer",
+			Key:  pingsourceKey,
+			Objects: []runtime.Object{
+				NewPingSourceV1Alpha2(pingSourceName, testNS,
+					WithPingSourceV1A2Spec(sourcesv1alpha2.PingSourceSpec{
+						Schedule: testSchedule,
+						JsonData: testData,
+						SourceSpec: duckv1.SourceSpec{
+							Sink:                sinkDest,
+							CloudEventOverrides: nil,
+						},
+					}),
+					WithInitPingSourceV1A2Conditions,
+					WithValidPingSourceV1A2Schedule,
+					WithPingSourceV1A2Deployed,
+					WithPingSourceV1A2Sink(sinkURI),
+					WithPingSourceV1A2CloudEventAttributes,
+					WithPingSourceV1A2Finalizers(defaultFinalizerName),
+					WithPingSourceV1A2Deleted,
+				),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "%s" finalizers`, pingSourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(testNS, pingSourceName, ""),
+			},
+			WantErr: false,
+		}, {
+			Name: "valid schedule, deleted without finalizer",
+			Key:  pingsourceKey,
+			Objects: []runtime.Object{
+				NewPingSourceV1Alpha2(pingSourceName, testNS,
+					WithPingSourceV1A2Spec(sourcesv1alpha2.PingSourceSpec{
+						Schedule: testSchedule,
+						JsonData: testData,
+						SourceSpec: duckv1.SourceSpec{
+							Sink:                sinkDest,
+							CloudEventOverrides: nil,
+						},
+					}),
+					WithInitPingSourceV1A2Conditions,
+					WithValidPingSourceV1A2Schedule,
+					WithPingSourceV1A2Deployed,
+					WithPingSourceV1A2Sink(sinkURI),
+					WithPingSourceV1A2CloudEventAttributes,
+					WithPingSourceV1A2Deleted,
+				),
+			},
+			WantErr: false,
+		},
+	}
+
+	logger := logtesting.TestLogger(t)
+	ce := adaptertesting.NewTestClient()
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		r := &Reconciler{
+			kubeClient:        testclient.NewSimpleClientset(),
+			eventingClientSet: eventingclient.Get(ctx),
+			pingsourceLister:  listers.GetPingSourceV1alpha2Lister(),
+			cronRunner:        NewCronJobsRunner(ce, testclient.NewSimpleClientset(), logger),
+			entryidMu:         sync.RWMutex{},
+			entryids:          make(map[string]cron.EntryID),
+		}
+		return pingsource.NewReconciler(ctx, logging.FromContext(ctx),
+			fakeeventingclient.Get(ctx), listers.GetPingSourceV1alpha2Lister(),
+			controller.GetEventRecorder(ctx), r)
+	}, false, logger))
+
+}
+
+func patchFinalizers(namespace, name string, finalizers string) clientgotesting.PatchActionImpl {
+	fstr := ""
+	if finalizers != "" {
+		fstr = `"` + finalizers + `"`
+	}
+	return clientgotesting.PatchActionImpl{
+		ActionImpl: clientgotesting.ActionImpl{
+			Namespace:   namespace,
+			Verb:        "patch",
+			Resource:    schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1alpha2", Resource: "pingsources"},
+			Subresource: "",
+		},
+		Name:      name,
+		PatchType: "application/merge-patch+json",
+		Patch:     []byte(`{"metadata":{"finalizers":[` + fstr + `],"resourceVersion":""}}`),
+	}
+}

--- a/pkg/reconciler/pingsource/controller.go
+++ b/pkg/reconciler/pingsource/controller.go
@@ -36,13 +36,11 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracker"
 
-	"knative.dev/eventing/pkg/adapter/mtping"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/eventing/pkg/apis/sources/v1alpha2"
 	pingsourceinformer "knative.dev/eventing/pkg/client/injection/informers/sources/v1alpha2/pingsource"
 	pingsourcereconciler "knative.dev/eventing/pkg/client/injection/reconciler/sources/v1alpha2/pingsource"
 	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
-	eventingcache "knative.dev/eventing/pkg/utils/cache"
 )
 
 // envConfig will be used to extract the required environment variables using
@@ -123,16 +121,6 @@ func NewController(
 				appsv1.SchemeGroupVersion.WithKind("Deployment"),
 			)),
 	})
-
-	// Create and start persistent store serializing PingSource
-	store := eventingcache.NewPersistedStore(
-		mtcomponent,
-		kubeclient.Get(ctx),
-		system.Namespace(),
-		"config-pingsource-mt-adapter",
-		pingSourceInformer.Informer(),
-		mtping.Project)
-	go store.Run(ctx)
 
 	return impl
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Partially reverting https://github.com/knative/eventing/pull/3451 causing a regression on the max number PingSources the adapter can handle.
- 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

This PR needs to be backported to 17.