### PR TITLE
Use SHOULD for TriggerSpec to keep compatibility

### DIFF
--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -54,10 +54,10 @@ with that particular Broker, while the `TriggerSpec.Delivery`, if configured,
 fully overrides `BrokerSpec.Delivery` for that particular Trigger, hence:
 
 - When `BrokerSpec.Delivery` and `TriggerSpec.Delivery` are both not configured,
-  no delivery spec MUST be used.
+  no delivery spec SHOULD be used.
 - When `BrokerSpec.Delivery` is configured, but not the specific
-  `TriggerSpec.Delivery`, then the `BrokerSpec.Delivery` MUST be used.
-- When `TriggerSpec.Delivery` is configured, then `TriggerSpec.Delivery` MUST be
+  `TriggerSpec.Delivery`, then the `BrokerSpec.Delivery` SHOULD be used.
+- When `TriggerSpec.Delivery` is configured, then `TriggerSpec.Delivery` SHOULD be
   used.
 
 ## Data Plane


### PR DESCRIPTION
Fixes #4837 

This is to keep compatibility with brokers that cannot support per trigger delivery.