### PR TITLE
Change Channel.spec.channelTemplate.spec type from string to object in OpenAPI schema

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -74,7 +74,7 @@ spec:
                     description: Spec defines the Spec to use for each channel
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
-                    type: string
+                    type: object
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -75,6 +75,7 @@ spec:
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/config/pre-install/v0.18.0/channel.yaml
+++ b/config/pre-install/v0.18.0/channel.yaml
@@ -74,7 +74,7 @@ spec:
                     description: Spec defines the Spec to use for each channel
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
-                    type: string
+                    type: object
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/config/pre-install/v0.18.0/channel.yaml
+++ b/config/pre-install/v0.18.0/channel.yaml
@@ -75,6 +75,7 @@ spec:
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -117,4 +117,11 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 	assert.Equal(t, "PT0.5S", spec["backoffDelay"])
 	assert.Equal(t, int64(5), spec["retry"])
 	assert.Equal(t, "exponential", spec["backoffPolicy"])
+
+	imc, err := c.Eventing.MessagingV1().InMemoryChannels(c.Namespace).Get(ctx, "xyx", metav1.GetOptions{})
+	assert.NotNil(t, err)
+
+	assert.Equal(t, "PT0.5S", imc.Spec.Delivery.BackoffPolicy)
+	assert.Equal(t, int64(5), imc.Spec.Delivery.Retry)
+	assert.Equal(t, "exponential", imc.Spec.Delivery.BackoffPolicy)
 }

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -118,7 +118,7 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 	assert.Equal(t, int64(5), spec["retry"])
 	assert.Equal(t, "exponential", spec["backoffPolicy"])
 
-	imc, err := c.Eventing.MessagingV1().InMemoryChannels(c.Namespace).Get(ctx, "xyx", metav1.GetOptions{})
+	imc, err := c.Eventing.MessagingV1().InMemoryChannels(c.Namespace).Get(ctx, "xyz", metav1.GetOptions{})
 	assert.NotNil(t, err)
 
 	assert.Equal(t, "PT0.5S", imc.Spec.Delivery.BackoffPolicy)

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -102,10 +102,15 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 		},
 	}
 
-	_, err = c.Dynamic.
+	createdObj, err := c.Dynamic.
 		Resource(schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "channels"}).
 		Namespace(c.Namespace).
 		Create(ctx, obj, metav1.CreateOptions{})
 
 	assert.Nil(t, err)
+
+	spec := createdObj.Object["spec"]
+	assert.NotNil(t, spec)
+
+	t.Log(spec)
 }

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -109,8 +109,12 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	spec := createdObj.Object["spec"]
-	assert.NotNil(t, spec)
+	spec := createdObj.Object["spec"].(map[string]interface{})
+	spec = spec["channelTemplate"].(map[string]interface{})
+	spec = spec["spec"].(map[string]interface{})
+	spec = spec["delivery"].(map[string]interface{})
 
-	t.Log(spec)
+	assert.Equal(t, "PT0.5S", spec["backoffDelay"])
+	assert.Equal(t, int64(5), spec["retry"])
+	assert.Equal(t, "exponential", spec["backoffPolicy"])
 }

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -1,0 +1,111 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"knative.dev/pkg/system"
+
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelNamespaceDefaulting(t *testing.T) {
+
+	ctx := context.Background()
+
+	const (
+		defaultChannelCM        = "default-ch-webhook"
+		defaultChannelConfigKey = "default-ch-config"
+	)
+
+	c := testlib.Setup(t, true)
+	defer testlib.TearDown(c)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
+		t.Log("Updating defaulting ConfigMap")
+
+		cm, err := c.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, defaultChannelCM, metav1.GetOptions{})
+		assert.Nil(t, err)
+
+		defaults := make(map[string]interface{})
+		err = yaml.Unmarshal([]byte(cm.Data["default-ch-config"]), defaults)
+		assert.Nil(t, err)
+
+		defaults["namespaceDefaults"] = map[string]interface{}{
+			c.Namespace: map[string]interface{}{
+				"apiVersion": "messaging.knative.dev/v1",
+				"kind":       "InMemoryChannel",
+				"spec": map[string]interface{}{
+					"delivery": map[string]interface{}{
+						"retry":         5,
+						"backoffPolicy": "exponential",
+						"backoffDelay":  "PT0.5S",
+					},
+				},
+			},
+		}
+
+		b, err := yaml.Marshal(defaults)
+		assert.Nil(t, err)
+
+		cm.Data[defaultChannelConfigKey] = string(b)
+
+		cm, err = c.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		b, err = yaml.Marshal(cm.Data[defaultChannelConfigKey])
+		if err != nil {
+			t.Log("error", err)
+		} else {
+			t.Log("CM updated - new values:", string(b))
+		}
+
+		return nil
+	})
+	assert.Nil(t, err)
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "messaging.knative.dev/v1",
+			"kind":       "Channel",
+			"metadata": map[string]interface{}{
+				"name":      "xyz",
+				"namespace": c.Namespace,
+			},
+		},
+	}
+
+	_, err = c.Dynamic.
+		Resource(schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "channels"}).
+		Namespace(c.Namespace).
+		Create(ctx, obj, metav1.CreateOptions{})
+
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Fixes #4491

Test output without the fix:
```
    namespace_default_channel_test.go:87: CM updated - new values: |
          clusterDefault:
            apiVersion: messaging.knative.dev/v1
            kind: InMemoryChannel
          namespaceDefaults:
            test-channel-namespace-defaulting-pzx9q:
              apiVersion: messaging.knative.dev/v1
              kind: InMemoryChannel
              spec:
                delivery:
                  backoffDelay: PT0.5S
                  backoffPolicy: exponential
                  retry: 5
    namespace_default_channel_test.go:110: 
        	Error Trace:	namespace_default_channel_test.go:110
        	Error:      	Expected nil, but got: &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:"Status", APIVersion:"v1"}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:"", RemainingItemCount:(*int64)(nil)}, Status:"Failure", Message:"Channel.messaging.knative.dev \"xyz\" is invalid: spec.channelTemplate.spec: Invalid value: \"object\": spec.channelTemplate.spec in body must be of type string: \"object\"", Reason:"Invalid", Details:(*v1.StatusDetails)(0xc0008692c0), Code:422}}
        	Test:       	TestChannelNamespaceDefaulting
```

## Proposed Changes

- Change Channel.spec.channelTemplate.spec type from string to object
- Add regression test

**Release Note**

```release-note
:bug: Fix bug
spec.channelTemplate.spec can be specified in default-ch-webhook.
```