### PR TITLE
Better k8s events log in e2e/conformance tests

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -194,7 +194,7 @@ func TearDown(client *Client) {
 		client.T.Logf("Could not list events in the namespace %q: %v", client.Namespace, err)
 	} else {
 		for _, e := range el.Items {
-			client.T.Logf("EVENT: %s", formatEvent(&e))
+			client.T.Log("EVENT: ", formatEvent(&e))
 		}
 	}
 
@@ -218,19 +218,19 @@ func formatEvent(e *corev1.Event) string {
 	return strings.Join([]string{`Event{`,
 		`ObjectMeta:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", e.ObjectMeta), "ObjectMeta", "v1.ObjectMeta", 1), `&`, ``, 1),
 		`InvolvedObject:` + strings.Replace(strings.Replace(e.InvolvedObject.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1),
-		`Reason:` + fmt.Sprintf("%v", e.Reason),
-		`Message:` + fmt.Sprintf("%v", e.Message),
+		`Reason:` + e.Reason,
+		`Message:` + e.Message,
 		`Source:` + strings.Replace(strings.Replace(e.Source.String(), "EventSource", "EventSource", 1), `&`, ``, 1),
 		`FirstTimestamp:` + e.FirstTimestamp.String(),
 		`LastTimestamp:` + e.LastTimestamp.String(),
-		`Count:` + fmt.Sprintf("%v", e.Count),
+		`Count:` + string(e.Count),
 		`Type:` + e.Type,
 		`EventTime:` + e.EventTime.String(),
 		`Series:` + strings.Replace(e.Series.String(), "EventSeries", "EventSeries", 1),
 		`Action:` + e.Action,
 		`Related:` + strings.Replace(e.Related.String(), "ObjectReference", "ObjectReference", 1),
-		`ReportingController:` + fmt.Sprintf("%v", e.ReportingController),
-		`ReportingInstance:` + fmt.Sprintf("%v", e.ReportingInstance),
+		`ReportingController:` + e.ReportingController,
+		`ReportingInstance:` + e.ReportingInstance,
 		`}`,
 	}, "\n")
 }

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,7 +194,7 @@ func TearDown(client *Client) {
 		client.T.Logf("Could not list events in the namespace %q: %v", client.Namespace, err)
 	} else {
 		for _, e := range el.Items {
-			client.T.Logf("EVENT: %v", e)
+			client.T.Logf("EVENT: %s", formatEvent(&e))
 		}
 	}
 
@@ -211,6 +212,27 @@ func TearDown(client *Client) {
 	if err := DeleteNameSpace(client); err != nil {
 		client.T.Logf("Could not delete the namespace %q: %v", client.Namespace, err)
 	}
+}
+
+func formatEvent(e *corev1.Event) string {
+	return strings.Join([]string{`Event{`,
+		`ObjectMeta:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", e.ObjectMeta), "ObjectMeta", "v1.ObjectMeta", 1), `&`, ``, 1),
+		`InvolvedObject:` + strings.Replace(strings.Replace(e.InvolvedObject.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1),
+		`Reason:` + fmt.Sprintf("%v", e.Reason),
+		`Message:` + fmt.Sprintf("%v", e.Message),
+		`Source:` + strings.Replace(strings.Replace(e.Source.String(), "EventSource", "EventSource", 1), `&`, ``, 1),
+		`FirstTimestamp:` + e.FirstTimestamp.String(),
+		`LastTimestamp:` + e.LastTimestamp.String(),
+		`Count:` + fmt.Sprintf("%v", e.Count),
+		`Type:` + e.Type,
+		`EventTime:` + e.EventTime.String(),
+		`Series:` + strings.Replace(e.Series.String(), "EventSeries", "EventSeries", 1),
+		`Action:` + e.Action,
+		`Related:` + strings.Replace(e.Related.String(), "ObjectReference", "ObjectReference", 1),
+		`ReportingController:` + fmt.Sprintf("%v", e.ReportingController),
+		`ReportingInstance:` + fmt.Sprintf("%v", e.ReportingInstance),
+		`}`,
+	}, "\n")
 }
 
 // CreateNamespaceIfNeeded creates a new namespace if it does not exist.

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -223,7 +223,7 @@ func formatEvent(e *corev1.Event) string {
 		`Source:` + strings.Replace(strings.Replace(e.Source.String(), "EventSource", "EventSource", 1), `&`, ``, 1),
 		`FirstTimestamp:` + e.FirstTimestamp.String(),
 		`LastTimestamp:` + e.LastTimestamp.String(),
-		`Count:` + string(e.Count),
+		`Count:` + fmt.Sprintf("%d", e.Count),
 		`Type:` + e.Type,
 		`EventTime:` + e.EventTime.String(),
 		`Series:` + strings.Replace(e.Series.String(), "EventSeries", "EventSeries", 1),

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -216,7 +216,7 @@ func TearDown(client *Client) {
 
 func formatEvent(e *corev1.Event) string {
 	return strings.Join([]string{`Event{`,
-		`ObjectMeta:` + strings.Replace(strings.Replace(fmt.Sprintf("%v", e.ObjectMeta), "ObjectMeta", "v1.ObjectMeta", 1), `&`, ``, 1),
+		`ObjectMeta:` + strings.Replace(strings.Replace(e.ObjectMeta.String(), "ObjectMeta", "v1.ObjectMeta", 1), `&`, ``, 1),
 		`InvolvedObject:` + strings.Replace(strings.Replace(e.InvolvedObject.String(), "ObjectReference", "ObjectReference", 1), `&`, ``, 1),
 		`Reason:` + e.Reason,
 		`Message:` + e.Message,

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -194,7 +194,7 @@ func TearDown(client *Client) {
 		client.T.Logf("Could not list events in the namespace %q: %v", client.Namespace, err)
 	} else {
 		for _, e := range el.Items {
-			client.T.Log("EVENT: ", formatEvent(&e))
+			client.T.Log(formatEvent(&e))
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This makes more readable the e2e test logs. This code was took from the original `Event.String()` generated code and made more readable with newlines. This also removes that noisy numbers when we use the `%v` format
