### PR TITLE
Use well known config map names, rather than bespoke constants

### DIFF
--- a/pkg/reconciler/apiserversource/controller_test.go
+++ b/pkg/reconciler/apiserversource/controller_test.go
@@ -23,14 +23,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"knative.dev/pkg/configmap"
-	. "knative.dev/pkg/reconciler/testing"
 
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
-	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/tracing/config"
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/apiserversource/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 func TestNew(t *testing.T) {
@@ -41,7 +44,7 @@ func TestNew(t *testing.T) {
 	os.Setenv("APISERVER_RA_IMAGE", "knative.dev/example")
 	c := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-observability",
+			Name:      metrics.ConfigMapName(),
 			Namespace: "knative-eventing",
 		},
 		Data: map[string]string{
@@ -49,7 +52,7 @@ func TestNew(t *testing.T) {
 		},
 	}, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-logging",
+			Name:      logging.ConfigMapName(),
 			Namespace: "knative-eventing",
 		},
 		Data: map[string]string{
@@ -59,7 +62,7 @@ func TestNew(t *testing.T) {
 		},
 	}, &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-tracing",
+			Name:      config.ConfigName,
 			Namespace: "knative-eventing",
 		},
 		Data: map[string]string{

--- a/pkg/reconciler/inmemorychannel/controller/resources/dispatcher.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/dispatcher.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/system"
 )
 
@@ -102,10 +104,10 @@ func makeEnv() []corev1.EnvVar {
 		Value: "knative.dev/inmemorychannel-dispatcher",
 	}, {
 		Name:  "CONFIG_OBSERVABILITY_NAME",
-		Value: "config-observability",
+		Value: metrics.ConfigMapName(),
 	}, {
 		Name:  "CONFIG_LOGGING_NAME",
-		Value: "config-logging",
+		Value: logging.ConfigMapName(),
 	}, {
 		Name: "NAMESPACE",
 		ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/inmemorychannel/controller/resources/dispatcher_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/dispatcher_test.go
@@ -25,6 +25,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/system"
 )
 
@@ -76,10 +78,10 @@ func TestNewDispatcher(t *testing.T) {
 								Value: "knative.dev/inmemorychannel-dispatcher",
 							}, {
 								Name:  "CONFIG_OBSERVABILITY_NAME",
-								Value: "config-observability",
+								Value: metrics.ConfigMapName(),
 							}, {
 								Name:  "CONFIG_LOGGING_NAME",
-								Value: "config-logging",
+								Value: logging.ConfigMapName(),
 							}, {
 								Name: "NAMESPACE",
 								ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/pingsource/controller_test.go
+++ b/pkg/reconciler/pingsource/controller_test.go
@@ -21,8 +21,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"knative.dev/pkg/configmap"
-	. "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/tracing/config"
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
@@ -31,6 +34,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 func TestNew(t *testing.T) {
@@ -38,7 +42,7 @@ func TestNew(t *testing.T) {
 	c := NewController(ctx, configmap.NewStaticWatcher(
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "config-observability",
+				Name:      metrics.ConfigMapName(),
 				Namespace: "knative-eventing",
 			},
 			Data: map[string]string{
@@ -46,7 +50,7 @@ func TestNew(t *testing.T) {
 			},
 		}, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "config-logging",
+				Name:      logging.ConfigMapName(),
 				Namespace: "knative-eventing",
 			},
 			Data: map[string]string{
@@ -56,7 +60,7 @@ func TestNew(t *testing.T) {
 			},
 		}, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "config-tracing",
+				Name:      config.ConfigName,
 				Namespace: "knative-eventing",
 			},
 			Data: map[string]string{

--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -133,19 +133,19 @@ func (c *Client) runCleanup() (err error) {
 }
 
 func getTracingConfig(c kubernetes.Interface) (corev1.EnvVar, error) {
-	cm, err := c.CoreV1().ConfigMaps(resources.SystemNamespace).Get(context.Background(), "config-tracing", metav1.GetOptions{})
+	cm, err := c.CoreV1().ConfigMaps(resources.SystemNamespace).Get(context.Background(), configtracing.ConfigName, metav1.GetOptions{})
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while retrieving the config-tracing config map: %+v", errors.WithStack(err))
+		return corev1.EnvVar{}, fmt.Errorf("error while retrieving the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
 	config, err := configtracing.NewTracingConfigFromConfigMap(cm)
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while parsing the config-tracing config map: %+v", errors.WithStack(err))
+		return corev1.EnvVar{}, fmt.Errorf("error while parsing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
 	configSerialized, err := configtracing.TracingConfigToJson(config)
 	if err != nil {
-		return corev1.EnvVar{}, fmt.Errorf("error while serializing the config-tracing config map: %+v", errors.WithStack(err))
+		return corev1.EnvVar{}, fmt.Errorf("error while serializing the %s config map: %+v", configtracing.ConfigName, errors.WithStack(err))
 	}
 
 	return corev1.EnvVar{Name: test_images.ConfigTracingEnv, Value: configSerialized}, nil


### PR DESCRIPTION

- 🧽 Update or clean up current behavior

/assign @n3wscott 