### PR TITLE
Eventing upgrade tests prober fully configurable

### DIFF
--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -52,9 +52,6 @@ func TestContinuousEventsPropagationWithProber(t *testing.T) {
 
 	config := prober.NewConfig(client.Namespace)
 
-	// FIXME: https://github.com/knative/eventing/issues/2665
-	config.FailOnErrors = false
-
 	// Use zap.SugarLogger instead of t.Logf because we want to see failures
 	// inline with other logs instead of buffered until the end.
 	log := createLogger()

--- a/test/upgrade/prober/config.toml
+++ b/test/upgrade/prober/config.toml
@@ -1,6 +1,6 @@
 # logLevel = 5 # DEBUG(5)
 [sender]
-address = '{{- .BrokerUrl -}}'
+address = '{{- .BrokerURL -}}'
 interval = {{ .Config.Interval.Nanoseconds }}
 [forwarder]
 target = 'http://wathola-receiver.{{- .Config.Namespace -}}.svc.cluster.local'

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -23,7 +23,9 @@ import (
 	"path"
 	"runtime"
 	"text/template"
+	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/wavesoftware/go-ensure"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
@@ -34,17 +36,82 @@ import (
 )
 
 const (
-	configName       = "wathola-config"
-	configMountPoint = "/home/nonroot/.config/wathola"
-	configFilename   = "config.toml"
-	watholaEventNs   = "com.github.cardil.wathola"
-	healthEndpoint   = "/healthz"
+	defaultConfigName          = "wathola-config"
+	defaultConfigHomedirPath   = ".config/wathola"
+	defaultHomedir             = "/home/nonroot"
+	defaultConfigFilename      = "config.toml"
+	defaultWatholaEventsPrefix = "com.github.cardil.wathola"
+	defaultBrokerName          = "default"
+	defaultHealthEndpoint      = "/healthz"
+	defaultFinishedSleep       = 5 * time.Second
 )
 
-var (
-	eventTypes = []string{"step", "finished"}
-	brokerName = "default"
-)
+var eventTypes = []string{"step", "finished"}
+
+// Config represents a configuration for prober.
+type Config struct {
+	Wathola       WatholaConfig
+	Namespace     string
+	Interval      time.Duration
+	FinishedSleep time.Duration
+	Serving       ServingConfig
+	FailOnErrors  bool
+}
+
+// WatholaConfig represents options related strictly to wathola testing tool.
+type WatholaConfig struct {
+	Config           ConfigMapConfig
+	EventsTypePrefix string
+	HealthEndpoint   string
+	BrokerName       string
+}
+
+// ConfigMapConfig represents options of wathola config toml file.
+type ConfigMapConfig struct {
+	Name       string
+	MountPoint string
+	Filename   string
+}
+
+// ServingConfig represents a options for serving test component (wathola-forwarder).
+type ServingConfig struct {
+	Use         bool
+	ScaleToZero bool
+}
+
+// NewConfig creates a new configuration object with default values filled in.
+// Values can be influenced by kelseyhightower/envconfig with
+// `e2e_upgrade_tests` prefix.
+func NewConfig(namespace string) *Config {
+	config := &Config{
+		Namespace:     "",
+		Interval:      Interval,
+		FinishedSleep: defaultFinishedSleep,
+		FailOnErrors:  true,
+		Serving: ServingConfig{
+			Use:         false,
+			ScaleToZero: true,
+		},
+		Wathola: WatholaConfig{
+			Config: ConfigMapConfig{
+				Name:       defaultConfigName,
+				MountPoint: fmt.Sprintf("%s/%s", defaultHomedir, defaultConfigHomedirPath),
+				Filename:   defaultConfigFilename,
+			},
+			EventsTypePrefix: defaultWatholaEventsPrefix,
+			HealthEndpoint:   defaultHealthEndpoint,
+			BrokerName:       defaultBrokerName,
+		},
+	}
+
+	// FIXME: remove while fixing https://github.com/knative/eventing/issues/2665
+	config.FailOnErrors = false
+
+	err := envconfig.Process("e2e_upgrade_tests", config)
+	ensure.NoError(err)
+	config.Namespace = namespace
+	return config
+}
 
 func (p *prober) deployConfiguration() {
 	p.deployBroker()
@@ -53,55 +120,64 @@ func (p *prober) deployConfiguration() {
 }
 
 func (p *prober) deployBroker() {
-	p.client.CreateBrokerV1Beta1OrFail(brokerName)
+	p.client.CreateBrokerV1Beta1OrFail(p.config.Wathola.BrokerName)
 }
 
-func (p *prober) fetchBrokerUrl() (*apis.URL, error) {
+func (p *prober) fetchBrokerURL() (*apis.URL, error) {
 	namespace := p.config.Namespace
-	p.log.Debugf("Fetching %s broker URL for ns %s", brokerName, namespace)
-	meta := resources.NewMetaResource(brokerName, p.config.Namespace, testlib.BrokerTypeMeta)
+	p.log.Debugf("Fetching %s broker URL for ns %s",
+		p.config.Wathola.BrokerName, namespace)
+	meta := resources.NewMetaResource(
+		p.config.Wathola.BrokerName, p.config.Namespace, testlib.BrokerTypeMeta,
+	)
 	err := duck.WaitForResourceReady(p.client.Dynamic, meta)
 	if err != nil {
 		return nil, err
 	}
-	broker, err := p.client.Eventing.EventingV1beta1().Brokers(namespace).Get(context.Background(), brokerName, metav1.GetOptions{})
+	broker, err := p.client.Eventing.EventingV1beta1().Brokers(namespace).Get(
+		context.Background(), p.config.Wathola.BrokerName, metav1.GetOptions{},
+	)
 	if err != nil {
 		return nil, err
 	}
 	url := broker.Status.Address.URL
-	p.log.Debugf("%s broker URL for ns %s is %v", brokerName, namespace, url)
+	p.log.Debugf("%s broker URL for ns %s is %v",
+		p.config.Wathola.BrokerName, namespace, url)
 	return url, nil
 }
 
 func (p *prober) deployConfigMap() {
-	name := configName
+	name := p.config.Wathola.Config.Name
 	p.log.Infof("Deploying config map: \"%s/%s\"", p.config.Namespace, name)
-	brokerUrl, err := p.fetchBrokerUrl()
+	brokerURL, err := p.fetchBrokerURL()
 	ensure.NoError(err)
-	configData := p.compileTemplate(configFilename, brokerUrl)
-	p.client.CreateConfigMapOrFail(name, p.config.Namespace, map[string]string{configFilename: configData})
+	configData := p.compileTemplate(p.config.Wathola.Config.Filename, brokerURL)
+	p.client.CreateConfigMapOrFail(name, p.config.Namespace, map[string]string{
+		p.config.Wathola.Config.Filename: configData,
+	})
 }
 
 func (p *prober) deployTriggers() {
 	for _, eventType := range eventTypes {
 		name := fmt.Sprintf("wathola-trigger-%v", eventType)
-		fullType := fmt.Sprintf("%v.%v", watholaEventNs, eventType)
+		fullType := fmt.Sprintf("%v.%v", p.config.Wathola.EventsTypePrefix, eventType)
 		subscriberOption := resources.WithSubscriberServiceRefForTriggerV1Beta1(receiverName)
 		if p.config.Serving.Use {
 			subscriberOption = resources.WithSubscriberKServiceRefForTrigger(forwarderName)
 		}
 		p.client.CreateTriggerOrFailV1Beta1(name,
-			resources.WithBrokerV1Beta1(brokerName),
+			resources.WithBrokerV1Beta1(p.config.Wathola.BrokerName),
 			resources.WithAttributesTriggerFilterV1Beta1(
 				eventingv1beta1.TriggerAnyFilter,
 				fullType,
 				map[string]interface{}{},
 			),
-			subscriberOption)
+			subscriberOption,
+		)
 	}
 }
 
-func (p *prober) compileTemplate(templateName string, brokerUrl *apis.URL) string {
+func (p *prober) compileTemplate(templateName string, brokerURL fmt.Stringer) string {
 	_, filename, _, _ := runtime.Caller(0)
 	templateFilepath := path.Join(path.Dir(filename), templateName)
 	templateBytes, err := ioutil.ReadFile(templateFilepath)
@@ -111,10 +187,10 @@ func (p *prober) compileTemplate(templateName string, brokerUrl *apis.URL) strin
 	var buff bytes.Buffer
 	data := struct {
 		*Config
-		BrokerUrl string
+		BrokerURL string
 	}{
 		p.config,
-		brokerUrl.String(),
+		brokerURL.String(),
 	}
 	ensure.NoError(tmpl.Execute(&buff, data))
 	return buff.String()

--- a/test/upgrade/prober/forwarder.go
+++ b/test/upgrade/prober/forwarder.go
@@ -78,20 +78,20 @@ func (p *prober) forwarderKService(name, namespace string) *unstructured.Unstruc
 						"name":  "forwarder",
 						"image": pkgTest.ImagePath(forwarderName),
 						"volumeMounts": []map[string]interface{}{{
-							"name":      p.config.Wathola.Config.Name,
-							"mountPath": p.config.Wathola.Config.MountPoint,
+							"name":      p.config.ConfigMapName,
+							"mountPath": p.config.ConfigMountPoint,
 							"readOnly":  true,
 						}},
 						"readinessProbe": map[string]interface{}{
 							"httpGet": map[string]interface{}{
-								"path": p.config.Wathola.HealthEndpoint,
+								"path": p.config.HealthEndpoint,
 							},
 						},
 					}},
 					"volumes": []map[string]interface{}{{
-						"name": p.config.Wathola.Config.Name,
+						"name": p.config.ConfigMapName,
 						"configMap": map[string]interface{}{
-							"name": p.config.Wathola.Config.Name,
+							"name": p.config.ConfigMapName,
 						},
 					}},
 				},

--- a/test/upgrade/prober/forwarder.go
+++ b/test/upgrade/prober/forwarder.go
@@ -35,7 +35,7 @@ var (
 func (p *prober) deployForwarder(ctx context.Context) {
 	p.log.Infof("Deploy forwarder knative service: %v", forwarderName)
 	serving := p.client.Dynamic.Resource(resources.KServicesGVR).Namespace(p.client.Namespace)
-	service := forwarderKService(forwarderName, p.client.Namespace)
+	service := p.forwarderKService(forwarderName, p.client.Namespace)
 	_, err := serving.Create(context.Background(), service, metav1.CreateOptions{})
 	ensure.NoError(err)
 
@@ -60,7 +60,7 @@ func (p *prober) removeForwarder() {
 	ensure.NoError(err)
 }
 
-func forwarderKService(name, namespace string) *unstructured.Unstructured {
+func (p *prober) forwarderKService(name, namespace string) *unstructured.Unstructured {
 	obj := map[string]interface{}{
 		"apiVersion": resources.KServiceType.APIVersion,
 		"kind":       resources.KServiceType.Kind,
@@ -78,20 +78,20 @@ func forwarderKService(name, namespace string) *unstructured.Unstructured {
 						"name":  "forwarder",
 						"image": pkgTest.ImagePath(forwarderName),
 						"volumeMounts": []map[string]interface{}{{
-							"name":      configName,
-							"mountPath": configMountPoint,
+							"name":      p.config.Wathola.Config.Name,
+							"mountPath": p.config.Wathola.Config.MountPoint,
 							"readOnly":  true,
 						}},
 						"readinessProbe": map[string]interface{}{
 							"httpGet": map[string]interface{}{
-								"path": healthEndpoint,
+								"path": p.config.Wathola.HealthEndpoint,
 							},
 						},
 					}},
 					"volumes": []map[string]interface{}{{
-						"name": configName,
+						"name": p.config.Wathola.Config.Name,
 						"configMap": map[string]interface{}{
-							"name": configName,
+							"name": p.config.Wathola.Config.Name,
 						},
 					}},
 				},

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kelseyhightower/envconfig"
 	"github.com/wavesoftware/go-ensure"
 	"go.uber.org/zap"
 	testlib "knative.dev/eventing/test/lib"
@@ -48,37 +47,6 @@ type Prober interface {
 	deploy(ctx context.Context)
 	// remove a prober from cluster
 	remove()
-}
-
-// Config represents a configuration for prober
-type Config struct {
-	Namespace     string
-	Interval      time.Duration
-	Serving       ServingConfig
-	FinishedSleep time.Duration
-	FailOnErrors  bool
-}
-
-type ServingConfig struct {
-	Use         bool
-	ScaleToZero bool
-}
-
-func NewConfig(namespace string) *Config {
-	config := &Config{
-		Namespace:     "",
-		Interval:      Interval,
-		FinishedSleep: 5 * time.Second,
-		FailOnErrors:  true,
-		Serving: ServingConfig{
-			Use:         false,
-			ScaleToZero: true,
-		},
-	}
-	err := envconfig.Process("e2e_upgrade_tests", config)
-	ensure.NoError(err)
-	config.Namespace = namespace
-	return config
 }
 
 // RunEventProber starts a single Prober of the given domain.

--- a/test/upgrade/prober/prober_test.go
+++ b/test/upgrade/prober/prober_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	defaultConfigFilename = "config.toml"
 	servingEnvName        = "E2E_UPGRADE_TESTS_SERVING_USE"
-	configFilenameEnvName = "E2E_UPGRADE_TESTS_WATHOLA_CONFIG_FILENAME"
+	configFilenameEnvName = "E2E_UPGRADE_TESTS_CONFIGFILENAME"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNewConfig(t *testing.T) {
 
 			assert.Equal(t, s.servingUse, config.Serving.Use)
 			assert.True(t, config.Serving.ScaleToZero)
-			assert.Equal(t, s.configFilename, config.Wathola.Config.Filename)
+			assert.Equal(t, s.configFilename, config.ConfigFilename)
 		})
 	}
 }

--- a/test/upgrade/prober/prober_test.go
+++ b/test/upgrade/prober/prober_test.go
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package prober
+package prober_test
 
 import (
 	"fmt"
@@ -21,40 +21,86 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"knative.dev/eventing/test/upgrade/prober"
 )
 
-type envValue uint
-
 const (
-	EnvFalse envValue = iota
-	EnvTrue
-	EnvUnset
+	defaultConfigFilename = "config.toml"
+	servingEnvName        = "E2E_UPGRADE_TESTS_SERVING_USE"
+	configFilenameEnvName = "E2E_UPGRADE_TESTS_WATHOLA_CONFIG_FILENAME"
 )
 
 func TestNewConfig(t *testing.T) {
-	envname := "E2E_UPGRADE_TESTS_SERVING_USE"
-	suite := []struct {
-		env envValue
-		out bool
-	}{
-		{EnvFalse, false},
-		{EnvTrue, true},
-		{EnvUnset, false},
+	unsetList := []string{
+		servingEnvName, configFilenameEnvName,
 	}
-	for _, s := range suite {
-		t.Run(fmt.Sprintf("env=%v,out=%t", s.env, s.out), func(t *testing.T) {
-			if s.env != EnvUnset {
-				val := "false"
-				if s.env == EnvTrue {
-					val = "true"
-				}
-				assert.NoError(t, os.Setenv(envname, val))
-				defer func() { assert.NoError(t, os.Unsetenv(envname)) }()
-			}
-			config := NewConfig("test-ns")
 
-			assert.Equal(t, s.out, config.Serving.Use)
+	for _, s := range createTestSuite() {
+		t.Run(fmt.Sprintf("env=%#v", s.env), func(t *testing.T) {
+			for envname, value := range s.env {
+				assert.NoError(t, os.Setenv(envname, value))
+			}
+			defer func() {
+				for _, envname := range unsetList {
+					assert.NoError(t, os.Unsetenv(envname))
+				}
+			}()
+
+			if s.panics {
+				assert.Panics(t, func() {
+					prober.NewConfig("test-ns")
+				})
+				return
+			}
+
+			config := prober.NewConfig("test-ns")
+
+			assert.Equal(t, s.servingUse, config.Serving.Use)
 			assert.True(t, config.Serving.ScaleToZero)
+			assert.Equal(t, s.configFilename, config.Wathola.Config.Filename)
 		})
 	}
+}
+
+type testCase struct {
+	env            map[string]string
+	panics         bool
+	servingUse     bool
+	configFilename string
+}
+
+func createTestSuite() []testCase {
+	return []testCase{
+		createTestCase(func(c *testCase) {
+			c.env = map[string]string{servingEnvName: "false"}
+		}),
+		createTestCase(func(c *testCase) {
+			c.env = map[string]string{servingEnvName: "true"}
+			c.servingUse = true
+		}),
+		createTestCase(func(c *testCase) {}),
+		createTestCase(func(c *testCase) {
+			c.env = map[string]string{
+				servingEnvName: "gibberish",
+			}
+			c.panics = true
+		}),
+		createTestCase(func(c *testCase) {
+			c.env = map[string]string{
+				configFilenameEnvName: "replaced.toml",
+			}
+			c.configFilename = "replaced.toml"
+		}),
+	}
+}
+
+func createTestCase(overrides func(*testCase)) testCase {
+	c := testCase{
+		map[string]string{},
+		false,
+		false,
+		defaultConfigFilename,
+	}
+	overrides(&c)
+	return c
 }

--- a/test/upgrade/prober/receiver.go
+++ b/test/upgrade/prober/receiver.go
@@ -51,10 +51,12 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: configName,
+					Name: p.config.Wathola.Config.Name,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: configName},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: p.config.Wathola.Config.Name,
+							},
 						},
 					},
 				},
@@ -65,15 +67,15 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 					Image: pkgTest.ImagePath(receiverName),
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      configName,
+							Name:      p.config.Wathola.Config.Name,
 							ReadOnly:  true,
-							MountPath: configMountPoint,
+							MountPath: p.config.Wathola.Config.MountPoint,
 						},
 					},
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path: healthEndpoint,
+								Path: p.config.Wathola.HealthEndpoint,
 								Port: intstr.FromInt(watholaconfig.DefaultReceiverPort),
 							},
 						},

--- a/test/upgrade/prober/receiver.go
+++ b/test/upgrade/prober/receiver.go
@@ -51,11 +51,11 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: p.config.Wathola.Config.Name,
+					Name: p.config.ConfigMapName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: p.config.Wathola.Config.Name,
+								Name: p.config.ConfigMapName,
 							},
 						},
 					},
@@ -67,15 +67,15 @@ func (p *prober) deployReceiverPod(ctx context.Context) {
 					Image: pkgTest.ImagePath(receiverName),
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      p.config.Wathola.Config.Name,
+							Name:      p.config.ConfigMapName,
 							ReadOnly:  true,
-							MountPath: p.config.Wathola.Config.MountPoint,
+							MountPath: p.config.ConfigMountPoint,
 						},
 					},
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path: p.config.Wathola.HealthEndpoint,
+								Path: p.config.HealthEndpoint,
 								Port: intstr.FromInt(watholaconfig.DefaultReceiverPort),
 							},
 						},

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -38,10 +38,12 @@ func (p *prober) deploySender(ctx context.Context) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: configName,
+					Name: p.config.Wathola.Config.Name,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: configName},
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: p.config.Wathola.Config.Name,
+							},
 						},
 					},
 				},
@@ -52,9 +54,9 @@ func (p *prober) deploySender(ctx context.Context) {
 					Image: pkgTest.ImagePath(senderName),
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      configName,
+							Name:      p.config.Wathola.Config.Name,
 							ReadOnly:  true,
-							MountPath: configMountPoint,
+							MountPath: p.config.Wathola.Config.MountPoint,
 						},
 					},
 				},

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -38,11 +38,11 @@ func (p *prober) deploySender(ctx context.Context) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: p.config.Wathola.Config.Name,
+					Name: p.config.ConfigMapName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: p.config.Wathola.Config.Name,
+								Name: p.config.ConfigMapName,
 							},
 						},
 					},
@@ -54,9 +54,9 @@ func (p *prober) deploySender(ctx context.Context) {
 					Image: pkgTest.ImagePath(senderName),
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      p.config.Wathola.Config.Name,
+							Name:      p.config.ConfigMapName,
 							ReadOnly:  true,
-							MountPath: p.config.Wathola.Config.MountPoint,
+							MountPath: p.config.ConfigMountPoint,
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #4420

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Makes Eventing upgrade tests prober fully configurable by environment variables
- Moving configuration stuff to `configuration.go` file