### PR TITLE
Relax empty logging config tests

### DIFF
--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -55,7 +55,7 @@ func TestNewConfigWatcher_defaults(t *testing.T) {
 			name: "With empty data",
 			cmw:  configMapWatcherWithEmptyData(),
 			// logging defaults to Knative's defaults
-			expectLoggingContains: `{"zap-logger-config":"{\n  \"level\": \"info\"`,
+			expectLoggingContains: ``,
 			// metrics defaults to empty ConfigMap
 			expectMetricsContains: `"ConfigMap":{}`,
 			// tracing defaults to None backend


### PR DESCRIPTION
Allows an empty logging config to represented by an empty
K_LOGGING_CONFIG value rather than requiring the population of default values.

Needed to allow changes in how logging configuration is handled in https://github.com/knative/pkg/pull/1773.