### PR TITLE
backport sinkbinding resolver fix

### DIFF
--- a/pkg/apis/sources/v1beta1/sinkbinding_context.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_context.go
@@ -20,16 +20,22 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/resolver"
 )
 
 // sinkURIKey is used as the key for associating information
 // with a context.Context.
 type sinkURIKey struct{}
+type resolverKey struct{}
 
 // WithSinkURI notes on the context for binding that the resolved SinkURI
 // is the provided apis.URL.
 func WithSinkURI(ctx context.Context, uri *apis.URL) context.Context {
 	return context.WithValue(ctx, sinkURIKey{}, uri)
+}
+
+func WithURIResolver(ctx context.Context, resolver *resolver.URIResolver) context.Context {
+	return context.WithValue(ctx, resolverKey{}, resolver)
 }
 
 // GetSinkURI accesses the apis.URL for the Sink URI that has been associated
@@ -40,4 +46,12 @@ func GetSinkURI(ctx context.Context) *apis.URL {
 		return nil
 	}
 	return value.(*apis.URL)
+}
+
+func GetURIResolver(ctx context.Context) *resolver.URIResolver {
+	value := ctx.Value(resolverKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*resolver.URIResolver)
 }

--- a/pkg/apis/sources/v1beta1/sinkbinding_context_test.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_context_test.go
@@ -41,3 +41,12 @@ func TestGetSinkURI(t *testing.T) {
 		t.Errorf("GetSinkURI() = %v, wanted %v", got, want)
 	}
 }
+
+func TestGetURIResolver(t *testing.T) {
+	ctx := context.Background()
+
+	if resolver := GetURIResolver(ctx); resolver != nil {
+		t.Errorf("GetURIResolver() = %v, wanted nil", resolver)
+	}
+
+}

--- a/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_lifecycle.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -33,7 +32,9 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-var sbCondSet = apis.NewLivingConditionSet()
+var sbCondSet = apis.NewLivingConditionSet(
+	SinkBindingConditionSinkProvided,
+)
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
 func (*SinkBinding) GetConditionSet() apis.ConditionSet {
@@ -82,16 +83,31 @@ func (sbs *SinkBindingStatus) MarkBindingAvailable() {
 	sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionReady)
 }
 
+// MarkSink sets the condition that the source has a sink configured.
+func (sbs *SinkBindingStatus) MarkSink(uri *apis.URL) {
+	sbs.SinkURI = uri
+	if uri != nil {
+		sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionSinkProvided)
+	} else {
+		sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.%s", "")
+	}
+}
+
 // Do implements psbinding.Bindable
 func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	// First undo so that we can just unconditionally append below.
 	sb.Undo(ctx, ps)
 
-	uri := GetSinkURI(ctx)
-	if uri == nil {
-		logging.FromContext(ctx).Errorf("No sink URI associated with context for %+v", sb)
+	resolver := GetURIResolver(ctx)
+	if resolver == nil {
+		logging.FromContext(ctx).Errorf("No Resolver associated with context for sink: %+v", sb)
+	}
+	uri, err := resolver.URIFromDestinationV1(ctx, sb.Spec.Sink, sb)
+	if err != nil {
+		logging.FromContext(ctx).Errorw("URI could not be extracted from destination: ", zap.Error(err))
 		return
 	}
+	sb.Status.MarkSink(uri)
 
 	var ceOverrides string
 	if sb.Spec.CloudEventOverrides != nil {

--- a/pkg/apis/sources/v1beta1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_lifecycle_test.go
@@ -24,11 +24,21 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 )
+
+func init() {
+	duckv1beta1.AddToScheme(scheme.Scheme)
+	duckv1.AddToScheme(scheme.Scheme)
+}
 
 func TestSinkBindingGetConditionSet(t *testing.T) {
 	r := &SinkBinding{}
@@ -89,6 +99,8 @@ func TestSinkBindingSetObsGen(t *testing.T) {
 }
 
 func TestSinkBindingStatusIsReady(t *testing.T) {
+	sink := apis.HTTP("table.ns.svc.cluster.local/flip")
+	sink.Scheme = "uri"
 	tests := []struct {
 		name string
 		s    *SinkBindingStatus
@@ -106,10 +118,20 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
-		name: "mark available",
+		name: "mark binding unavailable",
 		s: func() *SinkBindingStatus {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
+			s.MarkBindingUnavailable("TheReason", "this is the message")
+			return s
+		}(),
+		want: false,
+	}, {
+		name: "mark sink",
+		s: func() *SinkBindingStatus {
+			s := &SinkBindingStatus{}
+			s.InitializeConditions()
+			s.MarkSink(sink)
 			s.MarkBindingUnavailable("TheReason", "this is the message")
 			return s
 		}(),
@@ -119,6 +141,7 @@ func TestSinkBindingStatusIsReady(t *testing.T) {
 		s: func() *SinkBindingStatus {
 			s := &SinkBindingStatus{}
 			s.InitializeConditions()
+			s.MarkSink(sink)
 			s.MarkBindingAvailable()
 			return s
 		}(),
@@ -276,10 +299,12 @@ func TestSinkBindingUndo(t *testing.T) {
 }
 
 func TestSinkBindingDo(t *testing.T) {
-	sinkURI := &apis.URL{
-		Scheme: "http",
-		Host:   "thing.ns.svc.cluster.local",
-		Path:   "/a/path",
+	destination := duckv1.Destination{
+		URI: &apis.URL{
+			Scheme: "http",
+			Host:   "thing.ns.svc.cluster.local",
+			Path:   "/a/path",
+		},
 	}
 
 	overrides := duckv1.CloudEventOverrides{Extensions: map[string]string{"foo": "bar"}}
@@ -299,7 +324,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -318,7 +343,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -358,7 +383,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -409,7 +434,7 @@ func TestSinkBindingDo(t *testing.T) {
 							Image: "busybox",
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -426,7 +451,7 @@ func TestSinkBindingDo(t *testing.T) {
 								Value: "INGA",
 							}, {
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -439,7 +464,7 @@ func TestSinkBindingDo(t *testing.T) {
 								Value: "INGA",
 							}, {
 								Name:  "K_SINK",
-								Value: sinkURI.String(),
+								Value: destination.URI.String(),
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -455,10 +480,14 @@ func TestSinkBindingDo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.in
 
-			ctx := WithSinkURI(context.Background(), sinkURI)
+			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, got)
+			ctx = addressable.WithDuck(ctx)
+			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			ctx = WithURIResolver(context.Background(), r)
 
 			sb := &SinkBinding{Spec: SinkBindingSpec{
 				SourceSpec: duckv1.SourceSpec{
+					Sink:                destination,
 					CloudEventOverrides: &overrides,
 				},
 			}}

--- a/pkg/apis/sources/v1beta1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1beta1/sinkbinding_types.go
@@ -72,6 +72,10 @@ const (
 	// SinkBindingConditionReady is configured to indicate whether the Binding
 	// has been configured for resources subject to its runtime contract.
 	SinkBindingConditionReady = apis.ConditionReady
+
+	// SinkBindingConditionSinkProvided is configured to indicate whether the
+	// sink has been properly extracted from the resolver.
+	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
 )
 
 // SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).


### PR DESCRIPTION
related: #4161
related: #4374
related: #4377

## Proposed Changes

- backport changes of `sinkURI` -> `URIresolver` and related sinkbinding status updates
-
-

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
By moving the SinkURI resolution tol to the sinkbinding lifecycle, we avoid an error condition where WithContext cannot fetch the sinkURI (for whatever reason, including if it just hasn't been created yet). Moving that instead to the Do method where we can properly catch these kinds of errors
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
