### PR TITLE
Reorg of trigger filtering code

### DIFF
--- a/pkg/eventfilter/attributes/filter.go
+++ b/pkg/eventfilter/attributes/filter.go
@@ -1,3 +1,19 @@
+/*
+  Copyright 2020 The Knative Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 package attributes
 
 import (

--- a/pkg/eventfilter/attributes/filter.go
+++ b/pkg/eventfilter/attributes/filter.go
@@ -27,13 +27,14 @@ import (
 	"knative.dev/eventing/pkg/eventfilter"
 )
 
-type AttributesFilter map[string]string
+type attributesFilter map[string]string
 
+// NewAttributesFilter returns an event filter which performs the exact match on the attributes
 func NewAttributesFilter(attrs map[string]string) eventfilter.Filter {
-	return AttributesFilter(attrs)
+	return attributesFilter(attrs)
 }
 
-func (attrs AttributesFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
+func (attrs attributesFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
 	// Set standard context attributes. The attributes available may not be
 	// exactly the same as the attributes defined in the current version of the
 	// CloudEvents spec.
@@ -71,3 +72,5 @@ func (attrs AttributesFilter) Filter(ctx context.Context, event cloudevents.Even
 	}
 	return eventfilter.PassFilter
 }
+
+var _ eventfilter.Filter = attributesFilter{}

--- a/pkg/eventfilter/attributes/filter.go
+++ b/pkg/eventfilter/attributes/filter.go
@@ -1,17 +1,17 @@
 /*
-  Copyright 2020 The Knative Authors
+Copyright 2020 The Knative Authors
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package attributes

--- a/pkg/eventfilter/attributes/filter.go
+++ b/pkg/eventfilter/attributes/filter.go
@@ -1,0 +1,57 @@
+package attributes
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+
+	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/eventing/pkg/eventfilter"
+)
+
+type AttributesFilter map[string]string
+
+func NewAttributesFilter(attrs map[string]string) eventfilter.Filter {
+	return AttributesFilter(attrs)
+}
+
+func (attrs AttributesFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
+	// Set standard context attributes. The attributes available may not be
+	// exactly the same as the attributes defined in the current version of the
+	// CloudEvents spec.
+	ce := map[string]interface{}{
+		"specversion":     event.SpecVersion(),
+		"type":            event.Type(),
+		"source":          event.Source(),
+		"subject":         event.Subject(),
+		"id":              event.ID(),
+		"time":            event.Time().String(),
+		"schemaurl":       event.DataSchema(),
+		"datacontenttype": event.DataContentType(),
+		"datamediatype":   event.DataMediaType(),
+		// TODO: use data_base64 when SDK supports it.
+		"datacontentencoding": event.DeprecatedDataContentEncoding(),
+	}
+	ext := event.Extensions()
+	for k, v := range ext {
+		ce[k] = v
+	}
+
+	for k, v := range attrs {
+		var value interface{}
+		value, ok := ce[k]
+		// If the attribute does not exist in the event, return false.
+		if !ok {
+			logging.FromContext(ctx).Debug("Attribute not found", zap.String("attribute", k))
+			return eventfilter.FailFilter
+		}
+		// If the attribute is not set to any and is different than the one from the event, return false.
+		if v != eventingv1beta1.TriggerAnyFilter && v != value {
+			logging.FromContext(ctx).Debug("Attribute had non-matching value", zap.String("attribute", k), zap.String("filter", v), zap.Any("received", value))
+			return eventfilter.FailFilter
+		}
+	}
+	return eventfilter.PassFilter
+}

--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -1,0 +1,111 @@
+package attributes
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"knative.dev/eventing/pkg/eventfilter"
+	broker "knative.dev/eventing/pkg/mtbroker"
+)
+
+const (
+	eventType      = `com.example.someevent`
+	eventSource    = `/mycontext`
+	extensionName  = `myextension`
+	extensionValue = `my-extension-value`
+)
+
+func TestAttributesFilter_Filter(t *testing.T) {
+	tests := map[string]struct {
+		filter map[string]string
+		event  *cloudevents.Event
+		want   eventfilter.FilterResult
+	}{
+		"Wrong type": {
+			filter: attributesFilter("some-other-type", ""),
+			want:   eventfilter.FailFilter,
+		},
+		"Wrong type with attribs": {
+			filter: attributesFilter("some-other-type", ""),
+			want:   eventfilter.FailFilter,
+		},
+		"Wrong source": {
+			filter: attributesFilter("", "some-other-source"),
+			want:   eventfilter.FailFilter,
+		},
+		"Wrong source with attribs": {
+			filter: attributesFilter("", "some-other-source"),
+			want:   eventfilter.FailFilter,
+		},
+		"Wrong extension": {
+			filter: attributesFilter("", "some-other-source"),
+			want:   eventfilter.FailFilter,
+		},
+		"Any": {
+			filter: attributesFilter("", ""),
+			want:   eventfilter.PassFilter,
+		},
+		"Specific": {
+			filter: attributesFilter(eventType, eventSource),
+			want:   eventfilter.PassFilter,
+		},
+		"Extension with attribs": {
+			filter: attributesWithExtensionFilter(eventType, eventSource, extensionValue),
+			event:  makeEventWithExtension(extensionName, extensionValue),
+			want:   eventfilter.PassFilter,
+		},
+		"Any with attribs - Arrival extension": {
+			filter: attributesFilter("", ""),
+			event:  makeEventWithExtension(broker.EventArrivalTime, "2019-08-26T23:38:17.834384404Z"),
+			want:   eventfilter.PassFilter,
+		},
+		"Wrong Extension with attribs": {
+			filter: attributesWithExtensionFilter(eventType, eventSource, "some-other-extension-value"),
+			event:  makeEventWithExtension(extensionName, extensionValue),
+			want:   eventfilter.FailFilter,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := tt.event
+			if e == nil {
+				e = makeEvent()
+			}
+
+			if got := NewAttributesFilter(tt.filter).Filter(context.TODO(), *e); got != tt.want {
+				t.Errorf("Filter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func makeEvent() *cloudevents.Event {
+	e := cloudevents.NewEvent()
+	e.SetType(eventType)
+	e.SetSource(eventSource)
+	e.SetID("1234")
+	return &e
+}
+
+func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
+	e := makeEvent()
+	e.SetExtension(extName, extValue)
+	return e
+}
+
+func attributesFilter(t, s string) map[string]string {
+	return map[string]string{
+		"type":   t,
+		"source": s,
+	}
+}
+
+func attributesWithExtensionFilter(t, s, e string) map[string]string {
+	return map[string]string{
+		"type":        t,
+		"source":      s,
+		extensionName: e,
+	}
+}

--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -1,3 +1,19 @@
+/*
+  Copyright 2020 The Knative Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 package attributes
 
 import (

--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -40,45 +40,45 @@ func TestAttributesFilter_Filter(t *testing.T) {
 		want   eventfilter.FilterResult
 	}{
 		"Wrong type": {
-			filter: attributesFilter("some-other-type", ""),
+			filter: attributes("some-other-type", ""),
 			want:   eventfilter.FailFilter,
 		},
 		"Wrong type with attribs": {
-			filter: attributesFilter("some-other-type", ""),
+			filter: attributes("some-other-type", ""),
 			want:   eventfilter.FailFilter,
 		},
 		"Wrong source": {
-			filter: attributesFilter("", "some-other-source"),
+			filter: attributes("", "some-other-source"),
 			want:   eventfilter.FailFilter,
 		},
 		"Wrong source with attribs": {
-			filter: attributesFilter("", "some-other-source"),
+			filter: attributes("", "some-other-source"),
 			want:   eventfilter.FailFilter,
 		},
 		"Wrong extension": {
-			filter: attributesFilter("", "some-other-source"),
+			filter: attributes("", "some-other-source"),
 			want:   eventfilter.FailFilter,
 		},
 		"Any": {
-			filter: attributesFilter("", ""),
+			filter: attributes("", ""),
 			want:   eventfilter.PassFilter,
 		},
 		"Specific": {
-			filter: attributesFilter(eventType, eventSource),
+			filter: attributes(eventType, eventSource),
 			want:   eventfilter.PassFilter,
 		},
 		"Extension with attribs": {
-			filter: attributesWithExtensionFilter(eventType, eventSource, extensionValue),
+			filter: attributesWithExtension(eventType, eventSource, extensionValue),
 			event:  makeEventWithExtension(extensionName, extensionValue),
 			want:   eventfilter.PassFilter,
 		},
 		"Any with attribs - Arrival extension": {
-			filter: attributesFilter("", ""),
+			filter: attributes("", ""),
 			event:  makeEventWithExtension(broker.EventArrivalTime, "2019-08-26T23:38:17.834384404Z"),
 			want:   eventfilter.PassFilter,
 		},
 		"Wrong Extension with attribs": {
-			filter: attributesWithExtensionFilter(eventType, eventSource, "some-other-extension-value"),
+			filter: attributesWithExtension(eventType, eventSource, "some-other-extension-value"),
 			event:  makeEventWithExtension(extensionName, extensionValue),
 			want:   eventfilter.FailFilter,
 		},
@@ -111,14 +111,14 @@ func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
 	return e
 }
 
-func attributesFilter(t, s string) map[string]string {
+func attributes(t, s string) map[string]string {
 	return map[string]string{
 		"type":   t,
 		"source": s,
 	}
 }
 
-func attributesWithExtensionFilter(t, s, e string) map[string]string {
+func attributesWithExtension(t, s, e string) map[string]string {
 	return map[string]string{
 		"type":        t,
 		"source":      s,

--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -1,17 +1,17 @@
 /*
-  Copyright 2020 The Knative Authors
+Copyright 2020 The Knative Authors
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package attributes

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -46,6 +46,7 @@ func (x FilterResult) And(y FilterResult) FilterResult {
 
 // Filter is an interface representing an event filter of the trigger filter
 type Filter interface {
+	// Filter compute the predicate on the provided event and returns the result of the matching
 	Filter(ctx context.Context, event cloudevents.Event) FilterResult
 }
 
@@ -56,6 +57,10 @@ func (filters Filters) Filter(ctx context.Context, event cloudevents.Event) Filt
 	res := NoFilter
 	for _, f := range filters {
 		res = res.And(f.Filter(ctx, event))
+		// Short circuit to optimize it
+		if res == FailFilter {
+			return FailFilter
+		}
 	}
 	return res
 }

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -1,3 +1,19 @@
+/*
+  Copyright 2020 The Knative Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 package eventfilter
 
 import (

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -1,0 +1,45 @@
+package eventfilter
+
+import (
+	"context"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+const (
+	PassFilter FilterResult = "pass"
+	FailFilter FilterResult = "fail"
+	NoFilter   FilterResult = "no_filter"
+)
+
+// FilterResult has the result of the filtering operation.
+type FilterResult string
+
+func (x FilterResult) And(y FilterResult) FilterResult {
+	if x == NoFilter {
+		return y
+	}
+	if y == NoFilter {
+		return x
+	}
+	if x == PassFilter && y == PassFilter {
+		return PassFilter
+	}
+	return FailFilter
+}
+
+// Filter is an interface representing an event filter of the trigger filter
+type Filter interface {
+	Filter(ctx context.Context, event cloudevents.Event) FilterResult
+}
+
+// Filters is a wrapper that runs each filter and performs the and
+type Filters []Filter
+
+func (filters Filters) Filter(ctx context.Context, event cloudevents.Event) FilterResult {
+	res := NoFilter
+	for _, f := range filters {
+		res = res.And(f.Filter(ctx, event))
+	}
+	return res
+}

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -64,3 +64,5 @@ func (filters Filters) Filter(ctx context.Context, event cloudevents.Event) Filt
 	}
 	return res
 }
+
+var _ Filter = Filters{}

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -1,17 +1,17 @@
 /*
-  Copyright 2020 The Knative Authors
+Copyright 2020 The Knative Authors
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package eventfilter

--- a/pkg/eventfilter/filter_test.go
+++ b/pkg/eventfilter/filter_test.go
@@ -1,3 +1,19 @@
+/*
+  Copyright 2020 The Knative Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 package eventfilter
 
 import (

--- a/pkg/eventfilter/filter_test.go
+++ b/pkg/eventfilter/filter_test.go
@@ -1,0 +1,62 @@
+package eventfilter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFilter FilterResult
+
+func (p mockFilter) Filter(ctx context.Context, event cloudevents.Event) FilterResult {
+	return FilterResult(p)
+}
+
+func TestFilters(t *testing.T) {
+	tests := []struct {
+		have []FilterResult
+		want FilterResult
+	}{{
+		have: []FilterResult{},
+		want: NoFilter,
+	}, {
+		have: []FilterResult{PassFilter},
+		want: PassFilter,
+	}, {
+		have: []FilterResult{FailFilter},
+		want: FailFilter,
+	}, {
+		have: []FilterResult{PassFilter, PassFilter},
+		want: PassFilter,
+	}, {
+		have: []FilterResult{PassFilter, FailFilter},
+		want: FailFilter,
+	}, {
+		have: []FilterResult{FailFilter, FailFilter},
+		want: FailFilter,
+	}}
+	for _, tt := range tests {
+		t.Run(testName(tt.have, tt.want), func(t *testing.T) {
+			var filters Filters
+			for _, fr := range tt.have {
+				filters = append(filters, mockFilter(fr))
+			}
+			require.Equal(t, tt.want, filters.Filter(context.TODO(), cloudevents.Event{}))
+		})
+	}
+}
+
+func testName(res []FilterResult, want FilterResult) string {
+	if len(res) != 0 {
+		var operands []string
+		for _, r := range res {
+			operands = append(operands, fmt.Sprintf("'%s'", string(r)))
+		}
+		return strings.Join(operands, " and ") + " = '" + string(want) + "'"
+	}
+	return string(NoFilter) + " = '" + string(want) + "'"
+}

--- a/pkg/eventfilter/filter_test.go
+++ b/pkg/eventfilter/filter_test.go
@@ -1,17 +1,17 @@
 /*
-  Copyright 2020 The Knative Authors
+Copyright 2020 The Knative Authors
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package eventfilter

--- a/pkg/mtbroker/filter/filter_handler.go
+++ b/pkg/mtbroker/filter/filter_handler.go
@@ -34,6 +34,8 @@ import (
 
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	"knative.dev/eventing/pkg/eventfilter"
+	"knative.dev/eventing/pkg/eventfilter/attributes"
 	"knative.dev/eventing/pkg/kncloudevents"
 	broker "knative.dev/eventing/pkg/mtbroker"
 	"knative.dev/eventing/pkg/reconciler/sugar/trigger/path"
@@ -42,10 +44,6 @@ import (
 )
 
 const (
-	passFilter FilterResult = "pass"
-	failFilter FilterResult = "fail"
-	noFilter   FilterResult = "no_filter"
-
 	// TODO make these constants configurable (either as env variables, config map, or part of broker spec).
 	//  Issue: https://github.com/knative/eventing/issues/1777
 	// Constants for the underlying HTTP Client transport. These would enable better connection reuse.
@@ -68,9 +66,6 @@ type Handler struct {
 	triggerLister eventinglisters.TriggerLister
 	logger        *zap.Logger
 }
-
-// FilterResult has the result of the filtering operation.
-type FilterResult string
 
 // NewHandler creates a new Handler and its associated MessageReceiver. The caller is responsible for
 // Start()ing the returned Handler.
@@ -189,9 +184,14 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
 	// Check if the event should be sent.
 	ctx = logging.WithLogger(ctx, h.logger.Sugar())
-	filterResult := h.shouldSendEvent(ctx, &t.Spec, event)
+	filterResult, err := filterEvent(ctx, t.Spec.Filter, *event)
+	if err != nil {
+		h.logger.Error("Error while filtering", zap.Error(err))
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	if filterResult == failFilter {
+	if filterResult == eventfilter.FailFilter {
 		// We do not count the event. The event will be counted in the broker ingress.
 		// If the filter didn't pass, it means that the event wasn't meant for this Trigger.
 		return
@@ -329,54 +329,15 @@ func (h *Handler) getTrigger(ref path.NamespacedNameUID) (*eventingv1beta1.Trigg
 	return t, nil
 }
 
-// shouldSendEvent determines whether event 'event' should be sent based on the triggerSpec 'ts'.
-// Currently it supports exact matching on event context attributes and extension attributes.
-// If no filter is present, shouldSendEvent returns passFilter.
-func (h *Handler) shouldSendEvent(ctx context.Context, ts *eventingv1beta1.TriggerSpec, event *cloudevents.Event) FilterResult {
-	// No filter specified, default to passing everything.
-	if ts.Filter == nil || len(ts.Filter.Attributes) == 0 {
-		return noFilter
+func filterEvent(ctx context.Context, filter *eventingv1beta1.TriggerFilter, event cloudevents.Event) (eventfilter.FilterResult, error) {
+	if filter == nil {
+		return eventfilter.NoFilter, nil
 	}
-	return filterEventByAttributes(ctx, map[string]string(ts.Filter.Attributes), event)
-}
-
-func filterEventByAttributes(ctx context.Context, attrs map[string]string, event *cloudevents.Event) FilterResult {
-	// Set standard context attributes. The attributes available may not be
-	// exactly the same as the attributes defined in the current version of the
-	// CloudEvents spec.
-	ce := map[string]interface{}{
-		"specversion":     event.SpecVersion(),
-		"type":            event.Type(),
-		"source":          event.Source(),
-		"subject":         event.Subject(),
-		"id":              event.ID(),
-		"time":            event.Time().String(),
-		"schemaurl":       event.DataSchema(),
-		"datacontenttype": event.DataContentType(),
-		"datamediatype":   event.DataMediaType(),
-		// TODO: use data_base64 when SDK supports it.
-		"datacontentencoding": event.DeprecatedDataContentEncoding(),
+	var filters eventfilter.Filters
+	if filter.Attributes != nil && len(filter.Attributes) != 0 {
+		filters = append(filters, attributes.NewAttributesFilter(filter.Attributes))
 	}
-	ext := event.Extensions()
-	for k, v := range ext {
-		ce[k] = v
-	}
-
-	for k, v := range attrs {
-		var value interface{}
-		value, ok := ce[k]
-		// If the attribute does not exist in the event, return false.
-		if !ok {
-			logging.FromContext(ctx).Debug("Attribute not found", zap.String("attribute", k))
-			return failFilter
-		}
-		// If the attribute is not set to any and is different than the one from the event, return false.
-		if v != eventingv1beta1.TriggerAnyFilter && v != value {
-			logging.FromContext(ctx).Debug("Attribute had non-matching value", zap.String("attribute", k), zap.String("filter", v), zap.Any("received", value))
-			return failFilter
-		}
-	}
-	return passFilter
+	return filters.Filter(ctx, event), nil
 }
 
 // triggerFilterAttribute returns the filter attribute value for a given `attributeName`. If it doesn't not exist,


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This PR reorganizes the filtering code to be a little bit more extensible, although it doesn't add, nor modify, any current behaviour of the code. It just makes it simpler to contribute to extend it :smile: I did it to use as a base to enable people experiment new filters (play nice with #3771 and #4279). I have a couple of ideas I'm gonna show in next PRs on filtering, and this serves as a good base. Took from https://github.com/knative/eventing/pull/3771