### PR TITLE
Add soft Pod anti-affinity to IMC dispatchers

### DIFF
--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -30,6 +30,14 @@ spec:
     metadata:
       labels: *labels
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels: *labels
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: imc-dispatcher
       containers:
       - name: dispatcher


### PR DESCRIPTION
## Proposed Changes

- Add soft Pod anti-affinity to IMC dispatchers

Dispatchers consume a fair amount of CPU and may starve on CPU time under load, as observed in the graph below (load-test at 24K then 27K events/sec against 5 replicas). Defining requests and limits would be too opinionated because we don't know where Knative is being deployed, but we can at least _try_ to ensure dispatchers are spread across nodes.

![multi-dispatcher](https://user-images.githubusercontent.com/3299086/101615194-2636a280-3a0e-11eb-824f-11357cb1755d.png)


**Release Note**

```release-note
```

**Docs**