### PR TITLE
[#4744] Update conformance test helper

### DIFF
--- a/test/conformance/helpers/tracing/traces.go
+++ b/test/conformance/helpers/tracing/traces.go
@@ -169,12 +169,12 @@ func GetTraceTree(trace []model.SpanModel) (*SpanTree, error) {
 		return nil, fmt.Errorf("could not create span tree for %v: %v", PrettyPrintTrace(trace), err)
 	}
 
+	if len(parents) != 0 {
+		return nil, fmt.Errorf("left over spans after generating the SpanTree: %v. Original: %v", parents, PrettyPrintTrace(trace))
+	}
 	tree := SpanTree{
 		Root:     true,
 		Children: children,
-	}
-	if len(parents) != 0 {
-		return nil, fmt.Errorf("left over spans after generating the SpanTree: %v. Original: %v", parents, PrettyPrintTrace(trace))
 	}
 	return &tree, nil
 }

--- a/test/conformance/helpers/tracing/traces.go
+++ b/test/conformance/helpers/tracing/traces.go
@@ -160,6 +160,10 @@ func GetTraceTree(trace []model.SpanModel) (*SpanTree, error) {
 		}
 	}
 
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no root spans found in the trace: Original: %v", PrettyPrintTrace(trace))
+	}
+
 	children, err := getChildren(parents, roots)
 	if err != nil {
 		return nil, fmt.Errorf("could not create span tree for %v: %v", PrettyPrintTrace(trace), err)


### PR DESCRIPTION
## Proposed Changes
- :broom: fail with an explicit message if a trace doesn't have a root span.
  This scenario was being caught subsequently in the helper and failing
  with `left over spans after generating the SpanTree` which is more
  generic and a catch all.

  The idea is to make it clearer if the missing root span is a common
  failure scenario.

Ref - https://github.com/knative/eventing/issues/4744