### PR TITLE
Fixing some wording

### DIFF
--- a/test/test_images/performance/mako.config
+++ b/test/test_images/performance/mako.config
@@ -2,7 +2,7 @@ project_name: "Knative"
 benchmark_name: "Generic Eventing Benchmark"
 description: "Measure latency and throughput of an eventing component."
 
-### ATTENTION: This is a dummy benchmark config. Do not attempt to create or
+### ATTENTION: This is a sample benchmark config. Do not attempt to create or
 # update this benchmark with the mako tool. See
 test/performance/sample-dev.config for an example of a real benchmark config.
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

On `eventing-kafka`, some lint, reported:

```
 reviewdog: This is Pull-Request from forked repository.
  reviewdog: found at least one result in diff
  GitHub token doesn't have write permission of Check API, so reviewdog will
  report results via logging command [1].
  [1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
  reviewdog: Reporting results for "woke"
  Error: [woke] reported by reviewdog 🐶
  Error:  `dummy` may be insensitive, use `placeholder`, `sample` instead
  
  Raw Output:
  Error: knative.dev/eventing/test/test_images/performance/mako.config:5:25: [error] `dummy` may be insensitive, use `placeholder`, `sample` instead
  Error: Process completed with exit code 1.
```

