### PR TITLE
introducing the test observer

### DIFF
--- a/pkg/test/observer/doc.go
+++ b/pkg/test/observer/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package observer is intended to be a utility that can observe CloudEvents as
+// a Sink (addressable + CloudEvents) and fan out the observed events to
+// several EventLog implementations if required.
+//
+// The intention is something like:
+//
+//                                 +--> [Kubernetes Events via recorder]
+//                                 |
+// [Event Producer] --> [Observer] +--> [pod logs via writer]
+//                                 |
+//                                 +--> [http forward via http]
+//
+// Then we can collect all events observed with something like:
+//
+// [Kubernetes Events] <-- [collector]
+//
+package observer

--- a/pkg/test/observer/eventlog.go
+++ b/pkg/test/observer/eventlog.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package observer
+
+// EventLog is the contract for an event logger to vent an event.
+type EventLog interface {
+	Vent(observed Observed) error
+}

--- a/pkg/test/observer/http-vent/doc.go
+++ b/pkg/test/observer/http-vent/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package http_vent implements an observer.EventLog backed by a CloudEvents
+// HTTP client, following the eventing sources container runtime contract.
+package http_vent

--- a/pkg/test/observer/http-vent/http.go
+++ b/pkg/test/observer/http-vent/http.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http_vent
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/kelseyhightower/envconfig"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/logging"
+
+	"knative.dev/eventing/pkg/test/observer"
+)
+
+type envConfig struct {
+	Sink string `envconfig:"K_SINK"`
+	// CEOverrides are the CloudEvents overrides to be applied to the outbound event.
+	CEOverrides string `envconfig:"K_CE_OVERRIDES"`
+}
+
+func NewFromEnv(ctx context.Context) observer.EventLog {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Printf("[ERROR] Failed to process env var: %s", err)
+		os.Exit(1)
+	}
+
+	if env.Sink == "" {
+		return nil
+	}
+
+	p, err := cloudevents.NewHTTP(http.WithTarget(env.Sink))
+	if err != nil {
+		log.Printf("[ERROR] Failed to create cloudevents http protocol: %s", err)
+		os.Exit(1)
+	}
+
+	ce, err := cloudevents.NewClient(p, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+	if err != nil {
+		log.Printf("[ERROR] Failed to create cloudevents client: %s", err)
+		os.Exit(1)
+	}
+
+	var ceOverrides *duckv1.CloudEventOverrides
+	if len(env.CEOverrides) > 0 {
+		overrides := duckv1.CloudEventOverrides{}
+		err := json.Unmarshal([]byte(env.CEOverrides), &overrides)
+		if err != nil {
+			logging.FromContext(ctx).Errorf("[ERROR] Unparseable CloudEvents overrides %s: %v", env.CEOverrides, err)
+			os.Exit(1)
+		}
+		ceOverrides = &overrides
+	}
+
+	return &cloudevent{out: ce, ceOverrides: ceOverrides}
+}
+
+type cloudevent struct {
+	out         cloudevents.Client
+	ceOverrides *duckv1.CloudEventOverrides
+}
+
+// Forwards the event.
+func (w *cloudevent) Vent(observed observer.Observed) error {
+	event := observed.Event
+
+	if w.ceOverrides != nil && w.ceOverrides.Extensions != nil {
+		for n, v := range w.ceOverrides.Extensions {
+			event.SetExtension(n, v)
+		}
+	}
+
+	if result := w.out.Send(context.Background(), event); !cloudevents.IsACK(result) {
+		return result
+	}
+
+	return nil
+}

--- a/pkg/test/observer/observation.go
+++ b/pkg/test/observer/observation.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package observer
+
+import cloudevents "github.com/cloudevents/sdk-go/v2"
+
+// Observed is is the CloudEvent and metadata to relevant to an observation.
+type Observed struct {
+	Event    cloudevents.Event `json:"event"`
+	Origin   string            `json:"origin"`
+	Observer string            `json:"observer"`
+	Time     string            `json:"time"`
+}

--- a/pkg/test/observer/observer.go
+++ b/pkg/test/observer/observer.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package observer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// Observer is the entry point for sinking events into the event log.
+type Observer struct {
+	// Name is the name of this Observer, used to filter if multiple observers.
+	Name string
+	// EventLogs is the list of EventLog implementors to vent observed events.
+	EventLogs []EventLog
+}
+
+// New returns an observer that will vent observations to the list of provided
+// EventLog instances. It will listen on :8080.
+func New(eventLogs ...EventLog) *Observer {
+	return &Observer{
+		EventLogs: eventLogs,
+	}
+}
+
+type envConfig struct {
+	// ObserverName is used to identify this instance of the observer.
+	ObserverName string `envconfig:"OBSERVER_NAME" default:"observer-default" required:"true"`
+}
+
+// Start will create the CloudEvents client and start listening for inbound
+// HTTP requests. This is a is a blocking call.
+func (o *Observer) Start(ctx context.Context) error {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		return err
+	}
+	o.Name = env.ObserverName
+
+	ce, err := cloudevents.NewDefaultClient()
+	if err != nil {
+		return err
+	}
+
+	return ce.StartReceiver(ctx, o.onEvent)
+}
+
+func (o *Observer) onEvent(event cloudevents.Event) {
+	obs := Observed{
+		Event:    event,
+		Origin:   "http://todo.origin", // TODO: we do not have this part at the moment, to get this info we will have to use http directly.
+		Observer: o.Name,
+		Time:     cloudevents.Timestamp{Time: time.Now()}.String(),
+	}
+
+	for _, el := range o.EventLogs {
+		if el == nil {
+			continue
+		}
+		// Observe the event.
+		if err := el.Vent(obs); err != nil {
+			fmt.Println(err)
+		}
+	}
+}

--- a/pkg/test/observer/recorder-collector/collector.go
+++ b/pkg/test/observer/recorder-collector/collector.go
@@ -19,6 +19,7 @@ package recorder_collector
 import (
 	"context"
 	"encoding/json"
+
 	recorder_vent "knative.dev/eventing/pkg/test/observer/recorder-vent"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/test/observer/recorder-collector/collector.go
+++ b/pkg/test/observer/recorder-collector/collector.go
@@ -19,6 +19,7 @@ package recorder_collector
 import (
 	"context"
 	"encoding/json"
+	recorder_vent "knative.dev/eventing/pkg/test/observer/recorder-vent"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -62,7 +63,7 @@ func (c *collector) List(from duckv1.KReference, filters ...FilterFn) ([]observe
 
 	for _, v := range events.Items {
 		switch v.Reason {
-		case observer.EventReason:
+		case recorder_vent.EventReason:
 			ob := observer.Observed{}
 			if err := json.Unmarshal([]byte(v.Message), &ob); err != nil {
 				return nil, err

--- a/pkg/test/observer/recorder-collector/collector.go
+++ b/pkg/test/observer/recorder-collector/collector.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder_collector
+
+import (
+	"context"
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
+	"knative.dev/eventing/pkg/test/observer"
+)
+
+// Filter observed events, return true if the observation should be included.
+type FilterFn func(ob observer.Observed) bool
+
+type Collector interface {
+	// List all observed events from a ref, optionally filter (pass filter, && together)
+	List(from duckv1.KReference, filters ...FilterFn) ([]observer.Observed, error)
+}
+
+func New(ctx context.Context) Collector {
+	return &collector{client: kubeclient.Get(ctx)}
+}
+
+type collector struct {
+	client kubernetes.Interface
+}
+
+func (c *collector) List(from duckv1.KReference, filters ...FilterFn) ([]observer.Observed, error) {
+	var lister v1.EventInterface
+	if from.Kind == "Namespace" {
+		lister = c.client.CoreV1().Events(from.Name)
+	} else {
+		lister = c.client.CoreV1().Events(from.Namespace) // TODO: I do not understand how to do cluster scoped objects.
+	}
+	events, err := lister.List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	obs := make([]observer.Observed, 0)
+
+	for _, v := range events.Items {
+		switch v.Reason {
+		case observer.EventReason:
+			ob := observer.Observed{}
+			if err := json.Unmarshal([]byte(v.Message), &ob); err != nil {
+				return nil, err
+			}
+			if filters != nil {
+				skip := false
+				for _, fn := range filters {
+					if !fn(ob) {
+						skip = true
+					}
+				}
+				if skip {
+					continue
+				}
+			}
+
+			obs = append(obs, ob)
+			// TODO: worry about v.Count
+		}
+	}
+
+	// sort by time collected
+	return obs, nil
+}

--- a/pkg/test/observer/recorder-collector/doc.go
+++ b/pkg/test/observer/recorder-collector/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package recorder_collector holds a class to collect the logs from a recorder
+// vented event log.
+package recorder_collector

--- a/pkg/test/observer/recorder-vent/constructor.go
+++ b/pkg/test/observer/recorder-vent/constructor.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder_vent
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/kelseyhightower/envconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection/clients/dynamicclient"
+	"knative.dev/pkg/logging"
+
+	"knative.dev/eventing/pkg/test/observer"
+)
+
+type envConfig struct {
+	AgentName string `envconfig:"AGENT_NAME" default:"observer-default" required:"true"`
+	EventOn   string `envconfig:"K8S_EVENT_SINK" required:"true"`
+
+	Port int    `envconfig:"PORT" default:"8080" required:"true"`
+	Sink string `envconfig:"K_SINK"`
+}
+
+func NewFromEnv(ctx context.Context) observer.EventLog {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Printf("[ERROR] Failed to process env var: %s", err)
+		os.Exit(1)
+	}
+
+	var ref duckv1.KReference
+	if err := json.Unmarshal([]byte(env.EventOn), &ref); err != nil {
+		log.Printf("[ERROR] Failed to process env var [K8S_EVENT_SINK]: %s", err)
+		os.Exit(1)
+	}
+
+	return NewEventLog(ctx, env.AgentName, ref)
+}
+
+func NewEventLog(ctx context.Context, agentName string, ref duckv1.KReference) observer.EventLog {
+
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("failed to parse group version, %s", err)
+	}
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gv.WithKind(ref.Kind))
+
+	var on runtime.Object
+	if ref.Namespace == "" {
+		on, err = dynamicclient.Get(ctx).Resource(gvr).Get(ref.Name, metav1.GetOptions{})
+	} else {
+		on, err = dynamicclient.Get(ctx).Resource(gvr).Get(ref.Name, metav1.GetOptions{})
+	}
+	if err != nil {
+		logging.FromContext(ctx).Fatalf("failed to fetch object ref, %+v, %s", ref, err)
+
+	}
+
+	return &recorder{out: createRecorder(ctx, agentName), on: on}
+}
+
+func createRecorder(ctx context.Context, agentName string) record.EventRecorder {
+	logger := logging.FromContext(ctx)
+
+	recorder := controller.GetEventRecorder(ctx)
+	if recorder == nil {
+		// Create event broadcaster
+		logger.Debug("Creating event broadcaster")
+		eventBroadcaster := record.NewBroadcaster()
+		watches := []watch.Interface{
+			eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof),
+			eventBroadcaster.StartRecordingToSink(
+				&v1.EventSinkImpl{Interface: kubeclient.Get(ctx).CoreV1().Events("")}),
+		}
+		recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: agentName})
+		go func() {
+			<-ctx.Done()
+			for _, w := range watches {
+				w.Stop()
+			}
+		}()
+	}
+
+	return recorder
+}

--- a/pkg/test/observer/recorder-vent/doc.go
+++ b/pkg/test/observer/recorder-vent/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package recorder_vent implements an observer.EventLog backed by Kubernetes
+// Events using an event recorder.
+package recorder_vent

--- a/pkg/test/observer/recorder-vent/recorder.go
+++ b/pkg/test/observer/recorder-vent/recorder.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder_vent
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+
+	"knative.dev/eventing/pkg/test/observer"
+)
+
+const (
+	// EventReason is the Kubernetes event reason used for observed events.
+	EventReason = "EventObserved"
+)
+
+type recorder struct {
+	out record.EventRecorder
+	on  runtime.Object
+}
+
+func (r *recorder) Vent(observed observer.Observed) error {
+	b, err := json.Marshal(observed)
+	if err != nil {
+		return err
+	}
+
+	r.out.Eventf(r.on, corev1.EventTypeNormal, EventReason,
+		"%s", string(b))
+
+	return nil
+}

--- a/pkg/test/observer/writer-vent/doc.go
+++ b/pkg/test/observer/writer-vent/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package writer_vent implements an observer.EventLog backed by a io.Writer
+// instance, events are converted to json and written out to the writer.
+package writer_vent

--- a/pkg/test/observer/writer-vent/writer.go
+++ b/pkg/test/observer/writer-vent/writer.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package writer_vent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"knative.dev/eventing/pkg/test/observer"
+)
+
+func NewEventLog(ctx context.Context, out io.Writer) observer.EventLog {
+	return &writer{out: out}
+}
+
+type writer struct {
+	out io.Writer
+}
+
+var newline = []byte("\n")
+
+func (w *writer) Vent(observed observer.Observed) error {
+	b, err := json.Marshal(observed)
+	if err != nil {
+		return err
+	}
+	if _, err := w.out.Write(b); err != nil {
+		return err
+	}
+	if _, err := w.out.Write(newline); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Related to #3570

## Proposed Changes

- Adding an event observer to start to replace the in-memory event store for integration testing.

**Release Note**

```release-note
NONE
```

**Docs**

This is intended for testing only.
