### PR TITLE
Adding Logline for when a cloudevent has been successfully sent from APIServerSource to the sink

### DIFF
--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -78,6 +78,8 @@ func (a *resourceDelegate) sendCloudEvent(ctx context.Context, event cloudevents
 	if result := a.ce.Send(ctx, event); !cloudevents.IsACK(result) {
 		a.logger.Errorw("failed to send cloudevent", zap.Error(result), zap.String("source", source),
 			zap.String("subject", subject), zap.String("id", event.ID()))
+	} else {
+		a.logger.Debugf("cloudevent sent id: %s, source: %s, subject: %s", event.ID(), source, subject)
 	}
 }
 

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/adapter/apiserver/events"
@@ -36,51 +37,48 @@ type resourceDelegate struct {
 var _ cache.Store = (*resourceDelegate)(nil)
 
 func (a *resourceDelegate) Add(obj interface{}) error {
-	event, err := events.MakeAddEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeAddEvent(a.source, obj, a.ref)
 	if err != nil {
 		a.logger.Infow("event creation failed", zap.Error(err))
 		return err
 	}
-
-	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
-		a.logger.Errorw("failed to send event", zap.Error(result))
-	} else {
-		eventSub := event.Subject()
-		a.logger.Debugf("event sent for resource %s", eventSub)
-	}
+	a.sendCloudEvent(ctx, event)
 	return nil
 }
 
 func (a *resourceDelegate) Update(obj interface{}) error {
-	event, err := events.MakeUpdateEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeUpdateEvent(a.source, obj, a.ref)
 	if err != nil {
 		a.logger.Info("event creation failed", zap.Error(err))
 		return err
 	}
-
-	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
-		a.logger.Error("failed to send event", zap.Error(result))
-	} else {
-		eventSub := event.Subject()
-		a.logger.Debugf("event sent for resource %s", eventSub)
-	}
+	a.sendCloudEvent(ctx, event)
 	return nil
 }
 
 func (a *resourceDelegate) Delete(obj interface{}) error {
-	event, err := events.MakeDeleteEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeDeleteEvent(a.source, obj, a.ref)
 	if err != nil {
 		a.logger.Info("event creation failed", zap.Error(err))
 		return err
 	}
-
-	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
-		a.logger.Error("failed to send event", zap.Error(result))
-	} else {
-		eventSub := event.Subject()
-		a.logger.Debugf("event sent for resource %s", eventSub)
-	}
+	a.sendCloudEvent(ctx, event)
 	return nil
+}
+
+// sendCloudEvent sends a cloudevent everytime k8s api event is created, updated or deleted.
+func (a *resourceDelegate) sendCloudEvent(ctx context.Context, event cloudevents.Event) {
+	event = event.Clone()
+	event.SetID(uuid.New().String()) // provide an ID here so we can track it with logging
+	defer a.logger.Debug("Finished sending cloudevent id: ", event.ID())
+	source := event.Context.GetSource()
+	subject := event.Context.GetSubject()
+	a.logger.Debugf("sending cloudevent id: %s, source: %s, subject: %s", event.ID(), source, subject)
+
+	if result := a.ce.Send(ctx, event); !cloudevents.IsACK(result) {
+		a.logger.Errorw("failed to send cloudevent", zap.Error(result), zap.String("source", source),
+			zap.String("subject", subject), zap.String("id", event.ID()))
+	}
 }
 
 // Stub cache.Store impl

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2020 The Knative Authors
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +15,6 @@ package apiserver
 
 import (
 	"context"
-	"encoding/json"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -46,11 +42,8 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Errorw("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.Marshal(event.Extensions())
-		if err != nil {
-			a.logger.Error(err)
-		}
-		a.logger.Infof("event sent for resource %s", string(eventExt))
+		eventSub := event.Subject()
+		a.logger.Debugf("event sent for resource %s", eventSub)
 	}
 	return nil
 }
@@ -65,11 +58,8 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.Marshal(event.Extensions())
-		if err != nil {
-			a.logger.Error(err)
-		}
-		a.logger.Infof("event sent for resource %s", string(eventExt))
+		eventSub := event.Subject()
+		a.logger.Debugf("event sent for resource %s", eventSub)
 	}
 	return nil
 }
@@ -84,11 +74,8 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
 	} else {
-		eventExt, err := json.Marshal(event.Extensions())
-		if err != nil {
-			a.logger.Error(err)
-		}
-		a.logger.Infof("event sent for resource %s", string(eventExt))
+		eventSub := event.Subject()
+		a.logger.Debugf("event sent for resource %s", eventSub)
 	}
 	return nil
 }

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -68,7 +68,6 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 
 // sendCloudEvent sends a cloudevent everytime k8s api event is created, updated or deleted.
 func (a *resourceDelegate) sendCloudEvent(ctx context.Context, event cloudevents.Event) {
-	event = event.Clone()
 	event.SetID(uuid.New().String()) // provide an ID here so we can track it with logging
 	defer a.logger.Debug("Finished sending cloudevent id: ", event.ID())
 	source := event.Context.GetSource()

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+	"encoding/json"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -44,6 +45,12 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Errorw("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.Marshal(event.Extensions())
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }
@@ -57,6 +64,12 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.Marshal(event.Extensions())
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }
@@ -70,6 +83,12 @@ func (a *resourceDelegate) Delete(obj interface{}) error {
 
 	if result := a.ce.Send(context.Background(), event); !cloudevents.IsACK(result) {
 		a.logger.Error("failed to send event", zap.Error(result))
+	} else {
+		eventExt, err := json.Marshal(event.Extensions())
+		if err != nil {
+			a.logger.Error(err)
+		}
+		a.logger.Infof("event sent for resource %s", string(eventExt))
 	}
 	return nil
 }

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -84,7 +84,7 @@ func TestMakeAddEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeAddEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeAddEvent(tc.source, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -125,7 +125,7 @@ func TestMakeUpdateEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeUpdateEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeUpdateEvent(tc.source, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -166,7 +166,7 @@ func TestMakeDeleteEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeDeleteEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeDeleteEvent(tc.source, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -207,7 +207,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeAddEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeAddEvent(tc.source, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -248,7 +248,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeUpdateEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeUpdateEvent(tc.source, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -289,7 +289,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			got, err := events.MakeDeleteEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeDeleteEvent(tc.source, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}


### PR DESCRIPTION
Fixes #

Currently the APIServerSource only shows up a log on a failure of event delivery, this commit would output a log whenever an event is sucessfully routed as well.

## Proposed Changes

- Simply marshalling the event.Extensions map to []bytes and then printing it for Add(), Update() and Delete() scenarios.

EDIT:
- Instead of using marshalling the extensions, the code now uses the cloudevent source+subject as identifier. Mostly making reuse of the pingsource code. 
- Since context is now shared, I added `ContextWithMetricTag` in here as well, to fix https://github.com/knative/eventing/issues/4709
