### PR TITLE
Allow to specify platform for reconciler test

### DIFF
--- a/vendor/knative.dev/reconciler-test/pkg/images/ko.go
+++ b/vendor/knative.dev/reconciler-test/pkg/images/ko.go
@@ -18,12 +18,17 @@ package images
 
 import (
 	"fmt"
+	"os"
 )
 
 // Use ko to publish the image.
 func KoPublish(path string) (string, error) {
-	fmt.Println(fmt.Sprintf("ko publish -B %s", path))
-	out, err := runCmd(fmt.Sprintf("ko publish -B %s", path))
+	platform := os.Getenv("PLATFORM")
+	if len(platform) > 0 {
+		platform = "--platform=" + platform
+	}
+	fmt.Println(fmt.Sprintf("ko publish %s -B %s", platform, path))
+	out, err := runCmd(fmt.Sprintf("ko publish %s -B %s", platform, path))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is to make the reconciler test configurable for different platforms. This change is in line with https://github.com/knative/eventing/pull/4763.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add an argument `--platform` if the env variable `PLATFORM` is set, otherwise the argument is empty.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->