### PR TITLE
adding downstream tests for sample source and eventing-contrib

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -15,8 +15,6 @@
 name: Downstream
 
 on:
-  push:
-    branches: [ 'master', 'release-*' ]
   pull_request:
     branches: [ 'master', 'release-*' ]
 
@@ -28,29 +26,22 @@ jobs:
       matrix:
         go-version: [1.15.x]
         platform: [ubuntu-latest]
-
     runs-on: ${{ matrix.platform }}
-
     env:
       GOPATH: ${{ github.workspace }}
-
     steps:
-
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
       id: go
-
     - name: Install Dependencies
       run: |
         go get github.com/google/go-licenses
-
     - name: Checkout Upstream
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
-
     - name: Checkout Downstream
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -1,0 +1,108 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Downstream
+
+on:
+  push:
+    branches: [ 'master', 'release-*' ]
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+
+  downstream-eventing-contrib:
+    name: Eventing Contrib
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative/eventing-contrib
+        path: ./src/knative.dev/eventing-contrib
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/eventing-contrib
+
+
+  downstream-sample-source:
+    name: Sample Source
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    env:
+      GOPATH: ${{ github.workspace }}
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go get github.com/google/go-licenses
+
+    - name: Checkout Upstream
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/${{ github.event.repository.name }}
+
+    - name: Checkout Downstream
+      uses: actions/checkout@v2
+      with:
+        repository: knative-sandbox/sample-source
+        path: ./src/knative.dev/sample-source
+
+    - name: Test Downstream
+      uses: knative-sandbox/downstream-test-go@v1.0.1
+      with:
+        upstream-module: knative.dev/${{ github.event.repository.name }}
+        downstream-module: knative.dev/sample-source
+
+

--- a/pkg/leaderelection/context_test.go
+++ b/pkg/leaderelection/context_test.go
@@ -93,7 +93,7 @@ func TestWithBuilder(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	defer cancel()
 	go le.Run(ctx)
 
 	select {


### PR DESCRIPTION
Integrate the `knative-sandbox/downstream-test-go` action that takes two repos that are checked out and upgrades the downstream with an upstream module, and then runs the standard knative repo update-codegen and runs the unit tests.

This PR makes it an FYI that any future PR will test on the following:

- Eventing Contrib
- Sample Source
