### PR TITLE
Return when URIResolver is not set to avoid nil pointer reference.

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -102,6 +102,7 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	resolver := GetURIResolver(ctx)
 	if resolver == nil {
 		logging.FromContext(ctx).Errorf("No Resolver associated with context for sink: %+v", sb)
+		return
 	}
 	uri, err := resolver.URIFromDestinationV1(ctx, sb.Spec.Sink, sb)
 	if err != nil {


### PR DESCRIPTION
Follow up on #4161 

This is really nit though, I hope the panic wont happen again.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Return when URIResolver is not set to avoid nil pointer reference.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
NONE
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/cc lberk n3scott