### PR TITLE
Patch HPA eventing-webhook min replicas

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -143,9 +143,9 @@ function install_knative_eventing() {
     kubectl apply \
       -f "${EVENTING_CORE_NAME}" || return 1
     UNINSTALL_LIST+=( "${EVENTING_CORE_NAME}" )
-    
+
     kubectl patch horizontalpodautoscalers.autoscaling -n ${SYSTEM_NAMESPACE} eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}' || return 1
-    
+
   else
     local EVENTING_RELEASE_YAML=${TMP_DIR}/"eventing-${LATEST_RELEASE_VERSION}.yaml"
     # Download the latest release of Knative Eventing.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -143,6 +143,9 @@ function install_knative_eventing() {
     kubectl apply \
       -f "${EVENTING_CORE_NAME}" || return 1
     UNINSTALL_LIST+=( "${EVENTING_CORE_NAME}" )
+    
+    kubectl patch horizontalpodautoscalers.autoscaling -n ${SYSTEM_NAMESPACE} eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}' || return 1
+    
   else
     local EVENTING_RELEASE_YAML=${TMP_DIR}/"eventing-${LATEST_RELEASE_VERSION}.yaml"
     # Download the latest release of Knative Eventing.


### PR DESCRIPTION
Eventing webhook HPA config sets MinReplicas to 1 and while chaosduck
kills the webhook we get 0 replicas available during E2E tests.

Fixes recent flaky tests.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Patch HPA eventing-webhook min replicas
