### PR TITLE
Drop TEST_EVENTING_NAMESPACE

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -56,7 +56,6 @@ jobs:
       GO111MODULE: off
       KO_DOCKER_REPO: kind.local
       SYSTEM_NAMESPACE: knative-eventing
-      TEST_EVENTING_NAMESPACE: knative-eventing
       # Use a semi-random cluster suffix, but somewhat predictable
       # so reruns don't just give us a completely new value.
       CLUSTER_SUFFIX: c${{ github.run_id }}.local


### PR DESCRIPTION
- 🧽 Update or clean up current behavior

Related: https://github.com/knative/eventing/issues/4276