### PR TITLE
Move sinkbinding WithContext resolver call to Do() function

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -603,7 +603,6 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702 h1:nVgx26pAe6l/02mYomOuZssv28XkacGw/0WeiTVorqw=
 github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
 github.com/google/licenseclassifier v0.0.0-20200402202327-879cb1424de0/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
-github.com/google/licenseclassifier v0.0.0-20200708223521-3d09a0ea2f39 h1:nkr7S2ETn5pAuBeeoZggV5nXSwOm4nBLz3vscQfA/A8=
 github.com/google/licenseclassifier v0.0.0-20200708223521-3d09a0ea2f39/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
 github.com/google/mako v0.0.0-20190821191249-122f8dcef9e3 h1:/o5e44nTD/QEEiWPGSFT3bSqcq3Qg7q27N9bv4gKh5M=
 github.com/google/mako v0.0.0-20190821191249-122f8dcef9e3/go.mod h1:YzLcVlL+NqWnmUEPuhS1LxDDwGO9WNbVlEXaF4IH35g=
@@ -1448,7 +1447,6 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 h1:qDJKu1y/1SjhWac4BQZjLljqvqiWUhjmDMnonmVGDAU=
 golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/apis/sources/v1/sinkbinding_context.go
+++ b/pkg/apis/sources/v1/sinkbinding_context.go
@@ -20,16 +20,22 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/resolver"
 )
 
 // sinkURIKey is used as the key for associating information
 // with a context.Context.
 type sinkURIKey struct{}
+type resolverKey struct{}
 
 // WithSinkURI notes on the context for binding that the resolved SinkURI
 // is the provided apis.URL.
 func WithSinkURI(ctx context.Context, uri *apis.URL) context.Context {
 	return context.WithValue(ctx, sinkURIKey{}, uri)
+}
+
+func WithURIResolver(ctx context.Context, resolver *resolver.URIResolver) context.Context {
+	return context.WithValue(ctx, resolverKey{}, resolver)
 }
 
 // GetSinkURI accesses the apis.URL for the Sink URI that has been associated
@@ -40,4 +46,12 @@ func GetSinkURI(ctx context.Context) *apis.URL {
 		return nil
 	}
 	return value.(*apis.URL)
+}
+
+func GetURIResolver(ctx context.Context) *resolver.URIResolver {
+	value := ctx.Value(resolverKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*resolver.URIResolver)
 }

--- a/pkg/apis/sources/v1/sinkbinding_context_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_context_test.go
@@ -41,3 +41,12 @@ func TestGetSinkURI(t *testing.T) {
 		t.Errorf("GetSinkURI() = %v, wanted %v", got, want)
 	}
 }
+
+func TestGetURIResolver(t *testing.T) {
+	ctx := context.Background()
+
+	if resolver := GetURIResolver(ctx); resolver != nil {
+		t.Errorf("GetURIResolver() = %v, wanted nil", resolver)
+	}
+
+}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -24,8 +24,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/eventing/pkg/client/clientset/versioned/scheme"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 )
 
@@ -88,6 +92,8 @@ func TestSinkBindingSetObsGen(t *testing.T) {
 }
 
 func TestSinkBindingStatusIsReady(t *testing.T) {
+	sink := apis.HTTP("table.ns.svc.cluster.local/flip")
+	sink.Scheme = "uri"
 	tests := []struct {
 		name string
 		s    *SinkBindingStatus
@@ -105,10 +111,20 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
-		name: "mark available",
+		name: "mark binding unavailable",
 		s: func() *SinkBindingStatus {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
+			s.MarkBindingUnavailable("TheReason", "this is the message")
+			return s
+		}(),
+		want: false,
+	}, {
+		name: "mark sink",
+		s: func() *SinkBindingStatus {
+			s := &SinkBindingStatus{}
+			s.InitializeConditions()
+			s.MarkSink(sink)
 			s.MarkBindingUnavailable("TheReason", "this is the message")
 			return s
 		}(),
@@ -118,6 +134,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 		s: func() *SinkBindingStatus {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
+			s.MarkSink(sink)
 			s.MarkBindingAvailable()
 			return s
 		}(),
@@ -275,10 +292,12 @@ func TestSinkBindingUndo(t *testing.T) {
 }
 
 func TestSinkBindingDo(t *testing.T) {
-	sinkURI := &apis.URL{
-		Scheme: "http",
-		Host:   "thing.ns.svc.cluster.local",
-		Path:   "/a/path",
+	destination := duckv1.Destination{
+		URI: &apis.URL{
+			Scheme: "http",
+			Host:   "thing.ns.svc.cluster.local",
+			Path:   "/a/path",
+		},
 	}
 
 	overrides := duckv1.CloudEventOverrides{Extensions: map[string]string{"foo": "bar"}}
@@ -298,7 +317,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -317,7 +336,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -357,7 +376,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -408,7 +427,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -425,7 +444,7 @@ func TestSinkBindingDo(t *testing.T) {
 								Value: "INGA",
 							}, {
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -438,7 +457,7 @@ func TestSinkBindingDo(t *testing.T) {
 								Value: "INGA",
 							}, {
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -453,11 +472,14 @@ func TestSinkBindingDo(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.in
-
-			ctx := WithSinkURI(context.Background(), sinkURI)
+			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, got)
+			ctx = addressable.WithDuck(ctx)
+			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			ctx = WithURIResolver(context.Background(), r)
 
 			sb := &SinkBinding{Spec: SinkBindingSpec{
 				SourceSpec: duckv1.SourceSpec{
+					Sink:                destination,
 					CloudEventOverrides: &overrides,
 				},
 			}}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -25,13 +25,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/eventing/pkg/client/clientset/versioned/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 )
+
+func init() {
+	duckv1.AddToScheme(scheme.Scheme)
+}
 
 func TestSinkBindingGetConditionSet(t *testing.T) {
 	r := &SinkBinding{}

--- a/pkg/apis/sources/v1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1/sinkbinding_types.go
@@ -71,6 +71,10 @@ const (
 	// SinkBindingConditionReady is configured to indicate whether the Binding
 	// has been configured for resources subject to its runtime contract.
 	SinkBindingConditionReady = apis.ConditionReady
+
+	// SinkBindingConditionSinkProvided is configured to indicate whether the
+	// sink has been properly extracted from the resolver.
+	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
 )
 
 // SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).

--- a/pkg/apis/sources/v1beta1/sinkbinding_context.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_context.go
@@ -20,16 +20,22 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/resolver"
 )
 
 // sinkURIKey is used as the key for associating information
 // with a context.Context.
 type sinkURIKey struct{}
+type resolverKey struct{}
 
 // WithSinkURI notes on the context for binding that the resolved SinkURI
 // is the provided apis.URL.
 func WithSinkURI(ctx context.Context, uri *apis.URL) context.Context {
 	return context.WithValue(ctx, sinkURIKey{}, uri)
+}
+
+func WithURIResolver(ctx context.Context, resolver *resolver.URIResolver) context.Context {
+	return context.WithValue(ctx, resolverKey{}, resolver)
 }
 
 // GetSinkURI accesses the apis.URL for the Sink URI that has been associated
@@ -40,4 +46,12 @@ func GetSinkURI(ctx context.Context) *apis.URL {
 		return nil
 	}
 	return value.(*apis.URL)
+}
+
+func GetURIResolver(ctx context.Context) *resolver.URIResolver {
+	value := ctx.Value(resolverKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*resolver.URIResolver)
 }

--- a/pkg/apis/sources/v1beta1/sinkbinding_context_test.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_context_test.go
@@ -41,3 +41,12 @@ func TestGetSinkURI(t *testing.T) {
 		t.Errorf("GetSinkURI() = %v, wanted %v", got, want)
 	}
 }
+
+func TestGetURIResolver(t *testing.T) {
+	ctx := context.Background()
+
+	if resolver := GetURIResolver(ctx); resolver != nil {
+		t.Errorf("GetURIResolver() = %v, wanted nil", resolver)
+	}
+
+}

--- a/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
@@ -105,7 +105,7 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	}
 	uri, err := resolver.URIFromDestinationV1(ctx, sb.Spec.Sink, sb)
 	if err != nil {
-		logging.FromContext(ctx).Errorf("URI could not be extracted from destination: %w", err)
+		logging.FromContext(ctx).Errorw("URI could not be extracted from destination: ", zap.Error(err))
 		return
 	}
 	sb.Status.MarkSink(uri)

--- a/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
@@ -105,6 +105,7 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	}
 	uri, err := resolver.URIFromDestinationV1(ctx, sb.Spec.Sink, sb)
 	if err != nil {
+		logging.FromContext(ctx).Errorf("URI could not be extracted from destination: %w", err)
 		return
 	}
 	sb.Status.MarkSink(uri)

--- a/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
@@ -33,7 +33,9 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-var sbCondSet = apis.NewLivingConditionSet()
+var sbCondSet = apis.NewLivingConditionSet(
+	SinkBindingConditionSinkProvided,
+)
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
 func (*SinkBinding) GetConditionSet() apis.ConditionSet {
@@ -82,16 +84,30 @@ func (sbs *SinkBindingStatus) MarkBindingAvailable() {
 	sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionReady)
 }
 
+// MarkSink sets the condition that the source has a sink configured.
+func (sbs *SinkBindingStatus) MarkSink(uri *apis.URL) {
+	sbs.SinkURI = uri
+	if uri != nil {
+		sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionSinkProvided)
+	} else {
+		sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
+	}
+}
+
 // Do implements psbinding.Bindable
 func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	// First undo so that we can just unconditionally append below.
 	sb.Undo(ctx, ps)
 
-	uri := GetSinkURI(ctx)
-	if uri == nil {
-		logging.FromContext(ctx).Errorf("No sink URI associated with context for %+v", sb)
+	resolver := GetURIResolver(ctx)
+	if resolver == nil {
+		logging.FromContext(ctx).Errorf("No Resolver associated with context for sink: %+v", sb)
+	}
+	uri, err := resolver.URIFromDestinationV1(ctx, sb.Spec.Sink, sb)
+	if err != nil {
 		return
 	}
+	sb.Status.MarkSink(uri)
 
 	var ceOverrides string
 	if sb.Spec.CloudEventOverrides != nil {

--- a/pkg/apis/sources/v1beta1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_types.go
@@ -72,6 +72,10 @@ const (
 	// SinkBindingConditionReady is configured to indicate whether the Binding
 	// has been configured for resources subject to its runtime contract.
 	SinkBindingConditionReady = apis.ConditionReady
+
+	// SinkBindingConditionSinkProvided is configured to indicate whether the
+	// sink has been properly extracted from the resolver.
+	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
 )
 
 // SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/pkg/apis/sources/v1beta1"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -100,7 +99,7 @@ func NewController(
 	}
 
 	c.WithContext = func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1beta1.WithURIResolver(ctx, sbResolver), nil
+		return v1.WithURIResolver(ctx, sbResolver), nil
 	}
 	c.Tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 	c.Factory = &duck.CachedInformerFactory{
@@ -135,14 +134,14 @@ func ListAll(ctx context.Context, handler cache.ResourceEventHandler) psbinding.
 
 func WithContextFactory(ctx context.Context, handler func(types.NamespacedName)) psbinding.BindableContext {
 	r := resolver.NewURIResolver(ctx, handler)
+
 	return func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
 		return v1.WithURIResolver(ctx, r), nil
 	}
 }
 
 func (s *SinkBindingSubResourcesReconciler) Reconcile(ctx context.Context, b psbinding.Bindable) error {
-	sb := b.(*v1beta1.SinkBinding)
-	r := v1.GetURIResolver(ctx)
+	sb := b.(*v1.SinkBinding)
 	if s.res == nil {
 		err := fmt.Errorf("Resolver is nil")
 		logging.FromContext(ctx).Errorf("%w", err)


### PR DESCRIPTION
By moving this call to the sinkbinding lifecycle, we avoid an error condition where WithContext cannot fetch the sinkURI (for whatever reason).  Moving that instead to the Do method where we can properly catch these kinds of errors