### PR TITLE
Switch back to sharedmain.Main for MT Broker controller

### DIFF
--- a/cmd/mtchannel_broker/main.go
+++ b/cmd/mtchannel_broker/main.go
@@ -19,24 +19,23 @@ package main
 import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"flag"
 
-	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection/sharedmain"
-	"knative.dev/pkg/signals"
 
 	"knative.dev/eventing/pkg/reconciler/mtbroker"
 	mttrigger "knative.dev/eventing/pkg/reconciler/mtbroker/trigger"
 )
 
-func main() {
-	// TODO(https://github.com/knative/eventing/issues/3591): switch back to sharedmain.Main
-	clientQPS := flag.Float64("clientQPS", float64(rest.DefaultQPS), "Overrides rest.Config.DefaultQPS.")
-	clientBurst := flag.Int("clientBurst", rest.DefaultBurst, "Overrides rest.Config.Burst.")
+const (
+	component = "mt-broker-controller"
+)
 
-	// This parses flags.
-	cfg := sharedmain.ParseAndGetConfigOrDie()
-	cfg.QPS = float32(*clientQPS)
-	cfg.Burst = *clientBurst
-	sharedmain.MainWithConfig(signals.NewContext(), "mt-broker-controller", cfg, mtbroker.NewController, mttrigger.NewController)
+func main() {
+	sharedmain.Main(
+		component,
+
+		mtbroker.NewController,
+
+		mttrigger.NewController,
+	)
 }


### PR DESCRIPTION
Burst and QPS flags were added for debugging chaos testing
failures, see https://github.com/knative/eventing/issues/3591.

Also, those configurations should probably be in the `sharedmain`
package, so that we standardize the way of configuring them
for all controllers.

## Proposed Changes

- Switch back to `sharedmain.Main` for MT Broker controller