### PR TITLE
Update spec.md fix render typo on DeliverySpec

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -223,7 +223,7 @@ retrieved from ref.
 | deadLetterSink | Destination   | DeadLetterSink is the sink receiving event that could not be sent to a destination.                                                              |             |
 | retry          | String        | Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.                 |             |
 | backoffPolicy  | BackoffPolicy | BackoffPolicy is the retry backoff policy (linear, exponential).                                                                                 |             |
-| backoffDelay   | String        | For linear policy, backoff delay is backoffDelay\*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay\*2^<numberOfRetries>. |             |
+| backoffDelay   | String        | For linear policy, backoff delay is backoffDelay\*\<numberOfRetries>. For exponential policy, backoff delay is backoffDelay\*2^\<numberOfRetries>. |             |
 
 ### duck.SubscriberSpec
 


### PR DESCRIPTION
## Proposed Changes
The <numberOfRetries> field wasn't being rendered in the duck.DeliverySpec
Add escape character to render the field

- :broom: Update or clean up current behavior
