### PR TITLE
Reproduce issue 4645: broker components silently stop exposing metrics

### DIFF
--- a/cmd/mtbroker/ingress/main_test.go
+++ b/cmd/mtbroker/ingress/main_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// An attempt to reproduce knative/eventing#4645
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"knative.dev/pkg/signals"
+)
+
+func TestInconsistentPrometheusMetrics(t *testing.T) {
+	const concurrentTestSenders = 16
+
+	var pingEvent1Bytes = []byte(`{"data":{"hello":"world"},"datacontenttype":"application/json",` +
+		`"id":"837a1976-7a6b-4f7f-ac66-038142900355","source":"/apis/v1/namespaces/default/pingsources/hello",` +
+		`"specversion":"1.0","type":"dev.knative.sources.ping"}`)
+
+	var pingEvent2Bytes = []byte(`{"data":{"foo":"bar"},"datacontenttype":"application/json",` +
+		`"id":"837a1976-7a6b-4f7f-ac66-038142900355","source":"/apis/v1/namespaces/default/pingsources/cron",` +
+		`"specversion":"1.0","type":"dev.knative.sources.ping"}`)
+
+	var heartbeatEvent1Bytes = []byte(`{"data":{"id":545074,"label":""},"datacontenttype":"application/json",` +
+		`"id":"837a1976-7a6b-4f7f-ac66-038142900355","source":"https://knative.dev/eventing-contrib/cmd/heartbeats/#default/hb-0123-456",` +
+		`"the":"42","heart":"yes","beats":"true",` +
+		`"specversion":"1.0","type":"dev.knative.eventing.samples.heartbeat"}`)
+
+	var heartbeatEvent2Bytes = []byte(`{"data":{"id":4688462,"label":""},"datacontenttype":"application/json",` +
+		`"id":"837a1976-7a6b-4f7f-ac66-038142900355","source":"https://knative.dev/eventing-contrib/cmd/heartbeats/#default/hb-abcd-efg",` +
+		`"the":"42","heart":"yes","beats":"true",` +
+		`"specversion":"1.0","type":"dev.knative.eventing.samples.heartbeat"}`)
+
+	var drillEventBytes = []byte(`{"data":"` + strings.Repeat("0", 2048) + `","datacontenttype":"application/json",` +
+		`"id":"837a1976-7a6b-4f7f-ac66-038142900355","source":"cegen",` +
+		`"specversion":"1.0","type":"io.triggermesh.perf.drill"}`)
+
+	ctx, cancel := context.WithTimeout(signals.NewContext(), 59*time.Minute)
+	defer cancel()
+
+	os.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+	os.Setenv("CONTAINER_NAME", "ingress")
+	os.Setenv("POD_NAME", "mt-broker-ingress-5f58776864-zsd4p")
+	os.Setenv("METRICS_DOMAIN", "issue4645.example.com")
+
+	const scrapeInterval = 3 * time.Second
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		run(ctx)
+	}()
+	time.Sleep(3 * time.Second)
+
+	// scrape metrics regularly (in prod: every 30s) to invoke the gatherer
+	// and trigger a metric consistency check, which we expect to fail
+	// eventually
+	tickScape := time.Tick(scrapeInterval)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-tickScape:
+				resp, err := http.Get("http://127.0.0.1:9092/metrics")
+				if err != nil {
+					t.Log("Error scraping metrics:", err)
+					continue
+				}
+				resp.Body.Close()
+			}
+		}
+	}()
+	time.Sleep(1 * time.Second)
+
+	// simulate ping source (in prod: every 1m)
+	tickPing := time.Tick(2 * scrapeInterval)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-tickPing:
+				go func() {
+					resp, err := http.Post("http://127.0.0.1:8080/default/events",
+						cloudevents.ApplicationCloudEventsJSON, bytes.NewReader(pingEvent1Bytes))
+					if err != nil {
+						t.Log("Error sending fake ping event (hello):", err)
+						return
+					}
+					resp.Body.Close()
+				}()
+
+				go func() {
+					resp, err := http.Post("http://127.0.0.1:8080/default/default",
+						cloudevents.ApplicationCloudEventsJSON, bytes.NewReader(pingEvent2Bytes))
+					if err != nil {
+						t.Log("Error sending fake ping event (cron):", err)
+						return
+					}
+					resp.Body.Close()
+				}()
+			}
+		}
+	}()
+
+	// simulate heartbeat source (in prod: every 1s)
+	tickHeartbeat := time.Tick(1 * time.Second)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-tickHeartbeat:
+				go func() {
+					resp, err := http.Post("http://127.0.0.1:8080/default/events",
+						cloudevents.ApplicationCloudEventsJSON, bytes.NewReader(heartbeatEvent1Bytes))
+					if err != nil {
+						t.Log("Error sending heartbeat event (1):", err)
+						return
+					}
+					resp.Body.Close()
+				}()
+
+				go func() {
+					resp, err := http.Post("http://127.0.0.1:8080/default/events",
+						cloudevents.ApplicationCloudEventsJSON, bytes.NewReader(heartbeatEvent2Bytes))
+					if err != nil {
+						t.Log("Error sending heartbeat event (2):", err)
+						return
+					}
+					resp.Body.Close()
+				}()
+			}
+		}
+	}()
+
+	// simulate load test
+	for i := 0; i < concurrentTestSenders; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+
+				default:
+					resp, err := http.Post("http://127.0.0.1:8080/default/default",
+						cloudevents.ApplicationCloudEventsJSON, bytes.NewReader(drillEventBytes))
+					if err != nil {
+						t.Log("Error sending fake drill event:", err)
+						continue
+					}
+					resp.Body.Close()
+
+					time.Sleep(1 * time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/mtbroker/ingress/ingress_handler.go
+++ b/pkg/mtbroker/ingress/ingress_handler.go
@@ -191,7 +191,7 @@ func (h *Handler) receive(ctx context.Context, headers http.Header, event *cloud
 
 func (h *Handler) send(ctx context.Context, headers http.Header, event *cloudevents.Event, target string) (int, time.Duration) {
 
-	request, err := h.Sender.NewCloudEventRequestWithTarget(ctx, target)
+	request, err := h.Sender.NewCloudEventRequest(ctx)
 	if err != nil {
 		return http.StatusInternalServerError, noDuration
 	}

--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -886,10 +886,10 @@ func checkMetricConsistency(
 		h = hashAddByte(h, separatorByte)
 	}
 	if _, exists := metricHashes[h]; exists {
-		return fmt.Errorf(
+		panic(fmt.Errorf(
 			"collected metric %q { %s} was collected before with the same name and label values",
 			name, dtoMetric,
-		)
+		))
 	}
 	metricHashes[h] = struct{}{}
 	return nil


### PR DESCRIPTION
This is an attempt to reproduce #4645 using a test, mostly for discussion, therefore marking as draft+hold.

This test tries to reproduce the conditions in which I see the error happening, which is:
* a few ping events sent every minute _(every 6 sec in the test)_
* scrapes from Prometheus every 30 sec _(every 3 sec in the test)_
* some load testing with dummy 2 KiB payloads happening on the side _(the failure also occurs without, but extra load seems to reduce the time to failure in prod)_

Events are received on the "real" HTTP server, but sent to a black hole `httptest.Server` instead of the channel's URL. The rest of the ingress' code is untouched.

It requires:
* a running cluster
* a valid kubeconfig (or token, when ran inside a Pod)
* 2 brokers in the `default` namespace: `default` and `events` (I'm not sure if the number of brokers is even related, just trying to match what I usually observe).
 
It is configured to run for up to 60 min and is expected to panic when the first inconsistent metric is found. I typically run it with `go test -v -timeout 60m -race ./cmd/mtbroker/ingress`.

**So far I haven't been successful**, although the issue happens 100% of the time in our GKE cluster after a variable amount of time.

---

I created a small manifest to run this test in a cluster:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: issue4645
  namespace: knative-eventing
spec:
  restartPolicy: Never
  serviceAccountName: mt-broker-ingress

  containers:

  - name: test
    image: gcr.io/triggermesh/antoineco/issue4645

    resources:
      limits:
        cpu: "2"
        memory: 500Mi
      requests:
        cpu: 150m
        memory: 100Mi
```

If you don't trust my image, you can rebuild it from this branch with:
```console
$ go test -race -c ./cmd/mtbroker/ingress
```
```dockerfile
FROM gcr.io/distroless/base:nonroot
COPY ingress.test /
ENTRYPOINT ["/ingress.test"]
CMD ["-test.v", "-test.timeout=32m"]
```

This is what the resources usage should look like. We use the same requests/limits in our prod cluster:
![image](https://user-images.githubusercontent.com/3299086/102395087-f6256b80-3fda-11eb-9701-c1ac9066f68c.png)


---

/hold