### PR TITLE
Recordevent now sends events too

### DIFF
--- a/test/e2e/helpers/broker_redelivery_helper.go
+++ b/test/e2e/helpers/broker_redelivery_helper.go
@@ -114,7 +114,7 @@ func brokerRedelivery(ctx context.Context, t *testing.T, creator BrokerCreatorWi
 
 	client.SendEventToAddressable(ctx, senderName, brokerName, testlib.BrokerTypeMeta, eventToSend)
 
-	allEventTracker.AssertAtLeast(1, recordevents.MatchEvent(AllOf(
+	allEventTracker.AssertAtLeast(1, recordevents.MatchKind(recordevents.EventReceived), recordevents.MatchEvent(AllOf(
 		HasSource(eventSource),
 		HasType(eventType),
 		HasData([]byte(eventBody)),

--- a/test/e2e/helpers/channel_single_event_helper.go
+++ b/test/e2e/helpers/channel_single_event_helper.go
@@ -30,7 +30,6 @@ import (
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
-	"knative.dev/eventing/test/lib/sender"
 )
 
 type SubscriptionVersion string
@@ -109,14 +108,20 @@ func SingleEventForChannelTestHelper(
 			st.Fatalf("Cannot set the payload of the event: %s", err.Error())
 		}
 
-		client.SendEventToAddressable(
+		//TODO(slinkydeveloper) this is temporary, it will be replaced with SendEventToAddressable
+		uri, err := client.GetAddressableURI(channelName, &channel)
+		if err != nil {
+			client.T.Fatalf("Failed to get the URI for %+v-%s", &channel, channelName)
+		}
+
+		recordevents.DeployEventSenderOrFail(
 			ctx,
+			client,
 			senderName,
-			channelName,
-			&channel,
-			event,
-			sender.WithEncoding(encoding),
-			sender.EnableIncrementalId(),
+			uri,
+			recordevents.InputEvent(event),
+			recordevents.InputEncoding(encoding),
+			recordevents.EnableIncrementalId(),
 		)
 
 		// verify the logger service receives the event

--- a/test/lib/recordevents/event_info.go
+++ b/test/lib/recordevents/event_info.go
@@ -71,12 +71,10 @@ func (ei *EventInfo) String() string {
 		sb.WriteString("--- Event ---\n")
 		sb.WriteString(ei.Event.String())
 		sb.WriteRune('\n')
-		sb.WriteRune('\n')
 	}
 	if ei.Error != "" {
 		sb.WriteString("--- Error ---\n")
 		sb.WriteString(ei.Error)
-		sb.WriteRune('\n')
 		sb.WriteRune('\n')
 	}
 	if len(ei.HTTPHeaders) != 0 {
@@ -98,6 +96,7 @@ func (ei *EventInfo) String() string {
 	sb.WriteString("--- Observer: '" + ei.Observer + "' ---\n")
 	sb.WriteString("--- Time: " + ei.Time.String() + " ---\n")
 	sb.WriteString(fmt.Sprintf("--- Sequence: %d ---\n", ei.Sequence))
+	sb.WriteString("--------------------\n")
 	return sb.String()
 }
 
@@ -113,7 +112,7 @@ type SearchedInfo struct {
 // Pretty print the SearchedInfor for error messages
 func (s *SearchedInfo) String() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%d events seen, last %d events (total events seen %d, events ignored %d):",
+	sb.WriteString(fmt.Sprintf("%d events seen, last %d events (total events seen %d, events ignored %d):\n",
 		s.TotalEvent, len(s.LastNEvent), s.storeEventsSeen, s.storeEventsNotMine))
 	for _, ei := range s.LastNEvent {
 		sb.WriteString(ei.String())

--- a/test/lib/recordevents/event_info.go
+++ b/test/lib/recordevents/event_info.go
@@ -29,26 +29,44 @@ const (
 	CloudEventObservedReason = "CloudEventObserved"
 )
 
+type EventKind string
+
+const (
+	EventReceived EventKind = "Received"
+	EventRejected EventKind = "Rejected"
+
+	EventSent     EventKind = "Sent"
+	EventResponse EventKind = "Response"
+)
+
 // Structure to hold information about an event seen by recordevents pod.
 type EventInfo struct {
+	Kind EventKind `json:"kind"`
+
 	// Set if the http request received by the pod couldn't be decoded or
 	// didn't pass validation
 	Error string `json:"error,omitempty"`
 	// Event received if the cloudevent received by the pod passed validation
 	Event *cloudevents.Event `json:"event,omitempty"`
-	// HTTPHeaders of the connection that delivered the event
+	// In case there is a valid event in this instance, this contains only non CE headers.
+	// Otherwise, it contains all the headers
 	HTTPHeaders map[string][]string `json:"httpHeaders,omitempty"`
-	Origin      string              `json:"origin,omitempty"`
-	Observer    string              `json:"observer,omitempty"`
-	Time        time.Time           `json:"time,omitempty"`
-	Sequence    uint64              `json:"sequence"`
-	Dropped     bool                `json:"dropped"`
+	// In case there is a valid event in this instance, this field is not filled
+	Body []byte `json:"body,omitempty"`
+
+	StatusCode int `json:"statusCode,omitempty"`
+
+	Origin   string    `json:"origin,omitempty"`
+	Observer string    `json:"observer,omitempty"`
+	Time     time.Time `json:"time,omitempty"`
+	Sequence uint64    `json:"sequence"`
 }
 
 // Pretty print the event. Meant for debugging.
 func (ei *EventInfo) String() string {
 	var sb strings.Builder
 	sb.WriteString("-- EventInfo --\n")
+	sb.WriteString(fmt.Sprintf("--- Kind: %v ---\n", ei.Kind))
 	if ei.Event != nil {
 		sb.WriteString("--- Event ---\n")
 		sb.WriteString(ei.Event.String())
@@ -61,16 +79,25 @@ func (ei *EventInfo) String() string {
 		sb.WriteRune('\n')
 		sb.WriteRune('\n')
 	}
-	sb.WriteString("--- HTTP headers ---\n")
-	for k, v := range ei.HTTPHeaders {
-		sb.WriteString("  " + k + ": " + v[0] + "\n")
+	if len(ei.HTTPHeaders) != 0 {
+		sb.WriteString("--- HTTP headers ---\n")
+		for k, v := range ei.HTTPHeaders {
+			sb.WriteString("  " + k + ": " + v[0] + "\n")
+		}
+		sb.WriteRune('\n')
 	}
-	sb.WriteRune('\n')
+	if ei.Body != nil {
+		sb.WriteString("--- Body ---\n")
+		sb.Write(ei.Body)
+		sb.WriteRune('\n')
+	}
+	if ei.StatusCode != 0 {
+		sb.WriteString(fmt.Sprintf("--- Status Code: %d ---\n", ei.StatusCode))
+	}
 	sb.WriteString("--- Origin: '" + ei.Origin + "' ---\n")
 	sb.WriteString("--- Observer: '" + ei.Observer + "' ---\n")
 	sb.WriteString("--- Time: " + ei.Time.String() + " ---\n")
 	sb.WriteString(fmt.Sprintf("--- Sequence: %d ---\n", ei.Sequence))
-	sb.WriteString(fmt.Sprintf("--- Dropped: %v ---\n", ei.Dropped))
 	return sb.String()
 }
 

--- a/test/lib/recordevents/event_info_matchers.go
+++ b/test/lib/recordevents/event_info_matchers.go
@@ -84,6 +84,16 @@ func HasAdditionalHeader(key, value string) EventInfoMatcher {
 	}
 }
 
+// MatchKind matches the kind of EventInfo
+func MatchKind(kind EventKind) EventInfoMatcher {
+	return func(info EventInfo) error {
+		if kind != info.Kind {
+			return fmt.Errorf("event kind don't match. Expected: '%s', Actual: '%s'", kind, info.Kind)
+		}
+		return nil
+	}
+}
+
 // MatchHeartBeatsImageMessage matches that the data field of the event, in the format of the heartbeats image, contains the following msg field
 func MatchHeartBeatsImageMessage(expectedMsg string) cetest.EventMatcher {
 	return cetest.AllOf(

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -81,6 +81,10 @@ func NewEventInfoStore(client *testlib.Client, podName string, podNamespace stri
 	return store, nil
 }
 
+func (ei *EventInfoStore) getDebugInfo() string {
+	return fmt.Sprintf("Pod '%s' in namespace '%s'", ei.podName, ei.podNamespace)
+}
+
 func (ei *EventInfoStore) getEventInfo() []EventInfo {
 	ei.lock.Lock()
 	defer ei.lock.Unlock()
@@ -222,9 +226,10 @@ func (ei *EventInfoStore) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]Even
 		count := len(allMatch)
 		if count < min {
 			internalErr = fmt.Errorf(
-				"FAIL MATCHING: saw %d/%d matching events.\nRecent events: \n%s\nMatch errors: \n%s\n",
+				"FAIL MATCHING: saw %d/%d matching events.\n- EventInfoStore-\n%s\n- Recent events -\n%s\n- Match errors -\n%s\n",
 				count,
 				min,
+				ei.getDebugInfo(),
 				&sInfo,
 				formatErrors(matchErrs),
 			)

--- a/test/lib/recordevents/receiver/reply.go
+++ b/test/lib/recordevents/receiver/reply.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package observer
+package receiver
 
 import (
 	"context"

--- a/test/lib/recordevents/recorder_vent/constructor.go
+++ b/test/lib/recordevents/recorder_vent/constructor.go
@@ -18,7 +18,6 @@ package recorder_vent
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -48,7 +47,7 @@ const (
 func NewFromEnv(ctx context.Context) recordevents.EventLog {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
-		log.Fatal("Failed to process env var", err)
+		logging.FromContext(ctx).Fatal("Failed to process env var: ", err)
 	}
 
 	logging.FromContext(ctx).Infof("Recorder vent environment configuration: %+v", env)

--- a/test/lib/recordevents/recorder_vent/recorder.go
+++ b/test/lib/recordevents/recorder_vent/recorder.go
@@ -50,11 +50,11 @@ func (r *recorder) Vent(observed recordevents.EventInfo) error {
 
 	t := time.Now()
 	// Note: DO NOT SET EventTime, or you'll trigger k8s api server hilarity:
-	// - https://github.com/kubernetes/kubernetes/issues/95913
+	// - https://githubger.com/kubernetes/kubernetes/issues/95913
 	// - https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/events.go#L122
 	event := &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v.%d", r.ref.Name, observed.Sequence),
+			Name:      fmt.Sprintf("%v.%v.%d", r.ref.Name, observed.Kind, observed.Sequence),
 			Namespace: r.namespace,
 		},
 		InvolvedObject: *r.ref,

--- a/test/lib/recordevents/recorder_vent/recorder.go
+++ b/test/lib/recordevents/recorder_vent/recorder.go
@@ -50,7 +50,7 @@ func (r *recorder) Vent(observed recordevents.EventInfo) error {
 
 	t := time.Now()
 	// Note: DO NOT SET EventTime, or you'll trigger k8s api server hilarity:
-	// - https://githubger.com/kubernetes/kubernetes/issues/95913
+	// - https://github.com/kubernetes/kubernetes/issues/95913
 	// - https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/events.go#L122
 	event := &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -18,7 +18,10 @@ package recordevents
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -32,63 +35,103 @@ import (
 
 type EventRecordOption = func(*corev1.Pod, *testlib.Client) error
 
-// EchoEvent is an option to let the recordevents reply with the received event
-func EchoEvent(pod *corev1.Pod, client *testlib.Client) error {
-	pod.Spec.Containers[0].Env = append(
-		pod.Spec.Containers[0].Env,
-		corev1.EnvVar{Name: "REPLY", Value: "true"},
-	)
+func noop(pod *corev1.Pod, client *testlib.Client) error {
 	return nil
 }
 
-var _ EventRecordOption = EchoEvent
+func compose(options ...EventRecordOption) EventRecordOption {
+	return func(pod *corev1.Pod, client *testlib.Client) error {
+		for _, opt := range options {
+			if err := opt(pod, client); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
-// ReplyWithTransformedEvent is an option to let the recordevents reply with the transformed event
-func ReplyWithTransformedEvent(replyEventType string, replyEventSource string, replyEventData string) EventRecordOption {
+func envOptionalOpt(key, value string) EventRecordOption {
+	if value != "" {
+		return func(pod *corev1.Pod, client *testlib.Client) error {
+			pod.Spec.Containers[0].Env = append(
+				pod.Spec.Containers[0].Env,
+				corev1.EnvVar{Name: key, Value: value},
+			)
+			return nil
+		}
+	} else {
+		return noop
+	}
+}
+
+func envOption(key, value string) EventRecordOption {
 	return func(pod *corev1.Pod, client *testlib.Client) error {
 		pod.Spec.Containers[0].Env = append(
 			pod.Spec.Containers[0].Env,
-			corev1.EnvVar{Name: "REPLY", Value: "true"},
+			corev1.EnvVar{Name: key, Value: value},
 		)
-		if replyEventType != "" {
-			pod.Spec.Containers[0].Env = append(
-				pod.Spec.Containers[0].Env,
-				corev1.EnvVar{Name: "REPLY_EVENT_TYPE", Value: replyEventType},
-			)
-		}
-		if replyEventSource != "" {
-			pod.Spec.Containers[0].Env = append(
-				pod.Spec.Containers[0].Env,
-				corev1.EnvVar{Name: "REPLY_EVENT_SOURCE", Value: replyEventSource},
-			)
-		}
-		if replyEventData != "" {
-			pod.Spec.Containers[0].Env = append(
-				pod.Spec.Containers[0].Env,
-				corev1.EnvVar{Name: "REPLY_EVENT_DATA", Value: replyEventData},
-			)
-		}
-
 		return nil
 	}
+}
+
+// EchoEvent is an option to let the recordevents reply with the received event
+var EchoEvent EventRecordOption = envOption("REPLY", "true")
+
+// ReplyWithTransformedEvent is an option to let the recordevents reply with the transformed event
+func ReplyWithTransformedEvent(replyEventType string, replyEventSource string, replyEventData string) EventRecordOption {
+	return compose(
+		envOption("REPLY", "true"),
+		envOptionalOpt("REPLY_EVENT_TYPE", replyEventType),
+		envOptionalOpt("REPLY_EVENT_SOURCE", replyEventSource),
+		envOptionalOpt("REPLY_EVENT_DATA", replyEventData),
+	)
 }
 
 // ReplyWithAppendedData is an option to let the recordevents reply with the transformed event with appended data
 func ReplyWithAppendedData(appendData string) EventRecordOption {
-	return func(pod *corev1.Pod, client *testlib.Client) error {
-		pod.Spec.Containers[0].Env = append(
-			pod.Spec.Containers[0].Env,
-			corev1.EnvVar{Name: "REPLY", Value: "true"},
-		)
-		if appendData != "" {
-			pod.Spec.Containers[0].Env = append(
-				pod.Spec.Containers[0].Env,
-				corev1.EnvVar{Name: "REPLY_APPEND_DATA", Value: appendData},
-			)
-		}
+	return compose(
+		envOption("REPLY", "true"),
+		envOptionalOpt("REPLY_APPEND_DATA", appendData),
+	)
+}
 
-		return nil
+// InputEvent is an option to provide the event to send when deploying the event sender
+func InputEvent(event cloudevents.Event) EventRecordOption {
+	encodedEvent, err := json.Marshal(event)
+	if err != nil {
+		return func(pod *corev1.Pod, client *testlib.Client) error {
+			return err
+		}
 	}
+	return envOption("INPUT_EVENT", string(encodedEvent))
+}
+
+// AddTracing adds tracing headers when sending events.
+func AddTracing() EventRecordOption {
+	return envOption("ADD_TRACING", "true")
+}
+
+// EnableIncrementalId creates a new incremental id for each sent event.
+func EnableIncrementalId() EventRecordOption {
+	return envOption("INCREMENTAL_ID", "true")
+}
+
+// InputEncoding forces the encoding of the event for each sent event.
+func InputEncoding(encoding cloudevents.Encoding) EventRecordOption {
+	return envOption("EVENT_ENCODING", encoding.String())
+}
+
+// InputHeaders adds the following headers to the sent requests.
+func InputHeaders(headers map[string]string) EventRecordOption {
+	return envOption("INPUT_HEADERS", serializeHeaders(headers))
+}
+
+func serializeHeaders(headers map[string]string) string {
+	kv := make([]string, 0, len(headers))
+	for k, v := range headers {
+		kv = append(kv, k+":"+v)
+	}
+	return strings.Join(kv, ",")
 }
 
 // DeployEventRecordOrFail deploys the recordevents image with necessary sa, roles, rb to execute the image
@@ -108,13 +151,51 @@ func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name s
 	))
 	client.CreateRoleBindingOrFail(name, "Role", name, name, client.Namespace)
 
+	options = append(
+		options,
+		testlib.WithService(name),
+		envOption("EVENT_GENERATORS", "receiver"),
+	)
+
 	eventRecordPod := recordEventsPod("recordevents", name, name)
-	client.CreatePodOrFail(eventRecordPod, append(options, testlib.WithService(name))...)
+	client.CreatePodOrFail(eventRecordPod, options...)
 	err := pkgtest.WaitForPodRunning(ctx, client.Kube, name, client.Namespace)
 	if err != nil {
 		client.T.Fatalf("Failed to start the recordevent pod '%s': %v", name, errors.WithStack(err))
 	}
 	client.WaitForServiceEndpointsOrFail(ctx, name, 1)
+	return eventRecordPod
+}
+
+// DeployEventSenderOrFail deploys the recordevents image with necessary sa, roles, rb to execute the image
+func DeployEventSenderOrFail(ctx context.Context, client *testlib.Client, name string, sink string, options ...EventRecordOption) *corev1.Pod {
+	client.CreateServiceAccountOrFail(name)
+	client.CreateRoleOrFail(resources.Role(name,
+		resources.WithRuleForRole(&rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get"},
+		}),
+		resources.WithRuleForRole(&rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{rbacv1.VerbAll},
+		}),
+	))
+	client.CreateRoleBindingOrFail(name, "Role", name, name, client.Namespace)
+
+	options = append(
+		options,
+		envOption("EVENT_GENERATORS", "sender"),
+		envOption("SINK", sink),
+	)
+
+	eventRecordPod := recordEventsPod("recordevents", name, name)
+	client.CreatePodOrFail(eventRecordPod, options...)
+	err := pkgtest.WaitForPodRunning(ctx, client.Kube, name, client.Namespace)
+	if err != nil {
+		client.T.Fatalf("Failed to start the recordevent pod '%s': %v", name, errors.WithStack(err))
+	}
 	return eventRecordPod
 }
 
@@ -128,7 +209,7 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 			Containers: []corev1.Container{{
 				Name:            imageName,
 				Image:           pkgtest.ImagePath(imageName),
-				ImagePullPolicy: corev1.PullIfNotPresent,
+				ImagePullPolicy: corev1.PullAlways,
 				Env: []corev1.EnvVar{{
 					Name: "SYSTEM_NAMESPACE",
 					ValueFrom: &corev1.EnvVarSource{
@@ -139,6 +220,9 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 					},
+				}, {
+					Name:  "EVENT_LOGS",
+					Value: "recorder,logger",
 				}},
 			}},
 			ServiceAccountName: serviceAccountName,

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -209,7 +209,7 @@ func recordEventsPod(imageName string, name string, serviceAccountName string) *
 			Containers: []corev1.Container{{
 				Name:            imageName,
 				Image:           pkgtest.ImagePath(imageName),
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Env: []corev1.EnvVar{{
 					Name: "SYSTEM_NAMESPACE",
 					ValueFrom: &corev1.EnvVarSource{

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -116,7 +116,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 
 	var baseEvent *cloudevents.Event
 	if env.InputEvent != "" {
-		if err := json.Unmarshal([]byte(env.InputEvent), baseEvent); err != nil {
+		if err := json.Unmarshal([]byte(env.InputEvent), &baseEvent); err != nil {
 			return fmt.Errorf("unable to unmarshal the event from json: %w", err)
 		}
 	}

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sender
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	nethttp "net/http"
+	"strings"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/kelseyhightower/envconfig"
+	"go.opencensus.io/plugin/ochttp"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
+
+	"knative.dev/eventing/test/lib/recordevents"
+)
+
+type envConfig struct {
+	SenderName string `envconfig:"POD_NAME" default:"sender-default" required:"true"`
+
+	// Sink url for the message destination
+	Sink string `envconfig:"SINK" required:"true"`
+
+	// InputEvent json encoded
+	InputEvent string `envconfig:"INPUT_EVENT" required:"false"`
+
+	// InputHeaders to send (this overrides any event provided input)
+	InputHeaders map[string]string `envconfig:"INPUT_HEADERS" required:"false"`
+
+	// InputBody to send (this overrides any event provided input)
+	InputBody string `envconfig:"INPUT_BODY" required:"false"`
+
+	// The encoding of the cloud event: [binary, structured].
+	EventEncoding string `envconfig:"EVENT_ENCODING" default:"binary" required:"false"`
+
+	// The number of seconds between messages.
+	Period int `envconfig:"PERIOD" default:"5" required:"false"`
+
+	// The number of seconds to wait before starting sending the first message
+	Delay int `envconfig:"DELAY" default:"5" required:"false"`
+
+	// The number of messages to attempt to send. 0 for unlimited.
+	MaxMessages int `envconfig:"MAX_MESSAGES" default:"1" required:"false"`
+
+	// Should tracing be added to events sent.
+	AddTracing bool `envconfig:"ADD_TRACING" default:"false" required:"false"`
+
+	// Should add extension 'sequence' identifying the sequence number.
+	AddSequence bool `envconfig:"ADD_SEQUENCE" default:"false" required:"false"`
+
+	// Override the event id with an incremental id.
+	IncrementalId bool `envconfig:"INCREMENTAL_ID" default:"false" required:"false"`
+}
+
+func Start(ctx context.Context, logs *recordevents.EventLogs) error {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		return fmt.Errorf("failed to process env var. %w", err)
+	}
+
+	logging.FromContext(ctx).Infof("Sender environment configuration: %+v", env)
+
+	if env.InputEvent == "" && env.InputBody == "" && len(env.InputHeaders) == 0 {
+		return fmt.Errorf("input values not provided")
+	}
+
+	flag.Parse()
+	period := time.Duration(env.Period) * time.Second
+	delay := time.Duration(env.Delay) * time.Second
+
+	if delay > 0 {
+		logging.FromContext(ctx).Info("will sleep for ", delay)
+		time.Sleep(delay)
+		logging.FromContext(ctx).Info("awake, continuing")
+	}
+
+	switch env.EventEncoding {
+	case "binary":
+		ctx = cloudevents.WithEncodingBinary(ctx)
+	case "structured":
+		ctx = cloudevents.WithEncodingStructured(ctx)
+	default:
+		return fmt.Errorf("unsupported encoding option: %q", env.EventEncoding)
+	}
+
+	httpClient := &nethttp.Client{}
+	if env.AddTracing {
+		httpClient.Transport = &ochttp.Transport{
+			Base:        nethttp.DefaultTransport,
+			Propagation: tracecontextb3.TraceContextEgress,
+		}
+	}
+
+	var baseEvent *cloudevents.Event
+	if env.InputEvent != "" {
+		if err := json.Unmarshal([]byte(env.InputEvent), baseEvent); err != nil {
+			return fmt.Errorf("unable to unmarshal the event from json: %w", err)
+		}
+	}
+
+	sequence := 0
+
+	ticker := time.NewTicker(period)
+	for {
+		req, err := nethttp.NewRequest(nethttp.MethodPost, env.Sink, nil)
+		if err != nil {
+			logging.FromContext(ctx).Error("Cannot create the request: ", err)
+			return err
+		}
+
+		var event *cloudevents.Event
+		if baseEvent != nil {
+			e := baseEvent.Clone()
+			event = &e
+
+			sequence++
+			if env.AddSequence {
+				event.SetExtension("sequence", sequence)
+			}
+			if env.IncrementalId {
+				event.SetID(fmt.Sprintf("%d", sequence))
+			}
+
+			logging.FromContext(ctx).Info("I'm going to send\n", event)
+
+			err := cehttp.WriteRequest(ctx, binding.ToMessage(event), req)
+			if err != nil {
+				logging.FromContext(ctx).Error("Cannot write the event: ", err)
+				return err
+			}
+		}
+
+		if len(env.InputHeaders) != 0 {
+			for k, v := range env.InputHeaders {
+				req.Header.Add(k, v)
+			}
+		}
+
+		if env.InputBody != "" {
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(env.InputBody)))
+		}
+
+		res, err := httpClient.Do(req)
+
+		if err != nil {
+			// Publish error
+			if err := logs.Vent(recordevents.EventInfo{
+				Kind:     recordevents.EventSent,
+				Error:    err.Error(),
+				Origin:   env.SenderName,
+				Observer: env.SenderName,
+				Time:     time.Now(),
+				Sequence: uint64(sequence),
+			}); err != nil {
+				return fmt.Errorf("cannot forward event info: %w", err)
+			}
+		} else {
+			sentEventInfo := recordevents.EventInfo{
+				Kind:     recordevents.EventSent,
+				Event:    event,
+				Origin:   env.SenderName,
+				Observer: env.SenderName,
+				Time:     time.Now(),
+				Sequence: uint64(sequence),
+			}
+
+			sentHeaders := make(nethttp.Header)
+			for k, v := range req.Header {
+				if !strings.HasPrefix(k, "Ce-") {
+					sentHeaders[k] = v
+				}
+			}
+			sentEventInfo.HTTPHeaders = sentHeaders
+
+			if env.InputBody != "" {
+				sentEventInfo.Body = []byte(env.InputBody)
+			}
+
+			// Publish sent event info
+			if err := logs.Vent(sentEventInfo); err != nil {
+				return fmt.Errorf("cannot forward event info: %w", err)
+			}
+
+			// Now let's figure out what's inside the response
+			responseMessage := cehttp.NewMessageFromHttpResponse(res)
+
+			responseInfo := recordevents.EventInfo{
+				Kind:        recordevents.EventResponse,
+				HTTPHeaders: res.Header,
+				Origin:      env.Sink,
+				Observer:    env.SenderName,
+				Time:        time.Now(),
+				Sequence:    uint64(sequence),
+				StatusCode:  res.StatusCode,
+			}
+			if responseMessage.ReadEncoding() == binding.EncodingUnknown {
+				body, err := ioutil.ReadAll(res.Body)
+
+				if err != nil {
+					responseInfo.Error = err.Error()
+				} else {
+					responseInfo.Body = body
+				}
+			} else {
+				responseEvent, err := binding.ToEvent(ctx, responseMessage)
+				if err != nil {
+					responseInfo.Error = err.Error()
+				} else {
+					responseInfo.Event = responseEvent
+				}
+			}
+
+			// Vent the response info
+			if err := logs.Vent(responseInfo); err != nil {
+				return fmt.Errorf("cannot forward event info: %w", err)
+			}
+		}
+
+		// Wait for next tick
+		<-ticker.C
+		// Only send a limited number of messages.
+		if env.MaxMessages != 0 && env.MaxMessages == sequence {
+			return nil
+		}
+
+		// Check if ctx is done before the next loop
+		select {
+		case <-ctx.Done():
+			logging.FromContext(ctx).Infof("Canceled sending messages because context was closed")
+			return nil
+		default:
+		}
+	}
+}

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	nethttp "net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,7 +142,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 				event.SetExtension("sequence", sequence)
 			}
 			if env.IncrementalId {
-				event.SetID(fmt.Sprintf("%d", sequence))
+				event.SetID(strconv.Itoa(sequence))
 			}
 
 			logging.FromContext(ctx).Info("I'm going to send\n", event)

--- a/test/lib/sender/resources.go
+++ b/test/lib/sender/resources.go
@@ -166,7 +166,7 @@ func RequestSenderPod(imageName string, name string, sink string, headers map[st
 func serializeHeaders(headers map[string]string) string {
 	kv := make([]string, 0, len(headers))
 	for k, v := range headers {
-		kv = append(kv, k+"="+v)
+		kv = append(kv, k+":"+v)
 	}
 	return strings.Join(kv, ",")
 }

--- a/test/lib/sender/resources.go
+++ b/test/lib/sender/resources.go
@@ -27,6 +27,7 @@ import (
 )
 
 // EnableTracing enables tracing in sender pod
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events
 func EnableTracing() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -38,6 +39,7 @@ func EnableTracing() func(*corev1.Pod) {
 }
 
 // EnableIncrementalId creates a new incremental id for each event sent from the sender pod. Supported only by event-sender
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events
 func EnableIncrementalId() func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -49,6 +51,7 @@ func EnableIncrementalId() func(*corev1.Pod) {
 }
 
 // WithEncoding forces the encoding of the event to send from the sender pod. Supported only by event-sender
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events
 func WithEncoding(encoding cloudevents.Encoding) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -60,6 +63,7 @@ func WithEncoding(encoding cloudevents.Encoding) func(*corev1.Pod) {
 }
 
 // WithResponseSink sends the response information as CloudEvent to another sink
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events and start an EventInfoStore on it to assert the responses
 func WithResponseSink(responseSink string) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -71,6 +75,7 @@ func WithResponseSink(responseSink string) func(*corev1.Pod) {
 }
 
 // WithEncoding forces the encoding of the event to send from the sender pod. Supported only by event-sender
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events
 func WithAdditionalHeaders(headers map[string]string) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -82,6 +87,7 @@ func WithAdditionalHeaders(headers map[string]string) func(*corev1.Pod) {
 }
 
 // EventSenderPod creates a Pod that sends events to the given address.
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send events
 func EventSenderPod(imageName string, name string, sink string, event cloudevents.Event, options ...func(*corev1.Pod)) (*corev1.Pod, error) {
 	encodedEvent, err := json.Marshal(event)
 	if err != nil {
@@ -119,6 +125,7 @@ func EventSenderPod(imageName string, name string, sink string, event cloudevent
 }
 
 // WithMethod configures the method used to send the http request. Supported only by request-sender
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send requests
 func WithMethod(method string) func(*corev1.Pod) {
 	return func(pod *corev1.Pod) {
 		pod.Spec.Containers[0].Args = append(
@@ -130,6 +137,7 @@ func WithMethod(method string) func(*corev1.Pod) {
 }
 
 // EventSenderPod creates a Pod that sends http requests to the given address.
+// Deprecated: Now you should use recordevents.DeployEventSenderOrFail to send requests
 func RequestSenderPod(imageName string, name string, sink string, headers map[string]string, body string, options ...func(*corev1.Pod)) (*corev1.Pod, error) {
 	args := []string{
 		"-sink",
@@ -166,7 +174,7 @@ func RequestSenderPod(imageName string, name string, sink string, headers map[st
 func serializeHeaders(headers map[string]string) string {
 	kv := make([]string, 0, len(headers))
 	for k, v := range headers {
-		kv = append(kv, k+":"+v)
+		kv = append(kv, k+"="+v)
 	}
 	return strings.Join(kv, ",")
 }

--- a/test/test_images/recordevents/main.go
+++ b/test/test_images/recordevents/main.go
@@ -17,19 +17,29 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"log"
 
+	"github.com/kelseyhightower/envconfig"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 	_ "knative.dev/pkg/system/testing"
 
 	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/recordevents/logger_vent"
-	"knative.dev/eventing/test/lib/recordevents/observer"
+	"knative.dev/eventing/test/lib/recordevents/receiver"
 	"knative.dev/eventing/test/lib/recordevents/recorder_vent"
+	"knative.dev/eventing/test/lib/recordevents/sender"
 	"knative.dev/eventing/test/test_images"
 )
+
+type envConfig struct {
+	EventGenerators []string `envconfig:"EVENT_GENERATORS" required:"true"`
+	EventLogs       []string `envconfig:"EVENT_LOGS" required:"true"`
+}
 
 func main() {
 	cfg, err := rest.InClusterConfig()
@@ -44,16 +54,51 @@ func main() {
 		logging.FromContext(ctx).Fatal("Unable to setup trace publishing", err)
 	}
 
-	obs := observer.NewFromEnv(ctx,
-		logger_vent.Logger(logging.FromContext(ctx).Infof),
-		recorder_vent.NewFromEnv(ctx),
-	)
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		logging.FromContext(ctx).Fatal("Failed to process env var", err)
+	}
 
-	err = obs.Start(ctx, kncloudevents.CreateHandler)
+	eventLogs := createEventLogs(ctx, env.EventLogs)
+	err = startEventGenerators(ctx, env.EventGenerators, eventLogs)
 
 	if err != nil {
-		logging.FromContext(ctx).Fatal("Error during start", err)
+		logging.FromContext(ctx).Fatal("Error during start: ", err)
 	}
 
 	logging.FromContext(ctx).Info("Closing the recordevents process")
+}
+
+func createEventLogs(ctx context.Context, logTypes []string) *recordevents.EventLogs {
+	var l []recordevents.EventLog
+	for _, logType := range logTypes {
+		switch recordevents.EventLogType(logType) {
+		case recordevents.RecorderEventLog:
+			l = append(l, recorder_vent.NewFromEnv(ctx))
+		case recordevents.LoggerEventLog:
+			l = append(l, logger_vent.Logger(logging.FromContext(ctx).Named("event logger").Infof))
+		default:
+			logging.FromContext(ctx).Fatal("Cannot recognize event log type: ", logType)
+		}
+	}
+	return recordevents.NewEventLogs(l...)
+}
+
+func startEventGenerators(ctx context.Context, genTypes []string, eventLogs *recordevents.EventLogs) error {
+	errs, _ := errgroup.WithContext(ctx)
+	for _, genType := range genTypes {
+		switch recordevents.EventGeneratorType(genType) {
+		case recordevents.ReceiverEventGenerator:
+			errs.Go(func() error {
+				return receiver.NewFromEnv(ctx, eventLogs).Start(ctx, kncloudevents.CreateHandler)
+			})
+		case recordevents.SenderEventGenerator:
+			errs.Go(func() error {
+				return sender.Start(ctx, eventLogs)
+			})
+		default:
+			logging.FromContext(ctx).Fatal("Cannot recognize event generator type: ", genType)
+		}
+	}
+	return errs.Wait()
 }


### PR DESCRIPTION
Yeah, it sounds weird, look at #4368 for more details

Fixes #4368

## Proposed Changes

- Refactored recordevents code to host the send events. 
- Using recordevents to send events in `SingleEventForChannelTestHelper`

In a followup PR I'm going to replace the implementation of `Client.SendEvent` to use recordevents, so we won't need to rewrite all tests.