### PR TITLE
Bump golang linter version and timeout

### DIFF
--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -127,7 +127,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.35
 
       - name: misspell
         shell: bash

--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -128,6 +128,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.35
+          args: --timeout=10m
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
Ref #4796 

## Proposed Changes
- :broom: Bump golangci-lint to v1.35 and set a timeout of 10s. The workflow has been [failing](https://github.com/knative/eventing/actions?query=workflow%3A%22Code+Style%22+is%3Afailure) with a higher frequency recently. 
- The [golangci-lint](https://golangci-lint.run/usage/configuration/) has a default timeout of 1m. The [golangci-lint action](https://github.com/golangci/golangci-lint-action) doesn't seem to have a configured timeout so its weird that most of the timeouts  > ~300s not 60s. Setting the value to 10m to be conservative and validate if this resolves the failure.

