### PR TITLE
Adding Logline for when a cloudevent has been successfully sent from APIServerSource to the sink

### DIFF
--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -50,7 +50,7 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 		if err != nil {
 			a.logger.Error(err)
 		}
-		a.logger.Infof("event sent for resource %v", string(eventExt))
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 		if err != nil {
 			a.logger.Error(err)
 		}
-		a.logger.Infof("event sent for resource %v", string(eventExt))
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }
@@ -88,7 +88,7 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 		if err != nil {
 			a.logger.Error(err)
 		}
-		a.logger.Infof("event sent for resource %v", string(eventExt))
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -19,7 +19,7 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
-
+	
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
@@ -124,4 +124,3 @@ func (a *resourceDelegate) Replace([]interface{}, string) error {
 func (a *resourceDelegate) Resync() error {
 	return nil
 }
-

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -19,8 +19,8 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
-	
-	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+        cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/adapter/apiserver/events"

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -19,7 +19,6 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
@@ -46,7 +45,7 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Errorw("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		eventExt, err := json.Marshal(event.Extensions())
 		if err != nil {
 			a.logger.Error(err)
 		}
@@ -65,7 +64,7 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		eventExt, err := json.Marshal(event.Extensions())
 		if err != nil {
 			a.logger.Error(err)
 		}
@@ -84,7 +83,7 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		eventExt, err := json.Marshal(event.Extensions())
 		if err != nil {
 			a.logger.Error(err)
 		}

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+	"encoding/json"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -44,6 +45,12 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Errorw("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %v", string(eventExt))
 	}
 	return nil
 }
@@ -57,6 +64,12 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %v", string(eventExt))
 	}
 	return nil
 }
@@ -70,6 +83,12 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.MarshalIndent(event.Extensions(), "", "  ")
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %v", string(eventExt))
 	}
 	return nil
 }
@@ -105,3 +124,4 @@ func (a *resourceDelegate) Replace([]interface{}, string) error {
 func (a *resourceDelegate) Resync() error {
 	return nil
 }
+


### PR DESCRIPTION
Fixes #

Currently the APIServerSource only shows up a log on a failure of event delivery, this commit would output a log whenever an event is sucessfully routed as well. 
This change can probably go into other sources as well? 

## Proposed Changes

- Simply marshalling the `event.Extensions` map to []bytes and then printing it for Add(), Update() and Delete() scenarios. 


