### PR TITLE
change the test namespace to zipkin

### DIFF
--- a/pkg/channel/message_receiver_test.go
+++ b/pkg/channel/message_receiver_test.go
@@ -224,7 +224,7 @@ func TestMessageReceiver_ServerStart_trace_propagation(t *testing.T) {
 		Backend:        tracingconfig.Zipkin,
 		Debug:          true,
 		SampleRate:     1.0,
-		ZipkinEndpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans",
+		ZipkinEndpoint: "http://zipkin.zipkin.svc.cluster.local:9411/api/v2/spans",
 	}))
 
 	p, err := cloudevents.NewHTTP(

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -119,7 +119,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 		Backend:        tracingconfig.Zipkin,
 		Debug:          true,
 		SampleRate:     1.0,
-		ZipkinEndpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans",
+		ZipkinEndpoint: "http://zipkin.zipkin.svc.cluster.local:9411/api/v2/spans",
 	})
 
 	sh, err := swappable.NewEmptyMessageHandler(context.TODO(), logger, channel.NewMessageDispatcher(logger))


### PR DESCRIPTION
Use the zipkin namespace in the tests just for cosmetics.
