### PR TITLE
Microbenchmark for Trigger Filter

### DIFF
--- a/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 
+	"knative.dev/eventing/pkg/eventfilter"
 	"knative.dev/eventing/pkg/eventfilter/attributes"
 )
 
@@ -12,29 +13,35 @@ func BenchmarkAttributesFilter(b *testing.B) {
 	event := cetest.FullEvent()
 
 	RunFilterBenchmarks(b,
+		func(i interface{}) eventfilter.Filter {
+			return attributes.NewAttributesFilter(i.(map[string]string))
+		},
 		FilterBenchmark{
-			name:   "Pass with exact match of id",
-			filter: attributes.NewAttributesFilter(map[string]string{"id": event.ID()}),
-			event:  event,
+			name:  "Pass with exact match of id",
+			arg:   map[string]string{"id": event.ID()},
+			event: event,
 		},
 		FilterBenchmark{
 			// We don't test time because the exact match on the string apparently doesn't work well,
 			// which might cause the filter to fail.
 			name: "Pass with exact match of all context attributes (except time)",
-			filter: attributes.NewAttributesFilter(map[string]string{
+			arg: map[string]string{
 				"id":              event.ID(),
 				"source":          event.Source(),
 				"type":            event.Type(),
 				"dataschema":      event.DataSchema(),
 				"datacontenttype": event.DataContentType(),
 				"subject":         event.Subject(),
-			}),
+			},
 			event: event,
 		},
 		FilterBenchmark{
-			name:   "No pass with exact match of id and source",
-			filter: attributes.NewAttributesFilter(map[string]string{"id": "qwertyuiopasdfghjklzxcvbnm", "source": "qwertyuiopasdfghjklzxcvbnm"}),
-			event:  event,
+			name: "No pass with exact match of id and source",
+			arg: map[string]string{
+				"id":     "qwertyuiopasdfghjklzxcvbnm",
+				"source": "qwertyuiopasdfghjklzxcvbnm",
+			},
+			event: event,
 		},
 	)
 }

--- a/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
@@ -1,0 +1,40 @@
+package benchmarks
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+
+	"knative.dev/eventing/pkg/eventfilter/attributes"
+)
+
+func BenchmarkAttributesFilter(b *testing.B) {
+	event := cetest.FullEvent()
+
+	RunFilterBenchmarks(b,
+		FilterBenchmark{
+			name:   "Pass with exact match of id",
+			filter: attributes.NewAttributesFilter(map[string]string{"id": event.ID()}),
+			event:  event,
+		},
+		FilterBenchmark{
+			// We don't test time because the exact match on the string apparently doesn't work well,
+			// which might cause the filter to fail.
+			name: "Pass with exact match of all context attributes (except time)",
+			filter: attributes.NewAttributesFilter(map[string]string{
+				"id":              event.ID(),
+				"source":          event.Source(),
+				"type":            event.Type(),
+				"dataschema":      event.DataSchema(),
+				"datacontenttype": event.DataContentType(),
+				"subject":         event.Subject(),
+			}),
+			event: event,
+		},
+		FilterBenchmark{
+			name:   "No pass with exact match of id and source",
+			filter: attributes.NewAttributesFilter(map[string]string{"id": "qwertyuiopasdfghjklzxcvbnm", "source": "qwertyuiopasdfghjklzxcvbnm"}),
+			event:  event,
+		},
+	)
+}

--- a/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/attributes_benchmark_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package benchmarks
 
 import (

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -35,6 +35,9 @@ type FilterBenchmark struct {
 var Filter eventfilter.Filter
 var Result eventfilter.FilterResult
 
+// RunFilterBenchmarks executes 2 benchmark runs for each of the provided bench cases:
+// 1. "Creation: ..." benchmark measures the time/mem to create the filter, given the filter constructor and the argument
+// 2. "Run: ..." benchmark measures the time/mem to execute the filter, given a pre-built filter instance and the provided event
 func RunFilterBenchmarks(b *testing.B, filterCtor func(interface{}) eventfilter.Filter, filterBenchmarks ...FilterBenchmark) {
 	for _, fb := range filterBenchmarks {
 		b.Run("Creation: "+fb.name, func(b *testing.B) {

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -21,7 +21,7 @@ var R eventfilter.FilterResult
 
 func RunFilterBenchmarks(b *testing.B, filterCtor func(interface{}) eventfilter.Filter, filterBenchmarks ...FilterBenchmark) {
 	for _, fb := range filterBenchmarks {
-		b.Run("Parse: "+fb.name, func(b *testing.B) {
+		b.Run("Creation: "+fb.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				F = filterCtor(fb.arg)
 			}

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -1,0 +1,29 @@
+package benchmarks
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"knative.dev/eventing/pkg/eventfilter"
+)
+
+type FilterBenchmark struct {
+	name   string
+	filter eventfilter.Filter
+	event  cloudevents.Event
+}
+
+// Avoid DCE
+var R eventfilter.FilterResult
+
+func RunFilterBenchmarks(b *testing.B, filterBenchmarks ...FilterBenchmark) {
+	for _, fb := range filterBenchmarks {
+		b.Run(fb.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				R = fb.filter.Filter(context.TODO(), fb.event)
+			}
+		})
+	}
+}

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package benchmarks
 
 import (

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -32,21 +32,21 @@ type FilterBenchmark struct {
 }
 
 // Avoid DCE
-var F eventfilter.Filter
-var R eventfilter.FilterResult
+var Filter eventfilter.Filter
+var Result eventfilter.FilterResult
 
 func RunFilterBenchmarks(b *testing.B, filterCtor func(interface{}) eventfilter.Filter, filterBenchmarks ...FilterBenchmark) {
 	for _, fb := range filterBenchmarks {
 		b.Run("Creation: "+fb.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				F = filterCtor(fb.arg)
+				Filter = filterCtor(fb.arg)
 			}
 		})
 		// Filter to use for the run
 		f := filterCtor(fb.arg)
 		b.Run("Run: "+fb.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				R = f.Filter(context.TODO(), fb.event)
+				Result = f.Filter(context.TODO(), fb.event)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

This adds microbenchmarks to test implementations of `eventfilter.Filter`.

Note: although it doesn't make sense to test for the attributes filter the creation of the filter instance, it makes sense for more complex filters like in the context of #3359 and #4495, where creating the filter means transforming the user input in some middle representation (like an AST or a schema instance) which is not trivial to create

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add generic microbenchmark to test creation and run of the filter implementation
- Add attributes microbenchmark tests