### PR TITLE
[Release 0.19] Fix MTBroker Channel and IMC Channel Services length issue.

### DIFF
--- a/pkg/reconciler/inmemorychannel/controller/resources/service.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resources
 
 import (
@@ -21,7 +37,7 @@ const (
 type K8sServiceOption func(*corev1.Service) error
 
 func CreateChannelServiceName(name string) string {
-	return fmt.Sprintf("%s-kn-channel", name)
+	return kmeta.ChildName(name, "-kn-channel")
 }
 
 // ExternalService is a functional option for CreateK8sService to create a K8s service of type ExternalName

--- a/pkg/reconciler/inmemorychannel/controller/resources/service.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"

--- a/pkg/reconciler/mtbroker/resources/channel.go
+++ b/pkg/reconciler/mtbroker/resources/channel.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"encoding/json"
-	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +29,7 @@ import (
 // BrokerChannelName creates a name for the Channel for a Broker for a given
 // Channel type.
 func BrokerChannelName(brokerName, channelType string) string {
-	return fmt.Sprintf("%s-kne-%s", brokerName, channelType)
+	return kmeta.ChildName(brokerName, "-kne-"+channelType)
 }
 
 // test


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix naming for MTBroker Channels
- Fix naming for IMC Channel Services.

/kind bugfix

**Release Note**

```release-note
:bug: - Fix naming for MTBroker Channels for length issues.If Broker name was long enough (~40 chars) would not become ready.
:bug:  - Fix naming for IMC Channel Services for length issues. If IMC Channel name was long enough (~40 chars) would not become ready.
```