### PR TITLE
Fix metrics port mismatch between svc and deployment in broker manifests

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -52,7 +52,7 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        - containerPort: 9090
+        - containerPort: 9092
           name: metrics
           protocol: TCP
         terminationMessagePath: /dev/termination-log

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -52,7 +52,7 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
-        - containerPort: 9090
+        - containerPort: 9092
           name: metrics
           protocol: TCP
         terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
## Proposed Changes

- Fix metrics port mismatch between svc and deployment in broker manifests

It isn't clear from the manifests whether 9090 or 9092 is preferred, but the correct port is **9092**:

https://github.com/knative/eventing/blob/af999217845dc50de712fb88afdd898f5ebd081e/cmd/mtbroker/filter/main.go#L48-L51

See also #3181