### PR TITLE
ut for trigger/broker updates check immutable

### DIFF
--- a/pkg/apis/eventing/v1/broker_validation_test.go
+++ b/pkg/apis/eventing/v1/broker_validation_test.go
@@ -198,6 +198,88 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		b    Broker
+		bNew Broker
+		want *apis.FieldError
+	}{{
+		name: "valid config change",
+		b: Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"eventing.knative.dev/broker.class": "MTChannelBasedBroker"},
+			},
+			Spec: BrokerSpec{
+				Config: &duckv1.KReference{
+					Namespace:  "namespace",
+					Name:       "name",
+					Kind:       "kind",
+					APIVersion: "apiversion",
+				},
+			},
+		},
+		bNew: Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"eventing.knative.dev/broker.class": "MTChannelBasedBroker"},
+			},
+			Spec: BrokerSpec{
+				Config: &duckv1.KReference{
+					Namespace:  "namespace",
+					Name:       "name2",
+					Kind:       "kind",
+					APIVersion: "apiversion",
+				},
+			},
+		},
+	}, {
+		name: "invalid config change, broker.class",
+		b: Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"eventing.knative.dev/broker.class": "MTChannelBasedBroker"},
+			},
+			Spec: BrokerSpec{
+				Config: &duckv1.KReference{
+					Namespace:  "namespace",
+					Name:       "name",
+					Kind:       "kind",
+					APIVersion: "apiversion",
+				},
+			},
+		},
+		bNew: Broker{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"eventing.knative.dev/broker.class": "SomeOtherBrokerClass"},
+			},
+			Spec: BrokerSpec{
+				Config: &duckv1.KReference{
+					Namespace:  "namespace",
+					Name:       "name",
+					Kind:       "kind",
+					APIVersion: "apiversion",
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"annotations"},
+			Details: `{string}:
+	-: "MTChannelBasedBroker"
+	+: "SomeOtherBrokerClass"
+`,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithinUpdate(context.Background(), &test.b)
+			got := test.bNew.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Error("Broker.Validate (-want, +got) =", diff)
+			}
+		})
+	}
+}
+
 func TestValidSpec(t *testing.T) {
 	bop := eventingduckv1.BackoffPolicyExponential
 	tests := []struct {

--- a/pkg/apis/eventing/v1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1/trigger_validation_test.go
@@ -287,6 +287,53 @@ func TestTriggerValidation(t *testing.T) {
 	}
 }
 
+func TestTriggerUpdateValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *Trigger
+		tNew *Trigger
+		want *apis.FieldError
+	}{{
+		name: "invalid update, broker changed",
+		t: &Trigger{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "test-ns",
+			},
+			Spec: TriggerSpec{
+				Broker:     "test_broker",
+				Filter:     validEmptyFilter,
+				Subscriber: validSubscriber,
+			}},
+		tNew: &Trigger{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "test-ns",
+			},
+			Spec: TriggerSpec{
+				Broker:     "anotherBroker",
+				Filter:     validEmptyFilter,
+				Subscriber: validSubscriber,
+			}},
+		want: &apis.FieldError{
+			Message: "Immutable fields changed (-old +new)",
+			Paths:   []string{"spec", "broker"},
+			Details: `{string}:
+	-: "test_broker"
+	+: "anotherBroker"
+`,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := apis.WithinUpdate(context.Background(), test.t)
+			got := test.tNew.Validate(ctx)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Error("Trigger.Validate (-want, +got) =", diff)
+			}
+		})
+	}
+}
+
 func TestTriggerSpecValidation(t *testing.T) {
 	invalidString := "invalid time"
 	tests := []struct {

--- a/pkg/apis/eventing/v1beta1/trigger_validation.go
+++ b/pkg/apis/eventing/v1beta1/trigger_validation.go
@@ -38,6 +38,10 @@ func (t *Trigger) Validate(ctx context.Context) *apis.FieldError {
 	errs := t.Spec.Validate(ctx).ViaField("spec")
 	errs = t.validateAnnotation(errs, DependencyAnnotation, t.validateDependencyAnnotation)
 	errs = t.validateAnnotation(errs, InjectionAnnotation, t.validateInjectionAnnotation)
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*Trigger)
+		errs = errs.Also(t.CheckImmutableFields(ctx, original))
+	}
 	return errs
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- While we have tests for CheckImmutableFields, we did not have UT for running through the actual update, so added those for v1/v1beta1 broker/trigger.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fix bug where v1beta1 would allow mutations to immutable fields. v1beta1 trigger.spec.broker is immutable.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
