### PR TITLE
SinkBinding stored version v1 and migration tool

### DIFF
--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -59,11 +59,11 @@ spec:
     - <<: *version
       name: v1beta1
       served: true
-      storage: true
+      storage: false
     - <<: *version
       name: v1
       served: true
-      storage: false
+      storage: true
       schema:
         openAPIV3Schema:
           type: object

--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -35,6 +35,7 @@ rules:
   - apiGroups:
       - "sources.knative.dev"
     resources:
+      - "sinkbindings"
       - "apiserversources"
     verbs:
       - "get"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -37,4 +37,5 @@ spec:
         - name: migrate
           image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
+            - "sinkbindings.sources.knative.dev"
             - "apiserversources.sources.knative.dev"


### PR DESCRIPTION
Fixes #4264 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- SinkBinding stored version v1 
- Add migration tool

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Action Required: You need to run the storage migration tool after the upgrade to migrate from v1beta1 to v1 `sinkbindings.sources.knative.dev` resources.
```