### PR TITLE
[0.17] use Source informer instead of conditions (#4296)

### DIFF
--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -167,7 +167,7 @@ func (ts *TriggerStatus) MarkDependencyNotConfigured() {
 		"DependencyNotConfigured", "Dependency has not yet been reconciled.")
 }
 
-func (ts *TriggerStatus) PropagateDependencyStatus(ks *duckv1.KResource) {
+func (ts *TriggerStatus) PropagateDependencyStatus(ks *duckv1.Source) {
 	kc := ks.Status.GetCondition(apis.ConditionReady)
 	if kc == nil {
 		ts.MarkDependencyNotConfigured()

--- a/pkg/reconciler/mtbroker/trigger/controller.go
+++ b/pkg/reconciler/mtbroker/trigger/controller.go
@@ -31,7 +31,7 @@ import (
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/duck"
-	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/source"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -66,7 +66,7 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 
-	r.kresourceTracker = duck.NewListableTracker(ctx, conditions.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.sourceTracker = duck.NewListableTracker(ctx, source.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
 	r.uriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/mtbroker/trigger/controller_test.go
+++ b/pkg/reconciler/mtbroker/trigger/controller_test.go
@@ -26,7 +26,7 @@ import (
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
+	_ "knative.dev/pkg/client/injection/ducks/duck/v1/source/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 )
 

--- a/pkg/reconciler/mtbroker/trigger/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger/trigger.go
@@ -71,8 +71,8 @@ type Reconciler struct {
 	triggerLister      eventinglisters.TriggerLister
 	configmapLister    corev1listers.ConfigMapLister
 
-	// Dynamic tracker to track KResources. In particular, it tracks the dependency between Triggers and Sources.
-	kresourceTracker duck.ListableTracker
+	// Dynamic tracker to track Sources. In particular, it tracks the dependency between Triggers and Sources.
+	sourceTracker duck.ListableTracker
 
 	// Dynamic tracker to track AddressableTypes. In particular, it tracks Trigger subscribers.
 	uriResolver *resolver.URIResolver
@@ -143,7 +143,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 	}
 	t.Status.PropagateSubscriptionCondition(sub.Status.GetTopLevelCondition())
 
-	if err := r.checkDependencyAnnotation(ctx, t, b); err != nil {
+	if err := r.checkDependencyAnnotation(ctx, t); err != nil {
 		return err
 	}
 
@@ -229,16 +229,17 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, t *eventingv1.Tr
 	return newSub, nil
 }
 
-func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *eventingv1.Trigger, b *eventingv1.Broker) error {
+func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *eventingv1.Trigger) error {
 	if dependencyAnnotation, ok := t.GetAnnotations()[eventingv1.DependencyAnnotation]; ok {
 		dependencyObjRef, err := eventingv1.GetObjRefFromDependencyAnnotation(dependencyAnnotation)
 		if err != nil {
 			t.Status.MarkDependencyFailed("ReferenceError", "Unable to unmarshal objectReference from dependency annotation of trigger: %v", err)
 			return fmt.Errorf("getting object ref from dependency annotation %q: %v", dependencyAnnotation, err)
 		}
-		trackKResource := r.kresourceTracker.TrackInNamespace(b)
+		trackSource := r.sourceTracker.TrackInNamespace(ctx, t)
+
 		// Trigger and its dependent source are in the same namespace, we already did the validation in the webhook.
-		if err := trackKResource(dependencyObjRef); err != nil {
+		if err := trackSource(dependencyObjRef); err != nil {
 			return fmt.Errorf("tracking dependency: %v", err)
 		}
 		if err := r.propagateDependencyReadiness(ctx, t, dependencyObjRef); err != nil {
@@ -251,7 +252,7 @@ func (r *Reconciler) checkDependencyAnnotation(ctx context.Context, t *eventingv
 }
 
 func (r *Reconciler) propagateDependencyReadiness(ctx context.Context, t *eventingv1.Trigger, dependencyObjRef corev1.ObjectReference) error {
-	lister, err := r.kresourceTracker.ListerFor(dependencyObjRef)
+	lister, err := r.sourceTracker.ListerFor(dependencyObjRef)
 	if err != nil {
 		t.Status.MarkDependencyUnknown("ListerDoesNotExist", "Failed to retrieve lister: %v", err)
 		return fmt.Errorf("retrieving lister: %v", err)
@@ -265,7 +266,7 @@ func (r *Reconciler) propagateDependencyReadiness(ctx context.Context, t *eventi
 		}
 		return fmt.Errorf("getting the dependency: %v", err)
 	}
-	dependency := dependencyObj.(*duckv1.KResource)
+	dependency := dependencyObj.(*duckv1.Source)
 
 	// The dependency hasn't yet reconciled our latest changes to
 	// its desired state, so its conditions are outdated.

--- a/pkg/reconciler/mtbroker/trigger/trigger_test.go
+++ b/pkg/reconciler/mtbroker/trigger/trigger_test.go
@@ -43,7 +43,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1addr "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
-	"knative.dev/pkg/client/injection/ducks/duck/v1/conditions"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/source"
 	v1a1addr "knative.dev/pkg/client/injection/ducks/duck/v1alpha1/addressable"
 	v1b1addr "knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
 	"knative.dev/pkg/configmap"
@@ -655,17 +655,17 @@ func TestReconcile(t *testing.T) {
 		ctx = v1a1addr.WithDuck(ctx)
 		ctx = v1b1addr.WithDuck(ctx)
 		ctx = v1addr.WithDuck(ctx)
-		ctx = conditions.WithDuck(ctx)
+		ctx = source.WithDuck(ctx)
 		r := &Reconciler{
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			triggerLister:      listers.GetTriggerLister(),
 
-			brokerLister:     listers.GetBrokerLister(),
-			configmapLister:  listers.GetConfigMapLister(),
-			kresourceTracker: duck.NewListableTracker(ctx, conditions.Get, func(types.NamespacedName) {}, 0),
-			uriResolver:      resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
+			brokerLister:    listers.GetBrokerLister(),
+			configmapLister: listers.GetConfigMapLister(),
+			sourceTracker:   duck.NewListableTracker(ctx, source.Get, func(types.NamespacedName) {}, 0),
+			uriResolver:     resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 		}
 		return trigger.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetTriggerLister(),


### PR DESCRIPTION
Fixes #4294 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use source informer instead of conditions. Mismatch in informer / lister being used in the trigger reconciler..
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Dependency readiness could sometimes be missed because mismatched informer/lister was being used in the trigger reconciler.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
