### PR TITLE
[#4796] Bump golang lint timeout to 10m

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
   build-tags:
     - e2e


### PR DESCRIPTION
Fixes #4796


## Proposed Changes
- :broom: Update golangci linter timeout to 10m as the workflow has been [failing](https://github.com/knative/eventing/actions?query=workflow%3A%22Code+Style%22+is%3Afailure) due to a timeout with a higher frequency recently. 
