### PR TITLE
Use knative service for wathola receiver if available

### DIFF
--- a/test/upgrade/prober/kservice.go
+++ b/test/upgrade/prober/kservice.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"knative.dev/eventing/test/lib/resources"
+)
+
+func kService(meta metav1.ObjectMeta, spec corev1.PodSpec) *unstructured.Unstructured {
+	if len(spec.Containers) != 1 {
+		panic("kService func supports PodSpec with 1 container only")
+	}
+	container := spec.Containers[0]
+	if len(spec.Volumes) != 1 || len(container.VolumeMounts) != 1 {
+		panic("kService func supports PodSpec with 1 volume only")
+	}
+	volume := spec.Volumes[0]
+	volmount := container.VolumeMounts[0]
+	obj := map[string]interface{}{
+		"apiVersion": resources.KServiceType.APIVersion,
+		"kind":       resources.KServiceType.Kind,
+		"metadata": map[string]interface{}{
+			"name":      meta.Name,
+			"namespace": meta.Namespace,
+			"labels":    meta.Labels,
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": meta.Annotations,
+				},
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{{
+						"name":  container.Name,
+						"image": container.Image,
+						"volumeMounts": []map[string]interface{}{{
+							"name":      volmount.Name,
+							"mountPath": volmount.MountPath,
+							"readOnly":  true,
+						}},
+						"readinessProbe": map[string]interface{}{
+							"httpGet": map[string]interface{}{
+								"path": container.ReadinessProbe.HTTPGet.Path,
+							},
+						},
+					}},
+					"volumes": []map[string]interface{}{{
+						"name": volume.Name,
+						"configMap": map[string]interface{}{
+							"name": volume.ConfigMap.Name,
+						},
+					}},
+				},
+			},
+		},
+	}
+	return &unstructured.Unstructured{Object: obj}
+}

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -124,6 +124,7 @@ func (p *prober) deploy(ctx context.Context) {
 func (p *prober) remove() {
 	if p.config.Serving.Use {
 		p.removeForwarder()
+		p.removeReceiverKService()
 	}
 	ensure.NoError(p.client.Tracker.Clean(true))
 }


### PR DESCRIPTION
Is related to #3175

This PR isn't doing #3175 a full justice. This is a minor improvement, in which we can get receiver report even if given K8s cluster doesn't a worker node external, reachable address. It's done when there is a Serving component available.

Such a situation arisen on our team when we were trying to incorporate upgrade tests in our product (see https://github.com/openshift-knative/serverless-operator/pull/530#issuecomment-717367653).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- If _Serving.Use_ flag is set deploy a kservice and get it's URL instead of relying on worker node internal address