### PR TITLE
Drop the hardcoded cluster.local

### DIFF
--- a/test/e2e/trigger_dependency_annotation_test.go
+++ b/test/e2e/trigger_dependency_annotation_test.go
@@ -91,7 +91,7 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	if brokerClass == eventing.MTChannelBrokerClassValue {
 		pingSource.Spec.SourceSpec.Sink.URI = &apis.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("broker-ingress.%s.svc.cluster.local", resources.SystemNamespace),
+			Host:   fmt.Sprintf("broker-ingress.%s.svc", resources.SystemNamespace),
 			Path:   fmt.Sprintf("/%s/%s", client.Namespace, defaultBrokerName),
 		}
 	}


### PR DESCRIPTION
Experimenting with Eventing's e2e and a non-standard cluster suffix, I noticed that this test failed.

Once my change to support KinD for Eventing e2e lands, we can make that pseudo-randomize this to prevent bugs like this in the future.

- 🐛 Fix test bug

/cc @vaikas 
/assign @vaikas 

This was introduced in the initial MT broker change, I believe.  Perhaps we should replace this with proper Addressable resolution via the source, but this seemed like the smallest change to unblock the scenario I'm chasing.  LMK which you prefer.