### PR TITLE
Add enableServiceLinks:false to webhook yaml

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -40,7 +40,7 @@ spec:
             weight: 100
 
       serviceAccountName: eventing-webhook
-
+      enableServiceLinks: false
       containers:
       - name: eventing-webhook
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Kubernets adds additional env vars for each service with name
*_SERVICE_PORT, *_SERVICE_HOST and *_PORT, this causes trouble
in the webhook as it is using WEBHOOK_PORT to configure the
webhook port. Disabling it will enable using a default port.

Fixes #4671 
