### PR TITLE
fix log message

### DIFF
--- a/pkg/reconciler/mtbroker/trigger/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger/trigger.go
@@ -101,7 +101,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 
 	// If it's not my brokerclass, ignore
 	if b.Annotations[eventing.BrokerClassKey] != eventing.MTChannelBrokerClassValue {
-		logging.FromContext(ctx).Infow("Ignoring trigger %s/%s", t.Namespace, t.Name)
+		logging.FromContext(ctx).Infof("Ignoring trigger %s/%s", t.Namespace, t.Name)
 		return nil
 	}
 	t.Status.PropagateBrokerCondition(b.Status.GetTopLevelCondition())


### PR DESCRIPTION
Fix the incorrect message, would print %s/%s instead of t.ns/t.name

## Proposed Changes

- fix the log message
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
When not reconciling triggers not owned by my brokerclass, would print incorrect msg, logic was correct however, just wrong log message.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
