### PR TITLE
Reduce a prober test name length to prevent DNS label too long error

### DIFF
--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -35,7 +35,7 @@ const (
 	readyMessage = "prober ready"
 )
 
-func TestContinuousEventsPropagationWithProber(t *testing.T) {
+func TestEventsPropagationWithProber(t *testing.T) {
 	// We run the prober as a golang test because it fits in nicely with
 	// the rest of our integration tests, and AssertProberDefault needs
 	// a *testing.T. Unfortunately, "go test" intercepts signals, so we


### PR DESCRIPTION
Fixes #4441

<!-- Please include the 'why' behind your changes if no issue exists -->

Descriptive method names are good, but too long isn't good either.

## Proposed Changes

- Reduce the name of prober test method