### PR TITLE
Use ConfigAccessor's ToEnvVars method in PingSource

### DIFF
--- a/pkg/reconciler/pingsource/controller.go
+++ b/pkg/reconciler/pingsource/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -69,8 +70,7 @@ func NewController(
 		pingLister:       pingSourceInformer.Lister(),
 		deploymentLister: deploymentInformer.Lister(),
 		leConfig:         leConfig,
-		loggingContext:   ctx,
-		configs:          reconcilersource.WatchConfigurations(ctx, component, cmw),
+		configAcc:        reconcilersource.WatchConfigurations(ctx, component, cmw),
 	}
 
 	impl := pingsourcereconciler.NewImpl(ctx, r)
@@ -81,7 +81,7 @@ func NewController(
 	pingSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Tracker is used to notify us that the pingsource-mt-adapter Deployment has changed so that
-	// we can reconcile PingSources that depends on it
+	// we can reconcile PingSources that depend on it
 	r.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/pingsource/controller_test.go
+++ b/pkg/reconciler/pingsource/controller_test.go
@@ -1,7 +1,7 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
-Licensed under the Apache License, Veroute.on 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/pkg/reconciler/pingsource/resources/receive_adapter.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ import (
 )
 
 type Args struct {
-	MetricsConfig   string
-	LoggingConfig   string
-	TracingConfig   string
+	ConfigEnvVars   []corev1.EnvVar
 	LeConfig        string
 	NoShutdownAfter int
 	SinkTimeout     int
@@ -36,22 +34,13 @@ type Args struct {
 
 // MakeReceiveAdapterEnvVar generates the environment variables for the pingsources
 func MakeReceiveAdapterEnvVar(args Args) []corev1.EnvVar {
-	return []corev1.EnvVar{{
+	envs := []corev1.EnvVar{{
 		Name: system.NamespaceEnvKey,
 		ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{
 				FieldPath: "metadata.namespace",
 			},
 		},
-	}, {
-		Name:  adapter.EnvConfigMetricsConfig,
-		Value: args.MetricsConfig,
-	}, {
-		Name:  adapter.EnvConfigLoggingConfig,
-		Value: args.LoggingConfig,
-	}, {
-		Name:  adapter.EnvConfigTracingConfig,
-		Value: args.TracingConfig,
 	}, {
 		Name:  adapter.EnvConfigLeaderElectionConfig,
 		Value: args.LeConfig,
@@ -63,4 +52,5 @@ func MakeReceiveAdapterEnvVar(args Args) []corev1.EnvVar {
 		Value: strconv.Itoa(args.SinkTimeout),
 	}}
 
+	return append(envs, args.ConfigEnvVars...)
 }

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,15 +21,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	reconcilersource "knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
 
 func TestMakePingAdapter(t *testing.T) {
 	args := Args{
-		MetricsConfig:   "metrics",
-		LoggingConfig:   "logging",
-		TracingConfig:   "tracing",
+		ConfigEnvVars:   (&reconcilersource.EmptyVarsGenerator{}).ToEnvVars(),
 		NoShutdownAfter: 40,
 		SinkTimeout:     48,
 	}
@@ -42,15 +41,6 @@ func TestMakePingAdapter(t *testing.T) {
 			},
 		},
 	}, {
-		Name:  "K_METRICS_CONFIG",
-		Value: "metrics",
-	}, {
-		Name:  "K_LOGGING_CONFIG",
-		Value: "logging",
-	}, {
-		Name:  "K_TRACING_CONFIG",
-		Value: "tracing",
-	}, {
 		Name:  "K_LEADER_ELECTION_CONFIG",
 		Value: "",
 	}, {
@@ -59,6 +49,15 @@ func TestMakePingAdapter(t *testing.T) {
 	}, {
 		Name:  "K_SINK_TIMEOUT",
 		Value: "48",
+	}, {
+		Name:  "K_LOGGING_CONFIG",
+		Value: "",
+	}, {
+		Name:  "K_METRICS_CONFIG",
+		Value: "",
+	}, {
+		Name:  "K_TRACING_CONFIG",
+		Value: "",
 	}}
 
 	got := MakeReceiveAdapterEnvVar(args)


### PR DESCRIPTION
Follow up to #4877

## Proposed Changes

- Refactor code to invoke the ConfigAccessor's `ToEnvVars()` method instead of accessing each env var individually

/assign lionelvillard
cc @Shashankft9