### PR TITLE
Add schedule information in retrieval output for Knative Eventing PingSource

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -170,6 +170,9 @@ spec:
     - name: Sink
       type: string
       jsonPath: .status.sinkUri
+    - name: Schedule
+      type: string
+      jsonPath: .spec.schedule
     - name: Age
       type: date
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
Add ```EventsSchedule``` Information for Knative Eventing PingSource.

## Why
As of knative/eventing v0.17.0, Pingsource configured in particular namespace does not show schedule information for events.
Additional Print Columns added for including ```EventsSchedule``` information.

