### PR TITLE
Webhook has only namespaced Secret permissions, rather than cluster-wide.

### DIFF
--- a/config/200-webhook-role.yaml
+++ b/config/200-webhook-role.yaml
@@ -1,0 +1,1 @@
+core/roles/webhook-role.yaml

--- a/config/core/200-webhook-serviceaccount.yaml
+++ b/config/core/200-webhook-serviceaccount.yaml
@@ -40,6 +40,24 @@ roleRef:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: knative-eventing
+  name: eventing-webhook
+  labels:
+    eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: eventing-webhook
+    namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: knative-eventing-webhook
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -33,7 +33,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - "secrets"
       - "namespaces"
     verbs:
       - "get"

--- a/config/core/roles/webhook-role.yaml
+++ b/config/core/roles/webhook-role.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: knative-eventing
+  name: knative-eventing-webhook
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Webhook has only namespaced Secret permissions, rather than cluster-wide.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:broom: Webhook no longer has Cluster-wide Secret permissions. Now the Webhook's Secret permissions are restricted to the `knative-eventing` namespace.
```