### PR TITLE
Log error returned by adapter.Start at error level

### DIFF
--- a/pkg/adapter/v2/main.go
+++ b/pkg/adapter/v2/main.go
@@ -196,7 +196,7 @@ func MainWithInformers(ctx context.Context, component string, env EnvConfigAcces
 
 	// Finally start the adapter (blocking)
 	if err := adapter.Start(ctx); err != nil {
-		logging.FromContext(ctx).Warn("Start returned an error", zap.Error(err))
+		logging.FromContext(ctx).Errorw("Start returned an error", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

- Log the error returned by `adapter.Start` at the "error" level instead of "warn"
- Fix the format of the logged error

Context: I was a bit surprised to see runtime failures being logged at the "warn" level when this kind of error means the application is shutting down due to a problem.

Besides, the format of the `msg` is broken due to the usage of `Warn` instead of `Warnw`:

```jsonc
// expected
{
  "level": "warn",
  // ...
  "msg": "Start returned an error",
  "err": "no stream associated with table \"debug\""
}

// got
{
  "level": "warn",
  // ...
  "msg": "Start returned an error{error 26 0  no stream associated with table \"debug\"}"
}
```

**Release Note**

```release-note
:broom: Log runtime errors of sources' adapters at the "error" level instead of "warn"
```