### PR TITLE
Update COMMUNITY_CONTACTS.md

### DIFF
--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -13,6 +13,8 @@ community contact's duty (subject to change) is as followed:
   for unanswered questions.
 - You should already be added to @eventing-help usergroup by the previous
   contact person, and will be tagged into user questions in other channels.
+- Answer relevant [Stack Overflow Questions](https://stackoverflow.com/questions/tagged/knative-eventing?tab=Newest) 
+
 
 ## Weekly check list
 

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -13,7 +13,7 @@ community contact's duty (subject to change) is as followed:
   for unanswered questions.
 - You should already be added to @eventing-help usergroup by the previous
   contact person, and will be tagged into user questions in other channels.
-- Answer relevant [Stack Overflow Questions](https://stackoverflow.com/questions/tagged/knative-eventing?tab=Newest) 
+- Answer relevant [Stack Overflow Questions](https://stackoverflow.com/questions/tagged/knative-eventing?tab=Newest)
 
 ## Weekly check list
 

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -15,7 +15,6 @@ community contact's duty (subject to change) is as followed:
   contact person, and will be tagged into user questions in other channels.
 - Answer relevant [Stack Overflow Questions](https://stackoverflow.com/questions/tagged/knative-eventing?tab=Newest) 
 
-
 ## Weekly check list
 
 ### Monday


### PR DESCRIPTION
Adding Stack Overflow to list of responsibilities. Though many questions get answered via Slack, Slack is not very searchable and certainly isn't the lowest-friction way to get an answer when you're searching for one.