### PR TITLE
[#4721] Update e2e broker default webhook test

### DIFF
--- a/test/e2e/broker_defaults_webhook_test.go
+++ b/test/e2e/broker_defaults_webhook_test.go
@@ -65,6 +65,10 @@ func TestBrokerNamespaceDefaulting(t *testing.T) {
 		}
 
 		defaults["namespaceDefaults"][c.Namespace] = map[string]interface{}{
+			"apiVersion":  "v1",
+			"kind":        "ConfigMap",
+			"name":        "config-br-default-channel",
+			"namespace":   "knative-eventing",
 			"brokerClass": brokerClass,
 			"delivery": map[string]interface{}{
 				"retry":         5,


### PR DESCRIPTION
Fixes #4721

## Proposed Changes
- :broom: update broker config map so broker status is true and doesn't fail due to missing channel template


### Output Before
```
$ SYSTEM_NAMESPACE=knative-eventing go test -v -tags=e2e -count=1 ./test/e2e -run ^TestBrokerNamespaceDefaulting$
=== RUN   TestBrokerNamespaceDefaulting
    test_runner.go:153: namespace is : "test-broker-namespace-defaulting-lbkqf"
=== PAUSE TestBrokerNamespaceDefaulting
=== CONT  TestBrokerNamespaceDefaulting
    broker_defaults_webhook_test.go:53: Updating defaulting ConfigMap attempt: 0
    broker_defaults_webhook_test.go:94: CM updated - new values: |
          clusterDefault:
            apiVersion: v1
            brokerClass: MTChannelBasedBroker
            kind: ConfigMap
            name: config-br-default-channel
            namespace: knative-eventing
          namespaceDefaults:
            test-broker-namespace-defaulting-lbkqf:
              apiVersion: v1
              brokerClass: MTChannelBasedBroker
              delivery:
                backoffDelay: PT0.5S
                backoffPolicy: exponential
                retry: 5
              kind: ConfigMap
              name: config-br-default-channel
              namespace: knative-eventing

    k8s_events.go:66: EventListener stopped, 0 events seen
--- PASS: TestBrokerNamespaceDefaulting (3.53s)
PASS
ok  	knative.dev/eventing/test/e2e	3.687s
```
### Output with Change
```
$ SYSTEM_NAMESPACE=knative-eventing go test -v -tags=e2e -count=1 ./test/e2e -run ^TestBrokerNamespaceDefaulting$
=== RUN   TestBrokerNamespaceDefaulting
    test_runner.go:153: namespace is : "test-broker-namespace-defaulting-5tr5n"
=== PAUSE TestBrokerNamespaceDefaulting
=== CONT  TestBrokerNamespaceDefaulting
    broker_defaults_webhook_test.go:53: Updating defaulting ConfigMap attempt: 0
    broker_defaults_webhook_test.go:94: CM updated - new values: |
          clusterDefault:
            apiVersion: v1
            brokerClass: MTChannelBasedBroker
            kind: ConfigMap
            name: config-br-default-channel
            namespace: knative-eventing
          namespaceDefaults:
            test-broker-namespace-defaulting-5tr5n:
              brokerClass: MTChannelBasedBroker
              delivery:
                backoffDelay: PT0.5S
                backoffPolicy: exponential
                retry: 5
            
    k8s_events.go:66: EventListener stopped, 1 events seen
    test_runner.go:215: Event{
        ObjectMeta:v1.ObjectMeta{Name:xyz-0.165989dfa9fb48de,GenerateName:,Namespace:test-broker-namespace-defaulting-5tr5n,SelfLink:/api/v1/namespaces/test-broker-namespace-defaulting-5tr5n/events/xyz-0.165989dfa9fb48de,UID:a2133961-53ea-437d-8f84-a09416a2fcf8,ResourceVersion:103203,Generation:0,CreationTimestamp:2021-01-12 10:45:35 -0600 CST,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{},OwnerReferences:[]OwnerReference{},Finalizers:[],ClusterName:,ManagedFields:[]ManagedFieldsEntry{},}
        InvolvedObject:ObjectReference{Kind:Broker,Namespace:test-broker-namespace-defaulting-5tr5n,Name:xyz-0,UID:55bca8e5-d00b-4448-bb4b-9ac26593f9e5,APIVersion:eventing.knative.dev/v1,ResourceVersion:55704696,FieldPath:,}
        Reason:InternalError
        Message:failed to find channelTemplate
        Source:EventSource{Component:broker-controller,Host:,}
        FirstTimestamp:2021-01-12 10:45:35 -0600 CST
        LastTimestamp:2021-01-12 10:45:36 -0600 CST
        Count:8
        Type:Warning
        EventTime:0001-01-01 00:00:00 +0000 UTC
        Series:nil
        Action:
        Related:nil
        ReportingController:
        ReportingInstance:
        }
--- PASS: TestBrokerNamespaceDefaulting (1.61s)
PASS
ok  	knative.dev/eventing/test/e2e	2.045s
```