### PR TITLE
Add conversion webhook, CRD for ContainerSource v1

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -98,6 +98,7 @@ var ourTypes = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	// v1
 	sourcesv1.SchemeGroupVersion.WithKind("ApiServerSource"): &sourcesv1.ApiServerSource{},
 	sourcesv1.SchemeGroupVersion.WithKind("SinkBinding"):     &sourcesv1.SinkBinding{},
+	sourcesv1.SchemeGroupVersion.WithKind("ContainerSource"): &sourcesv1.ContainerSource{},
 
 	// For group flows.knative.dev
 	// v1beta1
@@ -344,12 +345,13 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 					sourcesv1_:       &sourcesv1.SinkBinding{},
 				},
 			},
-			sourcesv1beta1.Kind("ContainerSource"): {
+			sourcesv1.Kind("ContainerSource"): {
 				DefinitionName: sources.ContainerSourceResource.String(),
 				HubVersion:     sourcesv1alpha2_,
 				Zygotes: map[string]conversion.ConvertibleObject{
 					sourcesv1alpha2_: &sourcesv1alpha2.ContainerSource{},
 					sourcesv1beta1_:  &sourcesv1beta1.ContainerSource{},
+					sourcesv1_:       &sourcesv1.ContainerSource{},
 				},
 			},
 		},

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -409,6 +409,15 @@ spec:
       schema:
         openAPIV3Schema:
           <<: *openAPIV3Schema
+    - <<: *version
+      name: v1
+      served: true
+      storage: false
+      # the schema of v1 is exactly the same as v1beta1 schema
+      schema:
+        openAPIV3Schema:
+          <<: *openAPIV3Schema
+
   names:
     categories:
       - all

--- a/pkg/apis/sources/v1/container_conversion.go
+++ b/pkg/apis/sources/v1/container_conversion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertTo implements apis.Convertible
+// Converts source from v1.ContainerSource into a higher version.
+func (source *ContainerSource) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+// Converts obj from a higher version into v1.ContainerSource.
+func (sink *ContainerSource) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/sources/v1/container_conversion_test.go
+++ b/pkg/apis/sources/v1/container_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContainerSourceConversionBadType(t *testing.T) {
+	good, bad := &ContainerSource{}, &dummyObject{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/sources/v1alpha2/container_conversion.go
+++ b/pkg/apis/sources/v1alpha2/container_conversion.go
@@ -18,7 +18,6 @@ package v1alpha2
 
 import (
 	"context"
-	"fmt"
 
 	"knative.dev/eventing/pkg/apis/sources/v1beta1"
 	"knative.dev/pkg/apis"
@@ -35,7 +34,7 @@ func (source *ContainerSource) ConvertTo(ctx context.Context, obj apis.Convertib
 		sink.Status.SourceStatus = source.Status.SourceStatus
 		return nil
 	default:
-		return fmt.Errorf("Unknown conversion, got: %T", sink)
+		return apis.ConvertToViaProxy(ctx, source, &v1beta1.ContainerSource{}, sink)
 	}
 }
 
@@ -50,6 +49,6 @@ func (sink *ContainerSource) ConvertFrom(ctx context.Context, obj apis.Convertib
 		sink.Status.SourceStatus = source.Status.SourceStatus
 		return nil
 	default:
-		return fmt.Errorf("Unknown conversion, got: %T", source)
+		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.ContainerSource{}, sink)
 	}
 }

--- a/pkg/apis/sources/v1beta1/container_conversion.go
+++ b/pkg/apis/sources/v1beta1/container_conversion.go
@@ -18,17 +18,37 @@ package v1beta1
 
 import (
 	"context"
-	"fmt"
 
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/pkg/apis"
 )
 
-// ConvertTo implements apis.Convertible
-func (source *ContainerSource) ConvertTo(ctx context.Context, sink apis.Convertible) error {
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+// ConvertTo implements apis.Convertible.
+// Converts source from v1beta1.ContainerSource into a higher version.
+func (source *ContainerSource) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *v1.ContainerSource:
+		sink.ObjectMeta = source.ObjectMeta
+		sink.Spec.SourceSpec = source.Spec.SourceSpec
+		sink.Spec.Template = source.Spec.Template
+		sink.Status.SourceStatus = source.Status.SourceStatus
+		return nil
+	default:
+		return apis.ConvertToViaProxy(ctx, source, &v1.ContainerSource{}, sink)
+	}
 }
 
-// ConvertFrom implements apis.Convertible
-func (sink *ContainerSource) ConvertFrom(ctx context.Context, source apis.Convertible) error {
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+// ConvertFrom implements apis.Convertible.
+// Converts obj from a higher version into v1beta1.ContainerSource.
+func (sink *ContainerSource) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *v1.ContainerSource:
+		sink.ObjectMeta = source.ObjectMeta
+		sink.Spec.SourceSpec = source.Spec.SourceSpec
+		sink.Spec.Template = source.Spec.Template
+		sink.Status.SourceStatus = source.Status.SourceStatus
+		return nil
+	default:
+		return apis.ConvertFromViaProxy(ctx, source, &v1.ContainerSource{}, sink)
+	}
 }

--- a/pkg/apis/sources/v1beta1/container_conversion_test.go
+++ b/pkg/apis/sources/v1beta1/container_conversion_test.go
@@ -18,7 +18,15 @@ package v1beta1
 
 import (
 	"context"
+	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 func TestContainerSourceConversionBadType(t *testing.T) {
@@ -30,5 +38,274 @@ func TestContainerSourceConversionBadType(t *testing.T) {
 
 	if err := good.ConvertFrom(context.Background(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
+// This tests round tripping from v1beta1 to a higher version and back to v1beta1.
+func TestContainerSourceConversionRoundTripUp(t *testing.T) {
+	versions := []apis.Convertible{&v1.ContainerSource{}}
+
+	path := apis.HTTP("")
+	path.Path = "/path"
+	sink := duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Kind:       "Foo",
+			Namespace:  "Bar",
+			Name:       "Baz",
+			APIVersion: "Baf",
+		},
+		URI: path,
+	}
+	sinkUri := apis.HTTP("example.com")
+	sinkUri.Path = "path"
+
+	tests := []struct {
+		name string
+		in   *ContainerSource
+	}{{name: "empty",
+		in: &ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: ContainerSourceSpec{},
+			Status: ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "True",
+						}},
+					},
+				},
+			},
+		},
+	}, {name: "simple configuration",
+		in: &ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: ContainerSourceSpec{
+				SourceSpec: duckv1.SourceSpec{
+					Sink: sink,
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "test",
+							Image: "test-image",
+						}},
+					},
+				},
+			},
+			Status: ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "Unknown",
+						}},
+					},
+					SinkURI: sinkUri,
+				},
+			},
+		},
+	}, {name: "full",
+		in: &ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: ContainerSourceSpec{
+				SourceSpec: duckv1.SourceSpec{
+					Sink: sink,
+					CloudEventOverrides: &duckv1.CloudEventOverrides{
+						Extensions: map[string]string{
+							"foo": "bar",
+							"baz": "baf",
+						},
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "test",
+							Image: "test-image",
+						}},
+					},
+				},
+			},
+			Status: ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "True",
+						}},
+					},
+					SinkURI: sinkUri,
+				},
+			},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					t.Error("ConvertTo() =", err)
+				}
+
+				got := &ContainerSource{}
+
+				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					t.Error("ConvertFrom() =", err)
+				}
+				if diff := cmp.Diff(test.in, got); diff != "" {
+					t.Error("roundtrip (-want, +got) =", diff)
+				}
+			})
+		}
+	}
+}
+
+// This tests round tripping from a higher version -> v1beta1 and back to the higher version.
+func TestContainerSourceConversionRoundTripDown(t *testing.T) {
+	path := apis.HTTP("")
+	path.Path = "/path"
+	sink := duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Kind:       "Foo",
+			Namespace:  "Bar",
+			Name:       "Baz",
+			APIVersion: "Baf",
+		},
+		URI: path,
+	}
+	sinkUri := apis.HTTP("example.com")
+	sinkUri.Path = "path"
+
+	ceOverrides := duckv1.CloudEventOverrides{
+		Extensions: map[string]string{
+			"foo": "bar",
+			"baz": "baf",
+		},
+	}
+
+	tests := []struct {
+		name string
+		in   apis.Convertible
+	}{{name: "empty-v1",
+		in: &v1.ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: v1.ContainerSourceSpec{},
+			Status: v1.ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "True",
+						}},
+					},
+				},
+			},
+		},
+	}, {name: "simple configuration-v1",
+		in: &v1.ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: v1.ContainerSourceSpec{
+				SourceSpec: duckv1.SourceSpec{
+					Sink: sink,
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "test",
+							Image: "test-image",
+						}},
+					},
+				},
+			},
+			Status: v1.ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "Unknown",
+						}},
+					},
+					SinkURI: sinkUri,
+				},
+			},
+		},
+	}, {name: "full-v1",
+		in: &v1.ContainerSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "ping-name",
+				Namespace:  "ping-ns",
+				Generation: 17,
+			},
+			Spec: v1.ContainerSourceSpec{
+				SourceSpec: duckv1.SourceSpec{
+					Sink:                sink,
+					CloudEventOverrides: &ceOverrides,
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "test",
+							Image: "test-image",
+						}},
+					},
+				},
+			},
+			Status: v1.ContainerSourceStatus{
+				SourceStatus: duckv1.SourceStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{{
+							Type:   "Ready",
+							Status: "True",
+						}},
+					},
+					SinkURI: sinkUri,
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			down := &ContainerSource{}
+			if err := down.ConvertFrom(context.Background(), test.in); err != nil {
+				t.Error("ConvertTo() =", err)
+			}
+
+			got := (reflect.New(reflect.TypeOf(test.in).Elem()).Interface()).(apis.Convertible)
+
+			if err := down.ConvertTo(context.Background(), got); err != nil {
+				t.Error("ConvertFrom() =", err)
+			}
+			if diff := cmp.Diff(test.in, got); diff != "" {
+				t.Error("roundtrip (-want, +got) =", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Part of https://github.com/knative/eventing/issues/4175 , follow-up of https://github.com/knative/eventing/pull/4257

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🧽   Changed v1beta1, v1alpha2 container_conversion to allow conversion to/from v1
- 🎁   Add v1 to ContainterSource CRD
- 🎁   Configure conversion webhook for ContainerSource

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

