### PR TITLE
Decouple upgrade test prober from tests

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -135,7 +135,7 @@ func (c *Client) runCleanup() (err error) {
 func getTracingConfig(c *kubernetes.Clientset) (corev1.EnvVar, error) {
 	cm, err := c.CoreV1().ConfigMaps(resources.SystemNamespace).Get(context.Background(), "config-tracing", metav1.GetOptions{})
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while retrieving the config-tracing config map: %+v", errors.WithStack(err))
+		return corev1.EnvVar{}, fmt.Errorf("error while retrieving the config-tracing config map in namespace %s: %+v", resources.SystemNamespace, errors.WithStack(err))
 	}
 
 	config, err := configtracing.NewTracingConfigFromConfigMap(cm)

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -79,7 +79,7 @@ func removeProbeWithEventsValidation(t *testing.T, p prober.Prober, failOnErrors
 	p.Remove()
 }
 
-// assertEventProber will send finish event and then verify if all events propagated well
+// assertEventProber verifies if all events are propagated correctly
 func assertEventProber(t *testing.T, p prober.Prober, failOnErrors bool) {
 	errs, events := parseReport(p.Verify())
 	if len(errs) == 0 {
@@ -96,7 +96,7 @@ func reportErrors(t *testing.T, errors []error, failOnErrors bool) {
 		if failOnErrors {
 			t.Error(err)
 		} else {
-			Log.Warnf("Silenced FAIL: %v", err)
+			Log.Warn("Silenced FAIL: ", err)
 		}
 	}
 	if len(errors) > 0 && !failOnErrors {

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -46,17 +46,17 @@ var (
 	brokerName = "default"
 )
 
-func (p *prober) deployConfiguration() {
+func (p *Prober) deployConfiguration() {
 	p.deployBroker()
 	p.deployConfigMap()
 	p.deployTriggers()
 }
 
-func (p *prober) deployBroker() {
+func (p *Prober) deployBroker() {
 	p.client.CreateBrokerV1Beta1OrFail(brokerName)
 }
 
-func (p *prober) fetchBrokerUrl() (*apis.URL, error) {
+func (p *Prober) fetchBrokerUrl() (*apis.URL, error) {
 	namespace := p.config.Namespace
 	p.log.Debugf("Fetching %s broker URL for ns %s", brokerName, namespace)
 	meta := resources.NewMetaResource(brokerName, p.config.Namespace, testlib.BrokerTypeMeta)
@@ -73,7 +73,7 @@ func (p *prober) fetchBrokerUrl() (*apis.URL, error) {
 	return url, nil
 }
 
-func (p *prober) deployConfigMap() {
+func (p *Prober) deployConfigMap() {
 	name := configName
 	p.log.Infof("Deploying config map: \"%s/%s\"", p.config.Namespace, name)
 	brokerUrl, err := p.fetchBrokerUrl()
@@ -82,7 +82,7 @@ func (p *prober) deployConfigMap() {
 	p.client.CreateConfigMapOrFail(name, p.config.Namespace, map[string]string{configFilename: configData})
 }
 
-func (p *prober) deployTriggers() {
+func (p *Prober) deployTriggers() {
 	for _, eventType := range eventTypes {
 		name := fmt.Sprintf("wathola-trigger-%v", eventType)
 		fullType := fmt.Sprintf("%v.%v", watholaEventNs, eventType)
@@ -101,7 +101,7 @@ func (p *prober) deployTriggers() {
 	}
 }
 
-func (p *prober) compileTemplate(templateName string, brokerUrl *apis.URL) string {
+func (p *Prober) compileTemplate(templateName string, brokerUrl *apis.URL) string {
 	_, filename, _, _ := runtime.Caller(0)
 	templateFilepath := path.Join(path.Dir(filename), templateName)
 	templateBytes, err := ioutil.ReadFile(templateFilepath)

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -32,7 +32,8 @@ var (
 	Interval = 200 * time.Millisecond
 )
 
-// Prober is the interface for a prober, which checks the result of the probes when stopped.
+// Prober is the orchestrator object managing the lifecycle of the sender and receiver
+// The lifecycle is managed through the methods Deploy, Finish, Verify & Remove
 type Prober struct {
 	log    *zap.SugaredLogger
 	client *testlib.Client
@@ -45,7 +46,7 @@ type ImagesConfig struct {
 	Forwarder string
 }
 
-// Config represents a configuration for prober
+// Config represents a configuration for Prober
 type Config struct {
 	Namespace     string
 	Interval      time.Duration

--- a/test/upgrade/prober/receiver.go
+++ b/test/upgrade/prober/receiver.go
@@ -33,13 +33,19 @@ var (
 	receiverNodePort int32 = -1
 )
 
-func (p *prober) deployReceiver(ctx context.Context) {
+func (p *Prober) deployReceiver(ctx context.Context) {
 	p.deployReceiverPod(ctx)
 	p.deployReceiverService(ctx)
 }
 
-func (p *prober) deployReceiverPod(ctx context.Context) {
+func (p *Prober) deployReceiverPod(ctx context.Context) {
 	p.log.Infof("Deploy of receiver pod: %v", receiverName)
+
+	image := p.config.Images.Receiver
+	if image == "" {
+		image = pkgTest.ImagePath(receiverName)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      receiverName,
@@ -62,7 +68,7 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 			Containers: []corev1.Container{
 				{
 					Name:  "receiver",
-					Image: pkgTest.ImagePath(receiverName),
+					Image: image,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      configName,
@@ -90,7 +96,7 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 	})
 }
 
-func (p *prober) deployReceiverService(ctx context.Context) {
+func (p *Prober) deployReceiverService(ctx context.Context) {
 	p.log.Infof("Deploy of receiver service: %v", receiverName)
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -28,8 +28,14 @@ import (
 
 var senderName = "wathola-sender"
 
-func (p *prober) deploySender(ctx context.Context) {
+func (p *Prober) deploySender(ctx context.Context) {
 	p.log.Infof("Deploy sender pod: %v", senderName)
+
+	image := p.config.Images.Sender
+	if image == "" {
+		image = pkgTest.ImagePath(senderName)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      senderName,
@@ -49,7 +55,7 @@ func (p *prober) deploySender(ctx context.Context) {
 			Containers: []corev1.Container{
 				{
 					Name:  "sender",
-					Image: pkgTest.ImagePath(senderName),
+					Image: image,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      configName,
@@ -70,7 +76,7 @@ func (p *prober) deploySender(ctx context.Context) {
 	})
 }
 
-func (p *prober) removeSender(ctx context.Context) {
+func (p *Prober) removeSender(ctx context.Context) {
 	p.log.Infof("Remove of sender pod: %v", senderName)
 
 	err := p.client.Kube.Kube.CoreV1().Pods(p.client.Namespace).

--- a/test/upgrade/prober/wathola/event/operations.go
+++ b/test/upgrade/prober/wathola/event/operations.go
@@ -26,6 +26,7 @@ type FinishedStore interface {
 	RegisterFinished(finished *Finished)
 	State() State
 	Thrown() []string
+	InvalidEvents() map[string]int
 }
 
 // Typed says a type of an event

--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -17,6 +17,7 @@ package event
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -28,15 +29,17 @@ var lastProgressReport = time.Now()
 
 // ErrorStore contains errors that was thrown
 type ErrorStore struct {
-	state  State
-	thrown []thrown
+	state         State
+	thrown        []thrown
+	invalidEvents map[string]int
 }
 
 // NewErrorStore creates a new error store
 func NewErrorStore() *ErrorStore {
 	return &ErrorStore{
-		state:  Active,
-		thrown: make([]thrown, 0),
+		state:         Active,
+		thrown:        make([]thrown, 0),
+		invalidEvents: make(map[string]int),
 	}
 }
 
@@ -114,6 +117,10 @@ func (f *finishedStore) Thrown() []string {
 	return msgs
 }
 
+func (f *finishedStore) InvalidEvents() map[string]int {
+	return f.errors.invalidEvents
+}
+
 func (f *finishedStore) reportViolations(finished *Finished) {
 	steps := f.steps.(*stepStore)
 	for eventNo := 1; eventNo <= finished.Count; eventNo++ {
@@ -124,6 +131,7 @@ func (f *finishedStore) reportViolations(finished *Finished) {
 		if times != 1 {
 			f.errors.throw("event #%v should be received once, but was received %v times",
 				eventNo, times)
+			f.errors.invalidEvents[strconv.Itoa(eventNo)] = times
 		}
 	}
 }

--- a/test/upgrade/prober/wathola/receiver/services.go
+++ b/test/upgrade/prober/wathola/receiver/services.go
@@ -100,10 +100,12 @@ func (r reportHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		s := r.receiver.finished.State()
 		errs := r.receiver.finished.Thrown()
 		events := r.receiver.step.Count()
+		invalid := r.receiver.finished.InvalidEvents()
 		sj := &StateJSON{
-			State:  stateToString(s),
-			Events: events,
-			Thrown: errs,
+			State:         stateToString(s),
+			Events:        events,
+			Thrown:        errs,
+			InvalidEvents: invalid,
 		}
 		b, err := json.Marshal(sj)
 		ensure.NoError(err)
@@ -131,7 +133,8 @@ func stateToString(state event.State) string {
 
 // StateJSON represents state as JSON
 type StateJSON struct {
-	State  string   `json:"state"`
-	Events int      `json:"events"`
-	Thrown []string `json:"thrown"`
+	State         string         `json:"state"`
+	Events        int            `json:"events"`
+	Thrown        []string       `json:"thrown"`
+	InvalidEvents map[string]int `json:"invalid_events"`
 }

--- a/test/upgrade/prober/wathola/receiver/services_test.go
+++ b/test/upgrade/prober/wathola/receiver/services_test.go
@@ -34,9 +34,9 @@ import (
 
 func TestReceiverReceive(t *testing.T) {
 	// given
-	e1 := sender.NewCloudEvent(event.Step{Number: 42}, event.StepType)
-	e2 := sender.NewCloudEvent(event.Step{Number: 43}, event.StepType)
-	f := sender.NewCloudEvent(event.Finished{Count: 2}, event.FinishedType)
+	e1 := sender.NewCloudEvent("42", event.Step{Number: 42}, event.StepType)
+	e2 := sender.NewCloudEvent("43", event.Step{Number: 43}, event.StepType)
+	f := sender.NewCloudEvent(sender.NewEventID(), event.Finished{Count: 2}, event.FinishedType)
 
 	instance := New()
 	port := freeport.GetPort()


### PR DESCRIPTION
## Proposed Changes

- Make the prober unaware of tests (better separation of concerns and makes it reusable in non-test applications)
- Use the step event number as CE ID
- Include the missing and duplicate events in the receiver report