### PR TITLE
The V1 test should actually use V1 APIs

### DIFF
--- a/test/e2e/channel_dls_test.go
+++ b/test/e2e/channel_dls_test.go
@@ -31,5 +31,5 @@ func TestChannelDeadLetterSink(t *testing.T) {
 }
 
 func TestChannelDeadLetterSinkV1(t *testing.T) {
-	helpers.ChannelDeadLetterSinkTestHelper(context.Background(), t, helpers.SubscriptionV1beta1, channelTestRunner)
+	helpers.ChannelDeadLetterSinkTestHelper(context.Background(), t, helpers.SubscriptionV1, channelTestRunner)
 }

--- a/test/e2e/channel_dls_test.go
+++ b/test/e2e/channel_dls_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // TestChannelDeadLetterSink tests DeadLetterSink
-func TestChannelDeadLetterSink(t *testing.T) {
+func TestChannelDeadLetterSinkV1Beta1(t *testing.T) {
 	helpers.ChannelDeadLetterSinkTestHelper(context.Background(), t, helpers.SubscriptionV1beta1, channelTestRunner)
 }
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- fix V1 test invoke ...
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
