### PR TITLE
config-logging uses console encoding in tests

### DIFF
--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -42,5 +42,3 @@ data:
         "callerEncoder": ""
       }
     }
-  # Log level overrides
-  loglevel.mt-broker-controller: "debug"

--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -27,7 +27,7 @@ data:
       "development": false,
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
-      "encoding": "json",
+      "encoding": "console",
       "encoderConfig": {
         "timeKey": "ts",
         "levelKey": "level",


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This simplifies reading the logs in the CI artifacts

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- config-logging for tests uses console encoding
