### PR TITLE
fix(PingSource): event consumer should receive base64-decoded dataBase64

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -354,8 +354,8 @@ spec:
                         Mutually exclusive with `dataBase64`.'
                 type: string
               dataBase64:
-                description: 'DataBase64 is base64 encoded binary data used as the body of the event posted to the sink.
-                        Default is empty. Mutually exclusive with `data`.'
+                description: "DataBase64 is the base64-encoded string of the actual event's body posted to the sink.
+                        Default is empty. Mutually exclusive with `data`."
                 type: string
               schedule:
                 description: 'Schedule is the cron schedule. Defaults to `* * * * *`.'

--- a/pkg/adapter/mtping/runner.go
+++ b/pkg/adapter/mtping/runner.go
@@ -18,6 +18,7 @@ package mtping
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"time"
@@ -147,7 +148,7 @@ func makeEvent(source *v1beta2.PingSource) (cloudevents.Event, error) {
 
 	var data interface{}
 	if source.Spec.DataBase64 != "" {
-		data = []byte(source.Spec.DataBase64)
+		data, _ = base64.StdEncoding.DecodeString(source.Spec.DataBase64)
 	} else if source.Spec.Data != "" {
 		data = []byte(source.Spec.Data)
 	}

--- a/pkg/apis/sources/v1beta2/ping_types.go
+++ b/pkg/apis/sources/v1beta2/ping_types.go
@@ -77,7 +77,7 @@ type PingSourceSpec struct {
 	// +optional
 	Data string `json:"data,omitempty"`
 
-	// DataBase64 is base64 encoded binary data used as the body of the event posted to the sink. Default is empty.
+	// DataBase64 is the base64-encoded string of the actual event's body posted to the sink. Default is empty.
 	// Mutually exclusive with Data.
 	// +optional
 	DataBase64 string `json:"dataBase64,omitempty"`


### PR DESCRIPTION
Fixes: https://github.com/knative/eventing/issues/4852



## Proposed Changes

- :bug: BREAKING CHANGE: PingSource binary mode now sends the actual binary data in event body instead of base64-encoded form.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
BREAKING CHANGE: PingSource binary mode now sends the actual binary data in event body instead of base64-encoded form.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
