### PR TITLE
expose ChannelReference in UnknownChannelError

### DIFF
--- a/pkg/channel/message_receiver.go
+++ b/pkg/channel/message_receiver.go
@@ -36,11 +36,11 @@ import (
 // UnknownChannelError represents the error when an event is received by a channel dispatcher for a
 // channel that does not exist.
 type UnknownChannelError struct {
-	c ChannelReference
+	Channel ChannelReference
 }
 
 func (e *UnknownChannelError) Error() string {
-	return fmt.Sprint("unknown channel: ", e.c)
+	return fmt.Sprint("unknown channel: ", e.Channel)
 }
 
 // UnknownHostError represents the error when a ResolveMessageChannelFromHostHeader func cannot resolve an host

--- a/pkg/channel/message_receiver_test.go
+++ b/pkg/channel/message_receiver_test.go
@@ -70,7 +70,7 @@ func TestMessageReceiver_ServeHTTP(t *testing.T) {
 		},
 		"unknown channel error": {
 			receiverFunc: func(_ context.Context, c ChannelReference, _ binding.Message, _ []binding.Transformer, _ nethttp.Header) error {
-				return &UnknownChannelError{c: c}
+				return &UnknownChannelError{Channel: c}
 			},
 			expected: nethttp.StatusNotFound,
 		},


### PR DESCRIPTION
Fixes #3069 

## Proposed Changes
- Make the ChannelReference in UnknownChannelError public so that Channel implementations can populate it.

**Note:**  The distributed KafkaChannel "Receiver" was trying to populate this data in order to be a good citizen, but upon further review it seems it's never really used/logged (since receiving events for non-existent channels might be frequent and not considered "log-worthy" : )   So, this change will make it possible to identify the specific ChannelReference which was not found (or "Unknown") in case it's useful in a IDE/Debug scenario or is later logged somewhere, but otherwise shouldn't have any effect.


