### PR TITLE
dispatcher should be readonly

### DIFF
--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -82,7 +82,9 @@ func NewController(
 		inmemorychannelLister:   inmemorychannelInformer.Lister(),
 		inmemorychannelInformer: informer,
 	}
-	impl := inmemorychannelreconciler.NewImpl(ctx, r)
+	impl := inmemorychannelreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{SkipStatusUpdates: true}
+	})
 
 	// Nothing to filer, enqueue all imcs if configmap updates.
 	noopFilter := func(interface{}) bool { return true }


### PR DESCRIPTION
Addresses #3686 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Make the InMemoryChannel dispatcher reconciler read only.
- Our Dispatcher looks at the IMC spec to construct the dispatching logic, but there's no reason it should ever update status.
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Dispatcher was incorrectly behaving like a normal reconciler instead of skipping status updates. I wonder if this was causing grief battling the normal reconciler.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
