### PR TITLE
Adding HPA for eventing-webhook

### DIFF
--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -1,0 +1,49 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: eventing-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: eventing-webhook
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 100
+---
+# Webhook PDB.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: eventing-webhook-pdb
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+      app: eventing-webhook

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/hpa-webhook.yaml
+++ b/config/hpa-webhook.yaml
@@ -1,0 +1,1 @@
+core/deployments/webhook-hpa.yaml


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

- Set up HPA for eventing-webhook:
  - Scale Webhook based on CPU
  - Add initial PodDisruptionBudget

Similar to this PR on the serving component from September 2020: https://github.com/knative/serving/pull/9444


```release-note
Adding HorizontalPodAutoscaler and PodDisruptionBudget for the eventing webhook
```
