### PR TITLE
Dispatcher updates subscriber statuses

### DIFF
--- a/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
@@ -43,6 +43,8 @@ rules:
       - create
       - patch
 # Updates the finalizer so we can remove our handlers when channel is deleted
+# Patches the status.subscribers to reflect when the subscription dataplane has been
+# configured.
   - apiGroups:
       - messaging.knative.dev
     resources:

--- a/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
@@ -47,6 +47,7 @@ rules:
       - messaging.knative.dev
     resources:
       - inmemorychannels/finalizers
+      - inmemorychannels/status
       - inmemorychannels
     verbs:
       - patch

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -38,7 +38,6 @@ import (
 	"knative.dev/pkg/apis"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
-	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
@@ -157,15 +156,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel)
 	}
 	imc.Status.MarkChannelServiceTrue()
 	imc.Status.SetAddress(apis.HTTP(network.GetServiceHostname(svc.Name, svc.Namespace)))
-
-	imc.Status.Subscribers = make([]eventingduck.SubscriberStatus, 0)
-	for _, sub := range imc.Spec.Subscribers {
-		imc.Status.Subscribers = append(imc.Status.Subscribers, eventingduck.SubscriberStatus{
-			UID:                sub.UID,
-			ObservedGeneration: sub.Generation,
-			Ready:              corev1.ConditionTrue,
-		})
-	}
 
 	// Ok, so now the Dispatcher Deployment & Service have been created, we're golden since the
 	// dispatcher watches the Channel and where it needs to dispatch events to.

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -42,6 +42,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/channel"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	inmemorychannelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel"
 	"knative.dev/eventing/pkg/inmemorychannel"
 )
@@ -96,6 +97,7 @@ func NewController(
 	r := &Reconciler{
 		multiChannelMessageHandler: sh,
 		reporter:                   reporter,
+		messagingClientSet:         eventingclient.Get(ctx).MessagingV1(),
 	}
 	impl := inmemorychannelreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{SkipStatusUpdates: true, FinalizerName: finalizerName}

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
@@ -25,6 +25,8 @@ import (
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
+	// Fake injection client
+	_ "knative.dev/eventing/pkg/client/injection/client/fake"
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel/fake"
 )

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	messagingv1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -37,6 +36,7 @@ import (
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
+	messagingv1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1"
 	"knative.dev/pkg/apis/duck"
 )
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -19,6 +19,11 @@ package dispatcher
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	messagingv1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -27,10 +32,12 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
+	"knative.dev/pkg/apis/duck"
 )
 
 // Reconciler reconciles InMemory Channels.
@@ -38,6 +45,7 @@ type Reconciler struct {
 	eventDispatcherConfigStore *channel.EventDispatcherConfigStore
 	multiChannelMessageHandler multichannelfanout.MultiChannelMessageHandler
 	reporter                   channel.StatsReporter
+	messagingClientSet         messagingv1.MessagingV1Interface
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel) reconciler.Event {
@@ -74,7 +82,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel)
 			handler.SetSubscriptions(ctx, config.FanoutConfig.Subscriptions)
 		}
 	}
-	return nil
+
+	// Then patch the subscribers to reflect that they are now ready to go
+	return r.patchSubscriberStatus(ctx, imc)
 }
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, imc *v1.InMemoryChannel) reconciler.Event {
@@ -86,7 +96,35 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, imc *v1.InMemoryChannel) 
 		}
 	}
 	return nil
+}
 
+func (r *Reconciler) patchSubscriberStatus(ctx context.Context, imc *v1.InMemoryChannel) error {
+	after := imc.DeepCopy()
+
+	after.Status.Subscribers = make([]eventingduckv1.SubscriberStatus, 0)
+	for _, sub := range imc.Spec.Subscribers {
+		after.Status.Subscribers = append(after.Status.Subscribers, eventingduckv1.SubscriberStatus{
+			UID:                sub.UID,
+			ObservedGeneration: sub.Generation,
+			Ready:              corev1.ConditionTrue,
+		})
+	}
+	patch, err := duck.CreateMergePatch(imc, after)
+	if err != nil {
+		return err
+	}
+	// If there is nothing to patch, we are good, just return.
+	// Empty patch is {}, hence we check for that.
+	if len(patch) <= 2 {
+		return nil
+	}
+	patched, err := r.messagingClientSet.InMemoryChannels(imc.Namespace).Patch(ctx, imc.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+	if err != nil {
+		logging.FromContext(ctx).Warnw("Failed to patch the Channel", zap.Error(err), zap.Any("patch", patch))
+		return err
+	}
+	logging.FromContext(ctx).Infow("Patched resource", zap.Any("patch", patch), zap.Any("patched", patched))
+	return nil
 }
 
 // newConfigForInMemoryChannel creates a new Config for a single inmemory channel.

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -115,7 +115,7 @@ func (r *Reconciler) patchSubscriberStatus(ctx context.Context, imc *v1.InMemory
 		return fmt.Errorf("creating JSON patch: %w", err)
 	}
 	// If there is nothing to patch, we are good, just return.
-	// Empty patch is []], hence we check for that.
+	// Empty patch is [], hence we check for that.
 	if len(jsonPatch) == 0 {
 		return nil
 	}

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -180,9 +180,7 @@ func TestAllCases(t *testing.T) {
 			},
 
 			WantErr: false,
-			/* TODO: Add support to pkg for subresources for InduceFailure so we can test status patch fail
-			}, {
-
+		}, {
 			Name: "with subscribers, patch fails",
 			Key:  imcKey,
 			Objects: []runtime.Object{
@@ -196,17 +194,17 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
 			WithReactors: []clientgotesting.ReactionFunc{
-				InduceFailure("patch", "InMemoryChannels/status"),
+				InduceFailure("patch", "inmemorychannels/status"),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(testNS, imcName),
+				patchSubscriberBytes(testNS, imcName, twoSubscriberPatch),
 			},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "FinalizerUpdate", "Updated %q finalizers", imcName),
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
+				Eventf(corev1.EventTypeWarning, "InternalError", "Failed patching: inducing failure for patch inmemorychannels"),
 			},
-
-			WantErr: false,
-			*/
+			WantErr: true,
 		}, {
 			Name: "with subscribers, no patch",
 			Key:  imcKey,

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -23,8 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"knative.dev/eventing/pkg/kncloudevents"
 
@@ -373,7 +371,7 @@ func TestAllCases(t *testing.T) {
 		r := &Reconciler{
 			multiChannelMessageHandler: NewFakeMultiChannelHandler(),
 			eventDispatcherConfigStore: channel.NewEventDispatcherConfigStore(logger),
-			messagingClientSet:         eventingclient.Get(ctx).MessagingV1(),
+			messagingClientSet:         fakeeventingclient.Get(ctx).MessagingV1(),
 		}
 		return inmemorychannel.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetInMemoryChannelLister(),


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@vmware.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do not update subscriber statuses from the control plane, do it from the dispatcher by using patch to only modify the subscriber statuses

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Only update the subscriber statuses in IMC after they have been added to handlers. Reduces failures where the
subscribers have been marked before the dataplane has been actually configured.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
