### PR TITLE
Publish manually events to avoid event correlator

### DIFF
--- a/test/lib/recordevents/recorder_vent/constructor.go
+++ b/test/lib/recordevents/recorder_vent/constructor.go
@@ -19,16 +19,18 @@ package recorder_vent
 import (
 	"context"
 	"log"
-	"strings"
+	"math/rand"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	"k8s.io/apimachinery/pkg/api/errors"
+	restclient "k8s.io/client-go/rest"
 	"knative.dev/pkg/system"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -43,6 +45,11 @@ type envConfig struct {
 	PodName   string `envconfig:"POD_NAME" required:"true"`
 	Port      int    `envconfig:"PORT" default:"8080" required:"true"`
 }
+
+const (
+	maxRetry      = 5
+	sleepDuration = 5 * time.Second
+)
 
 func NewFromEnv(ctx context.Context) recordevents.EventLog {
 	var env envConfig
@@ -73,25 +80,11 @@ func createRecorder(ctx context.Context, agentName string) record.EventRecorder 
 	if recorder == nil {
 		// Create event broadcaster
 		logger.Debug("Creating event broadcaster")
-		eventBroadcaster := record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
-			KeyFunc: func(event *corev1.Event) (aggregateKey string, localKey string) {
-				return strings.Join([]string{
-					event.Source.Component,
-					event.Source.Host,
-					event.InvolvedObject.Kind,
-					event.InvolvedObject.Namespace,
-					event.InvolvedObject.Name,
-					string(event.InvolvedObject.UID),
-					event.InvolvedObject.APIVersion,
-					event.Type,
-					event.Reason,
-				}, ""), string(event.UID)
-			},
-		})
+		eventBroadcaster := record.NewBroadcaster()
 		watches := []watch.Interface{
 			eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof),
-			eventBroadcaster.StartRecordingToSink(
-				&v1.EventSinkImpl{Interface: kubeclient.Get(ctx).CoreV1().Events(system.Namespace())},
+			eventBroadcaster.StartEventWatcher(
+				sendToSink(ctx, kubeclient.Get(ctx).CoreV1().Events(system.Namespace()).CreateWithEventNamespace),
 			),
 		}
 		recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: agentName})
@@ -105,4 +98,58 @@ func createRecorder(ctx context.Context, agentName string) record.EventRecorder 
 	}
 
 	return recorder
+}
+
+func sendToSink(ctx context.Context, sender func(*corev1.Event) (*corev1.Event, error)) func(*corev1.Event) {
+	return func(event *corev1.Event) {
+		tries := 0
+		for {
+			if recordEvent(ctx, sender, event) {
+				break
+			}
+			tries++
+			if tries >= maxRetry {
+				logging.FromContext(ctx).Errorf("Unable to write event '%s' (retry limit exceeded!)", event.Name)
+				break
+			}
+			// Randomize the first sleep so that various clients won't all be
+			// synced up if the master goes down.
+			if tries == 1 {
+				time.Sleep(time.Duration(float64(sleepDuration) * rand.Float64()))
+			} else {
+				time.Sleep(sleepDuration)
+			}
+		}
+	}
+}
+
+func recordEvent(ctx context.Context, sender func(*corev1.Event) (*corev1.Event, error), event *corev1.Event) bool {
+	newEv, err := sender(event)
+	if err == nil {
+		logging.FromContext(ctx).Infof("Event '%s' sent correctly, uuid: %s", newEv.Name, newEv.UID)
+		return true
+	}
+
+	// If we can't contact the server, then hold everything while we keep trying.
+	// Otherwise, something about the event is malformed and we should abandon it.
+	switch err.(type) {
+	case *restclient.RequestConstructionError:
+		// We will construct the request the same next time, so don't keep trying.
+		logging.FromContext(ctx).Errorf("Unable to construct event '%s': '%v' (will not retry!)", event.Name, err)
+		return true
+	case *errors.StatusError:
+		if errors.IsAlreadyExists(err) {
+			logging.FromContext(ctx).Infof("Server rejected event '%s': '%v' (will not retry!)", event.Name, err)
+		} else {
+			logging.FromContext(ctx).Errorf("Server rejected event '%s': '%v' (will not retry!)", event.Name, err)
+		}
+		return true
+	case *errors.UnexpectedObjectError:
+		// We don't expect this; it implies the server's response didn't match a
+		// known pattern. Go ahead and retry.
+	default:
+		// This case includes actual http transport errors. Go ahead and retry.
+	}
+	logging.FromContext(ctx).Errorf("Unable to write event: '%v' (may retry after sleeping)", err)
+	return false
 }

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -108,7 +108,7 @@ func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name s
 	))
 	client.CreateRoleBindingOrFail(name, "Role", name, name, client.Namespace)
 
-	eventRecordPod := eventRecordPod(name, name)
+	eventRecordPod := recordEventsPod("recordevents", name, name)
 	client.CreatePodOrFail(eventRecordPod, append(options, testlib.WithService(name))...)
 	err := pkgtest.WaitForPodRunning(ctx, client.Kube, name, client.Namespace)
 	if err != nil {
@@ -116,11 +116,6 @@ func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name s
 	}
 	client.WaitForServiceEndpointsOrFail(ctx, name, 1)
 	return eventRecordPod
-}
-
-// eventRecordPod creates a Pod that stores received events for test retrieval.
-func eventRecordPod(name string, serviceAccountName string) *corev1.Pod {
-	return recordEventsPod("recordevents", name, serviceAccountName)
 }
 
 func recordEventsPod(imageName string, name string, serviceAccountName string) *corev1.Pod {
@@ -133,7 +128,7 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 			Containers: []corev1.Container{{
 				Name:            imageName,
 				Image:           pkgtest.ImagePath(imageName),
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Env: []corev1.EnvVar{{
 					Name: "SYSTEM_NAMESPACE",
 					ValueFrom: &corev1.EnvVarSource{

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -133,7 +133,7 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 			Containers: []corev1.Container{{
 				Name:            imageName,
 				Image:           pkgtest.ImagePath(imageName),
-				ImagePullPolicy: corev1.PullIfNotPresent,
+				ImagePullPolicy: corev1.PullAlways,
 				Env: []corev1.EnvVar{{
 					Name: "SYSTEM_NAMESPACE",
 					ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

`EventBroadcaster` imposes the usage of an "anti spam" event correlator. This potentially introduces issues in our tests where 2 similar events are sent to the event broadcaster but one of them is not published. 

This change removes the usage of the code path with the event correlator and manually publishes the k8s events.

For more info https://github.com/kubernetes/client-go/issues/885