### PR TITLE
Eager pingsource adapter creation

### DIFF
--- a/config/500-pingsource-mt-adapter.yaml
+++ b/config/500-pingsource-mt-adapter.yaml
@@ -1,0 +1,1 @@
+core/deployments/pingsource-mt-adapter.yaml

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -65,9 +65,6 @@ spec:
             value: config-observability
           - name: METRICS_DOMAIN
             value: knative.dev/eventing
-          # PingSource
-          - name: MT_PING_IMAGE
-            value: ko://knative.dev/eventing/cmd/mtping
           # APIServerSource
           - name: APISERVER_RA_IMAGE
             value: ko://knative.dev/eventing/cmd/apiserver_receive_adapter

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -1,0 +1,61 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pingsource-mt-adapter
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      eventing.knative.dev/source: ping-source-controller
+      sources.knative.dev/role: adapter
+  template:
+    metadata:
+      labels:
+        eventing.knative.dev/source: ping-source-controller
+        sources.knative.dev/role: adapter
+        eventing.knative.dev/release: devel
+    spec:
+      containers:
+        - name: dispatcher
+          image: ko://knative.dev/eventing/cmd/mtping
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K_METRICS_CONFIG
+              value: ''
+            - name: K_LOGGING_CONFIG
+              value: ''
+            - name: K_LOGGING_CONFIG
+              value: ''
+          ports:
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 125m
+              memory: 64Mi
+            limits:
+              cpu: 1000m
+              memory: 2048Mi
+      serviceAccountName: pingsource-mt-adapter

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -20,7 +20,8 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 spec:
-  replicas: 1
+  # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
+  replicas: 0
   selector:
     matchLabels:
       eventing.knative.dev/source: ping-source-controller

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -41,12 +41,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+
+            # The values below are being filled by the ping source controller
             - name: K_METRICS_CONFIG
               value: ''
             - name: K_LOGGING_CONFIG
               value: ''
             - name: K_LOGGING_CONFIG
               value: ''
+            - name: K_LEADER_ELECTION_CONFIG
+              value: ''
+            - name: K_NO_SHUTDOWN_AFTER
+              value: ''
+
           ports:
             - containerPort: 9090
               name: metrics

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -168,7 +168,7 @@ func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, source *v1beta
 	} else if update, c := needsUpdating(ctx, &d.Spec, expected); update {
 		c.Env = expected
 
-		if *d.Spec.Replicas == 0 {
+		if zero(d.Spec.Replicas) {
 			d.Spec.Replicas = pointer.Int32Ptr(1)
 		}
 
@@ -192,7 +192,7 @@ func needsUpdating(ctx context.Context, oldDeploymentSpec *appsv1.DeploymentSpec
 		return false, nil
 	}
 
-	return *oldDeploymentSpec.Replicas == 0 || !equality.Semantic.DeepEqual(container.Env, newEnvVars), container
+	return zero(oldDeploymentSpec.Replicas) || !equality.Semantic.DeepEqual(container.Env, newEnvVars), container
 }
 
 func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
@@ -202,4 +202,8 @@ func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
 		}
 	}
 	return nil
+}
+
+func zero(i *int32) bool {
+	return i != nil && *i == 0
 }

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -174,52 +174,6 @@ func TestAllCases(t *testing.T) {
 					WithPingSourceV1B1StatusObservedGeneration(generation),
 				),
 			}},
-		}, {
-			Name:                    "valid with cluster scope annotation, create deployment",
-			SkipNamespaceValidation: true,
-			Objects: []runtime.Object{
-				NewPingSourceV1Beta1(sourceName, testNS,
-					WithPingSourceV1B1Spec(sourcesv1beta1.PingSourceSpec{
-						Schedule: testSchedule,
-						JsonData: testData,
-						SourceSpec: duckv1.SourceSpec{
-							Sink: sinkDest,
-						},
-					}),
-					WithPingSourceV1B1UID(sourceUID),
-					WithPingSourceV1B1ObjectMetaGeneration(generation),
-				),
-				rtv1beta1.NewChannel(sinkName, testNS,
-					rtv1beta1.WithInitChannelConditions,
-					rtv1beta1.WithChannelAddress(sinkDNS),
-				),
-			},
-			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "PingSourceDeploymentCreated", `Cluster-scoped deployment created`),
-			},
-			WantCreates: []runtime.Object{
-				MakeMTAdapter(),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: NewPingSourceV1Beta1(sourceName, testNS,
-					WithPingSourceV1B1Spec(sourcesv1beta1.PingSourceSpec{
-						Schedule: testSchedule,
-						JsonData: testData,
-						SourceSpec: duckv1.SourceSpec{
-							Sink: sinkDest,
-						},
-					}),
-					WithPingSourceV1B1UID(sourceUID),
-					WithPingSourceV1B1ObjectMetaGeneration(generation),
-					// Status Update:
-					WithPingSourceV1B1NotDeployed(mtadapterName),
-					WithInitPingSourceV1B1Conditions,
-					WithPingSourceV1B1CloudEventAttributes,
-					WithPingSourceV1B1Sink(sinkURI),
-					WithPingSourceV1B1StatusObservedGeneration(generation),
-				),
-			}},
 		},
 	}
 
@@ -254,14 +208,14 @@ func MakeMTAdapter() *appsv1.Deployment {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.Namespace(),
-			Name:      "adaptername",
+			Name:      mtadapterName,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "dispatcher",
+							Name: containerName,
 							Env:  resources.MakeReceiveAdapterEnvVar(args),
 						}}}}}}
 

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+
 	"knative.dev/eventing/pkg/adapter/mtping"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -242,10 +245,26 @@ func TestAllCases(t *testing.T) {
 
 func MakeMTAdapter() *appsv1.Deployment {
 	args := resources.Args{
-		AdapterName:     mtadapterName,
 		NoShutdownAfter: mtping.GetNoShutDownAfterValue(),
 	}
-	return resources.MakeReceiveAdapter(args)
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployments",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      "adaptername",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "dispatcher",
+							Env:  resources.MakeReceiveAdapterEnvVar(args),
+						}}}}}}
+
 }
 
 func makeAvailableMTAdapter() *appsv1.Deployment {

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -67,16 +67,11 @@ var (
 )
 
 const (
-	image          = "github.com/knative/test/image"
-	mtimage        = "github.com/knative/test/mtimage"
-	sourceName     = "test-ping-source"
-	sourceUID      = "1234"
-	sourceNameLong = "test-pingserver-source-with-a-very-long-name"
-	sourceUIDLong  = "cafed00d-cafed00d-cafed00d-cafed00d-cafed00d"
-	testNS         = "testnamespace"
-	testSchedule   = "*/2 * * * *"
-	testData       = "data"
-	crName         = "knative-eventing-pingsource-adapter"
+	sourceName   = "test-ping-source"
+	sourceUID    = "1234"
+	testNS       = "testnamespace"
+	testSchedule = "*/2 * * * *"
+	testData     = "data"
 
 	sinkName   = "testsink"
 	generation = 1
@@ -229,11 +224,10 @@ func TestAllCases(t *testing.T) {
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		ctx = addressable.WithDuck(ctx)
 		r := &Reconciler{
-			kubeClientSet:       fakekubeclient.Get(ctx),
-			pingLister:          listers.GetPingSourceV1beta1Lister(),
-			deploymentLister:    listers.GetDeploymentLister(),
-			tracker:             tracker.New(func(types.NamespacedName) {}, 0),
-			receiveAdapterImage: mtimage,
+			kubeClientSet:    fakekubeclient.Get(ctx),
+			pingLister:       listers.GetPingSourceV1beta1Lister(),
+			deploymentLister: listers.GetDeploymentLister(),
+			tracker:          tracker.New(func(types.NamespacedName) {}, 0),
 		}
 		r.sinkResolver = resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
 
@@ -248,10 +242,8 @@ func TestAllCases(t *testing.T) {
 
 func MakeMTAdapter() *appsv1.Deployment {
 	args := resources.Args{
-		ServiceAccountName: mtadapterName,
-		AdapterName:        mtadapterName,
-		Image:              mtimage,
-		NoShutdownAfter:    mtping.GetNoShutDownAfterValue(),
+		AdapterName:     mtadapterName,
+		NoShutdownAfter: mtping.GetNoShutDownAfterValue(),
 	}
 	return resources.MakeReceiveAdapter(args)
 }

--- a/pkg/reconciler/pingsource/resources/receive_adapter.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter.go
@@ -21,34 +21,22 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/adapter/mtping"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/system"
 )
 
-var (
-	mtlabels = map[string]string{
-		"sources.knative.dev/role":    "adapter",
-		"eventing.knative.dev/source": controllerAgentName,
-	}
-)
-
 type Args struct {
-	ServiceAccountName string
-	AdapterName        string
-	Image              string
-	MetricsConfig      string
-	LoggingConfig      string
-	LeConfig           string
-	NoShutdownAfter    int
+	AdapterName     string
+	MetricsConfig   string
+	LoggingConfig   string
+	LeConfig        string
+	NoShutdownAfter int
 }
 
 // MakeReceiveAdapter generates the mtping deployment for pingsources
 func MakeReceiveAdapter(args Args) *v1.Deployment {
-	replicas := int32(1)
-
 	return &v1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -59,37 +47,30 @@ func MakeReceiveAdapter(args Args) *v1.Deployment {
 			Name:      args.AdapterName,
 		},
 		Spec: v1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: mtlabels,
-			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: mtlabels,
-				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Name:  "dispatcher",
-							Image: args.Image,
-							Env:   makeEnv(args),
-
-							// Set low resource requests and limits.
-							// This should be configurable.
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("125m"),
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
+							Name: "dispatcher",
+							Env: []corev1.EnvVar{{
+								Name: system.NamespaceEnvKey,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
 								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1000m"),
-									corev1.ResourceMemory: resource.MustParse("2048Mi"),
-								},
-							},
-							Ports: []corev1.ContainerPort{{
-								Name:          "metrics",
-								ContainerPort: 9090,
+							}, {
+								Name:  adapter.EnvConfigMetricsConfig,
+								Value: args.MetricsConfig,
+							}, {
+								Name:  adapter.EnvConfigLoggingConfig,
+								Value: args.LoggingConfig,
+							}, {
+								Name:  adapter.EnvConfigLeaderElectionConfig,
+								Value: args.LeConfig,
+							}, {
+								Name:  mtping.EnvNoShutdownAfter,
+								Value: strconv.Itoa(args.NoShutdownAfter),
 							}},
 						},
 					},
@@ -97,30 +78,4 @@ func MakeReceiveAdapter(args Args) *v1.Deployment {
 			},
 		},
 	}
-}
-
-func makeEnv(args Args) []corev1.EnvVar {
-	return []corev1.EnvVar{{
-		Name:  system.NamespaceEnvKey,
-		Value: system.Namespace(),
-	}, {
-		Name: adapter.EnvConfigNamespace,
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.namespace",
-			},
-		},
-	}, {
-		Name:  adapter.EnvConfigMetricsConfig,
-		Value: args.MetricsConfig,
-	}, {
-		Name:  adapter.EnvConfigLoggingConfig,
-		Value: args.LoggingConfig,
-	}, {
-		Name:  adapter.EnvConfigLeaderElectionConfig,
-		Value: args.LeConfig,
-	}, {
-		Name:  mtping.EnvNoShutdownAfter,
-		Value: strconv.Itoa(args.NoShutdownAfter),
-	}}
 }

--- a/pkg/reconciler/pingsource/resources/receive_adapter.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter.go
@@ -19,63 +19,40 @@ package resources
 import (
 	"strconv"
 
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/adapter/mtping"
 	"knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/system"
 )
 
 type Args struct {
-	AdapterName     string
 	MetricsConfig   string
 	LoggingConfig   string
 	LeConfig        string
 	NoShutdownAfter int
 }
 
-// MakeReceiveAdapter generates the mtping deployment for pingsources
-func MakeReceiveAdapter(args Args) *v1.Deployment {
-	return &v1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployments",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.Namespace(),
-			Name:      args.AdapterName,
-		},
-		Spec: v1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "dispatcher",
-							Env: []corev1.EnvVar{{
-								Name: system.NamespaceEnvKey,
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.namespace",
-									},
-								},
-							}, {
-								Name:  adapter.EnvConfigMetricsConfig,
-								Value: args.MetricsConfig,
-							}, {
-								Name:  adapter.EnvConfigLoggingConfig,
-								Value: args.LoggingConfig,
-							}, {
-								Name:  adapter.EnvConfigLeaderElectionConfig,
-								Value: args.LeConfig,
-							}, {
-								Name:  mtping.EnvNoShutdownAfter,
-								Value: strconv.Itoa(args.NoShutdownAfter),
-							}},
-						},
-					},
-				},
+// MakeReceiveAdapterEnvVar generates the environment variables for the pingsources
+func MakeReceiveAdapterEnvVar(args Args) []corev1.EnvVar {
+	return []corev1.EnvVar{{
+		Name: system.NamespaceEnvKey,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
 			},
 		},
-	}
+	}, {
+		Name:  adapter.EnvConfigMetricsConfig,
+		Value: args.MetricsConfig,
+	}, {
+		Name:  adapter.EnvConfigLoggingConfig,
+		Value: args.LoggingConfig,
+	}, {
+		Name:  adapter.EnvConfigLeaderElectionConfig,
+		Value: args.LeConfig,
+	}, {
+		Name:  mtping.EnvNoShutdownAfter,
+		Value: strconv.Itoa(args.NoShutdownAfter),
+	}}
+
 }

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -22,22 +22,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
 
 func TestMakePingAdapter(t *testing.T) {
-	replicas := int32(1)
-
 	args := Args{
-		ServiceAccountName: "test-sa",
-		AdapterName:        "test-name",
-		Image:              "test-image",
-		MetricsConfig:      "metrics",
-		LoggingConfig:      "logging",
-		NoShutdownAfter:    40,
+		AdapterName:     "test-name",
+		MetricsConfig:   "metrics",
+		LoggingConfig:   "logging",
+		NoShutdownAfter: 40,
 	}
 
 	want := &v1.Deployment{
@@ -50,25 +45,13 @@ func TestMakePingAdapter(t *testing.T) {
 			Name:      args.AdapterName,
 		},
 		Spec: v1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: mtlabels,
-			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: mtlabels,
-				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: args.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Name:  "dispatcher",
-							Image: args.Image,
+							Name: "dispatcher",
 							Env: []corev1.EnvVar{{
-								Name:  system.NamespaceEnvKey,
-								Value: system.Namespace(),
-							}, {
-								Name: "NAMESPACE",
+								Name: system.NamespaceEnvKey,
 								ValueFrom: &corev1.EnvVarSource{
 									FieldRef: &corev1.ObjectFieldSelector{
 										FieldPath: "metadata.namespace",
@@ -86,22 +69,6 @@ func TestMakePingAdapter(t *testing.T) {
 							}, {
 								Name:  "K_NO_SHUTDOWN_AFTER",
 								Value: "40",
-							}},
-							// Set low resource requests and limits.
-							// This should be configurable.
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("125m"),
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1000m"),
-									corev1.ResourceMemory: resource.MustParse("2048Mi"),
-								},
-							},
-							Ports: []corev1.ContainerPort{{
-								Name:          "metrics",
-								ContainerPort: 9090,
 							}},
 						},
 					},

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -20,64 +20,40 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
 
 func TestMakePingAdapter(t *testing.T) {
 	args := Args{
-		AdapterName:     "test-name",
 		MetricsConfig:   "metrics",
 		LoggingConfig:   "logging",
 		NoShutdownAfter: 40,
 	}
 
-	want := &v1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployments",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.Namespace(),
-			Name:      args.AdapterName,
-		},
-		Spec: v1.DeploymentSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "dispatcher",
-							Env: []corev1.EnvVar{{
-								Name: system.NamespaceEnvKey,
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.namespace",
-									},
-								},
-							}, {
-								Name:  "K_METRICS_CONFIG",
-								Value: "metrics",
-							}, {
-								Name:  "K_LOGGING_CONFIG",
-								Value: "logging",
-							}, {
-								Name:  "K_LEADER_ELECTION_CONFIG",
-								Value: "",
-							}, {
-								Name:  "K_NO_SHUTDOWN_AFTER",
-								Value: "40",
-							}},
-						},
-					},
-				},
+	want := []corev1.EnvVar{{
+		Name: system.NamespaceEnvKey,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
 			},
 		},
-	}
+	}, {
+		Name:  "K_METRICS_CONFIG",
+		Value: "metrics",
+	}, {
+		Name:  "K_LOGGING_CONFIG",
+		Value: "logging",
+	}, {
+		Name:  "K_LEADER_ELECTION_CONFIG",
+		Value: "",
+	}, {
+		Name:  "K_NO_SHUTDOWN_AFTER",
+		Value: "40",
+	}}
 
-	got := MakeReceiveAdapter(args)
+	got := MakeReceiveAdapterEnvVar(args)
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected condition (-want, +got) = %v", diff)


### PR DESCRIPTION
Fixes #3035

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- the mtping adapter is now created at installation time, replicas = 0
- the pingSource controller only updates environment variables
- the pingSource controller sets replicas to 1 (if set to 0) when first PingSource is created

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
