### PR TITLE
Propagate the entire delivery spec to the Channel

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -595,13 +595,9 @@ func deliverySpec(sub *v1.Subscription) *eventingduckv1beta1.DeliverySpec {
 		if delivery == nil {
 			delivery = &eventingduckv1beta1.DeliverySpec{}
 		}
-		delivery.BackoffPolicy = backoffPolicyV1Beta1(sub.Spec.Delivery.BackoffPolicy)
+		delivery.BackoffPolicy = (*eventingduckv1beta1.BackoffPolicyType)(sub.Spec.Delivery.BackoffPolicy)
 		delivery.Retry = sub.Spec.Delivery.Retry
 		delivery.BackoffDelay = sub.Spec.Delivery.BackoffDelay
 	}
 	return delivery
-}
-
-func backoffPolicyV1Beta1(policyType *eventingduckv1.BackoffPolicyType) *eventingduckv1beta1.BackoffPolicyType {
-	return (*eventingduckv1beta1.BackoffPolicyType)(policyType)
 }

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -524,6 +524,7 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, c
 				SubscriberURI:     sub.Status.PhysicalSubscription.SubscriberURI,
 				ReplyURI:          sub.Status.PhysicalSubscription.ReplyURI,
 				DeadLetterSinkURI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
+				Delivery:          deliverySpec(sub),
 			}},
 		}
 		return
@@ -536,6 +537,7 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, c
 			channel.Spec.Subscribable.Subscribers[i].SubscriberURI = sub.Status.PhysicalSubscription.SubscriberURI
 			channel.Spec.Subscribable.Subscribers[i].ReplyURI = sub.Status.PhysicalSubscription.ReplyURI
 			channel.Spec.Subscribable.Subscribers[i].DeadLetterSinkURI = sub.Status.PhysicalSubscription.DeadLetterSinkURI
+			channel.Spec.Subscribable.Subscribers[i].Delivery = deliverySpec(sub)
 			return
 		}
 	}
@@ -548,6 +550,7 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Alpha1(ctx context.Context, c
 			SubscriberURI:     sub.Status.PhysicalSubscription.SubscriberURI,
 			ReplyURI:          sub.Status.PhysicalSubscription.ReplyURI,
 			DeadLetterSinkURI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
+			Delivery:          deliverySpec(sub),
 		})
 }
 
@@ -558,15 +561,7 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, ch
 			channel.Spec.Subscribers[i].Generation = sub.Generation
 			channel.Spec.Subscribers[i].SubscriberURI = sub.Status.PhysicalSubscription.SubscriberURI
 			channel.Spec.Subscribers[i].ReplyURI = sub.Status.PhysicalSubscription.ReplyURI
-			// Only set the deadletter sink if it's not nil. Otherwise we'll just end up patching
-			// empty delivery in there.
-			if sub.Status.PhysicalSubscription.DeadLetterSinkURI != nil {
-				channel.Spec.Subscribers[i].Delivery = &eventingduckv1beta1.DeliverySpec{
-					DeadLetterSink: &duckv1.Destination{
-						URI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
-					},
-				}
-			}
+			channel.Spec.Subscribers[i].Delivery = deliverySpec(sub)
 			return
 		}
 	}
@@ -576,17 +571,37 @@ func (r *Reconciler) updateChannelAddSubscriptionV1Beta1(ctx context.Context, ch
 		Generation:    sub.Generation,
 		SubscriberURI: sub.Status.PhysicalSubscription.SubscriberURI,
 		ReplyURI:      sub.Status.PhysicalSubscription.ReplyURI,
+		Delivery:      deliverySpec(sub),
 	}
+
+	// Must not have been found. Add it.
+	channel.Spec.Subscribers = append(channel.Spec.Subscribers, toAdd)
+}
+
+func deliverySpec(sub *v1.Subscription) *eventingduckv1beta1.DeliverySpec {
+
+	var delivery *eventingduckv1beta1.DeliverySpec
+
 	// Only set the deadletter sink if it's not nil. Otherwise we'll just end up patching
 	// empty delivery in there.
 	if sub.Status.PhysicalSubscription.DeadLetterSinkURI != nil {
-		toAdd.Delivery = &eventingduckv1beta1.DeliverySpec{
+		delivery = &eventingduckv1beta1.DeliverySpec{
 			DeadLetterSink: &duckv1.Destination{
 				URI: sub.Status.PhysicalSubscription.DeadLetterSinkURI,
 			},
 		}
 	}
+	if sub.Spec.Delivery != nil && (sub.Spec.Delivery.BackoffDelay != nil || sub.Spec.Delivery.Retry != nil || sub.Spec.Delivery.BackoffPolicy != nil) {
+		if delivery == nil {
+			delivery = &eventingduckv1beta1.DeliverySpec{}
+		}
+		delivery.BackoffPolicy = backoffPolicyV1Beta1(sub.Spec.Delivery.BackoffPolicy)
+		delivery.Retry = sub.Spec.Delivery.Retry
+		delivery.BackoffDelay = sub.Spec.Delivery.BackoffDelay
+	}
+	return delivery
+}
 
-	// Must not have been found. Add it.
-	channel.Spec.Subscribers = append(channel.Spec.Subscribers, toAdd)
+func backoffPolicyV1Beta1(policyType *eventingduckv1.BackoffPolicyType) *eventingduckv1beta1.BackoffPolicyType {
+	return (*eventingduckv1beta1.BackoffPolicyType)(policyType)
 }


### PR DESCRIPTION
The subscription reconciler didn't propagate the entire `deliverySpec`
to the channel, only the `deadLetterSink` was propagated.

## Proposed Changes

- Propagate the entire delivery spec to the Channel

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

```release-note
- 🐛 Fix bug
The subscription reconciler correctly propagates delivery configurations to the channel (`retry`, `backoffDelay`, `backoffPolicy`).
```