### PR TITLE
Fix panic in the TestBrokerNamespaceDefaulting

### DIFF
--- a/test/e2e/broker_defaults_webhook_test.go
+++ b/test/e2e/broker_defaults_webhook_test.go
@@ -176,5 +176,5 @@ func webhookObservedBrokerUpdate(br *eventingv1.Broker) bool {
 }
 
 func webhookObservedBrokerUpdateFromDeliverySpec(d *eventingduck.DeliverySpec) bool {
-	return d.BackoffDelay != nil && d.Retry != nil && d.BackoffPolicy != nil
+	return d != nil && d.BackoffDelay != nil && d.Retry != nil && d.BackoffPolicy != nil
 }


### PR DESCRIPTION
Error was:
```
knative.dev/eventing/test/e2e.webhookObservedBrokerUpdateFromDeliverySpec(...)
	/home/runner/work/eventing/eventing/src/knative.dev/eventing/test/e2e/broker_defaults_webhook_test.go:179
```

Fixes #4710

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix panic in the TestBrokerNamespaceDefaulting
