### PR TITLE
Remove last (again) Json items.

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -169,7 +169,7 @@ func getLoggingConfig(c kubernetes.Interface) (*corev1.EnvVar, error) {
 		return nil, fmt.Errorf("error while parsing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}
 
-	configSerialized, err := logging.LoggingConfigToJson(config)
+	configSerialized, err := logging.ConfigToJSON(config)
 	if err != nil {
 		return nil, fmt.Errorf("error while serializing the %s config map: %+v", logging.ConfigMapName(), errors.WithStack(err))
 	}

--- a/test/test_images/utils.go
+++ b/test/test_images/utils.go
@@ -39,6 +39,8 @@ func ParseHeaders(serializedHeaders string) http.Header {
 	return h
 }
 
+// ParseDurationStr parses `durationStr` as number of seconds (not time.Duration string),
+// if parsing fails, returns back default duration.
 func ParseDurationStr(durationStr string, defaultDuration int) time.Duration {
 	var duration time.Duration
 	if d, err := strconv.Atoi(durationStr); err != nil {
@@ -73,7 +75,7 @@ func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 // ConfigureTracing can be used in test-images to configure tracing
 func ConfigureLogging(ctx context.Context, name string) context.Context {
 	loggingEnv := os.Getenv(ConfigLoggingEnv)
-	conf, err := logging.JsonToLoggingConfig(loggingEnv)
+	conf, err := logging.JSONToConfig(loggingEnv)
 	if err != nil {
 		logging.FromContext(ctx).Warn("Error while trying to read the config logging env: ", err)
 		return ctx


### PR DESCRIPTION
Something is wrong with my grepping it seems :/

For posterity :)
```
>rg "JsonTo" *
vendor/knative.dev/pkg/logging/config.go:241:// JsonToLoggingConfig converts a JSON string of a Config.
vendor/knative.dev/pkg/logging/config.go:244:func JsonToLoggingConfig(jsonCfg string) (*Config, error) { //nolint No rename due to backwards incompatibility.
vendor/knative.dev/pkg/tracing/config/tracing.go:137:// JsonToTracingConfig converts a json string of a Config.
vendor/knative.dev/pkg/tracing/config/tracing.go:139:func JsonToTracingConfig(jsonCfg string) (*Config, error) { //nolint // for backcompat.
```
All in vendor :)