### PR TITLE
Change link to GitHubSource

### DIFF
--- a/docs/source/receive-adapter.md
+++ b/docs/source/receive-adapter.md
@@ -151,7 +151,7 @@ number of receive adapter replicas for increase reliability and reducing
 downtime.
 
 The
-[GithubSource](https://github.com/knative/eventing-contrib/tree/master/github)
+[GithubSource](https://github.com/knative-sandbox/eventing-github)
 is a good example of a highly-available push-based receive adapter leveraging
 Knative Service.
 


### PR DESCRIPTION
Unblock https://github.com/knative/eventing/pull/3898 per comment https://github.com/knative/eventing/pull/3898#issuecomment-694205465.

## Proposed Changes

- Change link to GitHubSource
