### PR TITLE
Test eventing on KinD 1.17-1.19

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,0 +1,164 @@
+name: KinD e2e tests
+
+on:
+  pull_request:
+    branches: [ 'master' ]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./src/knative.dev/eventing
+
+jobs:
+
+  e2e-tests:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        k8s-version:
+        - v1.17.11
+        - v1.18.8
+        - v1.19.1
+
+        test-suite:
+        - ./test/e2e
+        # TODO(https://github.com/knative/eventing/issues/4275): Enable this.
+        # - ./test/conformance
+
+        # Map between K8s and KinD versions.
+        # This is attempting to make it a bit clearer what's being tested.
+        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
+        include:
+        - k8s-version: v1.17.11
+          kind-version: v0.9.0
+          kind-image-sha: sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+        - k8s-version: v1.18.8
+          kind-version: v0.9.0
+          kind-image-sha: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+        - k8s-version: v1.19.1
+          kind-version: v0.9.0
+          kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+
+        # Add the flags we use for each of these test suites.
+        - test-suite: ./test/e2e
+          extra-test-flags: -brokerclass=MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1alpha2:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1alpha2:PingSource
+        # TODO(https://github.com/knative/eventing/issues/4275): Enable this.
+        # - test-suite: ./test/conformance
+        #   extra-test-flags: -brokers=eventing.knative.dev/v1beta1:MTChannelBasedBroker -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel -sources=sources.knative.dev/v1beta1:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1beta1:PingSource
+
+    env:
+      GOPATH: ${{ github.workspace }}
+      GO111MODULE: off
+      KO_DOCKER_REPO: kind.local
+      SYSTEM_NAMESPACE: knative-eventing
+      TEST_EVENTING_NAMESPACE: knative-eventing
+      # Use a semi-random cluster suffix, but somewhat predictable
+      # so reruns don't just give us a completely new value.
+      CLUSTER_SUFFIX: c${{ github.run_id }}.local
+
+    steps:
+    - name: Set up Go 1.15.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+
+    - name: Install Dependencies
+      working-directory: ./
+      run: |
+        GO111MODULE=on go get github.com/google/ko/cmd/ko@master
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/eventing
+
+    - name: Install KinD
+      run: |
+        set -x
+
+        # Disable swap otherwise memory enforcement doesn't work
+        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600009955324200
+        sudo swapoff -a
+        sudo rm -f /swapfile
+
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+
+    - name: Configure KinD Cluster
+      working-directory: ./src/knative.dev/eventing
+      run: |
+        set -x
+
+        # KinD configuration.
+        cat > kind.yaml <<EOF
+        apiVersion: kind.x-k8s.io/v1alpha4
+        kind: Cluster
+
+        # This is needed in order to support projected volumes with service account tokens.
+        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+        kubeadmConfigPatches:
+          - |
+            apiVersion: kubeadm.k8s.io/v1beta2
+            kind: ClusterConfiguration
+            metadata:
+              name: config
+            apiServer:
+              extraArgs:
+                "service-account-issuer": "kubernetes.default.svc"
+                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+            networking:
+              dnsDomain: "${CLUSTER_SUFFIX}"
+        nodes:
+        - role: control-plane
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+        - role: worker
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+        EOF
+
+    - name: Create KinD Cluster
+      working-directory: ./src/knative.dev/eventing
+      run: |
+        set -x
+
+        kind create cluster --config kind.yaml
+
+    - name: Install Knative Eventing
+      run: |
+        set -o pipefail
+
+        kubectl create namespace ${SYSTEM_NAMESPACE}
+
+        # Build and Publish our containers to the docker daemon (including test assets)
+        export GO111MODULE=on
+        export GOFLAGS=-mod=vendor
+        ko apply --platform=all -Pf test/config/
+        ko apply --platform=all -P \
+           -f config/ \
+           `# Install the MT Broker` \
+           -f config/core/configmaps/default-broker.yaml \
+           -f config/brokers/mt-channel-broker \
+           `# Install the sugar controller` \
+           -f config/sugar/500-controller.yaml \
+           `# Install the in-memory channel` \
+           -f config/channels/in-memory-channel
+
+        # Be KinD to these tests.
+        kubectl scale -n${SYSTEM_NAMESPACE} deployment/chaosduck --replicas=0
+
+    - name: Upload Test Images
+      run: |
+        # Build and Publish our test images to the docker daemon.
+        ./test/upload-test-images.sh
+
+    - name: Wait for things to be up
+      run: |
+        kubectl wait pod --for=condition=Ready -n ${SYSTEM_NAMESPACE} -l '!job-name'
+
+    - name: Run e2e Tests
+      run: |
+        # Run the tests tagged as e2e on the KinD cluster.
+        go test -race -count=1 -parallel=12 -timeout=30m -tags=e2e \
+           ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}


### PR DESCRIPTION
## Proposed Changes

Run Eventing e2e on Github Actions with KinD to get coverage of supported version range: 1.17 - 1.19

TODO: It might be worth parallelizing on `-channel` and `-source`, if those make sense as dimensions to test in parallel to speed things up.

- 🎁 Add new feature

**Release Note**

```release-note
Eventing now tests the supported Kubernetes version range pre-submit.
```

**Docs**

N/A