### PR TITLE
fix 4509, remove finalizer

### DIFF
--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -122,6 +122,15 @@ func NewController(
 
 	// Watch for inmemory channels.
 	inmemorychannelInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: cache.FilteringResourceEventHandler{
+				FilterFunc: filterWithAnnotation(injection.HasNamespaceScope(ctx)),
+				Handler:    impl.Enqueue,
+			},
+			AddFunc:    h,
+			UpdateFunc: PassNew(h),
+			DeleteFunc: h,
+	}
 		cache.FilteringResourceEventHandler{
 			FilterFunc: filterWithAnnotation(injection.HasNamespaceScope(ctx)),
 			Handler:    controller.HandleAll(impl.Enqueue),

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -18,8 +18,9 @@ package dispatcher
 
 import (
 	"context"
-	"knative.dev/pkg/injection"
 	"time"
+
+	"knative.dev/pkg/injection"
 
 	"k8s.io/client-go/tools/cache"
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -151,12 +151,15 @@ func (r *Reconciler) newConfigForInMemoryChannel(imc *v1.InMemoryChannel) (*mult
 }
 
 func (r *Reconciler) deleteFunc(obj interface{}) {
+	if obj == nil {
+		return
+	}
 	acc, err := kmeta.DeletionHandlingAccessor(obj)
 	if err != nil {
 		return
 	}
 	imc, ok := acc.(*v1.InMemoryChannel)
-	if !ok {
+	if !ok || imc == nil {
 		return
 	}
 	if imc.Status.Address != nil && imc.Status.Address.URL != nil {

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -151,17 +151,17 @@ func (r *Reconciler) newConfigForInMemoryChannel(imc *v1.InMemoryChannel) (*mult
 }
 
 func (r *Reconciler) deleteFunc(obj interface{}) {
-	if acc, err := kmeta.DeletionHandlingAccessor(obj); err == nil {
-		if imc, ok := acc.(*v1.InMemoryChannel); ok {
-			// If the IMC has been deleted just make sure the handler is removed.
-			if !imc.GetDeletionTimestamp().IsZero() {
-				if imc.Status.Address != nil &&
-					imc.Status.Address.URL != nil {
-					if hostName := imc.Status.Address.URL.Host; hostName != "" {
-						r.multiChannelMessageHandler.DeleteChannelHandler(hostName)
-					}
-				}
-			}
+	acc, err := kmeta.DeletionHandlingAccessor(obj)
+	if err != nil {
+		return
+	}
+	imc, ok := acc.(*v1.InMemoryChannel)
+	if !ok {
+		return
+	}
+	if imc.Status.Address != nil && imc.Status.Address.URL != nil {
+		if hostName := imc.Status.Address.URL.Host; hostName != "" {
+			r.multiChannelMessageHandler.DeleteChannelHandler(hostName)
 		}
 	}
 }

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -132,13 +132,6 @@ func TestAllCases(t *testing.T) {
 			Objects: []runtime.Object{
 				NewInMemoryChannel(imcName, testNS, WithInitInMemoryChannelConditions),
 			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-			WantErr: false,
 		}, {
 			Name: "updated configuration, one channel",
 			Key:  imcKey,
@@ -151,13 +144,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelChannelServiceReady(),
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-			WantErr: false,
 		}, {
 			Name: "with subscribers",
 			Key:  imcKey,
@@ -172,14 +158,8 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
 				makePatch(testNS, imcName, twoSubscriberPatch),
 			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-
-			WantErr: false,
 		}, {
 			Name: "with subscribers, patch fails",
 			Key:  imcKey,
@@ -197,11 +177,9 @@ func TestAllCases(t *testing.T) {
 				InduceFailure("patch", "inmemorychannels/status"),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
 				makePatch(testNS, imcName, twoSubscriberPatch),
 			},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
 				Eventf(corev1.EventTypeWarning, "InternalError", "Failed patching: inducing failure for patch inmemorychannels"),
 			},
 			WantErr: true,
@@ -220,14 +198,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelReadySubscriberAndGeneration(string(subscriber2UID), subscriber2Generation),
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-
-			WantErr: false,
 		}, {
 			Name: "with subscribers, one removed one added to status",
 			Key:  imcKey,
@@ -244,14 +214,8 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
 				makePatch(testNS, imcName, oneSubscriberRemovedOneAddedPatch),
 			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-
-			WantErr: false,
 		}, {
 			Name: "subscriber with delivery spec",
 			Key:  imcKey,
@@ -281,13 +245,8 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
 				makePatch(testNS, imcName, oneSubscriberPatch),
 			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-			WantErr: false,
 		}, {
 			Name: "subscriber with invalid delivery spec",
 			Key:  imcKey,
@@ -316,11 +275,7 @@ func TestAllCases(t *testing.T) {
 					}),
 					WithInMemoryChannelAddress(channelServiceAddress)),
 			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(testNS, imcName),
-			},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
 				Eventf(corev1.EventTypeWarning, "InternalError", "failed to parse Spec.BackoffDelay: expected 'P' period mark at the start: garbage"),
 			},
 			WantErr: true,
@@ -354,13 +309,6 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelAddress(channelServiceAddress),
 					WithInMemoryChannelDeleted),
 			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchRemoveFinalizers(testNS, imcName),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", imcName),
-			},
-			WantErr: false,
 		},
 	}
 
@@ -529,7 +477,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 	}
 }
 
-func TestReconciler_FinalizeKind(t *testing.T) {
+func TestReconciler_ReconcileKindDeletion(t *testing.T) {
 	testCases := map[string]struct {
 		imc        *v1.InMemoryChannel
 		wantResult reconciler.Event
@@ -554,7 +502,7 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 				r := &Reconciler{
 					multiChannelMessageHandler: handler,
 				}
-				e := r.FinalizeKind(context.TODO(), tc.imc)
+				e := r.ReconcileKind(context.TODO(), tc.imc)
 				if e != tc.wantResult {
 					t.Errorf("Results differ, want %v have %v", tc.wantResult, e)
 				}
@@ -574,16 +522,6 @@ func makePatch(namespace, name, patch string) clientgotesting.PatchActionImpl {
 		Name:  name,
 		Patch: []byte(patch),
 	}
-}
-
-func patchFinalizers(namespace, name string) clientgotesting.PatchActionImpl {
-	return makePatch(namespace, name,
-		`{"metadata":{"finalizers":["`+finalizerName+`"],"resourceVersion":""}}`)
-}
-
-func patchRemoveFinalizers(namespace, name string) clientgotesting.PatchActionImpl {
-	return makePatch(namespace, name,
-		`{"metadata":{"finalizers":[],"resourceVersion":""}}`)
 }
 
 type fakeMultiChannelHandler struct {

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -477,10 +477,9 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 	}
 }
 
-func TestReconciler_ReconcileKindDeletion(t *testing.T) {
+func TestReconciler_Deletion(t *testing.T) {
 	testCases := map[string]struct {
-		imc        *v1.InMemoryChannel
-		wantResult reconciler.Event
+		imc *v1.InMemoryChannel
 	}{
 		"With address": {
 			imc: NewInMemoryChannel(imcName, testNS,
@@ -502,10 +501,7 @@ func TestReconciler_ReconcileKindDeletion(t *testing.T) {
 				r := &Reconciler{
 					multiChannelMessageHandler: handler,
 				}
-				e := r.ReconcileKind(context.TODO(), tc.imc)
-				if e != tc.wantResult {
-					t.Errorf("Results differ, want %v have %v", tc.wantResult, e)
-				}
+				r.deleteFunc(tc.imc)
 				if handler.GetChannelHandler(channelServiceAddress) != nil {
 					t.Error("Got handler")
 				}


### PR DESCRIPTION
Fixes #4509

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Do not use finalizer for IMC dispatcher

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :broom: Update or clean up current behavior
Do not set the finalizer for InMemoryChannel for dispatcher, just deal with it in reconcilekind
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
