### PR TITLE
Update test/conformance/README

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -12,6 +12,9 @@ Run test with e2e tag and optionally select conformance test
 > [test images](https://github.com/knative/eventing/tree/master/test#building-the-test-images)!
 
 ```shell
+ko apply -Rf test/config/
+export SYSTEM_NAMESPACE=knative-eventing 
+
 go test -v -tags=e2e -count=1 ./test/conformance/...
 
 go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestMustPassTracingHeaders$


### PR DESCRIPTION
## Why ?
Running a conformance test such as,
```
go test -v -tags=e2e -count=1 ./test/conformance -run ^TestChannelTracingWithReply$
```
fails due to missing dependencies

```
=== RUN   TestChannelTracingWithReply
=== PAUSE TestChannelTracingWithReply
=== CONT  TestChannelTracingWithReply
=== RUN   TestChannelTracingWithReply/InMemoryChannel-messaging.knative.dev/v1beta1
    test_runner.go:153: namespace is : "test-channel-tracing-with-reply-in-memory-channel-messaginpdlj5"
    test_runner.go:160: Couldn't initialize clients: error while retrieving the config-tracing config map: configmaps "config-tracing" not found
        knative.dev/eventing/test/lib.getTracingConfig
```

## Proposed Changes
- Update README to include additional steps required to run the tests
- :broom: Update or clean up current behavior


