### PR TITLE
Some nits in our test-infra I've found during a burning debugging session

### DIFF
--- a/test/lib/recordevents/event_info.go
+++ b/test/lib/recordevents/event_info.go
@@ -44,14 +44,32 @@ type EventInfo struct {
 	Sequence    uint64              `json:"sequence"`
 }
 
-// Pretty print the event. Meant for debugging.  This formats the validation error
-// or the full event as appropriate.  This does NOT format the headers.
+// Pretty print the event. Meant for debugging.
 func (ei *EventInfo) String() string {
+	var sb strings.Builder
+	sb.WriteString("-- EventInfo --\n")
 	if ei.Event != nil {
-		return ei.Event.String()
-	} else {
-		return fmt.Sprintf("invalid event %q", ei.Error)
+		sb.WriteString("--- Event ---\n")
+		sb.WriteString(ei.Event.String())
+		sb.WriteRune('\n')
+		sb.WriteRune('\n')
 	}
+	if ei.Error != "" {
+		sb.WriteString("--- Error ---\n")
+		sb.WriteString(ei.Error)
+		sb.WriteRune('\n')
+		sb.WriteRune('\n')
+	}
+	sb.WriteString("--- HTTP headers ---\n")
+	for k, v := range ei.HTTPHeaders {
+		sb.WriteString("  " + k + ": " + v[0] + "\n")
+	}
+	sb.WriteRune('\n')
+	sb.WriteString("--- Origin: '" + ei.Origin + "' ---\n")
+	sb.WriteString("--- Observer: '" + ei.Observer + "' ---\n")
+	sb.WriteString("--- Time: " + ei.Time.String() + " ---\n")
+	sb.WriteString(fmt.Sprintf("--- Sequence: %d ---\n", ei.Sequence))
+	return sb.String()
 }
 
 // This is mainly used for providing better failure messages

--- a/test/lib/recordevents/observer/observer.go
+++ b/test/lib/recordevents/observer/observer.go
@@ -46,7 +46,7 @@ type Observer struct {
 
 type envConfig struct {
 	// ObserverName is used to identify this instance of the observer.
-	ObserverName string `envconfig:"OBSERVER_NAME" default:"observer-default" required:"true"`
+	ObserverName string `envconfig:"POD_NAME" default:"observer-default" required:"true"`
 
 	// Reply is used to define if the observer should reply back
 	Reply bool `envconfig:"REPLY" default:"false" required:"false"`
@@ -120,6 +120,10 @@ func (o *Observer) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 
 	event, eventErr := cloudeventsbindings.ToEvent(context.TODO(), m)
 	header := request.Header
+	// Host header is removed from the request.Header map by net/http
+	if request.Host != "" {
+		header.Set("Host", request.Host)
+	}
 
 	eventErrStr := ""
 	if eventErr != nil {

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -135,9 +135,6 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 					},
 				}, {
-					Name:  "OBSERVER",
-					Value: "recorder-" + name,
-				}, {
 					Name: "POD_NAME",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- k8s events printed at the end of the test now are reordered before being printed
- Set the observer name in recordevents
- Include the host header in recordevents
- Proper logging of event info