### PR TITLE
A few adjustments for actions.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -138,7 +138,7 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         export GO111MODULE=on
         export GOFLAGS=-mod=vendor
-        ko apply --platform=all -P \
+        ko apply -P \
            -f config/ \
            `# Install the MT Broker` \
            -f config/core/configmaps/default-broker.yaml \
@@ -149,8 +149,7 @@ jobs:
            -f config/channels/in-memory-channel
 
         # Change the cluster domain to the correct one.
-        sed -i "s/svc\.cluster\.local/svc\.${CLUSTER_SUFFIX}/g" test/config/config-tracing.yaml
-        ko apply --platform=all -Pf test/config/
+        ko apply -Pf test/config/
 
         # Be KinD to these tests.
         kubectl scale -n${SYSTEM_NAMESPACE} deployment/chaosduck --replicas=0

--- a/test/config/config-tracing.yaml
+++ b/test/config/config-tracing.yaml
@@ -19,6 +19,6 @@ metadata:
   namespace: knative-eventing
 data:
   backend: "zipkin"
-  zipkin-endpoint: "http://zipkin.knative-eventing.svc.cluster.local:9411/api/v2/spans"
+  zipkin-endpoint: "http://zipkin.knative-eventing.svc:9411/api/v2/spans"
   debug: "true"
   sample-rate: "1.0"


### PR DESCRIPTION
1. Drop the `cluster.local` in test/config/config-tracing.yaml and rely on ndots instead.
2. Drop the `sed` in the actions that mitigated the above (no longer needed)
3. Drop `--platform=all` during actions, this is now 4 architectures, which can get really slow.

- 🧽 Update or clean up current behavior

**Release Note**

```release-note
None
```
