### PR TITLE
Fix spec #4515

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -66,8 +66,9 @@ spec:
                         holding it if left out.'
                     type: string
               delivery:
-                description: 'Delivery is the delivery specification for Events within
-                    the Broker mesh. This includes things like retries, DLQ, etc.'
+                description: 'Delivery contains the default delivery spec for each trigger
+                        to this Broker. Each trigger delivery spec, if any, overrides this
+                        global delivery spec.'
                 type: object
                 properties:
                   backoffDelay:

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -66,7 +66,7 @@ spec:
                         holding it if left out.'
                     type: string
               delivery:
-                description: 'Delivery contains the default delivery spec for each trigger
+                description: 'Delivery contains the delivery spec for each trigger
                         to this Broker. Each trigger delivery spec, if any, overrides this
                         global delivery spec.'
                 type: object

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -91,6 +91,59 @@ spec:
                   uri:
                     type: string
                     description: 'the target URI or, if ref is provided, a relative URI reference that will be combined with ref to produce a target URI.'
+              delivery:
+                description: 'Delivery contains the delivery spec for this specific trigger.'
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                                      information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                                      - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                                      backoff delay is backoffDelay*<numberOfRetries>. For
+                                      exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: ' BackoffPolicy is the retry backoff policy (linear,
+                                      exponential).'
+                    type: string
+                  deadLetterSink:
+                    description: 'DeadLetterSink is the sink receiving event that
+                                      could not be sent to a destination.'
+                    type: object
+                    properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info:
+                                                  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info:
+                                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More
+                                                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                                  This is optional field, it gets defaulted
+                                                  to the object holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty
+                                          scheme and non-empty host) pointing to the target
+                                          or a relative URI. Relative URIs will be resolved
+                                          using the base URI retrieved from Ref.'
+                        type: string
+                  retry:
+                    description: 'Retry is the minimum number of retries the sender
+                                      should attempt when sending an event before moving it
+                                      to the dead letter sink.'
+                    type: integer
+                    format: int32
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -46,8 +46,8 @@ extension attributes that match all key-value pairs exactly.
 
 ### Delivery Spec
 
-Both BrokerSpec and TriggerSpec have a `Delivery` field of type `duck.DeliverySpec` (per `v1`).
-This field allows the user to define the dead letter sink and retries.
+Both BrokerSpec and TriggerSpec have a `Delivery` field of type [`duck.DeliverySpec`](./spec.md#eventingduckv1deliveryspec).
+This field, among the other features, allows the user to define the dead letter sink and retries.
 The `BrokerSpec.Delivery` field is global across all the Triggers registered with that particular
 Broker, while the `TriggerSpec.Delivery`, if configured, fully overrides `BrokerSpec.Delivery` for
 that particular Trigger.

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -46,9 +46,9 @@ extension attributes that match all key-value pairs exactly.
 
 ### Delivery Spec
 
-Both BrokerSpec and TriggerSpec has a `Delivery` field of type `duck.DeliverySpec` (per `v1`).
+Both BrokerSpec and TriggerSpec have a `Delivery` field of type `duck.DeliverySpec` (per `v1`).
 This field allows the user to define the dead letter sink and retries.
-The `BrokerSpec.Delivery` field is global across all the Triggers registered to that particular
+The `BrokerSpec.Delivery` field is global across all the Triggers registered with that particular
 Broker, while the `TriggerSpec.Delivery`, if configured, fully overrides `BrokerSpec.Delivery` for
 that particular Trigger.
 

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -44,6 +44,14 @@ The attributes filter specifying a list of key-value pairs MUST be supported by
 Trigger. Events that pass the attributes filter MUST include context or
 extension attributes that match all key-value pairs exactly.
 
+### Delivery Spec
+
+Both BrokerSpec and TriggerSpec has a `Delivery` field of type `duck.DeliverySpec` (per `v1`).
+This field allows the user to define the dead letter sink and retries.
+The `BrokerSpec.Delivery` field is global across all the Triggers registered to that particular
+Broker, while the `TriggerSpec.Delivery`, if configured, fully overrides `BrokerSpec.Delivery` for
+that particular Trigger.
+
 ## Data Plane
 
 ### Ingress

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -50,7 +50,11 @@ Both BrokerSpec and TriggerSpec have a `Delivery` field of type [`duck.DeliveryS
 This field, among the other features, allows the user to define the dead letter sink and retries.
 The `BrokerSpec.Delivery` field is global across all the Triggers registered with that particular
 Broker, while the `TriggerSpec.Delivery`, if configured, fully overrides `BrokerSpec.Delivery` for
-that particular Trigger.
+that particular Trigger, hence:
+
+* When `BrokerSpec.Delivery` and `TriggerSpec.Delivery` are both not configured, no delivery spec MUST be used.
+* When `BrokerSpec.Delivery` is configured, but not the specific `TriggerSpec.Delivery`, then the `BrokerSpec.Delivery` MUST be used.
+* When `TriggerSpec.Delivery` is configured, then `TriggerSpec.Delivery` MUST be used.
 
 ## Data Plane
 

--- a/pkg/apis/eventing/v1/broker_types.go
+++ b/pkg/apis/eventing/v1/broker_types.go
@@ -74,7 +74,7 @@ type BrokerSpec struct {
 	// +optional
 	Config *duckv1.KReference `json:"config,omitempty"`
 
-	// Delivery contains the default delivery spec for each trigger
+	// Delivery contains the delivery spec for each trigger
 	// to this Broker. Each trigger delivery spec, if any, overrides this
 	// global delivery spec.
 	// +optional

--- a/pkg/apis/eventing/v1/broker_types.go
+++ b/pkg/apis/eventing/v1/broker_types.go
@@ -74,8 +74,9 @@ type BrokerSpec struct {
 	// +optional
 	Config *duckv1.KReference `json:"config,omitempty"`
 
-	// Delivery is the delivery specification for Events within the Broker mesh.
-	// This includes things like retries, DLQ, etc.
+	// Delivery contains the default delivery spec for each trigger
+	// to this Broker. Each trigger delivery spec, if any, overrides this
+	// global delivery spec.
 	// +optional
 	Delivery *eventingduckv1.DeliverySpec `json:"delivery,omitempty"`
 }

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -87,7 +87,7 @@ type TriggerSpec struct {
 	// is required.
 	Subscriber duckv1.Destination `json:"subscriber"`
 
-	// Delivery configuration
+	// Delivery contains the delivery spec for this specific trigger.
 	// +optional
 	Delivery *eventingduckv1.DeliverySpec `json:"delivery,omitempty"`
 }

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -22,6 +22,8 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
 const (
@@ -84,6 +86,10 @@ type TriggerSpec struct {
 	// Subscriber is the addressable that receives events from the Broker that pass the Filter. It
 	// is required.
 	Subscriber duckv1.Destination `json:"subscriber"`
+
+	// Delivery configuration
+	// +optional
+	Delivery *eventingduckv1.DeliverySpec `json:"delivery,omitempty"`
 }
 
 type TriggerFilter struct {

--- a/pkg/apis/eventing/v1/trigger_validation.go
+++ b/pkg/apis/eventing/v1/trigger_validation.go
@@ -69,6 +69,12 @@ func (ts *TriggerSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(fe.ViaField("subscriber"))
 	}
 
+	if ts.Delivery != nil {
+		if de := ts.Delivery.Validate(ctx); de != nil {
+			errs = errs.Also(de.ViaField("delivery"))
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -247,6 +247,11 @@ func (in *TriggerSpec) DeepCopyInto(out *TriggerSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Subscriber.DeepCopyInto(&out.Subscriber)
+	if in.Delivery != nil {
+		in, out := &in.Delivery, &out.Delivery
+		*out = new(apisduckv1.DeliverySpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/eventing/v1beta1/trigger_types.go
+++ b/pkg/apis/eventing/v1beta1/trigger_types.go
@@ -22,6 +22,8 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
+
+	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 )
 
 const (
@@ -87,6 +89,10 @@ type TriggerSpec struct {
 	// Subscriber is the addressable that receives events from the Broker that pass the Filter. It
 	// is required.
 	Subscriber duckv1.Destination `json:"subscriber"`
+
+	// Delivery contains the delivery spec for this specific trigger.
+	// +optional
+	Delivery *eventingduckv1beta1.DeliverySpec `json:"delivery,omitempty"`
 }
 
 type TriggerFilter struct {

--- a/pkg/apis/eventing/v1beta1/trigger_validation.go
+++ b/pkg/apis/eventing/v1beta1/trigger_validation.go
@@ -65,6 +65,12 @@ func (ts *TriggerSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(fe.ViaField("subscriber"))
 	}
 
+	if ts.Delivery != nil {
+		if de := ts.Delivery.Validate(ctx); de != nil {
+			errs = errs.Also(de.ViaField("delivery"))
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
@@ -351,6 +351,11 @@ func (in *TriggerSpec) DeepCopyInto(out *TriggerSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Subscriber.DeepCopyInto(&out.Subscriber)
+	if in.Delivery != nil {
+		in, out := &in.Delivery, &out.Delivery
+		*out = new(duckv1beta1.DeliverySpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

PR to modify the spec according to #4515

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Add the Trigger.Delivery field
- :broom: Now Broker.Delivery defaults the Trigger.Delivery field. Note: **this is a breaking change** for mtbroker users that are using the Broker.Delivery field, because this field, even if it remains the same, will change meaning for them (in a followup I'll perform the actual change)

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:gift: Add Trigger.Delivery field which allows configuration of Delivery per Trigger.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
