### PR TITLE
backport issue 3945 to .17

### DIFF
--- a/pkg/apis/flows/v1/parallel_lifecycle.go
+++ b/pkg/apis/flows/v1/parallel_lifecycle.go
@@ -77,7 +77,7 @@ func (ps *ParallelStatus) InitializeConditions() {
 // PropagateSubscriptionStatuses sets the ParallelConditionSubscriptionsReady based on
 // the status of the incoming subscriptions.
 func (ps *ParallelStatus) PropagateSubscriptionStatuses(filterSubscriptions []*messagingv1.Subscription, subscriptions []*messagingv1.Subscription) {
-	if ps.BranchStatuses == nil {
+	if ps.BranchStatuses == nil || len(subscriptions) != len(ps.BranchStatuses) {
 		ps.BranchStatuses = make([]ParallelBranchStatus, len(subscriptions))
 	}
 	allReady := true
@@ -136,7 +136,7 @@ func (ps *ParallelStatus) PropagateSubscriptionStatuses(filterSubscriptions []*m
 // PropagateChannelStatuses sets the ChannelStatuses and ParallelConditionChannelsReady based on the
 // status of the incoming channels.
 func (ps *ParallelStatus) PropagateChannelStatuses(ingressChannel *duckv1.Channelable, channels []*duckv1.Channelable) {
-	if ps.BranchStatuses == nil {
+	if ps.BranchStatuses == nil || len(channels) != len(ps.BranchStatuses) {
 		ps.BranchStatuses = make([]ParallelBranchStatus, len(channels))
 	}
 	allReady := true

--- a/pkg/apis/flows/v1/parallel_lifecycle_test.go
+++ b/pkg/apis/flows/v1/parallel_lifecycle_test.go
@@ -293,6 +293,37 @@ func TestParallelPropagateChannelStatuses(t *testing.T) {
 	}
 }
 
+func TestParallelPropagateChannelStatusUpdated(t *testing.T) {
+	inChannel := getChannelable(true)
+	initialChannels := []*eventingduckv1.Channelable{getChannelable(true)}
+	afterChannels := []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)}
+	ps := ParallelStatus{}
+	ps.PropagateChannelStatuses(inChannel, initialChannels)
+	if len(ps.BranchStatuses) != 1 {
+		t.Errorf("unexpected branchstatuses want 1 got %d", len(ps.BranchStatuses))
+	}
+	ps.PropagateChannelStatuses(inChannel, afterChannels)
+	if len(ps.BranchStatuses) != 2 {
+		t.Errorf("unexpected branchstatuses want 2 got %d", len(ps.BranchStatuses))
+	}
+}
+
+func TestParallelPropagateSubscriptionStatusUpdated(t *testing.T) {
+	initialFsubs := []*messagingv1.Subscription{getSubscription("fsub0", true)}
+	initialSubs := []*messagingv1.Subscription{getSubscription("sub0", true)}
+	afterFsubs := []*messagingv1.Subscription{getSubscription("fsub0", true), getSubscription("fsub1", true)}
+	afterSubs := []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)}
+	ps := ParallelStatus{}
+	ps.PropagateSubscriptionStatuses(initialFsubs, initialSubs)
+	if len(ps.BranchStatuses) != 1 {
+		t.Errorf("unexpected branchstatuses want 1 got %d", len(ps.BranchStatuses))
+	}
+	ps.PropagateSubscriptionStatuses(afterFsubs, afterSubs)
+	if len(ps.BranchStatuses) != 2 {
+		t.Errorf("unexpected branchstatuses want 2 got %d", len(ps.BranchStatuses))
+	}
+}
+
 func TestParallelReady(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/conformance/helpers/broker_data_plane_test_helper.go
+++ b/test/conformance/helpers/broker_data_plane_test_helper.go
@@ -317,12 +317,13 @@ func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 		event.SetSource(source)
 		msg := []byte(`{"msg":"Transformed!"}`)
 		transformPod := resources.EventTransformationPod(
-			"tranformer-pod",
+			"transformer-pod",
 			"reply-check-type",
 			"reply-check-source",
 			msg,
 		)
 		client.CreatePodOrFail(transformPod, testlib.WithService("transformer-pod"))
+		client.WaitForServiceEndpointsOrFail("transformer-pod", 1)
 		transformTrigger := client.CreateTriggerOrFailV1Beta1(
 			"transform-trigger",
 			resources.WithBrokerV1Beta1(broker.Name),


### PR DESCRIPTION
Backport #3945 to .17 release.

Also backport 3918, 3900. (helps with test flakes)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Check the length of the branches and if they change, realloc the array of BranchStatuses. Otherwise, if branches are added, panic happens.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
If you create a Parallel, then later add branches to it, caused a panic.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
