### PR TITLE
Adding check for -1 status code for the default retry impl

### DIFF
--- a/pkg/kncloudevents/message_sender.go
+++ b/pkg/kncloudevents/message_sender.go
@@ -162,7 +162,7 @@ func RetryConfigFromDeliverySpec(spec duckv1.DeliverySpec) (RetryConfig, error) 
 
 // Simple default implementation
 func RetryIfGreaterThan300(_ context.Context, response *nethttp.Response, err error) (bool, error) {
-	return !(response != nil && (response.StatusCode < 300)), err
+	return !(response != nil && (response.StatusCode < 300 && response.StatusCode != -1)), err
 }
 
 // Alternative function to determine whether to retry based on response

--- a/pkg/kncloudevents/message_sender_test.go
+++ b/pkg/kncloudevents/message_sender_test.go
@@ -336,7 +336,7 @@ func TestRetryIfGreaterThan300(t *testing.T) {
 		{
 			name:     "Http StatusCode -1",
 			response: &http.Response{StatusCode: -1},
-			result:   false,
+			result:   true,
 		},
 		{
 			name:     "Http StatusCode 100",


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adding a try if the statusCode is `-1`, similar to the new alternative/approach 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
We now do a retry if we have a -1 statusCode
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
