### PR TITLE
Use wait_for_pods instead of kubectl wait for pods. Fix #4725

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -168,7 +168,9 @@ jobs:
 
     - name: Wait for things to be up
       run: |
-        kubectl -v 9 wait pod --for=condition=Ready -n ${SYSTEM_NAMESPACE} -l '!job-name'
+        set -e
+        source ./vendor/knative.dev/hack/infra-library.sh
+        wait_until_pods_running ${SYSTEM_NAMESPACE}
 
     - name: Run e2e Tests
       run: |


### PR DESCRIPTION
Fixes #4725

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Use ./hack scripts instead of simple kubectl wait.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- :bug: Fix bug where sometimes the pods were not deemed up during setup. #4725

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
