### PR TITLE
Set default in-mem delivery spec

### DIFF
--- a/pkg/apis/messaging/v1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_defaults.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	"knative.dev/eventing/pkg/apis/messaging"
+
+	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
 func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
@@ -39,5 +41,8 @@ func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 }
 
 func (imcs *InMemoryChannelSpec) SetDefaults(ctx context.Context) {
-	// TODO: Nothing to default here...
+	if imcs.Delivery == nil {
+		imcs.Delivery = new(duckv1.DeliverySpec)
+		imcs.Delivery.SetDefaults(ctx)
+	}
 }


### PR DESCRIPTION
May fix https://github.com/knative/eventing/issues/2357

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set default in-memory channel delivery spec.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🧽 By default, the in-memory channel retries sending events for 10 seconds before giving up
```

**Docs**

TODO: add doc issue link if this PR is accepted.

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

@devguyio @vaikas @cardil Can you please take a look?