### PR TITLE
Update COMMUNITY_CONTACTS.md test grid link

### DIFF
--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -23,7 +23,7 @@ community contact's duty (subject to change) is as followed:
 - Check 'Eventing Triage' Peribolos group
   https://github.com/knative/community/blob/509d00841920181611a8457da3f655ef014ff9bf/peribolos/knative.yaml#L669
   and send a PR to add yourself if you aren't already in there.
-- Check the [Eventing test grid](https://testgrid.knative.dev/eventing) for
+- Check the [Eventing test grid](https://testgrid.k8s.io/knative-eventing) for
   flakiness to pick a test and focus on fixing it during your week. Once you
   pick the test flake, assign the corresponding bug filed by flakiness test
   reporter to yourself so that others won't pick the same test to fix.


### PR DESCRIPTION
## Proposed Changes
- :broom: replace link that appears to be deprecated `https://testgrid.knative.dev/eventing` with the functional one `https://testgrid.k8s.io/knative-eventing