### PR TITLE
Added log on completed assertions in EventInfoStore

### DIFF
--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -19,7 +19,6 @@ package recordevents
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -242,28 +241,31 @@ func (ei *EventInfoStore) Find(matchers ...EventInfoMatcher) ([]EventInfo, Searc
 // Assert that there are at least min number of match for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertAtLeast(min int, matchers ...EventInfoMatcher) []EventInfo {
+	ei.tb.Helper()
 	events, err := ei.waitAtLeastNMatch(AllOf(matchers...), min)
 	if err != nil {
 		ei.tb.Fatalf("Timeout waiting for at least %d matches.\nError: %+v", min, errors.WithStack(err))
 	}
-	ei.logAssertCompleted()
+	ei.tb.Logf("Assert passed")
 	return events
 }
 
 // Assert that there are at least min number of matches and at most max number of matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertInRange(min int, max int, matchers ...EventInfoMatcher) []EventInfo {
+	ei.tb.Helper()
 	events := ei.AssertAtLeast(min, matchers...)
 	if max > 0 && len(events) > max {
 		ei.tb.Fatalf("Assert in range failed: %+v", errors.WithStack(fmt.Errorf("expected <= %d events, saw %d", max, len(events))))
 	}
-	ei.logAssertCompleted()
+	ei.tb.Logf("Assert passed")
 	return events
 }
 
 // Assert that there aren't any matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertNot(matchers ...EventInfoMatcher) []EventInfo {
+	ei.tb.Helper()
 	res, recentEvents, _, err := ei.Find(matchers...)
 	if err != nil {
 		ei.tb.Fatalf("Unexpected error during find on recordevents '%s': %+v", ei.podName, errors.WithStack(err))
@@ -274,15 +276,16 @@ func (ei *EventInfoStore) AssertNot(matchers ...EventInfoMatcher) []EventInfo {
 			fmt.Errorf("Unexpected matches on recordevents '%s', found: %v. %s", ei.podName, res, &recentEvents)),
 		)
 	}
-	ei.logAssertCompleted()
+	ei.tb.Logf("Assert passed")
 	return res
 }
 
 // Assert that there are exactly n matches for the provided matchers.
 // This method fails the test if the assert is not fulfilled.
 func (ei *EventInfoStore) AssertExact(n int, matchers ...EventInfoMatcher) []EventInfo {
+	ei.tb.Helper()
 	events := ei.AssertInRange(n, n, matchers...)
-	ei.logAssertCompleted()
+	ei.tb.Logf("Assert passed")
 	return events
 }
 
@@ -316,15 +319,6 @@ func (ei *EventInfoStore) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]Even
 		return true, nil
 	})
 	return matchRet, internalErr
-}
-
-// This function prints the place where the assert was invoked
-func (ei *EventInfoStore) logAssertCompleted() {
-	const depth = 1
-	var pcs [depth]uintptr
-	_ = runtime.Callers(3, pcs[:])
-	f := errors.Frame(pcs[0])
-	ei.tb.Logf("Assert passed: %n at %v", f, f)
 }
 
 func formatErrors(errs []error) string {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This simplifies a bit the diagnostic of completed and failed assertions

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Added a log line to identify succeeded assertions

```
    event_info_store.go:327: Assert passed: SingleEventForChannelTestHelper.func1 at channel_single_event_helper.go:123
```