### PR TITLE
Resolve addressable uri in test lib now retries

### DIFF
--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -158,7 +158,7 @@ func BrokerChannelFlowWithTransformation(
 		client.WaitForResourceReadyOrFail(channelName, &channel)
 
 		// create trigger3 to receive the transformed event, and send it to the channel
-		channelURL := client.WaitForAddressableURIOrFail(channelName, &channel)
+		channelURL := client.WaitForAddressableURLOrFail(channelName, &channel)
 		if triggerVersion == "v1" {
 			client.CreateTriggerV1OrFail(
 				triggerName3,

--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -158,10 +158,7 @@ func BrokerChannelFlowWithTransformation(
 		client.WaitForResourceReadyOrFail(channelName, &channel)
 
 		// create trigger3 to receive the transformed event, and send it to the channel
-		channelURL, err := client.GetAddressableURI(channelName, &channel)
-		if err != nil {
-			st.Fatalf("Failed to get the url for the channel %q: %+v", channelName, err)
-		}
+		channelURL := client.WaitForAddressableURIOrFail(channelName, &channel)
 		if triggerVersion == "v1" {
 			client.CreateTriggerV1OrFail(
 				triggerName3,

--- a/test/lib/operation.go
+++ b/test/lib/operation.go
@@ -50,9 +50,9 @@ func (c *Client) LabelNamespace(labels map[string]string) error {
 	return err
 }
 
-// WaitForAddressableURIOrFail waits for a given addressable to be resolved and returns the URI of the addressable resource.
+// WaitForAddressableURLOrFail waits for a given addressable to be resolved and returns the URI of the addressable resource.
 // To use this function, the given resource must have implemented the Addressable duck-type.
-func (c *Client) WaitForAddressableURIOrFail(addressableName string, typeMeta *metav1.TypeMeta) string {
+func (c *Client) WaitForAddressableURLOrFail(addressableName string, typeMeta *metav1.TypeMeta) string {
 	metaAddressable := resources.NewMetaResource(addressableName, c.Namespace, typeMeta)
 	var u url.URL
 	err := wait.PollImmediate(interval, timeout, func() (done bool, err error) {

--- a/test/lib/send_event.go
+++ b/test/lib/send_event.go
@@ -38,7 +38,7 @@ func (c *Client) SendEventToAddressable(
 	event cloudevents.Event,
 	option ...func(*corev1.Pod),
 ) {
-	c.SendEvent(ctx, senderName, c.WaitForAddressableURIOrFail(addressableName, typemeta), event, option...)
+	c.SendEvent(ctx, senderName, c.WaitForAddressableURLOrFail(addressableName, typemeta), event, option...)
 }
 
 // SendEvent will create a sender pod, which will send the given event to the given url.
@@ -70,7 +70,7 @@ func (c *Client) SendRequestToAddressable(
 	body string,
 	option ...func(*corev1.Pod),
 ) {
-	c.SendRequest(ctx, senderName, c.WaitForAddressableURIOrFail(addressableName, typemeta), headers, body, option...)
+	c.SendRequest(ctx, senderName, c.WaitForAddressableURLOrFail(addressableName, typemeta), headers, body, option...)
 }
 
 // SendRequest will create a sender pod, which will send the given request to the given url.

--- a/test/lib/send_event.go
+++ b/test/lib/send_event.go
@@ -38,11 +38,7 @@ func (c *Client) SendEventToAddressable(
 	event cloudevents.Event,
 	option ...func(*corev1.Pod),
 ) {
-	uri, err := c.GetAddressableURI(addressableName, typemeta)
-	if err != nil {
-		c.T.Fatalf("Failed to get the URI for %+v-%s", typemeta, addressableName)
-	}
-	c.SendEvent(ctx, senderName, uri, event, option...)
+	c.SendEvent(ctx, senderName, c.WaitForAddressableURIOrFail(addressableName, typemeta), event, option...)
 }
 
 // SendEvent will create a sender pod, which will send the given event to the given url.
@@ -74,11 +70,7 @@ func (c *Client) SendRequestToAddressable(
 	body string,
 	option ...func(*corev1.Pod),
 ) {
-	uri, err := c.GetAddressableURI(addressableName, typemeta)
-	if err != nil {
-		c.T.Fatalf("Failed to get the URI for %+v-%s", typemeta, addressableName)
-	}
-	c.SendRequest(ctx, senderName, uri, headers, body, option...)
+	c.SendRequest(ctx, senderName, c.WaitForAddressableURIOrFail(addressableName, typemeta), headers, body, option...)
 }
 
 // SendRequest will create a sender pod, which will send the given request to the given url.


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

We're experiencing issues in our downstream CI where sometimes the addressable resolution fails in tests. This adds a retry to the addressable resolution to avoid such issue.  

## Proposed Changes

- Retry the addressable url resolution