### PR TITLE
Refactor broker conformance tests to use brokerTestRunner

### DIFF
--- a/test/conformance/broker_control_plane_test.go
+++ b/test/conformance/broker_control_plane_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestBrokerV1Beta1ControlPlane(t *testing.T) {
-	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
+	brokerTestRunner.RunTests(t, testlib.FeatureBasic, func(t *testing.T, channel metav1.TypeMeta) {
 
 		client := testlib.Setup(t, true, testlib.SetupClientOptionNoop)
 		defer testlib.TearDown(client)
@@ -36,7 +36,7 @@ func TestBrokerV1Beta1ControlPlane(t *testing.T) {
 		helpers.BrokerV1Beta1ControlPlaneTest(
 			t,
 			func(client *testlib.Client, name string) {
-				helpers.BrokerDataPlaneSetupHelper(client, name, brokerNamespace, brokerClass)
+				helpers.BrokerDataPlaneSetupHelper(client, brokerClass, brokerTestRunner)
 			},
 			testlib.SetupClientOptionNoop,
 		)

--- a/test/conformance/broker_data_plane_test.go
+++ b/test/conformance/broker_data_plane_test.go
@@ -22,20 +22,12 @@ import (
 	"testing"
 
 	"knative.dev/eventing/test/conformance/helpers"
-	testlib "knative.dev/eventing/test/lib"
 )
 
 func TestBrokerV1Beta1DataPlaneIngress(t *testing.T) {
-	client := testlib.Setup(t, true, helpers.BrokerDataPlaneNamespaceSetupOption(brokerNamespace))
-	defer testlib.TearDown(client)
-
-	broker := helpers.BrokerDataPlaneSetupHelper(client, brokerName, brokerNamespace, brokerClass)
-	helpers.BrokerV1Beta1IngressDataPlaneTestHelper(t, client, broker)
+	helpers.BrokerV1Beta1IngressDataPlaneTestHelper(t, brokerClass, brokerTestRunner, helpers.BrokerDataPlaneNamespaceSetupOption(brokerTestRunner.ComponentNamespace))
 }
-func TestBrokerV1Beta1DataPlaneConsumer(t *testing.T) {
-	client := testlib.Setup(t, true, helpers.BrokerDataPlaneNamespaceSetupOption(brokerNamespace))
-	defer testlib.TearDown(client)
 
-	broker := helpers.BrokerDataPlaneSetupHelper(client, brokerName, brokerNamespace, brokerClass)
-	helpers.BrokerV1Beta1ConsumerDataPlaneTestHelper(t, client, broker)
+func TestBrokerV1Beta1DataPlaneConsumer(t *testing.T) {
+	helpers.BrokerV1Beta1ConsumerDataPlaneTestHelper(t, brokerClass, brokerTestRunner, helpers.BrokerDataPlaneNamespaceSetupOption(brokerTestRunner.ComponentNamespace))
 }

--- a/test/conformance/helpers/broker_data_plane_test_helper.go
+++ b/test/conformance/helpers/broker_data_plane_test_helper.go
@@ -32,9 +32,11 @@ import (
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 )
 
-func BrokerDataPlaneSetupHelper(client *testlib.Client, brokerName, brokerNamespace, brokerClass string) *eventingv1beta1.Broker {
+func BrokerDataPlaneSetupHelper(client *testlib.Client, brokerClass string, brokerTestRunner testlib.ComponentsTestRunner) *eventingv1beta1.Broker {
 	var broker *eventingv1beta1.Broker
 	var err error
+	brokerName := brokerTestRunner.ComponentName
+	brokerNamespace := brokerTestRunner.ComponentNamespace
 	if brokerName == "" || brokerNamespace == "" {
 		brokerName = "br"
 		config := client.CreateBrokerConfigMapOrFail(brokerName, &testlib.DefaultChannel)
@@ -70,136 +72,141 @@ func BrokerDataPlaneNamespaceSetupOption(namespace string) testlib.SetupClientOp
 //Reject non-POST requests to publish URI
 func BrokerV1Beta1IngressDataPlaneTestHelper(
 	t *testing.T,
-	client *testlib.Client,
-	broker *eventingv1beta1.Broker,
-) {
-	triggerName := "trigger"
-	loggerName := "logger-pod"
-	eventTracker, _ := recordevents.StartEventRecordOrFail(client, loggerName)
-	client.WaitForAllTestResourcesReadyOrFail()
+	brokerClass string,
+	brokerTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
+	brokerTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, source metav1.TypeMeta) {
+		client := testlib.Setup(t, false, options...)
+		defer testlib.TearDown(client)
 
-	trigger := client.CreateTriggerOrFailV1Beta1(
-		triggerName,
-		resources.WithBrokerV1Beta1(broker.Name),
-		resources.WithAttributesTriggerFilterV1Beta1(eventingv1beta1.TriggerAnyFilter, eventingv1beta1.TriggerAnyFilter, nil),
-		resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
-	)
+		broker := BrokerDataPlaneSetupHelper(client, brokerClass, brokerTestRunner)
+		triggerName := "trigger"
+		loggerName := "logger-pod"
+		eventTracker, _ := recordevents.StartEventRecordOrFail(client, loggerName)
+		client.WaitForAllTestResourcesReadyOrFail()
 
-	client.WaitForResourceReadyOrFail(trigger.Name, testlib.TriggerTypeMeta)
-
-	t.Run("Ingress Supports CE0.3", func(t *testing.T) {
-		eventID := "CE0.3"
-		event := ce.NewEvent()
-		event.SetID(eventID)
-		event.SetType(testlib.DefaultEventType)
-		event.SetSource("0.3.event.sender.test.knative.dev")
-		body := fmt.Sprintf(`{"msg":%q}`, eventID)
-
-		if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
-			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
-		}
-		event.Context.AsV03()
-		event.SetSpecVersion("0.3")
-		client.SendEventToAddressable("v03-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
-			cetest.HasId(eventID),
-			cetest.HasSpecVersion("0.3"),
-		))
-		eventTracker.AssertAtLeast(1, originalEventMatcher)
-	})
-
-	t.Run("Ingress Supports CE1.0", func(t *testing.T) {
-		eventID := "CE1.0"
-		event := ce.NewEvent()
-		event.SetID(eventID)
-		event.SetType(testlib.DefaultEventType)
-		event.SetSource("1.0.event.sender.test.knative.dev")
-		body := fmt.Sprintf(`{"msg":%q}`, eventID)
-		if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
-			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
-		}
-
-		client.SendEventToAddressable("v10-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
-			cetest.HasId(eventID),
-			cetest.HasSpecVersion("1.0"),
-		))
-		eventTracker.AssertAtLeast(1, originalEventMatcher)
-
-	})
-	t.Run("Ingress Supports Structured Mode", func(t *testing.T) {
-		eventID := "Structured-Mode"
-		event := ce.NewEvent()
-		event.SetID(eventID)
-		event.SetType(testlib.DefaultEventType)
-		event.SetSource("structured.mode.event.sender.test.knative.dev")
-		body := fmt.Sprintf(`{"msg":%q}`, eventID)
-		if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
-			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
-		}
-
-		client.SendEventToAddressable("structured-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
-			cetest.HasId(eventID),
-		))
-		eventTracker.AssertAtLeast(1, originalEventMatcher)
-	})
-
-	t.Run("Ingress Supports Binary Mode", func(t *testing.T) {
-		eventID := "Binary-Mode"
-		event := ce.NewEvent()
-		event.SetID(eventID)
-		event.SetType(testlib.DefaultEventType)
-		event.SetSource("binary.mode.event.sender.test.knative.dev")
-		body := fmt.Sprintf(`{"msg":%q}`, eventID)
-		if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
-			t.Fatalf("Cannot set the payload of the event: %s", err.Error())
-		}
-
-		client.SendEventToAddressable("binary-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingBinary))
-		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
-			cetest.HasId(eventID),
-		))
-		eventTracker.AssertAtLeast(1, originalEventMatcher)
-	})
-
-	t.Run("Respond with 2XX on good CE", func(t *testing.T) {
-		eventID := "2hundred-on-good-ce"
-		body := fmt.Sprintf(`{"msg":%q}`, eventID)
-		responseSink := "http://" + client.GetServiceHost(loggerName)
-		client.SendRequestToAddressable("twohundred-test-sender", broker.Name, testlib.BrokerTypeMeta,
-			map[string]string{
-				"ce-specversion": "1.0",
-				"ce-type":        testlib.DefaultEventType,
-				"ce-source":      "2xx.request.sender.test.knative.dev",
-				"ce-id":          eventID,
-				"content-type":   ce.ApplicationJSON,
-			},
-			body,
-			sender.WithResponseSink(responseSink),
+		trigger := client.CreateTriggerOrFailV1Beta1(
+			triggerName,
+			resources.WithBrokerV1Beta1(broker.Name),
+			resources.WithAttributesTriggerFilterV1Beta1(eventingv1beta1.TriggerAnyFilter, eventingv1beta1.TriggerAnyFilter, nil),
+			resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
 		)
 
-		eventTracker.AssertExact(1, recordevents.MatchEvent(sender.MatchStatusCode(202))) // should probably be a range
+		client.WaitForResourceReadyOrFail(trigger.Name, testlib.TriggerTypeMeta)
+		st.Run("Ingress Supports CE0.3", func(t *testing.T) {
+			eventID := "CE0.3"
+			event := ce.NewEvent()
+			event.SetID(eventID)
+			event.SetType(testlib.DefaultEventType)
+			event.SetSource("0.3.event.sender.test.knative.dev")
+			body := fmt.Sprintf(`{"msg":%q}`, eventID)
 
-	})
-	//Respond with 400 on bad CE
-	t.Run("Respond with 400 on bad CE", func(t *testing.T) {
-		eventID := "four-hundred-on-bad-ce"
-		body := ";la}{kjsdf;oai2095{}{}8234092349807asdfashdf"
-		responseSink := "http://" + client.GetServiceHost(loggerName)
-		client.SendRequestToAddressable("fourhundres-test-sender", broker.Name, testlib.BrokerTypeMeta,
-			map[string]string{
-				"ce-specversion": "9000.1", //its over 9,000!
-				"ce-type":        testlib.DefaultEventType,
-				"ce-source":      "400.request.sender.test.knative.dev",
-				"ce-id":          eventID,
-				"content-type":   ce.ApplicationJSON,
-			},
-			body,
-			sender.WithResponseSink(responseSink))
-		eventTracker.AssertExact(1, recordevents.MatchEvent(sender.MatchStatusCode(400)))
-	})
+			if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
+				t.Fatalf("Cannot set the payload of the event: %s", err.Error())
+			}
+			event.Context.AsV03()
+			event.SetSpecVersion("0.3")
+			client.SendEventToAddressable("v03-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
+				cetest.HasId(eventID),
+				cetest.HasSpecVersion("0.3"),
+			))
+			eventTracker.AssertAtLeast(1, originalEventMatcher)
+		})
 
+		st.Run("Ingress Supports CE1.0", func(t *testing.T) {
+			eventID := "CE1.0"
+			event := ce.NewEvent()
+			event.SetID(eventID)
+			event.SetType(testlib.DefaultEventType)
+			event.SetSource("1.0.event.sender.test.knative.dev")
+			body := fmt.Sprintf(`{"msg":%q}`, eventID)
+			if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
+				t.Fatalf("Cannot set the payload of the event: %s", err.Error())
+			}
+
+			client.SendEventToAddressable("v10-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
+				cetest.HasId(eventID),
+				cetest.HasSpecVersion("1.0"),
+			))
+			eventTracker.AssertAtLeast(1, originalEventMatcher)
+
+		})
+
+		st.Run("Ingress Supports Structured Mode", func(t *testing.T) {
+			eventID := "Structured-Mode"
+			event := ce.NewEvent()
+			event.SetID(eventID)
+			event.SetType(testlib.DefaultEventType)
+			event.SetSource("structured.mode.event.sender.test.knative.dev")
+			body := fmt.Sprintf(`{"msg":%q}`, eventID)
+			if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
+				t.Fatalf("Cannot set the payload of the event: %s", err.Error())
+			}
+
+			client.SendEventToAddressable("structured-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
+				cetest.HasId(eventID),
+			))
+			eventTracker.AssertAtLeast(1, originalEventMatcher)
+		})
+
+		st.Run("Ingress Supports Binary Mode", func(t *testing.T) {
+			eventID := "Binary-Mode"
+			event := ce.NewEvent()
+			event.SetID(eventID)
+			event.SetType(testlib.DefaultEventType)
+			event.SetSource("binary.mode.event.sender.test.knative.dev")
+			body := fmt.Sprintf(`{"msg":%q}`, eventID)
+			if err := event.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
+				t.Fatalf("Cannot set the payload of the event: %s", err.Error())
+			}
+
+			client.SendEventToAddressable("binary-test-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingBinary))
+			originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
+				cetest.HasId(eventID),
+			))
+			eventTracker.AssertAtLeast(1, originalEventMatcher)
+		})
+
+		st.Run("Respond with 2XX on good CE", func(t *testing.T) {
+			eventID := "2hundred-on-good-ce"
+			body := fmt.Sprintf(`{"msg":%q}`, eventID)
+			responseSink := "http://" + client.GetServiceHost(loggerName)
+			client.SendRequestToAddressable("twohundred-test-sender", broker.Name, testlib.BrokerTypeMeta,
+				map[string]string{
+					"ce-specversion": "1.0",
+					"ce-type":        testlib.DefaultEventType,
+					"ce-source":      "2xx.request.sender.test.knative.dev",
+					"ce-id":          eventID,
+					"content-type":   ce.ApplicationJSON,
+				},
+				body,
+				sender.WithResponseSink(responseSink),
+			)
+
+			eventTracker.AssertExact(1, recordevents.MatchEvent(sender.MatchStatusCode(202))) // should probably be a range
+
+		})
+		//Respond with 400 on bad CE
+		st.Run("Respond with 400 on bad CE", func(t *testing.T) {
+			eventID := "four-hundred-on-bad-ce"
+			body := ";la}{kjsdf;oai2095{}{}8234092349807asdfashdf"
+			responseSink := "http://" + client.GetServiceHost(loggerName)
+			client.SendRequestToAddressable("fourhundres-test-sender", broker.Name, testlib.BrokerTypeMeta,
+				map[string]string{
+					"ce-specversion": "9000.1", //its over 9,000!
+					"ce-type":        testlib.DefaultEventType,
+					"ce-source":      "400.request.sender.test.knative.dev",
+					"ce-id":          eventID,
+					"content-type":   ce.ApplicationJSON,
+				},
+				body,
+				sender.WithResponseSink(responseSink))
+			eventTracker.AssertExact(1, recordevents.MatchEvent(sender.MatchStatusCode(400)))
+		})
+	})
 }
 
 //At consumer
@@ -212,154 +219,161 @@ func BrokerV1Beta1IngressDataPlaneTestHelper(
 //Replies that are unsuccessfully forwarded cause initial message to be redelivered (Very difficult to test, can be ignored)
 func BrokerV1Beta1ConsumerDataPlaneTestHelper(
 	t *testing.T,
-	client *testlib.Client,
-	broker *eventingv1beta1.Broker,
-) {
-	triggerName := "trigger"
-	secondTriggerName := "second-trigger"
-	loggerName := "logger-pod"
-	secondLoggerName := "second-logger-pod"
-	transformerName := "transformer-pod"
-	replySource := "origin-for-reply"
-	eventID := "consumer-broker-tests"
-	baseSource := "consumer-test-sender"
-	eventTracker, _ := recordevents.StartEventRecordOrFail(client, loggerName)
-	secondTracker, _ := recordevents.StartEventRecordOrFail(client, secondLoggerName)
+	brokerClass string,
+	brokerTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
+	brokerTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, source metav1.TypeMeta) {
+		client := testlib.Setup(t, false, options...)
+		defer testlib.TearDown(client)
 
-	baseEvent := ce.NewEvent()
-	baseEvent.SetID(eventID)
-	baseEvent.SetType(testlib.DefaultEventType)
-	baseEvent.SetSource(baseSource)
-	baseEvent.SetSpecVersion("1.0")
-	body := fmt.Sprintf(`{"msg":%q}`, eventID)
-	if err := baseEvent.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
-		t.Fatalf("Cannot set the payload of the baseEvent: %s", err.Error())
-	}
+		broker := BrokerDataPlaneSetupHelper(client, brokerClass, brokerTestRunner)
 
-	transformMsg := []byte(`{"msg":"Transformed!"}`)
-	transformPod := resources.EventTransformationPod(
-		transformerName,
-		"reply-check-type",
-		"reply-check-source",
-		transformMsg,
-	)
-	client.CreatePodOrFail(transformPod, testlib.WithService(transformerName))
-	client.WaitForAllTestResourcesReadyOrFail()
+		triggerName := "trigger"
+		secondTriggerName := "second-trigger"
+		loggerName := "logger-pod"
+		secondLoggerName := "second-logger-pod"
+		transformerName := "transformer-pod"
+		replySource := "origin-for-reply"
+		eventID := "consumer-broker-tests"
+		baseSource := "consumer-test-sender"
+		eventTracker, _ := recordevents.StartEventRecordOrFail(client, loggerName)
+		secondTracker, _ := recordevents.StartEventRecordOrFail(client, secondLoggerName)
 
-	trigger := client.CreateTriggerOrFailV1Beta1(
-		triggerName,
-		resources.WithBrokerV1Beta1(broker.Name),
-		resources.WithAttributesTriggerFilterV1Beta1(eventingv1beta1.TriggerAnyFilter, eventingv1beta1.TriggerAnyFilter, nil),
-		resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
-	)
+		baseEvent := ce.NewEvent()
+		baseEvent.SetID(eventID)
+		baseEvent.SetType(testlib.DefaultEventType)
+		baseEvent.SetSource(baseSource)
+		baseEvent.SetSpecVersion("1.0")
+		body := fmt.Sprintf(`{"msg":%q}`, eventID)
+		if err := baseEvent.SetData(ce.ApplicationJSON, []byte(body)); err != nil {
+			t.Fatalf("Cannot set the payload of the baseEvent: %s", err.Error())
+		}
 
-	client.WaitForResourceReadyOrFail(trigger.Name, testlib.TriggerTypeMeta)
-	secondTrigger := client.CreateTriggerOrFailV1Beta1(
-		secondTriggerName,
-		resources.WithBrokerV1Beta1(broker.Name),
-		resources.WithAttributesTriggerFilterV1Beta1("filtered-event", eventingv1beta1.TriggerAnyFilter, nil),
-		resources.WithSubscriberServiceRefForTriggerV1Beta1(secondLoggerName),
-	)
-	client.WaitForResourceReadyOrFail(secondTrigger.Name, testlib.TriggerTypeMeta)
-
-	transformTrigger := client.CreateTriggerOrFailV1Beta1(
-		"transform-trigger",
-		resources.WithBrokerV1Beta1(broker.Name),
-		resources.WithAttributesTriggerFilterV1Beta1(replySource, baseEvent.Type(), nil),
-		resources.WithSubscriberServiceRefForTriggerV1Beta1(transformerName),
-	)
-	replyTrigger := client.CreateTriggerOrFailV1Beta1(
-		"reply-trigger",
-		resources.WithBrokerV1Beta1(broker.Name),
-		resources.WithAttributesTriggerFilterV1Beta1("reply-check-source", "reply-check-type", nil),
-		resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
-	)
-
-	t.Run("No upgrade of version", func(t *testing.T) {
-		event := baseEvent
-		source := "no-upgrade"
-		event.SetID(source)
-		event.Context = event.Context.AsV03()
-
-		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
-			cetest.HasSpecVersion("0.3"),
-			cetest.HasId("no-upgrade"),
-		))
-		eventTracker.AssertExact(1, originalEventMatcher)
-
-	})
-
-	t.Run("Attributes received should be the same as produced (attributes may be added)", func(t *testing.T) {
-		event := baseEvent
-		id := "identical-attibutes"
-		event.SetID(id)
-		client.SendEventToAddressable(id+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(
-			cetest.HasId(id),
-			cetest.HasType(testlib.DefaultEventType),
-			cetest.HasSource(baseSource),
-			cetest.HasSpecVersion("1.0"),
+		transformMsg := []byte(`{"msg":"Transformed!"}`)
+		transformPod := resources.EventTransformationPod(
+			transformerName,
+			"reply-check-type",
+			"reply-check-source",
+			transformMsg,
 		)
-		eventTracker.AssertExact(1, originalEventMatcher)
-	})
+		client.CreatePodOrFail(transformPod, testlib.WithService(transformerName))
+		client.WaitForAllTestResourcesReadyOrFail()
 
-	t.Run("Events are filtered", func(t *testing.T) {
-		event := baseEvent
-		source := "filtered-event"
-		event.SetSource(source)
-		secondEvent := baseEvent
-
-		client.SendEventToAddressable("first-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		client.SendEventToAddressable("second-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, secondEvent, sender.WithEncoding(ce.EncodingStructured))
-		filteredEventMatcher := recordevents.MatchEvent(
-			cetest.HasSource(source),
+		trigger := client.CreateTriggerOrFailV1Beta1(
+			triggerName,
+			resources.WithBrokerV1Beta1(broker.Name),
+			resources.WithAttributesTriggerFilterV1Beta1(eventingv1beta1.TriggerAnyFilter, eventingv1beta1.TriggerAnyFilter, nil),
+			resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
 		)
-		nonEventMatcher := recordevents.MatchEvent(
-			cetest.HasSource(baseSource),
+
+		client.WaitForResourceReadyOrFail(trigger.Name, testlib.TriggerTypeMeta)
+		secondTrigger := client.CreateTriggerOrFailV1Beta1(
+			secondTriggerName,
+			resources.WithBrokerV1Beta1(broker.Name),
+			resources.WithAttributesTriggerFilterV1Beta1("filtered-event", eventingv1beta1.TriggerAnyFilter, nil),
+			resources.WithSubscriberServiceRefForTriggerV1Beta1(secondLoggerName),
 		)
-		secondTracker.AssertAtLeast(1, filteredEventMatcher)
-		secondTracker.AssertNot(nonEventMatcher)
-	})
+		client.WaitForResourceReadyOrFail(secondTrigger.Name, testlib.TriggerTypeMeta)
 
-	t.Run("Events are delivered to multiple subscribers", func(t *testing.T) {
-		event := baseEvent
-		source := "filtered-event"
-		event.SetSource(source)
-		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		filteredEventMatcher := recordevents.MatchEvent(
-			cetest.HasSource(source),
+		transformTrigger := client.CreateTriggerOrFailV1Beta1(
+			"transform-trigger",
+			resources.WithBrokerV1Beta1(broker.Name),
+			resources.WithAttributesTriggerFilterV1Beta1(replySource, baseEvent.Type(), nil),
+			resources.WithSubscriberServiceRefForTriggerV1Beta1(transformerName),
 		)
-		eventTracker.AssertAtLeast(1, filteredEventMatcher)
-		secondTracker.AssertAtLeast(1, filteredEventMatcher)
-	})
-
-	t.Run("Deliveries succeed at least once", func(t *testing.T) {
-		event := baseEvent
-		source := "delivery-check"
-		event.SetSource(source)
-		client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		originalEventMatcher := recordevents.MatchEvent(
-			cetest.HasSource(source),
+		replyTrigger := client.CreateTriggerOrFailV1Beta1(
+			"reply-trigger",
+			resources.WithBrokerV1Beta1(broker.Name),
+			resources.WithAttributesTriggerFilterV1Beta1("reply-check-source", "reply-check-type", nil),
+			resources.WithSubscriberServiceRefForTriggerV1Beta1(loggerName),
 		)
-		eventTracker.AssertAtLeast(1, originalEventMatcher)
-	})
 
-	t.Run("Replies are accepted and delivered", func(t *testing.T) {
-		event := baseEvent
+		st.Run("No upgrade of version", func(t *testing.T) {
+			event := baseEvent
+			source := "no-upgrade"
+			event.SetID(source)
+			event.Context = event.Context.AsV03()
 
-		event.SetSource(replySource)
-		client.WaitForServiceEndpointsOrFail(transformerName, 1)
+			client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(cetest.AllOf(
+				cetest.HasSpecVersion("0.3"),
+				cetest.HasId("no-upgrade"),
+			))
+			eventTracker.AssertExact(1, originalEventMatcher)
 
-		client.WaitForResourceReadyOrFail(transformTrigger.Name, testlib.TriggerTypeMeta)
+		})
 
-		client.WaitForResourceReadyOrFail(replyTrigger.Name, testlib.TriggerTypeMeta)
-		client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
-		transformedEventMatcher := recordevents.MatchEvent(
-			cetest.HasSource("reply-check-source"),
-			cetest.HasType("reply-check-type"),
-			cetest.HasData(transformMsg),
-		)
-		eventTracker.AssertAtLeast(2, transformedEventMatcher)
+		st.Run("Attributes received should be the same as produced (attributes may be added)", func(t *testing.T) {
+			event := baseEvent
+			id := "identical-attibutes"
+			event.SetID(id)
+			client.SendEventToAddressable(id+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(
+				cetest.HasId(id),
+				cetest.HasType(testlib.DefaultEventType),
+				cetest.HasSource(baseSource),
+				cetest.HasSpecVersion("1.0"),
+			)
+			eventTracker.AssertExact(1, originalEventMatcher)
+		})
+
+		st.Run("Events are filtered", func(t *testing.T) {
+			event := baseEvent
+			source := "filtered-event"
+			event.SetSource(source)
+			secondEvent := baseEvent
+
+			client.SendEventToAddressable("first-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			client.SendEventToAddressable("second-"+source+"-sender", broker.Name, testlib.BrokerTypeMeta, secondEvent, sender.WithEncoding(ce.EncodingStructured))
+			filteredEventMatcher := recordevents.MatchEvent(
+				cetest.HasSource(source),
+			)
+			nonEventMatcher := recordevents.MatchEvent(
+				cetest.HasSource(baseSource),
+			)
+			secondTracker.AssertAtLeast(1, filteredEventMatcher)
+			secondTracker.AssertNot(nonEventMatcher)
+		})
+
+		st.Run("Events are delivered to multiple subscribers", func(t *testing.T) {
+			event := baseEvent
+			source := "filtered-event"
+			event.SetSource(source)
+			client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			filteredEventMatcher := recordevents.MatchEvent(
+				cetest.HasSource(source),
+			)
+			eventTracker.AssertAtLeast(1, filteredEventMatcher)
+			secondTracker.AssertAtLeast(1, filteredEventMatcher)
+		})
+
+		st.Run("Deliveries succeed at least once", func(t *testing.T) {
+			event := baseEvent
+			source := "delivery-check"
+			event.SetSource(source)
+			client.SendEventToAddressable(source+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			originalEventMatcher := recordevents.MatchEvent(
+				cetest.HasSource(source),
+			)
+			eventTracker.AssertAtLeast(1, originalEventMatcher)
+		})
+
+		st.Run("Replies are accepted and delivered", func(t *testing.T) {
+			event := baseEvent
+
+			event.SetSource(replySource)
+			client.WaitForServiceEndpointsOrFail(transformerName, 1)
+
+			client.WaitForResourceReadyOrFail(transformTrigger.Name, testlib.TriggerTypeMeta)
+
+			client.WaitForResourceReadyOrFail(replyTrigger.Name, testlib.TriggerTypeMeta)
+			client.SendEventToAddressable(replySource+"-sender", broker.Name, testlib.BrokerTypeMeta, event, sender.WithEncoding(ce.EncodingStructured))
+			transformedEventMatcher := recordevents.MatchEvent(
+				cetest.HasSource("reply-check-source"),
+				cetest.HasType("reply-check-type"),
+				cetest.HasData(transformMsg),
+			)
+			eventTracker.AssertAtLeast(2, transformedEventMatcher)
+		})
 	})
 }

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -40,9 +40,8 @@ const (
 
 var channelTestRunner testlib.ComponentsTestRunner
 var sourcesTestRunner testlib.ComponentsTestRunner
+var brokerTestRunner testlib.ComponentsTestRunner
 var brokerClass string
-var brokerName string
-var brokerNamespace string
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
@@ -55,9 +54,13 @@ func TestMain(m *testing.M) {
 			ComponentFeatureMap: testlib.SourceFeatureMap,
 			ComponentsToTest:    test.EventingFlags.Sources,
 		}
+		brokerTestRunner = testlib.ComponentsTestRunner{
+			ComponentFeatureMap: testlib.BrokerFeatureMap,
+			ComponentsToTest:    test.EventingFlags.Brokers,
+			ComponentName:       test.EventingFlags.BrokerName,
+			ComponentNamespace:  test.EventingFlags.BrokerNamespace,
+		}
 		brokerClass = test.EventingFlags.BrokerClass
-		brokerName = test.EventingFlags.BrokerName
-		brokerNamespace = test.EventingFlags.BrokerNamespace
 
 		addSourcesInitializers()
 		// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -33,6 +33,6 @@ source "$(dirname "$0")/e2e-common.sh"
 initialize $@ --skip-istio-addon
 
 echo "Running tests with Multi Tenant Channel Based Broker"
-go_test_e2e -timeout=30m -parallel=12 ./test/conformance -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1beta1:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
+go_test_e2e -timeout=30m -parallel=12 ./test/conformance -brokers=eventing.knative.dev/v1beta1:MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1beta1:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource || fail_test
 
 success

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -32,12 +32,14 @@ const (
 	ChannelUsage = "The names of the channel type metas, separated by comma. " +
 		"Example: \"messaging.knative.dev/v1alpha1:InMemoryChannel," +
 		"messaging.cloud.google.com/v1alpha1:Channel,messaging.knative.dev/v1alpha1:KafkaChannel\"."
-	BrokerUsage = "Which brokerclass to test, requires the proper Broker " +
+	BrokerClassUsage = "Which brokerclass to test, requires the proper Broker " +
 		"implementation to have been installed, and only one value. brokerclass " +
 		"must be (for now) 'MTChannelBasedBroker'."
 	SourceUsage = "The names of the source type metas, separated by comma. " +
 		"Example: \"sources.knative.dev/v1alpha1:ApiServerSource," +
 		"sources.knative.dev/v1alpha1:PingSource\"."
+	BrokerUsage = "The name of the broker type metas, separated by comma. " +
+		"Example: \"eventing.knative.dev/v1beta1:MTChannelBasedBroker"
 	BrokerNameUsage = "When testing a pre-existing broker, specify the Broker name so the conformance tests " +
 		"won't create their own."
 	BrokerNamespaceUsage = "When testing a pre-existing broker, this variable specifies the namespace the broker can be found in."
@@ -51,10 +53,11 @@ var EventingFlags testflags.EventingEnvironmentFlags
 func InitializeEventingFlags() {
 
 	flag.Var(&EventingFlags.Channels, "channels", ChannelUsage)
-	flag.StringVar(&EventingFlags.BrokerClass, "brokerclass", "MTChannelBasedBroker", BrokerUsage)
+	flag.StringVar(&EventingFlags.BrokerClass, "brokerclass", "MTChannelBasedBroker", BrokerClassUsage)
 	flag.Var(&EventingFlags.Sources, "sources", SourceUsage)
 	flag.StringVar(&EventingFlags.PipeFile, "pipefile", "/tmp/prober-signal", "Temporary file to write the prober signal into.")
 	flag.StringVar(&EventingFlags.ReadyFile, "readyfile", "/tmp/prober-ready", "Temporary file to get the prober result.")
+	flag.Var(&EventingFlags.Brokers, "brokers", BrokerUsage)
 	flag.StringVar(&EventingFlags.BrokerName, "brokername", "", BrokerNameUsage)
 	flag.StringVar(&EventingFlags.BrokerNamespace, "brokernamespace", "", BrokerNamespaceUsage)
 	flag.Parse()

--- a/test/flags/brokers.go
+++ b/test/flags/brokers.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Brokers holds the Brokers we want to run test against.
+type Brokers []metav1.TypeMeta
+
+func (brokers *Brokers) String() string {
+	return fmt.Sprint(*brokers)
+}
+
+// Set appends the input string to Brokers.
+func (brokers *Brokers) Set(value string) error {
+	*brokers = csvToObjects(value, isValidBroker)
+	return nil
+}
+
+// Check if the broker kind is valid.
+func isValidBroker(broker string) bool {
+	return strings.HasSuffix(broker, "Broker")
+}

--- a/test/flags/eventing_environment.go
+++ b/test/flags/eventing_environment.go
@@ -21,6 +21,7 @@ type EventingEnvironmentFlags struct {
 	BrokerClass string
 	Channels
 	Sources
+	Brokers
 	PipeFile        string
 	ReadyFile       string
 	BrokerName      string

--- a/test/lib/config.go
+++ b/test/lib/config.go
@@ -61,6 +61,10 @@ var SourceFeatureMap = map[metav1.TypeMeta][]Feature{
 	PingSourceTypeMeta:      {FeatureBasic, FeatureLongLiving},
 }
 
+var BrokerFeatureMap = map[metav1.TypeMeta][]Feature{
+	*BrokerTypeMeta: {FeatureBasic},
+}
+
 // Feature is the feature supported by the channel.
 type Feature string
 

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -51,6 +51,8 @@ type ComponentsTestRunner struct {
 	ComponentFeatureMap map[metav1.TypeMeta][]Feature
 	ComponentsToTest    []metav1.TypeMeta
 	componentOptions    map[metav1.TypeMeta][]SetupClientOption
+	ComponentName       string
+	ComponentNamespace  string
 }
 
 // RunTests will use all components that support the given feature, to run


### PR DESCRIPTION
Add a broker test runner, move individual tests into a
subtest (hopefully this will reduce testgrid marking these tests as
flaky)