### PR TITLE
Remove double invocations to responseWriter.WriteHeader in filter handler

### DIFF
--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -273,7 +273,7 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 			// Note that we could just use StatusInternalServerError, but to distinguish
 			// between the failure cases, we use a different code here.
 			writer.WriteHeader(http.StatusBadGateway)
-			return resp.StatusCode, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
+			return http.StatusBadGateway, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
 		}
 		h.logger.Debug("Response doesn't contain a CloudEvent, replying with an empty response", zap.Any("target", target))
 		writer.WriteHeader(resp.StatusCode)
@@ -286,7 +286,7 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 		// between the failure cases, we use a different code here.
 		writer.WriteHeader(http.StatusBadGateway)
 		// Malformed event, reply with err
-		return resp.StatusCode, err
+		return http.StatusBadGateway, err
 	}
 
 	// Reattach the TTL (with the same value) to the response event before sending it to the Broker.

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -219,17 +219,8 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 	statusCode, err := h.writeResponse(ctx, writer, response, ttl, target)
 	if err != nil {
 		h.logger.Error("failed to write response", zap.Error(err))
-		// Ok, so writeResponse will return the HTTPStatus of the function. That may have
-		// succeeded (200), but it may have returned a malformed event, so if the
-		// function succeeded, convert this to an StatusBadGateway instead to indicate
-		// error. Note that we could just use StatusInternalServerError, but to distinguish
-		// between the two failure cases, we use a different code here.
-		if statusCode == http.StatusOK {
-			statusCode = http.StatusBadGateway
-		}
 	}
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)
-	writer.WriteHeader(statusCode)
 }
 
 func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target string, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, error) {
@@ -265,6 +256,7 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 	return resp, err
 }
 
+// The return values are the status
 func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter, resp *http.Response, ttl int32, target string) (int, error) {
 	response := cehttp.NewMessageFromHttpResponse(resp)
 	defer response.Finish(nil)
@@ -278,20 +270,30 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 		n, _ := response.BodyReader.Read(body)
 		response.BodyReader.Close()
 		if n != 0 {
+			// Note that we could just use StatusInternalServerError, but to distinguish
+			// between the two failure cases, we use a different code here.
+			writer.WriteHeader(http.StatusBadGateway)
 			return resp.StatusCode, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
 		}
 		h.logger.Debug("Response doesn't contain a CloudEvent, replying with an empty response", zap.Any("target", target))
+		writer.WriteHeader(resp.StatusCode)
 		return resp.StatusCode, nil
 	}
 
 	event, err := binding.ToEvent(ctx, response)
 	if err != nil {
+		// Note that we could just use StatusInternalServerError, but to distinguish
+		// between the two failure cases, we use a different code here.
+		writer.WriteHeader(http.StatusBadGateway)
 		// Malformed event, reply with err
 		return resp.StatusCode, err
 	}
 
 	// Reattach the TTL (with the same value) to the response event before sending it to the Broker.
 	if err := broker.SetTTL(event.Context, ttl); err != nil {
+		// Note that we could just use StatusInternalServerError, but to distinguish
+		// between the two failure cases, we use a different code here.
+		writer.WriteHeader(http.StatusInternalServerError)
 		return http.StatusInternalServerError, fmt.Errorf("failed to reset TTL: %w", err)
 	}
 

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -271,7 +271,7 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 		response.BodyReader.Close()
 		if n != 0 {
 			// Note that we could just use StatusInternalServerError, but to distinguish
-			// between the two failure cases, we use a different code here.
+			// between the failure cases, we use a different code here.
 			writer.WriteHeader(http.StatusBadGateway)
 			return resp.StatusCode, errors.New("received a non-empty response not recognized as CloudEvent. The response MUST be or empty or a valid CloudEvent")
 		}
@@ -282,8 +282,8 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 
 	event, err := binding.ToEvent(ctx, response)
 	if err != nil {
-		// Note that we could just use StatusInternalServerError, but to distinguish
-		// between the two failure cases, we use a different code here.
+		// Like in the above case, we could just use StatusInternalServerError, but to distinguish
+		// between the failure cases, we use a different code here.
 		writer.WriteHeader(http.StatusBadGateway)
 		// Malformed event, reply with err
 		return resp.StatusCode, err
@@ -291,8 +291,6 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 
 	// Reattach the TTL (with the same value) to the response event before sending it to the Broker.
 	if err := broker.SetTTL(event.Context, ttl); err != nil {
-		// Note that we could just use StatusInternalServerError, but to distinguish
-		// between the two failure cases, we use a different code here.
 		writer.WriteHeader(http.StatusInternalServerError)
 		return http.StatusInternalServerError, fmt.Errorf("failed to reset TTL: %w", err)
 	}

--- a/pkg/mtbroker/filter/filter_handler_test.go
+++ b/pkg/mtbroker/filter/filter_handler_test.go
@@ -540,7 +540,7 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			defer h.response.Body.Close()
 			body, err := ioutil.ReadAll(h.response.Body)
 			if err != nil {
-				h.t.Fatalf("Unable to read body: %v", err)
+				h.t.Fatal("Unable to read body: ", err)
 			}
 			resp.Write(body)
 		}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #4464

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Removed double invocations to responseWriter.WriteHeader in filter handler
- Testing in filter_handler_test.go if `WriteHeader` is invoked more than once