### PR TITLE
Allow to specify build platform for test images

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -135,6 +135,10 @@ build and push the test images used by the e2e tests. It requires:
   [authenticated with your `KO_DOCKER_REPO`](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#environment-setup)
 - [`docker`](https://docs.docker.com/install/) to be installed
 
+`PLATFORM` environment variable is optional. If it is specified, test images
+will be built for specific hardware architecture, according to its value
+(for instance,`linux/arm64`).
+
 To run the script for all end to end test images:
 
 ```bash

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -30,9 +30,17 @@ function upload_test_images() {
     tag_option="--tags $docker_tag,latest"
   fi
 
+  # If PLATFORM environment variable is specified, then images will be built for
+  # specific hardware architecture.
+  # Example of the variable values - "linux/arm64", "linux/s390x".
+  local platform=""
+  if [ -n "${PLATFORM}" ]; then
+    platform="--platform ${PLATFORM}"
+  fi
+
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
-  ko resolve ${tag_option} -RBf "${image_dir}" > /dev/null
+  ko resolve ${platform} ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
## Proposed Changes

By default if no platform is specified, ko uses `linux/amd64`,
which breaks the test images usage  for other architectures.
Using PLATFORM env variable provides ability to specify for which
platform do the build, for instance, linux/arm64 or linux/s390x.
