### PR TITLE
Add event reply header to spec

### DIFF
--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,21 +93,20 @@ CloudEvents received by Sink MAY have
 
 ### HTTP Attributes
 
-An event sender, including Source and Broker and Channel, MUST include
+An event sender, including Source and Broker and Channel, SHOULD include
 all the non-default HTTP attributes with header key `K-Eventing-Http-Attr` in
-every event delivery to specify
-what HTTP features it can support. Without a certain attribute, the receiver
-MUST assume the corresponding HTTP feature is not supported. A list of HTTP
-attributes can be found below:
+every event delivery to specify what HTTP features it can support. Without a
+certain attribute, the receiver SHOULD assume the corresponding HTTP feature
+is not supported. A list of HTTP attributes can be found below:
 
 | Attributes         | HTTP Feature Description                                                  |
 | ------------------ | ------------------------------------------------------------------------- |
 | `callable`         | If the event sender supports event reply in HTTP response.                |
 
-An example is that a broker supporting event reply MUST send events with
+An example is that a Broker supporting event reply sends events with
 an additional header `K-Eventing-Http-Attr: ["callable"]` so that the sink connected
-to the broker knows event replies will be accepted. While a source
-may send events without the header, in which case the sink connected directly
+to the Broker knows event replies will be accepted. While a source
+sends events without the header, in which case the sink connected directly
 to the source will assume that any event reply will be dropped.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,17 +93,17 @@ CloudEvents received by Sink MAY have
 
 ### Event reply contract
 
-An event sender supporting event replies SHOULD include a `Prefer: callable` header
+An event sender supporting event replies SHOULD include a `Prefer: reply` header
 in delivery requests to indicate to the sink that event reply is supported. An event
-sender MAY ignore an event reply in the delivery response if the `Prefer: callable`
+sender MAY ignore an event reply in the delivery response if the `Prefer: reply`
 header was not included in the delivery request.
 
 An example is that a Broker supporting event reply sends events with an additional header
-`Prefer: callable` so that the sink connected to the Broker knows event replies will
+`Prefer: reply` so that the sink connected to the Broker knows event replies will
 be accepted. While a source sends events without the header, in which case the sink may
 assume that any event reply will be dropped without error or retry attempt. If a sink
 wishes to ensure the reply events will be delivered, it can check for the existence of
-the `Prefer: callable` header in the delivery request and respond with an error code
+the `Prefer: reply` header in the delivery request and respond with an error code
 if the header is not present.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,17 +93,17 @@ CloudEvents received by Sink MAY have
 
 ### Event reply contract
 
-An event sender supporting event replies SHOULD include a `Prefer: ["callable"]` header
+An event sender supporting event replies SHOULD include a `Prefer: callable` header
 in delivery requests to indicate to the sink that event reply is supported. An event
-sender MAY ignore an event reply in the delivery response if the `Prefer: ["callable"]`
+sender MAY ignore an event reply in the delivery response if the `Prefer: callable`
 header was not included in the delivery request.
 
 An example is that a Broker supporting event reply sends events with an additional header
-`Prefer: ["callable"]` so that the sink connected to the Broker knows event replies will
+`Prefer: callable` so that the sink connected to the Broker knows event replies will
 be accepted. While a source sends events without the header, in which case the sink may
 assume that any event reply will be dropped without error or retry attempt. If a sink
 wishes to ensure the reply events will be delivered, it can check for the existence of
-the `Prefer: ["callable"]` header in the delivery request and respond with an error code
+the `Prefer: callable` header in the delivery request and respond with an error code
 if the header is not present.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,9 +93,10 @@ CloudEvents received by Sink MAY have
 
 ### Event reply header
 
-An event forward entity, including Source and Broker and Channel, SHOULD include
-the event reply header `K-Eventing-Event-Reply: reponse` if it supports response
-events. If no event reply header is present or the header is not set to `response`,
+An event sender, including Source and Broker and Channel, SHOULD include
+the event reply header `K-Eventing-Event-Reply: response` in an event delivery
+request if it supports response events. If no event reply header is present
+or the header is present but does not include the value `response`,
 the Sink SHOULD assume that response events are NOT supported.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -91,13 +91,24 @@ delivered.
 CloudEvents received by Sink MAY have
 [Distributed Tracing Extension Attribute](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md).
 
-### Event reply header
+### HTTP Attributes
 
-An event sender, including Source and Broker and Channel, SHOULD include
-the event reply header `K-Eventing-Accept-Reply: response` in an event delivery
-request if it supports response events. If no event reply header is present
-or the header is present but does not include the value `response`,
-the Sink SHOULD assume that response events are not supported.
+An event sender, including Source and Broker and Channel, MUST include
+all the non-default HTTP attributes with header key `K-Eventing-Http-Attr` in
+every event delivery to specify
+what HTTP features it can support. Without a certain attribute, the receiver
+MUST assume the corresponding HTTP feature is not supported. A list of HTTP
+attributes can be found below:
+
+| Attributes         | HTTP Feature Description                                                  |
+| ------------------ | ------------------------------------------------------------------------- |
+| `callable`         | If the event sender supports event reply in HTTP response.                |
+
+An example is that a broker supporting event reply MUST send events with
+an additional header `K-Eventing-Http-Attr: ["callable"]` so that the sink connected
+to the broker knows event replies will be accepted. While a source
+may send events without the header, in which case the sink connected directly
+to the source will assume that any event reply will be dropped.
 
 ### Data plane contract for Sources
 

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -94,10 +94,10 @@ CloudEvents received by Sink MAY have
 ### Event reply header
 
 An event sender, including Source and Broker and Channel, SHOULD include
-the event reply header `K-Eventing-Event-Reply: response` in an event delivery
+the event reply header `K-Eventing-Accept-Reply: response` in an event delivery
 request if it supports response events. If no event reply header is present
 or the header is present but does not include the value `response`,
-the Sink SHOULD assume that response events are NOT supported.
+the Sink SHOULD assume that response events are not supported.
 
 ### Data plane contract for Sources
 

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -91,23 +91,20 @@ delivered.
 CloudEvents received by Sink MAY have
 [Distributed Tracing Extension Attribute](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md).
 
-### HTTP Attributes
+### Event reply contract
 
-An event sender, including Source and Broker and Channel, SHOULD include
-all the non-default HTTP attributes with header key `K-Eventing-Http-Attr` in
-every event delivery to specify what HTTP features it can support. Without a
-certain attribute, the receiver SHOULD assume the corresponding HTTP feature
-is not supported. A list of HTTP attributes can be found below:
+An event sender supporting event replies SHOULD include a `Prefer: ["callable"]` header
+in delivery requests to indicate to the sink that event reply is supported. An event
+sender MAY ignore an event reply in the delivery response if the `Prefer: ["callable"]`
+header was not included in the delivery request.
 
-| Attributes         | HTTP Feature Description                                                  |
-| ------------------ | ------------------------------------------------------------------------- |
-| `callable`         | If the event sender supports event reply in HTTP response.                |
-
-An example is that a Broker supporting event reply sends events with
-an additional header `K-Eventing-Http-Attr: ["callable"]` so that the sink connected
-to the Broker knows event replies will be accepted. While a source
-sends events without the header, in which case the sink connected directly
-to the source will assume that any event reply will be dropped.
+An example is that a Broker supporting event reply sends events with an additional header
+`Prefer: ["callable"]` so that the sink connected to the Broker knows event replies will
+be accepted. While a source sends events without the header, in which case the sink may
+assume that any event reply will be dropped without error or retry attempt. If a sink
+wishes to ensure the reply events will be delivered, it can check for the existence of
+the `Prefer: ["callable"]` header in the delivery request and respond with an error code
+if the header is not present.
 
 ### Data plane contract for Sources
 

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -91,6 +91,13 @@ delivered.
 CloudEvents received by Sink MAY have
 [Distributed Tracing Extension Attribute](https://github.com/cloudevents/spec/blob/v1.0/extensions/distributed-tracing.md).
 
+### Event reply header
+
+An event forward entity, including Source and Broker and Channel, SHOULD include
+the event reply header `K-Eventing-Event-Reply: reponse` if it supports response
+events. If no event reply header is present or the header is not set to `response`,
+the Sink SHOULD assume that response events are NOT supported.
+
 ### Data plane contract for Sources
 
 See [Source Delivery specification](../spec/sources.md#source-event-delivery)


### PR DESCRIPTION
This is one of the steps to solve #4127. 

This is a follow up of the discussion in the [event reply proposal](https://docs.google.com/document/d/1ELQtKOMz6T5vTXbWp30E8r6oLYOXPjWacv4AVRi36-w) to add the contract to the spec.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add event reply header to the spec

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :gift: Add event reply header contract to the spec
```
