### PR TITLE
Use more eventing specific value for accepting event reply

### DIFF
--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,17 +93,17 @@ CloudEvents received by Sink MAY have
 
 ### Event reply contract
 
-An event sender supporting event replies SHOULD include a `Prefer: reply` header
-in delivery requests to indicate to the sink that event reply is supported. An
+An event sender supporting event replies SHOULD include a `Prefer: kn-eventing-reply`
+header in delivery requests to indicate to the sink that event reply is supported. An
 event sender MAY ignore an event reply in the delivery response if the
-`Prefer: reply` header was not included in the delivery request.
+`Prefer: kn-eventing-reply` header was not included in the delivery request.
 
-An example is that a Broker supporting event reply sends events with an
-additional header `Prefer: reply` so that the sink connected to the Broker knows
+An example is that a Broker supporting event reply sends events with an additional
+header `Prefer: kn-eventing-reply` so that the sink connected to the Broker knows
 event replies will be accepted. While a source sends events without the header,
 in which case the sink may assume that any event reply will be dropped without
-error or retry attempt. If a sink wishes to ensure the reply events will be
-delivered, it can check for the existence of the `Prefer: reply` header in the
+error or retry attempt. If a sink wishes to ensure the reply events will be delivered,
+it can check for the existence of the `Prefer: kn-eventing-reply` header in the
 delivery request and respond with an error code if the header is not present.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,17 +93,17 @@ CloudEvents received by Sink MAY have
 
 ### Event reply contract
 
-An event sender supporting event replies SHOULD include a `Prefer: cloudevents-reply`
+An event sender supporting event replies SHOULD include a `Prefer: kn-eventing-reply`
 header in delivery requests to indicate to the sink that event reply is supported. An
 event sender MAY ignore an event reply in the delivery response if the
-`Prefer: cloudevents-reply` header was not included in the delivery request.
+`Prefer: kn-eventing-reply` header was not included in the delivery request.
 
 An example is that a Broker supporting event reply sends events with an additional
-header `Prefer: cloudevents-reply` so that the sink connected to the Broker knows
+header `Prefer: kn-eventing-reply` so that the sink connected to the Broker knows
 event replies will be accepted. While a source sends events without the header,
 in which case the sink may assume that any event reply will be dropped without
 error or retry attempt. If a sink wishes to ensure the reply events will be delivered,
-it can check for the existence of the `Prefer: cloudevents-reply` header in the
+it can check for the existence of the `Prefer: kn-eventing-reply` header in the
 delivery request and respond with an error code if the header is not present.
 
 ### Data plane contract for Sources

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -93,17 +93,17 @@ CloudEvents received by Sink MAY have
 
 ### Event reply contract
 
-An event sender supporting event replies SHOULD include a `Prefer: kn-eventing-reply`
+An event sender supporting event replies SHOULD include a `Prefer: cloudevents-reply`
 header in delivery requests to indicate to the sink that event reply is supported. An
 event sender MAY ignore an event reply in the delivery response if the
-`Prefer: kn-eventing-reply` header was not included in the delivery request.
+`Prefer: cloudevents-reply` header was not included in the delivery request.
 
 An example is that a Broker supporting event reply sends events with an additional
-header `Prefer: kn-eventing-reply` so that the sink connected to the Broker knows
+header `Prefer: cloudevents-reply` so that the sink connected to the Broker knows
 event replies will be accepted. While a source sends events without the header,
 in which case the sink may assume that any event reply will be dropped without
 error or retry attempt. If a sink wishes to ensure the reply events will be delivered,
-it can check for the existence of the `Prefer: kn-eventing-reply` header in the
+it can check for the existence of the `Prefer: cloudevents-reply` header in the
 delivery request and respond with an error code if the header is not present.
 
 ### Data plane contract for Sources


### PR DESCRIPTION
This is a PR following up with my previous comment: https://github.com/knative/eventing/pull/4560#issuecomment-760516761

After some research on the Prefer header [spec](https://tools.ietf.org/pdf/rfc7240.pdf) and how the header is used in [outlook](https://docs.microsoft.com/en-us/graph/api/user-list-events?view=graph-rest-1.0&tabs=http#request-headers), I am inclined to use a more knative specific value than simply `reply` because `reply` is too generic that it may soon be registered as a standard Prefer header value like `wait`, in which case the spec will have to be updated. For example, outlook is using `Prefer: outlook.timezone=xxx` instead of simply `Prefer: timezone`.

Any preference token can work as long as the chance of conflict is low. eg. `kn-eventing.reply` or `kn-eventing-reply`.