### PR TITLE
Revert the "Revert "Remove deprecated annotation"" PR 

### DIFF
--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -28,9 +28,6 @@ const (
 	// DependencyAnnotation is the annotation key used to mark the sources that the Trigger depends on.
 	// This will be used when the kn client creates a source and trigger pair for the user such that the trigger only receives events produced by the paired source.
 	DependencyAnnotation = "knative.dev/dependency"
-	// DeprecatedInjectionAnnotation
-	// Deprecated: v0.16, please use InjectionAnnotation.
-	DeprecatedInjectionAnnotation = "knative-eventing-injection"
 
 	// InjectionAnnotation is the annotation key used to enable knative eventing
 	// injection for a namespace to automatically create a broker.

--- a/pkg/apis/eventing/v1/trigger_validation.go
+++ b/pkg/apis/eventing/v1/trigger_validation.go
@@ -37,7 +37,6 @@ var (
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs := t.Spec.Validate(ctx).ViaField("spec")
 	errs = t.validateAnnotation(errs, DependencyAnnotation, t.validateDependencyAnnotation)
-	errs = t.validateAnnotation(errs, DeprecatedInjectionAnnotation, t.validateInjectionAnnotation)
 	errs = t.validateAnnotation(errs, InjectionAnnotation, t.validateInjectionAnnotation)
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Trigger)

--- a/pkg/apis/eventing/v1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1/trigger_validation_test.go
@@ -200,23 +200,6 @@ func TestTriggerValidation(t *testing.T) {
 				Message: "missing field(s)",
 			},
 		}, {
-			name: "invalid injection annotation value - deprecated",
-			t: &Trigger{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test-ns",
-					Annotations: map[string]string{
-						DeprecatedInjectionAnnotation: invalidInjectionAnnotation,
-					}},
-				Spec: TriggerSpec{
-					Broker:     "default",
-					Filter:     validEmptyFilter,
-					Subscriber: validSubscriber,
-				}},
-			want: &apis.FieldError{
-				Paths:   []string{fmt.Sprintf("metadata.annotations[%s]", DeprecatedInjectionAnnotation)},
-				Message: "The provided injection annotation value can only be \"enabled\" or \"disabled\", not \"wut\"",
-			},
-		}, {
 			name: "invalid injection annotation value",
 			t: &Trigger{
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/apis/eventing/v1beta1/trigger_types.go
+++ b/pkg/apis/eventing/v1beta1/trigger_types.go
@@ -31,10 +31,6 @@ const (
 
 	// These are copied from ./pkg/reconcilers/sugar
 
-	// DeprecatedInjectionAnnotation
-	// Deprecated: v0.16, please use InjectionAnnotation.
-	DeprecatedInjectionAnnotation = "knative-eventing-injection"
-
 	// InjectionAnnotation is the annotation key used to enable knative eventing
 	// injection for a namespace to automatically create a broker.
 	InjectionAnnotation = "eventing.knative.dev/injection"

--- a/pkg/apis/eventing/v1beta1/trigger_validation.go
+++ b/pkg/apis/eventing/v1beta1/trigger_validation.go
@@ -37,7 +37,6 @@ var (
 func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs := t.Spec.Validate(ctx).ViaField("spec")
 	errs = t.validateAnnotation(errs, DependencyAnnotation, t.validateDependencyAnnotation)
-	errs = t.validateAnnotation(errs, DeprecatedInjectionAnnotation, t.validateInjectionAnnotation)
 	errs = t.validateAnnotation(errs, InjectionAnnotation, t.validateInjectionAnnotation)
 	return errs
 }

--- a/pkg/apis/eventing/v1beta1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1beta1/trigger_validation_test.go
@@ -214,23 +214,6 @@ func TestTriggerValidation(t *testing.T) {
 				Paths:   []string{injectionAnnotationPath},
 				Message: "The provided injection annotation value can only be \"enabled\" or \"disabled\", not \"wut\"",
 			},
-		}, {
-			name: "invalid injection annotation value",
-			t: &Trigger{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test-ns",
-					Annotations: map[string]string{
-						DeprecatedInjectionAnnotation: invalidInjectionAnnotation,
-					}},
-				Spec: TriggerSpec{
-					Broker:     "default",
-					Filter:     validEmptyFilter,
-					Subscriber: validSubscriber,
-				}},
-			want: &apis.FieldError{
-				Paths:   []string{fmt.Sprintf("metadata.annotations[%s]", DeprecatedInjectionAnnotation)},
-				Message: "The provided injection annotation value can only be \"enabled\" or \"disabled\", not \"wut\"",
-			},
 		},
 	}
 

--- a/pkg/reconciler/sugar/filters_test.go
+++ b/pkg/reconciler/sugar/filters_test.go
@@ -38,18 +38,6 @@ func TestOnByDefault(t *testing.T) {
 			},
 			want: true,
 		},
-		"deprecated, enabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionEnabledLabelValue,
-			},
-			want: true,
-		},
-		"deprecated, disabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionDisabledLabelValue,
-			},
-			want: false,
-		},
 		"labeled, enabled": {
 			given: map[string]string{
 				InjectionLabelKey: InjectionEnabledLabelValue,
@@ -59,20 +47,6 @@ func TestOnByDefault(t *testing.T) {
 		"labeled, disabled": {
 			given: map[string]string{
 				InjectionLabelKey: InjectionDisabledLabelValue,
-			},
-			want: false,
-		},
-		"double labeled, fqn wins, enabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionDisabledLabelValue,
-				InjectionLabelKey:           InjectionEnabledLabelValue,
-			},
-			want: true,
-		},
-		"double labeled, fqn wins, disabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionEnabledLabelValue,
-				InjectionLabelKey:           InjectionDisabledLabelValue,
 			},
 			want: false,
 		},
@@ -105,18 +79,6 @@ func TestOffByDefault(t *testing.T) {
 			},
 			want: false,
 		},
-		"deprecated, enabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionEnabledLabelValue,
-			},
-			want: true,
-		},
-		"deprecated, disabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionDisabledLabelValue,
-			},
-			want: false,
-		},
 		"labeled, enabled": {
 			given: map[string]string{
 				InjectionLabelKey: InjectionEnabledLabelValue,
@@ -126,20 +88,6 @@ func TestOffByDefault(t *testing.T) {
 		"labeled, disabled": {
 			given: map[string]string{
 				InjectionLabelKey: InjectionDisabledLabelValue,
-			},
-			want: false,
-		},
-		"double labeled, fqn wins, enabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionDisabledLabelValue,
-				InjectionLabelKey:           InjectionEnabledLabelValue,
-			},
-			want: true,
-		},
-		"double labeled, fqn wins, disabled": {
-			given: map[string]string{
-				DeprecatedInjectionLabelKey: InjectionEnabledLabelValue,
-				InjectionLabelKey:           InjectionDisabledLabelValue,
 			},
 			want: false,
 		},

--- a/pkg/reconciler/sugar/labels.go
+++ b/pkg/reconciler/sugar/labels.go
@@ -18,20 +18,14 @@ package sugar
 
 const (
 	// Label to enable Knative Eventing in a Namespace.
-	// DeprecatedInjectionLabelKey, fully qualified label keys recommended.
-	// Please use InjectionLabelKey.
-	DeprecatedInjectionLabelKey = "knative-eventing-injection"
 	InjectionLabelKey           = "eventing.knative.dev/injection"
 	InjectionEnabledLabelValue  = "enabled"
 	InjectionDisabledLabelValue = "disabled"
 )
 
 func InjectionLabelKeys() []string {
-	// Note: InjectionLabelKey needs to be first, order matters for conflicts
-	// with DeprecatedInjectionLabelKey. InjectionLabelKey should win.
 	return []string{
 		InjectionLabelKey,
-		DeprecatedInjectionLabelKey,
 	}
 }
 

--- a/pkg/reconciler/sugar/trigger/trigger_test.go
+++ b/pkg/reconciler/sugar/trigger/trigger_test.go
@@ -88,7 +88,7 @@ func TestEnabledByDefault(t *testing.T) {
 		Name: "Trigger is deleted no resources",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionEnabledLabelValue),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionEnabledLabelValue),
 				WithTriggerDeleted),
 		},
 		Key: testNS + "/" + triggerName,
@@ -96,7 +96,7 @@ func TestEnabledByDefault(t *testing.T) {
 		Name: "Trigger enabled",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionEnabledLabelValue)),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionEnabledLabelValue)),
 		},
 		Key:                     testNS + "/" + triggerName,
 		SkipNamespaceValidation: true,
@@ -111,7 +111,7 @@ func TestEnabledByDefault(t *testing.T) {
 		Name: "Trigger enabled, broker exists",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionEnabledLabelValue),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionEnabledLabelValue),
 			),
 			resources.MakeBroker(testNS, resources.DefaultBrokerName),
 		},
@@ -122,7 +122,7 @@ func TestEnabledByDefault(t *testing.T) {
 		Name: "Trigger enabled, broker exists with no label",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionDisabledLabelValue)),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionDisabledLabelValue)),
 			&v1beta1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNS,
@@ -179,13 +179,6 @@ func TestDisabledByDefault(t *testing.T) {
 		},
 		Key: testNS + "/" + triggerName,
 	}, {
-		Name: "Trigger is labeled disabled - deprecated",
-		Objects: []runtime.Object{
-			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionDisabledLabelValue)),
-		},
-		Key: testNS + "/" + triggerName,
-	}, {
 		Name: "Trigger is deleted no resources",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
@@ -194,10 +187,10 @@ func TestDisabledByDefault(t *testing.T) {
 		},
 		Key: testNS + "/" + triggerName,
 	}, {
-		Name: "Trigger enabled - deprecated",
+		Name: "Trigger enabled",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionEnabledLabelValue)),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionEnabledLabelValue)),
 		},
 		Key:                     testNS + "/" + triggerName,
 		SkipNamespaceValidation: true,
@@ -212,7 +205,7 @@ func TestDisabledByDefault(t *testing.T) {
 		Name: "Trigger enabled, broker exists",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionEnabledLabelValue)),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionEnabledLabelValue)),
 			resources.MakeBroker(testNS, resources.DefaultBrokerName),
 		},
 		Key:                     testNS + "/" + triggerName,
@@ -222,7 +215,7 @@ func TestDisabledByDefault(t *testing.T) {
 		Name: "Trigger enabled, broker exists with no label",
 		Objects: []runtime.Object{
 			NewTrigger(triggerName, testNS, brokerName,
-				WithAnnotation(sugar.DeprecatedInjectionLabelKey, sugar.InjectionDisabledLabelValue)),
+				WithAnnotation(sugar.InjectionLabelKey, sugar.InjectionDisabledLabelValue)),
 			&v1beta1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNS,


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #3874

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- remove deprecated code

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🗑️ Remove feature or internal logic

The deprecated `knative-eventing-injection` annotation is now removed. Make sure to use the `eventing.knative.dev/injection` annotation instead
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
