### PR TITLE
make pingsource adapter controller read-only

### DIFF
--- a/pkg/adapter/mtping/controller.go
+++ b/pkg/adapter/mtping/controller.go
@@ -66,7 +66,11 @@ func NewController(ctx context.Context, adapter adapter.Adapter) *controller.Imp
 	//	}
 	//}
 
-	impl := pingsourcereconciler.NewImpl(ctx, r)
+	impl := pingsourcereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			SkipStatusUpdates: true,
+		}
+	})
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 	pingsourceinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/adapter/mtping/pingsource.go
+++ b/pkg/adapter/mtping/pingsource.go
@@ -41,11 +41,7 @@ var _ pingsourcereconciler.Finalizer = (*Reconciler)(nil)
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1beta1.PingSource) reconciler.Event {
 	if !source.Status.IsReady() {
-		// The source might have been previously ready
-		// Make sure the adapter does not handle it
-		r.mtadapter.Remove(ctx, source)
-
-		return fmt.Errorf("PingSource is not ready")
+		return fmt.Errorf("warning: PingSource is not ready")
 	}
 
 	// Update the adapter state


### PR DESCRIPTION
Fixes #4028

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- The adapter controller does not attempt to update the CR status
- Revert to previous behavior when the source is not ready. When a pod is deleted, a source becomes temporarily not ready, leading to lost events.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
