### PR TITLE
[0.18] Change Channel.spec.channelTemplate.spec type to object in OpenAPI schema

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -74,7 +74,8 @@ spec:
                     description: Spec defines the Spec to use for each channel
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
-                    type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/config/pre-install/v0.18.0/channel.yaml
+++ b/config/pre-install/v0.18.0/channel.yaml
@@ -74,7 +74,8 @@ spec:
                     description: Spec defines the Spec to use for each channel
                         created. Passed in verbatim to the Channel CRD as Spec
                         section.
-                    type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
               delivery: &deliverySpec
                 description: DeliverySpec contains options controlling the event delivery
                 type: object

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -1,0 +1,138 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"knative.dev/pkg/system"
+
+	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelNamespaceDefaulting(t *testing.T) {
+
+	ctx := context.Background()
+
+	const (
+		defaultChannelCM        = "default-ch-webhook"
+		defaultChannelConfigKey = "default-ch-config"
+	)
+
+	c := testlib.Setup(t, true)
+	defer testlib.TearDown(c)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
+		t.Log("Updating defaulting ConfigMap")
+
+		cm, err := c.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, defaultChannelCM, metav1.GetOptions{})
+		assert.Nil(t, err)
+
+		defaults := make(map[string]interface{})
+		err = yaml.Unmarshal([]byte(cm.Data["default-ch-config"]), defaults)
+		assert.Nil(t, err)
+
+		defaults["namespaceDefaults"] = map[string]interface{}{
+			c.Namespace: map[string]interface{}{
+				"apiVersion": "messaging.knative.dev/v1",
+				"kind":       "InMemoryChannel",
+				"spec": map[string]interface{}{
+					"delivery": map[string]interface{}{
+						"retry":         5,
+						"backoffPolicy": "exponential",
+						"backoffDelay":  "PT0.5S",
+					},
+				},
+			},
+		}
+
+		b, err := yaml.Marshal(defaults)
+		assert.Nil(t, err)
+
+		cm.Data[defaultChannelConfigKey] = string(b)
+
+		cm, err = c.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		b, err = yaml.Marshal(cm.Data[defaultChannelConfigKey])
+		if err != nil {
+			t.Log("error", err)
+		} else {
+			t.Log("CM updated - new values:", string(b))
+		}
+
+		return nil
+	})
+	assert.Nil(t, err)
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "messaging.knative.dev/v1",
+			"kind":       "Channel",
+			"metadata": map[string]interface{}{
+				"name":      "xyz",
+				"namespace": c.Namespace,
+			},
+		},
+	}
+
+	createdObj, err := c.Dynamic.
+		Resource(schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "channels"}).
+		Namespace(c.Namespace).
+		Create(ctx, obj, metav1.CreateOptions{})
+
+	assert.Nil(t, err)
+
+	spec := createdObj.Object["spec"].(map[string]interface{})
+	spec = spec["channelTemplate"].(map[string]interface{})
+	spec = spec["spec"].(map[string]interface{})
+	spec = spec["delivery"].(map[string]interface{})
+
+	assert.Equal(t, "PT0.5S", spec["backoffDelay"])
+	assert.Equal(t, int64(5), spec["retry"])
+	assert.Equal(t, "exponential", spec["backoffPolicy"])
+
+	wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+		imc, err := c.Eventing.MessagingV1().InMemoryChannels(c.Namespace).Get(ctx, "xyz", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		assert.Nil(t, err)
+
+		assert.Equal(t, "PT0.5S", *imc.Spec.Delivery.BackoffDelay)
+		assert.Equal(t, int32(5), *imc.Spec.Delivery.Retry)
+		assert.Equal(t, eventingduck.BackoffPolicyExponential, *imc.Spec.Delivery.BackoffPolicy)
+
+		return true, nil
+	})
+}

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -57,7 +57,7 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 
 		t.Log("Updating defaulting ConfigMap")
 
-		cm, err := c.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, defaultChannelCM, metav1.GetOptions{})
+		cm, err := c.Kube.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, defaultChannelCM, metav1.GetOptions{})
 		assert.Nil(t, err)
 
 		// Preserve existing namespace defaults.
@@ -82,7 +82,7 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 
 		cm.Data[defaultChannelConfigKey] = string(b)
 
-		cm, err = c.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		cm, err = c.Kube.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/test/e2e/namespace_default_channel_test.go
+++ b/test/e2e/namespace_default_channel_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	"knative.dev/pkg/system"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -57,7 +57,8 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 
 		t.Log("Updating defaulting ConfigMap")
 
-		cm, err := c.Kube.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, defaultChannelCM, metav1.GetOptions{})
+		namespace := os.Getenv("TEST_EVENTING_NAMESPACE")
+		cm, err := c.Kube.Kube.CoreV1().ConfigMaps(namespace).Get(ctx, defaultChannelCM, metav1.GetOptions{})
 		assert.Nil(t, err)
 
 		// Preserve existing namespace defaults.
@@ -82,7 +83,7 @@ func TestChannelNamespaceDefaulting(t *testing.T) {
 
 		cm.Data[defaultChannelConfigKey] = string(b)
 
-		cm, err = c.Kube.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		cm, err = c.Kube.Kube.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #4491

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Backport https://github.com/knative/eventing/pull/4492
- Backport https://github.com/knative/eventing/pull/4500

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fix bug
spec.channelTemplate.spec can be specified in default-ch-webhook.
```

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/cc @vaikas 