### PR TITLE
jsondataLimiitSetmap set default to -1 seems empty map breaks downstream

### DIFF
--- a/config/core/configmaps/default-pingsource.yaml
+++ b/config/core/configmaps/default-pingsource.yaml
@@ -23,5 +23,5 @@ metadata:
     knative.dev/example-checksum: "6eaeecba"
 data:
   ping-config: |
-    # dataMaxSize: 10  # Max number of bytes allowed to be sent for message excluding any base64 decoding.
-                       # Default is no limit set for data
+     dataMaxSize: -1  # Max number of bytes allowed to be sent for message excluding any base64 decoding.
+                      # -1 For no limit


### PR DESCRIPTION
Signed-off-by: rickr <cr22rc@users.noreply.github.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
