### PR TITLE
use v1beta2 as the storage version of PingSource

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -184,7 +184,7 @@ spec:
   - <<: *version
     name: v1beta1
     served: true
-    storage: true
+    storage: false
     schema:
       openAPIV3Schema:
         type: object
@@ -323,7 +323,7 @@ spec:
   - <<: *version
     name: v1beta2
     served: true
-    storage: false
+    storage: true
     schema:
       openAPIV3Schema:
         type: object

--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -35,9 +35,7 @@ rules:
   - apiGroups:
       - "sources.knative.dev"
     resources:
-      - "sinkbindings"
-      - "apiserversources"
-      - "containersources"
+      - "pingsources"
     verbs:
       - "get"
       - "list"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -15,7 +15,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: storage-version-migration
+  # Adding a prefix to avoid naming conflict with previous version's post-install jobs,
+  # we cannot use `generateName` here as it's not supported by `kubectl apply -f`
+  #
+  # If `ttlSecondsAfterFinished` feature gate becomes generally available in the future,
+  # we can rely on that and keep using the same Job name.
+  name: v0.21-storage-version-migration
   namespace: knative-eventing
   labels:
     app: "storage-version-migration"
@@ -37,6 +42,4 @@ spec:
         - name: migrate
           image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
-            - "sinkbindings.sources.knative.dev"
-            - "apiserversources.sources.knative.dev"
-            - "containersources.sources.knative.dev"
+            - "pingsources.sources.knative.dev"


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/4539

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- 🧹 flip storage version to v1beta2 in PingSource CRD
- 🎁 add post-install job to migrate existing PingSource objects to v1beta2
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Action Required: You need to run the storage migration tool after the upgrade to migrate from v1beta1 to v1 `pingsources.sources.knative.dev` resources.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
