### PR TITLE
[WIP] Set channel address before marking channel status condition

### DIFF
--- a/pkg/apis/messaging/v1/channel_lifecycle.go
+++ b/pkg/apis/messaging/v1/channel_lifecycle.go
@@ -101,6 +101,11 @@ func (cs *ChannelStatus) MarkBackingChannelReady() {
 }
 
 func (cs *ChannelStatus) PropagateStatuses(chs *eventingduck.ChannelableStatus) {
+	// Set the address and update the Addressable conditions.
+	cs.SetAddress(chs.AddressStatus.Address)
+	// Set the subscribable status.
+	cs.SubscribableStatus = chs.SubscribableStatus
+
 	// TODO: Once you can get a Ready status from Channelable in a generic way, use it here.
 	readyCondition := chs.Status.GetCondition(apis.ConditionReady)
 	if readyCondition == nil {
@@ -117,8 +122,4 @@ func (cs *ChannelStatus) PropagateStatuses(chs *eventingduck.ChannelableStatus) 
 			cs.MarkBackingChannelUnknown("BackingChannelUnknown", "The status of BackingChannel is invalid: %v", readyCondition.Status)
 		}
 	}
-	// Set the address and update the Addressable conditions.
-	cs.SetAddress(chs.AddressStatus.Address)
-	// Set the subscribable status.
-	cs.SubscribableStatus = chs.SubscribableStatus
 }

--- a/pkg/apis/messaging/v1beta1/channel_lifecycle.go
+++ b/pkg/apis/messaging/v1beta1/channel_lifecycle.go
@@ -101,6 +101,11 @@ func (cs *ChannelStatus) MarkBackingChannelReady() {
 }
 
 func (cs *ChannelStatus) PropagateStatuses(chs *eventingduck.ChannelableStatus) {
+	// Set the address and update the Addressable conditions.
+	cs.SetAddress(chs.AddressStatus.Address)
+	// Set the subscribable status.
+	cs.SubscribableStatus = chs.SubscribableStatus
+
 	// TODO: Once you can get a Ready status from Channelable in a generic way, use it here.
 	readyCondition := chs.Status.GetCondition(apis.ConditionReady)
 	if readyCondition == nil {
@@ -117,8 +122,4 @@ func (cs *ChannelStatus) PropagateStatuses(chs *eventingduck.ChannelableStatus) 
 			cs.MarkBackingChannelUnknown("BackingChannelUnknown", "The status of BackingChannel is invalid: %v", readyCondition.Status)
 		}
 	}
-	// Set the address and update the Addressable conditions.
-	cs.SetAddress(chs.AddressStatus.Address)
-	// Set the subscribable status.
-	cs.SubscribableStatus = chs.SubscribableStatus
 }


### PR DESCRIPTION
Fixes #4059 and likely a few others channel-related flaky tests.

## Proposed Changes

- Set channel address in status before declaring channel status condition.