### PR TITLE
Change trigger spec to indicate assigned broker should be immutable

### DIFF
--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -34,8 +34,9 @@ subscriber.
 While a Trigger is Ready, it SHOULD indicate its subscriber's URI via the
 `status.subscriberUri` field.
 
-Triggers MUST be assigned to exactly one Broker. Triggers SHOULD be assigned a
-default Broker upon creation if no Broker is specified by the user.
+Triggers MUST be assigned to exactly one Broker. The assigned Broker of a
+trigger SHOULD be immutable. Triggers SHOULD be assigned a default Broker
+upon creation if no Broker is specified by the user.
 
 A Trigger MAY be created before its assigned Broker exists. A Trigger SHOULD
 progress to Ready when its assigned Broker exists and is Ready.


### PR DESCRIPTION
Fixes #
- This is to clarify whether the broker of a trigger is allowed to be changed 
- This is originated from the discussion [here](https://github.com/knative/eventing/pull/4816#issuecomment-771014943) where it's found that the current **v1beta1** trigger allows broker to be changed and some conformance tests are modifying the broker of a trigger. If it's decided here the assigned broker should be immutable, a followup PR need to fix the conformance tests and the validation code.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
