### PR TITLE
ContainerSource stored version v1 and migration tool

### DIFF
--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -404,7 +404,7 @@ spec:
     - <<: *version
       name: v1beta1
       served: true
-      storage: true
+      storage: false
       # the schema of v1beta1 is exactly the same as v1alpha2 schema
       schema:
         openAPIV3Schema:
@@ -412,7 +412,7 @@ spec:
     - <<: *version
       name: v1
       served: true
-      storage: false
+      storage: true
       # the schema of v1 is exactly the same as v1beta1 schema
       schema:
         openAPIV3Schema:

--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -36,6 +36,7 @@ rules:
       - "sources.knative.dev"
     resources:
       - "apiserversources"
+      - "containersources"
     verbs:
       - "get"
       - "list"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -38,3 +38,4 @@ spec:
           image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
             - "apiserversources.sources.knative.dev"
+            - "containersources.sources.knative.dev"


### PR DESCRIPTION
Fixes #4325 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-  ContainerSource stored version v1 
- Add migration tool

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Action Required: You need to run the storage migration tool after the upgrade to migrate from v1beta1 to v1 `containersources.sources.knative.dev` resources.
```
