### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -75,9 +75,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/docs/decisions/broker-trigger.md
+++ b/docs/decisions/broker-trigger.md
@@ -162,5 +162,5 @@ Accepted decisions (2+ votes)
   - Future user stories could change this and motivate a particular
     implementation.
 
-[UX Proposals Comparision](https://docs.google.com/document/d/1fRpM4u4mP2fGUBmScKQ9_e77rKz_7xh_Thwxp8QXhUA/edit#)
+[UX Proposals Comparison](https://docs.google.com/document/d/1fRpM4u4mP2fGUBmScKQ9_e77rKz_7xh_Thwxp8QXhUA/edit#)
 (includes background and discussion)

--- a/docs/planning/bug_triage.md
+++ b/docs/planning/bug_triage.md
@@ -33,7 +33,7 @@ process.
   triaged weekly (this could be modified based on incoming bugs rate), and upon
   triage will be assigned a priority or closed.
 - During each release/sprint planning, all priority/important-soon and some of
-  priority/important-longterm bugs need to be accounted while commiting to new
+  priority/important-longterm bugs need to be accounted while committing to new
   features and improvements. These will be marked with approapriate release
   along with the planned features.
 - Bugs marked with current release always take priority over feature work in a

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -332,7 +332,7 @@ function wait_for_file() {
   waits=300
   timeout=$waits
 
-  echo "Waiting for existance of file: ${file}"
+  echo "Waiting for existence of file: ${file}"
 
   while [ ! -f "${file}" ]; do
     # When the timeout is equal to zero, show an error and leave the loop.


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc n3wscott grantr matzew
/assign n3wscott grantr matzew