### PR TITLE
Using recordevents as sequencestepper

### DIFF
--- a/test/e2e/helpers/sequence_test_helper.go
+++ b/test/e2e/helpers/sequence_test_helper.go
@@ -76,9 +76,11 @@ func SequenceTestHelper(
 			// create a stepper Pod with Service
 			podName := config.podName
 			msgAppender := config.msgAppender
-			stepperPod := resources.SequenceStepperPod(podName, msgAppender)
+			recordevents.DeployEventRecordOrFail(
+				ctx, client, podName,
+				recordevents.ReplyWithAppendedData(msgAppender),
+			)
 
-			client.CreatePodOrFail(stepperPod, testlib.WithService(podName))
 			// create a new step
 			step := v1beta1.SequenceStep{
 				Destination: duckv1.Destination{
@@ -131,8 +133,7 @@ func SequenceTestHelper(
 		event.SetSource(eventSource)
 		event.SetType(testlib.DefaultEventType)
 		msg := fmt.Sprintf("TestSequence %s", uuid.New().String())
-		body := fmt.Sprintf(`{"msg":"%s"}`, msg)
-		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
+		if err := event.SetData(cloudevents.TextPlain, msg); err != nil {
 			st.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}
 		client.SendEventToAddressable(
@@ -149,7 +150,8 @@ func SequenceTestHelper(
 		}
 		eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
 			cetest.HasSource(eventSource),
-			cetest.DataContains(expectedMsg),
+			cetest.HasDataContentType(cloudevents.TextPlain),
+			cetest.HasData([]byte(expectedMsg)),
 		))
 	})
 }
@@ -192,9 +194,11 @@ func SequenceV1TestHelper(
 			// create a stepper Pod with Service
 			podName := config.podName
 			msgAppender := config.msgAppender
-			stepperPod := resources.SequenceStepperPod(podName, msgAppender)
+			recordevents.DeployEventRecordOrFail(
+				ctx, client, podName,
+				recordevents.ReplyWithAppendedData(msgAppender),
+			)
 
-			client.CreatePodOrFail(stepperPod, testlib.WithService(podName))
 			// create a new step
 			step := flowsv1.SequenceStep{
 				Destination: duckv1.Destination{
@@ -247,8 +251,7 @@ func SequenceV1TestHelper(
 		event.SetSource(eventSource)
 		event.SetType(testlib.DefaultEventType)
 		msg := fmt.Sprintf("TestSequence %s", uuid.New().String())
-		body := fmt.Sprintf(`{"msg":"%s"}`, msg)
-		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
+		if err := event.SetData(cloudevents.TextPlain, msg); err != nil {
 			st.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}
 		client.SendEventToAddressable(
@@ -265,7 +268,8 @@ func SequenceV1TestHelper(
 		}
 		eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
 			cetest.HasSource(eventSource),
-			cetest.DataContains(expectedMsg),
+			cetest.HasDataContentType(cloudevents.TextPlain),
+			cetest.HasData([]byte(expectedMsg)),
 		))
 	})
 }

--- a/test/lib/recordevents/observer/observer.go
+++ b/test/lib/recordevents/observer/observer.go
@@ -58,6 +58,10 @@ type envConfig struct {
 
 	// The event data to use in the reply, if enabled
 	ReplyEventData string `envconfig:"REPLY_EVENT_DATA" default:"" required:"false"`
+
+	// This string to append in the data field in the reply, if enabled.
+	// This will threat the data as text/plain field
+	ReplyAppendData string `envconfig:"REPLY_APPEND_DATA" default:"" required:"false"`
 }
 
 func NewFromEnv(ctx context.Context, eventLogs ...recordevents.EventLog) *Observer {
@@ -71,7 +75,7 @@ func NewFromEnv(ctx context.Context, eventLogs ...recordevents.EventLog) *Observ
 	var replyFunc func(context.Context, http.ResponseWriter, recordevents.EventInfo)
 	if env.Reply {
 		logging.FromContext(ctx).Info("Observer will reply with an event")
-		replyFunc = ReplyTransformerFunc(env.ReplyEventType, env.ReplyEventSource, env.ReplyEventData)
+		replyFunc = ReplyTransformerFunc(env.ReplyEventType, env.ReplyEventSource, env.ReplyEventData, env.ReplyAppendData)
 	} else {
 		logging.FromContext(ctx).Info("Observer won't reply with an event")
 		replyFunc = NoOpReply

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -73,6 +73,24 @@ func ReplyWithTransformedEvent(replyEventType string, replyEventSource string, r
 	}
 }
 
+// ReplyWithAppendedData is an option to let the recordevents reply with the transformed event with appended data
+func ReplyWithAppendedData(appendData string) EventRecordOption {
+	return func(pod *corev1.Pod, client *testlib.Client) error {
+		pod.Spec.Containers[0].Env = append(
+			pod.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: "REPLY", Value: "true"},
+		)
+		if appendData != "" {
+			pod.Spec.Containers[0].Env = append(
+				pod.Spec.Containers[0].Env,
+				corev1.EnvVar{Name: "REPLY_APPEND_DATA", Value: appendData},
+			)
+		}
+
+		return nil
+	}
+}
+
 // DeployEventRecordOrFail deploys the recordevents image with necessary sa, roles, rb to execute the image
 func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name string, options ...EventRecordOption) *corev1.Pod {
 	client.CreateServiceAccountOrFail(name)


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This enables recordevents to act as sequencestepper. For more info on why: https://github.com/knative/eventing/pull/4291

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Now recordevents can act as sequencestepper
