### PR TITLE
Remvoing contrib refs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Once you meet these requirements, you can
 > :information_source: If you intend to use event sinks based on Knative
 > Services as described in some of our examples, consider installing
 > [Knative Serving](http://github.com/knative/serving). A few
-> [contrib](http://github.com/knative/eventing-contrib) projects also have a
+> [Knative Sandbox](https://github.com/knative-sandbox/?q=eventing&type=&language=) projects also have a
 > dependency on Serving.
 
 Before submitting a PR, see also [contribution guidelines](./CONTRIBUTING.md).

--- a/docs/decisions/broker-trigger.md
+++ b/docs/decisions/broker-trigger.md
@@ -24,7 +24,7 @@ abstraction which can optimize the underlying routing layer dynamically.
 - **Event Source**: a helper object that can be used to connect an Event
   Producer to the Knative eventing system by routing events to an Event
   Consumer. E.g. the
-  [GitHub Knative Contrib](https://github.com/knative-sandbox/eventing-github/tree/master/pkg/reconciler/source)
+  [GitHub Knative Sandbox](https://github.com/knative-sandbox/eventing-github/tree/master/pkg/reconciler/source)
 - **Receive Adapter**: a data plane entity (Knative Service, Deployment, etc)
   which performs the event routing from outside the Knative cluster to the
   Knative eventing system. Receive Adapters are created by Event Sources to

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -36,11 +36,9 @@ _Service_ only when the _Trigger_ filter matches.
 ![Resource Types Overview](images/resource-types-overview.svg)
 
 Channels as well as Sources are defined by independent CRDs that can be
-installed into a cluster. For more information see
-[Knative Eventing Contrib](https://github.com/knative/eventing-contrib). Both
-Sources and Channels implementations can be created directly. A Channel however
-offers also a way to create the backing implementation as part of the generic
-Channel (using a _channelTemplate_).
+installed into a cluster. Both Sources and Channels implementations can be created directly.
+A Channel however offers also a way to create the backing implementation as part of the
+generic Channel (using a _channelTemplate_).
 
 ## Trigger
 

--- a/test/e2e/helpers/README.md
+++ b/test/e2e/helpers/README.md
@@ -1,5 +1,4 @@
 # helpers
 
 This package contains helper functions that are used in the actual tests. These
-functions can be referenced in other repositories (like `eventing-contrib`) for
-adding similar tests.
+functions can be referenced in other repositories (like inside the `eventing-***` inside the `knative-sandbox` organization) for adding similar tests.


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- found a few references to "contrib" repo... replaced/removed them as needed

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
