### PR TITLE
Properly define linear backoff in documentation

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -74,8 +74,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: ' BackoffPolicy is the retry backoff policy (linear,

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -83,8 +83,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: BackoffPolicy is the retry backoff policy (linear,

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -54,9 +54,9 @@ spec:
                               retrying. More information on Duration format:
                               - https://www.iso.org/iso-8601-date-and-time-format.html
                               - https://en.wikipedia.org/wiki/ISO_8601  For
-                              linear policy, backoff delay is the time interval
-                              between retries. For exponential policy ,
-                              backoff delay is backoffDelay*2^<numberOfRetries>.'
+                              linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+                              For exponential policy, backoff delay is
+                              backoffDelay*2^<numberOfRetries>.'
                           type: string
                         backoffPolicy:
                           description: BackoffPolicy is the retry backoff

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -110,9 +110,9 @@ spec:
                               retrying. More information on Duration format:
                               - https://www.iso.org/iso-8601-date-and-time-format.html
                               - https://en.wikipedia.org/wiki/ISO_8601  For
-                              linear policy, backoff delay is the time interval
-                              between retries. For exponential policy ,
-                              backoff delay is backoffDelay*2^<numberOfRetries>.'
+                              linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+                              For exponential policy, backoff delay is
+                              backoffDelay*2^<numberOfRetries>.'
                           type: string
                         backoffPolicy:
                           description: BackoffPolicy is the retry backoff

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -52,9 +52,9 @@ spec:
               channel:
                 description: 'Reference to a channel that will be used to create the
                     subscription You can specify only the following fields of the
-                    ObjectReference: 
-                      - Kind 
-                      - APIVersion 
+                    ObjectReference:
+                      - Kind
+                      - APIVersion
                       - Name The resource pointed
                     by this ObjectReference must meet the contract to the ChannelableSpec
                     duck type. If the resource does not meet this contract it will
@@ -106,8 +106,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: 'BackoffPolicy is the retry backoff policy (linear,

--- a/config/pre-install/v0.18.0/broker.yaml
+++ b/config/pre-install/v0.18.0/broker.yaml
@@ -74,8 +74,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: ' BackoffPolicy is the retry backoff policy (linear,

--- a/config/pre-install/v0.18.0/channel.yaml
+++ b/config/pre-install/v0.18.0/channel.yaml
@@ -83,8 +83,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: BackoffPolicy is the retry backoff policy (linear,

--- a/config/pre-install/v0.18.0/parallel.yaml
+++ b/config/pre-install/v0.18.0/parallel.yaml
@@ -54,9 +54,9 @@ spec:
                               retrying. More information on Duration format:
                               - https://www.iso.org/iso-8601-date-and-time-format.html
                               - https://en.wikipedia.org/wiki/ISO_8601  For
-                              linear policy, backoff delay is the time interval
-                              between retries. For exponential policy ,
-                              backoff delay is backoffDelay*2^<numberOfRetries>.'
+                              linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+                              For exponential policy, backoff delay is
+                              backoffDelay*2^<numberOfRetries>.'
                           type: string
                         backoffPolicy:
                           description: BackoffPolicy is the retry backoff

--- a/config/pre-install/v0.18.0/sequence.yaml
+++ b/config/pre-install/v0.18.0/sequence.yaml
@@ -110,9 +110,9 @@ spec:
                               retrying. More information on Duration format:
                               - https://www.iso.org/iso-8601-date-and-time-format.html
                               - https://en.wikipedia.org/wiki/ISO_8601  For
-                              linear policy, backoff delay is the time interval
-                              between retries. For exponential policy ,
-                              backoff delay is backoffDelay*2^<numberOfRetries>.'
+                              linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+                              For exponential policy, backoff delay is
+                              backoffDelay*2^<numberOfRetries>.'
                           type: string
                         backoffPolicy:
                           description: BackoffPolicy is the retry backoff

--- a/config/pre-install/v0.18.0/subscription.yaml
+++ b/config/pre-install/v0.18.0/subscription.yaml
@@ -52,9 +52,9 @@ spec:
               channel:
                 description: 'Reference to a channel that will be used to create the
                     subscription You can specify only the following fields of the
-                    ObjectReference: 
-                      - Kind 
-                      - APIVersion 
+                    ObjectReference:
+                      - Kind
+                      - APIVersion
                       - Name The resource pointed
                     by this ObjectReference must meet the contract to the ChannelableSpec
                     duck type. If the resource does not meet this contract it will
@@ -106,8 +106,8 @@ spec:
                     description: 'BackoffDelay is the delay before retrying. More
                         information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
                         - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is the time interval between retries. For
-                        exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                        backoff delay is backoffDelay*<numberOfRetries>. For
+                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
                     description: 'BackoffPolicy is the retry backoff policy (linear,

--- a/docs/delivery/README.md
+++ b/docs/delivery/README.md
@@ -100,8 +100,8 @@ type DeliverySpec struct {
 	//  - https://www.iso.org/iso-8601-date-and-time-format.html
 	//  - https://en.wikipedia.org/wiki/ISO_8601
 	//
-	// For linear policy, backoff delay is the time interval between retries.
-	// For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>
+	// For linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+	// For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.
 	// +optional
 	BackoffDelay *string `json:"backoffDelay,omitempty"`
 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -223,7 +223,7 @@ retrieved from ref.
 | deadLetterSink | Destination   | DeadLetterSink is the sink receiving event that could not be sent to a destination.                                                                 |             |
 | retry          | String        | Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.                    |             |
 | backoffPolicy  | BackoffPolicy | BackoffPolicy is the retry backoff policy (linear, exponential).                                                                                    |             |
-| backoffDelay   | String        | For linear policy, backoff delay is the time interval between retries. For exponential policy , backoff delay is backoffDelay\*2^<numberOfRetries>. |             |
+| backoffDelay   | String        | For linear policy, backoff delay is backoffDelay\*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay\*2^<numberOfRetries>. |             |
 
 ### duck.SubscriberSpec
 

--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -46,8 +46,8 @@ type DeliverySpec struct {
 	//  - https://www.iso.org/iso-8601-date-and-time-format.html
 	//  - https://en.wikipedia.org/wiki/ISO_8601
 	//
-	// For linear policy, backoff delay is the time interval between retries.
-	// For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.
+	// For linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+	// For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.
 	// +optional
 	BackoffDelay *string `json:"backoffDelay,omitempty"`
 }

--- a/pkg/apis/duck/v1beta1/delivery_types.go
+++ b/pkg/apis/duck/v1beta1/delivery_types.go
@@ -47,8 +47,8 @@ type DeliverySpec struct {
 	//  - https://www.iso.org/iso-8601-date-and-time-format.html
 	//  - https://en.wikipedia.org/wiki/ISO_8601
 	//
-	// For linear policy, backoff delay is the time interval between retries.
-	// For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.
+	// For linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+	// For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.
 	// +optional
 	BackoffDelay *string `json:"backoffDelay,omitempty"`
 }


### PR DESCRIPTION
The current delivery spec documentation confuses linear backoff with constant backoff. In linear backoff, the delay between retries grows linearly; in constant backoff, the delay between retries is constant. This change proposes correcting the definition.

## Proposed Changes

- Update all documentation references to the backoff delay to properly define linear backoff