### PR TITLE
Add roadmap for 2021 for Eventing, Eventing Sources and Event Delivery WGs

### DIFF
--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -1,6 +1,9 @@
 # Eventing
+
 ## Next 3 Months (Short-term)
+
 ### Event Discovery
+
 [Description TBD]
 
 **GitHub Issue:** TBD
@@ -8,13 +11,15 @@
 **Owner:** Grant Rodgers
 
 ### Spec Solidification
+
 [Description TBD]
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative/eventing/issues/4595
 
 **Owner:** Grant Rodgers
 
 ### Better Trigger Filtering
+
 Trigger filtering today is limited. We need more expressive filtering.
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/3359
@@ -22,15 +27,24 @@ Trigger filtering today is limited. We need more expressive filtering.
 **Owner:** Francesco Guardiani
 
 ### Tenant Targeted Logging
-Hosting Knative as a multi-tenant cloud offering, there is currently no means to distinguish logging events that are necessary for servicing the hosted Knative service and those that may be meaningful to a tenant consuming the service.  The tenant of the hosted service would like to see besides their hosted application logging, pertinent log messages from Knative service to help diagnose their issues. However, providing all logging messages from the Knative service internals would be counterproductive for a tenant not familiar with Knative internals
+
+Hosting Knative as a multi-tenant cloud offering, there is currently no means to
+distinguish logging events that are necessary for servicing the hosted Knative
+service and those that may be meaningful to a tenant consuming the service. The
+tenant of the hosted service would like to see besides their hosted application
+logging, pertinent log messages from Knative service to help diagnose their
+issues. However, providing all logging messages from the Knative service
+internals would be counterproductive for a tenant not familiar with Knative
+internals
 
 **Theme:** Multi-Tenant environment support
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative/eventing/issues/3299
 
 **Owner:** Rick Rineholt
 
 ### Autotrigger Sugar Controller
+
 [Description TBD]
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/4547
@@ -38,6 +52,7 @@ Hosting Knative as a multi-tenant cloud offering, there is currently no means to
 **Owner:** Scott Nichols
 
 ### Remove v1beta1 API [eventing, flows, messaging]
+
 [Description TBD]
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/4836
@@ -45,52 +60,64 @@ Hosting Knative as a multi-tenant cloud offering, there is currently no means to
 **Owner:** Ville Aikas
 
 ## Next 6 Months (Midterm)
+
 ### Protocol negotiation contract
+
 [Description TBD]
 
 **Theme:** Multiple protocol and protocol option support
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative/eventing/issues/4868
 
 **Owner:** Grant Rodgers
 
 ### Preflight protocol negotiation
+
 [Description TBD]
 
 **Theme:** Multiple protocol and protocol option support
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative/eventing/issues/4868
 
 **Owner:** Grant Rodgers
 
 ## Icebox (Wishlist)
+
 ### Broker Performance Tests
+
 [Description TBD]
 
 **GitHub Issue:** TBD
 
-**Owner:** TBD 
+**Owner:** TBD
 
 ### Cross Namespace Eventing
+
 [Description TBD]
 
 **GitHub Issue:** TBD
 
 **Owner:** Grant Rodgers
 
-### Advanced Workflow and Streaming processing
+### Streaming Processing
+
 [Description TBD]
 
 **GitHub Issue:** TBD
 
-**Owner:** ?
+**Owner:** Lionel Villard
 
 ## Won’t Do
-__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason
+
+_These are the issues the working group decided to not work on whether for
+being out of the WG scope or some other reason_
 
 # Eventing Sources
+
 ## Next 3 Months (Short-term)
+
 ### Introduce and define Multi-tenant Sources
+
 [Description TBD]
 
 **Theme:** Multi-Tenant environment support
@@ -100,6 +127,7 @@ __These are the issues the working group decided to not work on whether for bein
 **Owner:** Scott Nichols
 
 ### Multi-Tenant Kafka Source
+
 [Description TBD]
 
 **Theme:** Multi-Tenant environment support
@@ -109,6 +137,7 @@ __These are the issues the working group decided to not work on whether for bein
 **Owner:** Lionel Villard
 
 ### GitHub Vanity domain support
+
 [Description TBD]
 
 **Theme:** Multi-Tenant environment support
@@ -118,6 +147,7 @@ __These are the issues the working group decided to not work on whether for bein
 **Owner:** Lionel Villard
 
 ### Find Maintainers for source repos
+
 [Description TBD]
 
 **Theme:** No repo left behind
@@ -126,16 +156,26 @@ __These are the issues the working group decided to not work on whether for bein
 
 **Owner:** Ville Aikas
 
-
 ### v1 for Core Sources
-[Description TBD]
 
-**GitHub Issue:** TBD
+Let's promote PingSource to v1
 
-**Owner:** ?
+**GitHub Issue:** https://github.com/knative/eventing/issues/4865
+
+**Owner:** Lionel Villard
+
+### v1 for Kafka Sources
+
+Let's promote KafkaSource to v1
+
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/389
+
+**Owner:** Matthis Wessendorf
 
 ## Next 6 Months (Midterm)
+
 ### Multi-Tenant RedisStream Source
+
 [Description TBD]
 
 **Theme:** Multi-Tenant environment support
@@ -145,35 +185,67 @@ __These are the issues the working group decided to not work on whether for bein
 **Owner:** Lionel Villard
 
 ## Icebox
+
 ### Removal of v1alpha1 Sources
+
 [Description TBD]
 
 **GitHub Issue:** TBD
 
 ## Won’t Do
-__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason
+
+_These are the issues the working group decided to not work on whether for
+being out of the WG scope or some other reason_
 
 # Event Delivery
+
 ## Next 3 Months (Short-term)
+
 ### Kafka Code Share Improvements
-[Description TBD]
+
+KafkaChannel code refactorings to increase code sharing between the two implementations
 
 **Theme:** Kafka Code Share Improvements
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/386
 
 **Owner:** Matthias
 
 ## Next 6 Months (Midterm)
+
+### KafkaChannel Unification
+
+Desired exit goal: One backing implemetation for the `KafkaChannel` API.
+
+**Theme:** Kafka Code Share Improvements
+
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/386
+
+**Owner:** Matthias
+
+### V1 for KafkaChannel
+
+Promote the `KafkaChannel` to V1
+
+**Theme:** Kafka Code Share Improvements
+
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/386
+
+**Owner:** Matthias
+
 ### Various QoS guarantees for Kakfa
-Today only at-least-once and ordered is supported by the Kafka-backed channel implementation. At-most-once and unordered should also be supported. 
+
+Today only at-least-once and ordered is supported by the Kafka-backed channel
+implementation. At-most-once and unordered should also be supported.
 
 **GitHub Issue:** TDB
 
 **Owner:** Lionel Villard
 
 ## Icebox
+
 ### HTTP/2
+
 [Description TBD]
 
 **GitHub Issue:** TDB
@@ -181,4 +253,5 @@ Today only at-least-once and ordered is supported by the Kafka-backed channel im
 **Owner:** Francesco Guardiani
 
 ## Won’t Do
-__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason
+
+_These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason_

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -4,15 +4,17 @@
 
 ### Event Discovery
 
-[Description TBD]
+Event discovery have been a needed feature with many attempts to implement it. There's a need that users can discover various existing eventing components. One attempt to solve it was via the event registry and EventType CRD #929. The new Discovery API offers a more promising approach.
 
-**GitHub Issue:** TBD
+We need a more unified story for discovery in eventing that potentially leverages the Discovery API and aligns the event registry and EventType features accordingly.
 
-**Owner:** Grant Rodgers
+**GitHub Issue:** https://github.com/knative/eventing/issues/4892
+
+**Owner:** Matthis Wessendorf
 
 ### Spec Solidification
 
-[Description TBD]
+Review and update documented specification to reflect the existing implementation (v1 API).
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/4595
 
@@ -45,7 +47,7 @@ internals
 
 ### Autotrigger Sugar Controller
 
-[Description TBD]
+Simplify operations for developers using Knative by allowing addressable resources to have autotrigger sugar labels. AutoTrigger creates triggers based on annotations on a resource, and then assigns owner references between the Trigger and Addressable, allowing cleanup and a lot less operational complexity with the developer thinking about fewer resources
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/4547
 
@@ -53,7 +55,8 @@ internals
 
 ### Remove v1beta1 API [eventing, flows, messaging]
 
-[Description TBD]
+Removal of v1beta1 APIs as per [our deprecation policy](
+https://knative.dev/community/contributing/mechanics/release-versioning-principles/). We guarantee 9 months of support for v1beta1 APIs. This makes the release 18/05/2021 the earliest release where we can remove v1beta1 API, and we want to target that release.
 
 **GitHub Issue:** https://github.com/knative/eventing/issues/4836
 
@@ -63,7 +66,7 @@ internals
 
 ### Protocol negotiation contract
 
-[Description TBD]
+Defined a standard that senders and receivers could use to communicate or negotiate protocol versions and features for a request, or a connection session to advance our capabilities, without leaving existing containers behind.
 
 **Theme:** Multiple protocol and protocol option support
 
@@ -82,14 +85,6 @@ internals
 **Owner:** Grant Rodgers
 
 ## Icebox (Wishlist)
-
-### Broker Performance Tests
-
-[Description TBD]
-
-**GitHub Issue:** TBD
-
-**Owner:** TBD
 
 ### Cross Namespace Eventing
 
@@ -128,7 +123,9 @@ being out of the WG scope or some other reason_
 
 ### Multi-Tenant Kafka Source
 
-[Description TBD]
+Introduce a multi-tenant KafkaSource with a Multi-tenant receive adapter that handles more than one source instance at a time, typically all source instances in a namespace or all source instances in a cluster.
+
+The goal of multi-tenant receive adapters is to minimize the cost of running sources that are barely (i.e. no or few processed events) used at a particular point in time.  
 
 **Theme:** Multi-Tenant environment support
 
@@ -138,23 +135,15 @@ being out of the WG scope or some other reason_
 
 ### GitHub Vanity domain support
 
-[Description TBD]
+The MT githubsource controller generates webhook of the form `http://githubsource-adapter.knative-sources.<domain>/<ns>/<name>` where `ns` and `name` corresponds the githubsource CR.
+
+Instead it should generate webhook of the form `http://<name>.<ns>.<domain>.`
 
 **Theme:** Multi-Tenant environment support
 
 **GitHub Issue:** https://github.com/knative-sandbox/eventing-github/issues/65
 
 **Owner:** Lionel Villard
-
-### Find Maintainers for source repos
-
-[Description TBD]
-
-**Theme:** No repo left behind
-
-**GitHub Issue:** We should create one if we think this is valuable
-
-**Owner:** Ville Aikas
 
 ### v1 for Core Sources
 
@@ -185,12 +174,6 @@ Let's promote KafkaSource to v1
 **Owner:** Lionel Villard
 
 ## Icebox
-
-### Removal of v1alpha1 Sources
-
-[Description TBD]
-
-**GitHub Issue:** TBD
 
 ## Won’t Do
 
@@ -246,9 +229,9 @@ implementation. At-most-once and unordered should also be supported.
 
 ### HTTP/2
 
-[Description TBD]
+Support HTTP/2 in eventing components supports transparently with possibly little/zero configuration in the full event flow
 
-**GitHub Issue:** TDB
+**GitHub Issue:** https://github.com/knative/eventing/issues/3312
 
 **Owner:** Francesco Guardiani
 

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -1,0 +1,184 @@
+# Eventing
+## Next 3 Months (Short-term)
+### Event Discovery
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** Grant Rodgers
+
+### Spec Solidification
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** Grant Rodgers
+
+### Better Trigger Filtering
+Trigger filtering today is limited. We need more expressive filtering.
+
+**GitHub Issue:** https://github.com/knative/eventing/issues/3359
+
+**Owner:** Francesco Guardiani
+
+### Tenant Targeted Logging
+Hosting Knative as a multi-tenant cloud offering, there is currently no means to distinguish logging events that are necessary for servicing the hosted Knative service and those that may be meaningful to a tenant consuming the service.  The tenant of the hosted service would like to see besides their hosted application logging, pertinent log messages from Knative service to help diagnose their issues. However, providing all logging messages from the Knative service internals would be counterproductive for a tenant not familiar with Knative internals
+
+**Theme:** Multi-Tenant environment support
+
+**GitHub Issue:** TBD
+
+**Owner:** Rick Rineholt
+
+### Autotrigger Sugar Controller
+[Description TBD]
+
+**GitHub Issue:** https://github.com/knative/eventing/issues/4547
+
+**Owner:** Scott Nichols
+
+### Remove v1beta1 API [eventing, flows, messaging]
+[Description TBD]
+
+**GitHub Issue:** https://github.com/knative/eventing/issues/4836
+
+**Owner:** Ville Aikas
+
+## Next 6 Months (Midterm)
+### Protocol negotiation contract
+[Description TBD]
+
+**Theme:** Multiple protocol and protocol option support
+
+**GitHub Issue:** TBD
+
+**Owner:** Grant Rodgers
+
+### Preflight protocol negotiation
+[Description TBD]
+
+**Theme:** Multiple protocol and protocol option support
+
+**GitHub Issue:** TBD
+
+**Owner:** Grant Rodgers
+
+## Icebox (Wishlist)
+### Broker Performance Tests
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** TBD 
+
+### Cross Namespace Eventing
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** Grant Rodgers
+
+### Advanced Workflow and Streaming processing
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** ?
+
+## Won’t Do
+__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason
+
+# Eventing Sources
+## Next 3 Months (Short-term)
+### Introduce and define Multi-tenant Sources
+[Description TBD]
+
+**Theme:** Multi-Tenant environment support
+
+**GitHub Issue:** TBD
+
+**Owner:** Scott Nichols
+
+### Multi-Tenant Kafka Source
+[Description TBD]
+
+**Theme:** Multi-Tenant environment support
+
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/219
+
+**Owner:** Lionel Villard
+
+### GitHub Vanity domain support
+[Description TBD]
+
+**Theme:** Multi-Tenant environment support
+
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-github/issues/65
+
+**Owner:** Lionel Villard
+
+### Find Maintainers for source repos
+[Description TBD]
+
+**Theme:** No repo left behind
+
+**GitHub Issue:** We should create one if we think this is valuable
+
+**Owner:** Ville Aikas
+
+
+### v1 for Core Sources
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+**Owner:** ?
+
+## Next 6 Months (Midterm)
+### Multi-Tenant RedisStream Source
+[Description TBD]
+
+**Theme:** Multi-Tenant environment support
+
+**GitHub Issue:** TBD
+
+**Owner:** Lionel Villard
+
+## Icebox
+### Removal of v1alpha1 Sources
+[Description TBD]
+
+**GitHub Issue:** TBD
+
+## Won’t Do
+__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason
+
+# Event Delivery
+## Next 3 Months (Short-term)
+### Kafka Code Share Improvements
+[Description TBD]
+
+**Theme:** Kafka Code Share Improvements
+
+**GitHub Issue:** TBD
+
+**Owner:** Matthias
+
+## Next 6 Months (Midterm)
+### Various QoS guarantees for Kakfa
+Today only at-least-once and ordered is supported by the Kafka-backed channel implementation. At-most-once and unordered should also be supported. 
+
+**GitHub Issue:** TDB
+
+**Owner:** Lionel Villard
+
+## Icebox
+### HTTP/2
+[Description TBD]
+
+**GitHub Issue:** TDB
+
+**Owner:** Francesco Guardiani
+
+## Won’t Do
+__These are the issues the working group decided to not work on whether for being out of the WG scope or some other reason

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -221,7 +221,7 @@ Promote the `KafkaChannel` to V1
 Today only at-least-once and ordered is supported by the Kafka-backed channel
 implementation. At-most-once and unordered should also be supported.
 
-**GitHub Issue:** TDB
+**GitHub Issue:** TBD
 
 **Owner:** Lionel Villard
 

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -111,16 +111,6 @@ being out of the WG scope or some other reason_
 
 ## Next 3 Months (Short-term)
 
-### Introduce and define Multi-tenant Sources
-
-[Description TBD]
-
-**Theme:** Multi-Tenant environment support
-
-**GitHub Issue:** TBD
-
-**Owner:** Scott Nichols
-
 ### Multi-Tenant Kafka Source
 
 Introduce a multi-tenant KafkaSource implementation capable of handling more than one source instance at a time, typically all source instances in a namespace or all source instances in a cluster.

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -96,9 +96,9 @@ Defined a standard that senders and receivers could use to communicate or negoti
 
 ### Streaming Processing
 
-[Description TBD]
+The goal of this proposal is to build an efficient event mesh that allows stateless and stateful even processing. We want to empower end users to describe event flows, made by streams and processors.
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative/eventing/issues/4901
 
 **Owner:** Lionel Villard
 
@@ -123,7 +123,7 @@ being out of the WG scope or some other reason_
 
 ### Multi-Tenant Kafka Source
 
-Introduce a multi-tenant KafkaSource with a Multi-tenant receive adapter that handles more than one source instance at a time, typically all source instances in a namespace or all source instances in a cluster.
+Introduce a multi-tenant KafkaSource implementation capable of handling more than one source instance at a time, typically all source instances in a namespace or all source instances in a cluster.
 
 The goal of multi-tenant receive adapters is to minimize the cost of running sources that are barely (i.e. no or few processed events) used at a particular point in time.  
 
@@ -165,11 +165,11 @@ Let's promote KafkaSource to v1
 
 ### Multi-Tenant RedisStream Source
 
-[Description TBD]
+Introduce a multi-tenant KafkaRedis implementation capable of handling more than one source instance at a time, typically all source instances in a namespace or all source instances in a cluster
 
 **Theme:** Multi-Tenant environment support
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-redis/issues/95
 
 **Owner:** Lionel Villard
 
@@ -221,7 +221,7 @@ Promote the `KafkaChannel` to V1
 Today only at-least-once and ordered is supported by the Kafka-backed channel
 implementation. At-most-once and unordered should also be supported.
 
-**GitHub Issue:** TBD
+**GitHub Issue:** https://github.com/knative-sandbox/eventing-kafka/issues/413
 
 **Owner:** Lionel Villard
 


### PR DESCRIPTION
Fixes #2426 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add roadmap for 2021 for Eventing, Eventing Sources and Event Delivery WGs

## TODO

- [x] Create GitHub issues for all items
- [x] Add missing descriptions
- [x] Find owners for items with no owners or remove the item

/cc @vaikas @grantr @lionelvillard @n3wscott @matzew @slinkydeveloper 