### PR TITLE
Make mt-broker labels consistent with ingress/filter

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -23,11 +23,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mt-broker-controller
+      eventing.knative.dev/brokerRole: controller
   template:
     metadata:
       labels:
-        app: mt-broker-controller
+        eventing.knative.dev/brokerRole: controller
         eventing.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.


### PR DESCRIPTION
## Proposed Changes

- Make mt-broker labels consistent with ingress/filter

Not only this makes the naming scheme consistent, but it also helps creating `PodMonitors` (Prometheus) that match all components at once.

---

edit: I forgot the selector is immutable in a deployment 🤦 If we don't have any workaround, feel free to close this.