### PR TITLE
Retry on network failures

### DIFF
--- a/pkg/kncloudevents/message_sender.go
+++ b/pkg/kncloudevents/message_sender.go
@@ -189,6 +189,6 @@ func RetryConfigFromDeliverySpec(spec duckv1.DeliverySpec) (RetryConfig, error) 
 	return retryConfig, nil
 }
 
-func checkRetry(_ context.Context, resp *nethttp.Response, _ error) (bool, error) {
-	return resp != nil && resp.StatusCode >= 300, nil
+func checkRetry(_ context.Context, resp *nethttp.Response, err error) (bool, error) {
+	return !(resp != nil && resp.StatusCode < 300), err
 }

--- a/pkg/kncloudevents/message_sender_test.go
+++ b/pkg/kncloudevents/message_sender_test.go
@@ -18,9 +18,6 @@ package kncloudevents
 
 import (
 	"context"
-	"fmt"
-	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -186,10 +183,9 @@ func TestHTTPMessageSenderSendWithRetries(t *testing.T) {
 
 func TestRetriesOnNetworkErrors(t *testing.T) {
 
-	port := rand.Int31n(math.MaxUint16-1024) + 1024
 	n := int32(10)
 	linear := duckv1.BackoffPolicyLinear
-	target := fmt.Sprint("127.0.0.1:", port)
+	target := "127.0.0.1:63468"
 
 	calls := make(chan struct{})
 	defer close(calls)
@@ -203,7 +199,6 @@ func TestRetriesOnNetworkErrors(t *testing.T) {
 		for range calls {
 
 			nCalls++
-
 			// Simulate that the target service is back up.
 			//
 			// First n/2-1 calls we get connection refused since there is no server running.

--- a/pkg/kncloudevents/message_sender_test.go
+++ b/pkg/kncloudevents/message_sender_test.go
@@ -18,6 +18,10 @@ package kncloudevents
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -178,6 +182,86 @@ func TestHTTPMessageSenderSendWithRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetriesOnNetworkErrors(t *testing.T) {
+
+	port := rand.Int31n(math.MaxUint16-1024) + 1024
+	n := int32(10)
+	linear := duckv1.BackoffPolicyLinear
+	target := fmt.Sprint("127.0.0.1:", port)
+
+	calls := make(chan struct{})
+	defer close(calls)
+
+	nCalls := int32(0)
+
+	cont := make(chan struct{})
+	defer close(cont)
+
+	go func() {
+		for range calls {
+
+			nCalls++
+
+			// Simulate that the target service is back up.
+			//
+			// First n/2-1 calls we get connection refused since there is no server running.
+			// Now we start a server that responds with a retryable error, so we expect that
+			// the client continues to retry for a different reason.
+			//
+			// The last time we return 200, so we don't expect a new retry.
+			if n/2 == nCalls {
+
+				l, err := net.Listen("tcp", target)
+				assert.Nil(t, err)
+
+				s := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+					if n-1 != nCalls {
+						writer.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+				}))
+				defer s.Close() //nolint // defers in this range loop won't run unless the channel gets closed
+
+				assert.Nil(t, s.Listener.Close())
+
+				s.Listener = l
+
+				s.Start()
+			}
+			cont <- struct{}{}
+		}
+	}()
+
+	r, err := RetryConfigFromDeliverySpec(duckv1.DeliverySpec{
+		Retry:         pointer.Int32Ptr(n),
+		BackoffPolicy: &linear,
+		BackoffDelay:  pointer.StringPtr("PT0.1S"),
+	})
+	assert.Nil(t, err)
+
+	checkRetry := r.CheckRetry
+
+	r.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		calls <- struct{}{}
+		<-cont
+
+		return checkRetry(ctx, resp, err)
+	}
+
+	req, err := http.NewRequest("POST", "http://"+target, nil)
+	assert.Nil(t, err)
+
+	sender, err := NewHTTPMessageSender(nil, "")
+	assert.Nil(t, err)
+
+	_, err = sender.SendWithRetries(req, &r)
+	assert.Nil(t, err)
+
+	// nCalls keeps track of how many times a call to check retry occurs.
+	// Since the number of request are n + 1 and the last one is successful the expected number of calls are n.
+	assert.Equal(t, n, nCalls, "expected %d got %d", n, nCalls)
 }
 
 func TestHTTPMessageSenderSendWithRetriesWithBufferedMessage(t *testing.T) {


### PR DESCRIPTION
Fixes #4453

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Retry on network failures

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Retry on network failures
```

Test execution logs:
```
2020/11/03 13:25:27 [DEBUG] POST http://127.0.0.1:21697
2020/11/03 13:25:27 [ERR] POST http://127.0.0.1:21697 request failed: Post "http://127.0.0.1:21697": dial tcp 127.0.0.1:21697: connect: connection refused
2020/11/03 13:25:27 [DEBUG] POST http://127.0.0.1:21697: retrying in 0s (10 left)
2020/11/03 13:25:27 [ERR] POST http://127.0.0.1:21697 request failed: Post "http://127.0.0.1:21697": dial tcp 127.0.0.1:21697: connect: connection refused
2020/11/03 13:25:27 [DEBUG] POST http://127.0.0.1:21697: retrying in 100ms (9 left)
2020/11/03 13:25:27 [ERR] POST http://127.0.0.1:21697 request failed: Post "http://127.0.0.1:21697": dial tcp 127.0.0.1:21697: connect: connection refused
2020/11/03 13:25:27 [DEBUG] POST http://127.0.0.1:21697: retrying in 200ms (8 left)
2020/11/03 13:25:27 [ERR] POST http://127.0.0.1:21697 request failed: Post "http://127.0.0.1:21697": dial tcp 127.0.0.1:21697: connect: connection refused
2020/11/03 13:25:27 [DEBUG] POST http://127.0.0.1:21697: retrying in 300ms (7 left)
2020/11/03 13:25:28 [ERR] POST http://127.0.0.1:21697 request failed: Post "http://127.0.0.1:21697": dial tcp 127.0.0.1:21697: connect: connection refused
2020/11/03 13:25:28 [DEBUG] POST http://127.0.0.1:21697: retrying in 400ms (6 left)
2020/11/03 13:25:28 [DEBUG] POST http://127.0.0.1:21697 (status: 503): retrying in 500ms (5 left)
2020/11/03 13:25:29 [DEBUG] POST http://127.0.0.1:21697 (status: 503): retrying in 600ms (4 left)
2020/11/03 13:25:29 [DEBUG] POST http://127.0.0.1:21697 (status: 503): retrying in 700ms (3 left)
2020/11/03 13:25:30 [DEBUG] POST http://127.0.0.1:21697 (status: 503): retrying in 800ms (2 left)
--- PASS: TestRetriesOnNetworkErrors (3.61s)
PASS

Process finished with exit code 0
```