### PR TITLE
v1beta1.Trigger delivery should be v1.DeliverySpec

### DIFF
--- a/pkg/apis/eventing/v1beta1/trigger_conversion.go
+++ b/pkg/apis/eventing/v1beta1/trigger_conversion.go
@@ -20,8 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 )
@@ -42,10 +41,8 @@ func (source *Trigger) ConvertTo(ctx context.Context, to apis.Convertible) error
 			}
 		}
 		if source.Spec.Delivery != nil {
-			sink.Spec.Delivery = &duckv1.DeliverySpec{}
-			if err := source.Spec.Delivery.ConvertTo(ctx, sink.Spec.Delivery); err != nil {
-				return err
-			}
+			sink.Spec.Delivery = &eventingduckv1.DeliverySpec{}
+			source.Spec.Delivery.DeepCopyInto(sink.Spec.Delivery)
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.SubscriberURI = source.Status.SubscriberURI
@@ -72,10 +69,8 @@ func (sink *Trigger) ConvertFrom(ctx context.Context, from apis.Convertible) err
 			}
 		}
 		if source.Spec.Delivery != nil {
-			sink.Spec.Delivery = &duckv1beta1.DeliverySpec{}
-			if err := sink.Spec.Delivery.ConvertFrom(ctx, source.Spec.Delivery); err != nil {
-				return err
-			}
+			sink.Spec.Delivery = &eventingduckv1.DeliverySpec{}
+			source.Spec.Delivery.DeepCopyInto(sink.Spec.Delivery)
 		}
 		sink.Status.Status = source.Status.Status
 		sink.Status.SubscriberURI = source.Status.SubscriberURI

--- a/pkg/apis/eventing/v1beta1/trigger_types.go
+++ b/pkg/apis/eventing/v1beta1/trigger_types.go
@@ -23,7 +23,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
-	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
 const (
@@ -92,7 +92,7 @@ type TriggerSpec struct {
 
 	// Delivery contains the delivery spec for this specific trigger.
 	// +optional
-	Delivery *eventingduckv1beta1.DeliverySpec `json:"delivery,omitempty"`
+	Delivery *eventingduckv1.DeliverySpec `json:"delivery,omitempty"`
 }
 
 type TriggerFilter struct {

--- a/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta1
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	apis "knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -353,7 +354,7 @@ func (in *TriggerSpec) DeepCopyInto(out *TriggerSpec) {
 	in.Subscriber.DeepCopyInto(&out.Subscriber)
 	if in.Delivery != nil {
 		in, out := &in.Delivery, &out.Delivery
-		*out = new(duckv1beta1.DeliverySpec)
+		*out = new(duckv1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
 	return


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Followup to #4654 and change the trigger.Spec.DeliverySpec from v1beta1 duck to v1. Add UT.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
