### PR TITLE
Propagate config-logging in test images

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -174,5 +174,5 @@ func getLoggingConfig(c kubernetes.Interface) (*corev1.EnvVar, error) {
 		return nil, fmt.Errorf("error while serializing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}
 
-	return &corev1.EnvVar{Name: test_images.ConfigLoggingEnv, Value: configSerialized}, nil
+	return &corev1.EnvVar{Name: ti.ConfigLoggingEnv, Value: configSerialized}, nil
 }

--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"testing"
 
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 
 	"github.com/pkg/errors"
@@ -57,6 +58,7 @@ type Client struct {
 	podsCreated []string
 
 	tracingEnv corev1.EnvVar
+	loggingEnv *corev1.EnvVar
 
 	cleanup func()
 }
@@ -104,6 +106,11 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 		return nil, err
 	}
 
+	client.loggingEnv, err = getLoggingConfig(client.Kube)
+	if err != nil {
+		t.Log("Cannot retrieve the logging config map: ", err)
+	}
+
 	return client, nil
 }
 
@@ -149,4 +156,23 @@ func getTracingConfig(c kubernetes.Interface) (corev1.EnvVar, error) {
 	}
 
 	return corev1.EnvVar{Name: ti.ConfigTracingEnv, Value: configSerialized}, nil
+}
+
+func getLoggingConfig(c kubernetes.Interface) (*corev1.EnvVar, error) {
+	cm, err := c.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), logging.ConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+	}
+
+	config, err := logging.NewConfigFromMap(cm.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+	}
+
+	configSerialized, err := logging.LoggingConfigToJson(config)
+	if err != nil {
+		return nil, fmt.Errorf("error while serializing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
+	}
+
+	return &corev1.EnvVar{Name: test_images.ConfigLoggingEnv, Value: configSerialized}, nil
 }

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -751,7 +751,7 @@ func (c *Client) CreatePodOrFail(pod *corev1.Pod, options ...func(*corev1.Pod, *
 		}
 	}
 
-	c.applyTracingEnv(&pod.Spec)
+	c.applyAdditionalEnv(&pod.Spec)
 
 	err := reconciler.RetryUpdateConflicts(func(attempts int) (err error) {
 		c.T.Logf("Creating pod %+v", pod)
@@ -782,7 +782,7 @@ func (c *Client) CreateDeploymentOrFail(deploy *appsv1.Deployment, options ...fu
 		}
 	}
 
-	c.applyTracingEnv(&deploy.Spec.Template.Spec)
+	c.applyAdditionalEnv(&deploy.Spec.Template.Spec)
 
 	c.T.Logf("Creating deployment %+v", deploy)
 	if _, err := c.Kube.AppsV1().Deployments(deploy.Namespace).Create(context.Background(), deploy, metav1.CreateOptions{}); err != nil {
@@ -803,7 +803,7 @@ func (c *Client) CreateCronJobOrFail(cronjob *batchv1beta1.CronJob, options ...f
 		}
 	}
 
-	c.applyTracingEnv(&cronjob.Spec.JobTemplate.Spec.Template.Spec)
+	c.applyAdditionalEnv(&cronjob.Spec.JobTemplate.Spec.Template.Spec)
 
 	c.T.Logf("Creating cronjob %+v", cronjob)
 	if _, err := c.Kube.BatchV1beta1().CronJobs(cronjob.Namespace).Create(context.Background(), cronjob, metav1.CreateOptions{}); err != nil {
@@ -917,8 +917,11 @@ func (c *Client) CreateRBACResourcesForBrokers() {
 	)
 }
 
-func (c *Client) applyTracingEnv(pod *corev1.PodSpec) {
+func (c *Client) applyAdditionalEnv(pod *corev1.PodSpec) {
 	for i := 0; i < len(pod.Containers); i++ {
 		pod.Containers[i].Env = append(pod.Containers[i].Env, c.tracingEnv)
+		if c.loggingEnv != nil {
+			pod.Containers[i].Env = append(pod.Containers[i].Env, *c.loggingEnv)
+		}
 	}
 }

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 	//nolint // nil ctx is fine here, look at the code of EnableInjectionOrDie
 	ctx, _ := injection.EnableInjectionOrDie(nil, cfg)
-	ctx = test_images.ConfigureLogging(ctx)
+	ctx = test_images.ConfigureLogging(ctx, "recordevents")
 
 	if err := test_images.ConfigureTracing(logging.FromContext(ctx), ""); err != nil {
 		logging.FromContext(ctx).Fatal("Unable to setup trace publishing", err)

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -40,6 +40,7 @@ func main() {
 	}
 	//nolint // nil ctx is fine here, look at the code of EnableInjectionOrDie
 	ctx, _ := injection.EnableInjectionOrDie(nil, cfg)
+	ctx = test_images.ConfigureLogging(ctx)
 
 	if err := test_images.ConfigureTracing(logging.FromContext(ctx), ""); err != nil {
 		logging.FromContext(ctx).Fatal("Unable to setup trace publishing", err)

--- a/test/test_images/utils.go
+++ b/test/test_images/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test_images
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"strconv"
@@ -24,6 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/tracing"
 	"knative.dev/pkg/tracing/config"
 )
@@ -47,7 +49,10 @@ func ParseDurationStr(durationStr string, defaultDuration int) time.Duration {
 	return duration
 }
 
-const ConfigTracingEnv = "K_CONFIG_TRACING"
+const (
+	ConfigTracingEnv = "K_CONFIG_TRACING"
+	ConfigLoggingEnv = "K_CONFIG_LOGGING"
+)
 
 // ConfigureTracing can be used in test-images to configure tracing
 func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
@@ -63,4 +68,11 @@ func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 	}
 
 	return tracing.SetupStaticPublishing(logger, serviceName, conf)
+}
+
+// ConfigureTracing can be used in test-images to configure tracing
+func ConfigureLogging(ctx context.Context) context.Context {
+	loggingEnv := os.Getenv(ConfigLoggingEnv)
+	l, _ := logging.NewLogger(loggingEnv, "")
+	return logging.WithLogger(ctx, l)
 }

--- a/test/test_images/utils.go
+++ b/test/test_images/utils.go
@@ -71,8 +71,13 @@ func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 }
 
 // ConfigureTracing can be used in test-images to configure tracing
-func ConfigureLogging(ctx context.Context) context.Context {
+func ConfigureLogging(ctx context.Context, name string) context.Context {
 	loggingEnv := os.Getenv(ConfigLoggingEnv)
-	l, _ := logging.NewLogger(loggingEnv, "")
+	conf, err := logging.JsonToLoggingConfig(loggingEnv)
+	if err != nil {
+		logging.FromContext(ctx).Warn("Error while trying to read the config logging env: ", err)
+		return ctx
+	}
+	l, _ := logging.NewLoggerFromConfig(conf, name)
 	return logging.WithLogger(ctx, l)
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

## Proposed Changes

- The config-logging is propagated to recordevents (and potentially, to any pod brought up by tests)
