### PR TITLE
[#4744] Bump test zipkin version

### DIFF
--- a/test/config/monitoring/monitoring.yaml
+++ b/test/config/monitoring/monitoring.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.13.0
+        image: docker.io/openzipkin/zipkin:2.23.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411


### PR DESCRIPTION
## Proposed Changes
- :broom: Bump zipkin version to the latest available as the currently referenced one is ~2 yrs old. The motivation for this change is to reduce the probability that the older version of zipkin was contributing to test flakiness observed in https://github.com/knative/eventing/issues/4744. 