### PR TITLE
Reject negative Retry config

### DIFF
--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -60,6 +60,11 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 	if dlse := ds.DeadLetterSink.Validate(ctx); dlse != nil {
 		errs = errs.Also(dlse).ViaField("deadLetterSink")
 	}
+
+	if ds.Retry != nil && *ds.Retry < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*ds.Retry, "retry"))
+	}
+
 	if ds.BackoffPolicy != nil {
 		switch *ds.BackoffPolicy {
 		case BackoffPolicyExponential, BackoffPolicyLinear:
@@ -68,6 +73,7 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 			errs = errs.Also(apis.ErrInvalidValue(*ds.BackoffPolicy, "backoffPolicy"))
 		}
 	}
+
 	if ds.BackoffDelay != nil {
 		_, te := period.Parse(*ds.BackoffDelay)
 		if te != nil {

--- a/pkg/apis/duck/v1/delivery_types_test.go
+++ b/pkg/apis/duck/v1/delivery_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -63,6 +64,18 @@ func TestDeliverySpecValidation(t *testing.T) {
 		want: func() *apis.FieldError {
 			return apis.ErrGeneric("invalid value: "+invalidBackoffDelay, "backoffDelay")
 		}(),
+	}, {
+		name: "negative retry",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(-1)},
+		want: func() *apis.FieldError {
+			return apis.ErrGeneric("invalid value: -1", "retry")
+		}(),
+	}, {
+		name: "valid retry 0",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(0)},
+	}, {
+		name: "valid retry 1",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(1)},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/duck/v1beta1/delivery_types.go
+++ b/pkg/apis/duck/v1beta1/delivery_types.go
@@ -61,6 +61,11 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 	if dlse := ds.DeadLetterSink.Validate(ctx); dlse != nil {
 		errs = errs.Also(dlse).ViaField("deadLetterSink")
 	}
+
+	if ds.Retry != nil && *ds.Retry < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*ds.Retry, "retry"))
+	}
+
 	if ds.BackoffPolicy != nil {
 		switch *ds.BackoffPolicy {
 		case BackoffPolicyExponential, BackoffPolicyLinear:
@@ -69,6 +74,7 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 			errs = errs.Also(apis.ErrInvalidValue(*ds.BackoffPolicy, "backoffPolicy"))
 		}
 	}
+
 	if ds.BackoffDelay != nil {
 		_, te := period.Parse(*ds.BackoffDelay)
 		if te != nil {

--- a/pkg/apis/duck/v1beta1/delivery_types_test.go
+++ b/pkg/apis/duck/v1beta1/delivery_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -63,6 +64,18 @@ func TestDeliverySpecValidation(t *testing.T) {
 		want: func() *apis.FieldError {
 			return apis.ErrGeneric("invalid value: "+invalidBackoffDelay, "backoffDelay")
 		}(),
+	}, {
+		name: "negative retry",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(-1)},
+		want: func() *apis.FieldError {
+			return apis.ErrGeneric("invalid value: -1", "retry")
+		}(),
+	}, {
+		name: "valid retry 0",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(0)},
+	}, {
+		name: "valid retry 1",
+		spec: &DeliverySpec{Retry: pointer.Int32Ptr(1)},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
A user can specify a negative number of retries without getting any
validation error. This PR adds a check to validate that
`deliverySpec.retry` is a non negative integer.

## Proposed Changes

- Reject negative Retry config

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

```release-note
- 🧽 Update or clean up current behavior
DeliverySpec validation rejects a negative retry config.
```