### PR TITLE
Adopt Resource Model for Broker and Trigger Metrics

### DIFF
--- a/vendor/knative.dev/pkg/controller/controller.go
+++ b/vendor/knative.dev/pkg/controller/controller.go
@@ -266,7 +266,7 @@ func (c *Impl) EnqueueAfter(obj interface{}, after time.Duration) {
 func (c *Impl) EnqueueSlowKey(key types.NamespacedName) {
 	c.workQueue.SlowLane().Add(key)
 	c.logger.With(zap.String(logkey.Key, key.String())).
-		Debugf("Adding to the slow queue %s (depth(total/slow): %d/%d)",
+		Infof("Adding to the slow queue %s (depth(total/slow): %d/%d)",
 			safeKey(key), c.workQueue.Len(), c.workQueue.SlowLane().Len())
 }
 
@@ -400,6 +400,7 @@ func (c *Impl) EnqueueKey(key types.NamespacedName) {
 // MaybeEnqueueBucketKey takes a Bucket and namespace/name string and puts it onto
 // the slow work queue.
 func (c *Impl) MaybeEnqueueBucketKey(bkt reconciler.Bucket, key types.NamespacedName) {
+	c.logger.Infof("Enqueueing bucket key")
 	if bkt.Has(key) {
 		c.EnqueueSlowKey(key)
 	}
@@ -455,7 +456,7 @@ func (c *Impl) RunContext(ctx context.Context, threadiness int) error {
 
 	c.logger.Info("Started workers")
 	<-ctx.Done()
-	c.logger.Info("Shutting down workers")
+	c.logger.Infow("Shutting down workers", "err", ctx.Err())
 
 	return nil
 }

--- a/vendor/knative.dev/pkg/webhook/certificates/certificates.go
+++ b/vendor/knative.dev/pkg/webhook/certificates/certificates.go
@@ -52,10 +52,12 @@ var _ pkgreconciler.LeaderAware = (*reconciler)(nil)
 
 // Reconcile implements controller.Reconciler
 func (r *reconciler) Reconcile(ctx context.Context, key string) error {
+	logging.FromContext(ctx).Infof("Reconciling cert", "key", key)
 	if r.IsLeaderFor(r.key) {
 		// only reconciler the certificate when we are leader.
 		return r.reconcileCertificate(ctx)
 	}
+	logging.FromContext(ctx).Warnf("Not leader", r.key)
 	return nil
 }
 


### PR DESCRIPTION
See https://github.com/knative/pkg/pull/1392

## Proposed Changes

- Use knative_broker and knative_trigger OpenCensus resources when reporting ingress and filter metrics.
