### PR TITLE
fix error during upgrade from 0.17 to 0.18

### DIFF
--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -38,6 +38,7 @@ spec:
           image: ko://knative.dev/eventing/cmd/mtping
           env:
             - name: SYSTEM_NAMESPACE
+              value: ''
               valueFrom:
                 fieldRef:
                   apiVersion: v1


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fixes this error:

`The Deployment "pingsource-mt-adapter" is invalid: spec.template.spec.containers[0].env[0].valueFrom: Invalid value: "": may not be specified when "value` is not empty`

when upgrading from 0.17 to 0.18

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/cc @aliok @cr22rc 

Note that in 0.17 the adapter is managed by the controller. When applying 0.18, the mtping adapter configuration might be overridden by the 0.17 eventing controller that hasn't been rolled out yet to the new version. The fix is to wait a bit and then apply the mtping adapter configuration a second  time. That should do it.

Needs to be backported.