### PR TITLE
Set failure policy to ignore for webhook

### DIFF
--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -25,7 +25,7 @@ webhooks:
       name: eventing-webhook
       namespace: knative-eventing
   sideEffects: None
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: config.webhook.eventing.knative.dev
   namespaceSelector:
     matchExpressions:


### PR DESCRIPTION
Fixes #3244

## Proposed Changes

- Set failure policy to ignore for webhook
- This allows setup to get out of failure loop described in #3244 
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**
- :bug: Fix #3244 - webhook creation fails under certain race condition

