### PR TITLE
fix the link to head

### DIFF
--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -21,7 +21,7 @@ community contact's duty (subject to change) is as followed:
 ### Monday
 
 - Check 'Eventing Triage' Peribolos group
-  https://github.com/knative/community/blob/509d00841920181611a8457da3f655ef014ff9bf/peribolos/knative.yaml#L669
+  https://github.com/knative/community/blob/master/peribolos/knative.yaml#L702
   and send a PR to add yourself if you aren't already in there.
 - Check the [Eventing test grid](https://testgrid.k8s.io/knative-eventing) for
   flakiness to pick a test and focus on fixing it during your week. Once you

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -21,7 +21,7 @@ community contact's duty (subject to change) is as followed:
 ### Monday
 
 - Check 'Eventing Triage' Peribolos group
-  https://github.com/knative/community/blob/master/peribolos/knative.yaml#L702
+  https://github.com/knative/community/blob/master/peribolos/knative.yaml
   and send a PR to add yourself if you aren't already in there.
 - Check the [Eventing test grid](https://testgrid.k8s.io/knative-eventing) for
   flakiness to pick a test and focus on fixing it during your week. Once you


### PR DESCRIPTION
@zhongduo as discussed on the slack. Changing the link to point to head.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix the link to Eventing Triage to be head instead of an older branch which is confusing.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
