### PR TITLE
message receiver supports customized liveness and readiness check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,8 +42,8 @@ require (
 	k8s.io/apiserver v0.18.12
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
-	knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
-	knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
+	knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c
+	knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0
 	knative.dev/reconciler-test v0.0.0-20210108100436-db4d65735605
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,8 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 	knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
-	knative.dev/pkg v0.0.0-20210106161935-0ef9bd9cf2ef
-	knative.dev/reconciler-test v0.0.0-20201124190335-83a44efcdfef
+	knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0
+	knative.dev/reconciler-test v0.0.0-20210107160936-51ba158ab902
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,12 @@ k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7Mpm
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24 h1:kIztWfvnIFV8Lhlea02K3YO2mIzcDyQNzrBLn0Oq9sA=
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c h1:B/FwfbGrZRCwujjxVzFCc1sqNcAGL5oOm0ZkSSovSU8=
+knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/pkg v0.0.0-20210107022335-51c72e24c179 h1:lkrgrv69iUk2qhOG9symy15kJUaJZmMybSloi7C3gIw=
 knative.dev/pkg v0.0.0-20210107022335-51c72e24c179/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
+knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0 h1:oLySohpGJOAo7LFCKpGEn1JOtZkzZ6QS8tQ03Pgll/0=
+knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
 knative.dev/reconciler-test v0.0.0-20210108100436-db4d65735605 h1:gTcj4/ULCzgXEtW+sSd08C5LE3dcPGHU+6/wLT+PVMU=
 knative.dev/reconciler-test v0.0.0-20210108100436-db4d65735605/go.mod h1:rmQpZseeqDpg6/ToFzIeV5hTRkOJujaXBCK7iYL7M4E=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=

--- a/go.sum
+++ b/go.sum
@@ -1107,10 +1107,10 @@ knative.dev/hack v0.0.0-20201118155651-b31d3bb6bff9/go.mod h1:PHt8x8yX5Z9pPquBEf
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24 h1:kIztWfvnIFV8Lhlea02K3YO2mIzcDyQNzrBLn0Oq9sA=
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/pkg v0.0.0-20201117221452-0fccc54273ed/go.mod h1:nxlh3CUvx6WBPr1WKD96AHxFZPD2UKRDo9RUp8ILTyQ=
-knative.dev/pkg v0.0.0-20210106161935-0ef9bd9cf2ef h1:sEk+5pCmGkMzr0nVwV021VvJR45DhXIGu2NtFuZyUvg=
-knative.dev/pkg v0.0.0-20210106161935-0ef9bd9cf2ef/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
-knative.dev/reconciler-test v0.0.0-20201124190335-83a44efcdfef h1:8PttDFSsac32mq6Va+uPOyOR5CfX8JQT9g+MnHNyJ94=
-knative.dev/reconciler-test v0.0.0-20201124190335-83a44efcdfef/go.mod h1:YSs1y1rgnjs8w39/drLIOQbWvZUQwqApvd+EizO8UsA=
+knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0 h1:oLySohpGJOAo7LFCKpGEn1JOtZkzZ6QS8tQ03Pgll/0=
+knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
+knative.dev/reconciler-test v0.0.0-20210107160936-51ba158ab902 h1:Ig9gN2PFEZxXKShcfjzKzb1UPwn3OzdLbe8U6BVT9/w=
+knative.dev/reconciler-test v0.0.0-20210107160936-51ba158ab902/go.mod h1:YSs1y1rgnjs8w39/drLIOQbWvZUQwqApvd+EizO8UsA=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -41,18 +41,26 @@ type HTTPMessageReceiver struct {
 	checker http.HandlerFunc
 }
 
-func NewHTTPMessageReceiver(port int) *HTTPMessageReceiver {
-	return &HTTPMessageReceiver{
+// HTTPMessageReceiverOption enables further configuration of a HTTPMessageReceiver.
+type HTTPMessageReceiverOption func(*HTTPMessageReceiver)
+
+func NewHTTPMessageReceiver(port int, o ...HTTPMessageReceiverOption) *HTTPMessageReceiver {
+	h := &HTTPMessageReceiver{
 		port: port,
 	}
+	for _, opt := range o {
+		opt(h)
+	}
+	return h
 }
 
-// NewHTTPMessageReceiverWithChecker takes a handler func,
-// which runs as an additional health check in Drainer.
-func NewHTTPMessageReceiverWithChecker(port int, checker http.HandlerFunc) *HTTPMessageReceiver {
-	return &HTTPMessageReceiver{
-		port:    port,
-		checker: checker,
+// WithChecker takes a handler func which will run as an additional health check in Drainer.
+// kncloudevents HTTPMessageReceiver uses Drainer to perform health check.
+// By default, Drainer directly writes StatusOK to kubelet probe if the Pod is not draining.
+// Users can configure customized liveness and readiness check logic by defining checker here.
+func WithChecker(checker http.HandlerFunc) HTTPMessageReceiverOption {
+	return func(h *HTTPMessageReceiver) {
+		h.checker = checker
 	}
 }
 

--- a/vendor/knative.dev/pkg/network/handlers/drain.go
+++ b/vendor/knative.dev/pkg/network/handlers/drain.go
@@ -47,7 +47,8 @@ var newTimer = func(d time.Duration) timer {
 }
 
 // Drainer wraps an inner http.Handler to support responding to kubelet
-// probes and KProbes with a "200 OK" until the handler is told to Drain.
+// probes and KProbes with a "200 OK" until the handler is told to Drain,
+// or Drainer will optionally run the HealthCheck if it is defined.
 // When the Drainer is told to Drain, it will immediately start to fail
 // probes with a "500 shutting down", and the call will block until no
 // requests have been received for QuietPeriod (defaults to
@@ -55,6 +56,10 @@ var newTimer = func(d time.Duration) timer {
 type Drainer struct {
 	// Mutex guards the initialization and resets of the timer
 	sync.RWMutex
+
+	// HealthCheck is an optional health check that is performed until the drain signal is received.
+	// When unspecified, a "200 OK" is returned, otherwise this function is invoked.
+	HealthCheck http.HandlerFunc
 
 	// Inner is the http.Handler to which we delegate actual requests.
 	Inner http.Handler
@@ -78,6 +83,8 @@ func (d *Drainer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if network.IsKubeletProbe(r) { // Respond to probes regardless of path.
 		if d.draining() {
 			http.Error(w, "shutting down", http.StatusServiceUnavailable)
+		} else if d.HealthCheck != nil {
+			d.HealthCheck(w, r)
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -966,11 +966,11 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
+# knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c
 ## explicit
 knative.dev/hack
 knative.dev/hack/shell
-# knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
+# knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -970,7 +970,7 @@ k8s.io/utils/trace
 ## explicit
 knative.dev/hack
 knative.dev/hack/shell
-# knative.dev/pkg v0.0.0-20210106161935-0ef9bd9cf2ef
+# knative.dev/pkg v0.0.0-20210107211936-93874f0ea7c0
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1097,7 +1097,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20201124190335-83a44efcdfef
+# knative.dev/reconciler-test v0.0.0-20210107160936-51ba158ab902
 ## explicit
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Message receiver uses Drainer to run liveness and readiness check. Previously, when the Pod is not in draining status, Drainer directly writes statusOK to kube probe request, without going through the inner handler logic. This makes any customized health check in inner handler useless. 

Now that Drainer supports customized check, let message receiver support it as well. This would help users who want to use kn event message receiver and in the time want to configure their own check.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
message receiver supports customized liveness and readiness check 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
