### PR TITLE
Proper logging for filter handler malformed response

### DIFF
--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -279,7 +279,7 @@ func writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.R
 		n, _ := response.BodyReader.Read(body)
 		response.BodyReader.Close()
 		if n != 0 {
-			return resp.StatusCode, errors.New("Received a malformed event in reply")
+			return resp.StatusCode, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
 		}
 		return resp.StatusCode, nil
 	}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #4071

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Proper logging to explain when the user replies with a malformed response to the filter handler

