### PR TITLE
fix broken in-mem channel namespace mode

### DIFF
--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -36,6 +36,14 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - inmemorychannels/finalizers
+      - inmemorychannels/status
+      - inmemorychannels
+    verbs:
+      - patch
+  - apiGroups:
       - ""
     resources:
       - services

--- a/pkg/reconciler/inmemorychannel/controller/resources/dispatcher.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/dispatcher.go
@@ -129,6 +129,16 @@ func makeEnv(dispatcherConfig config.EventDispatcherConfig) []corev1.EnvVar {
 			},
 		},
 	}, {
+		Name: "POD_NAME",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.name",
+			},
+		},
+	}, {
+		Name:  "CONTAINER_NAME",
+		Value: "dispatcher",
+	}, {
 		Name:  "MAX_IDLE_CONNS",
 		Value: strconv.Itoa(dispatcherConfig.MaxIdleConns),
 	}, {

--- a/pkg/reconciler/inmemorychannel/controller/resources/dispatcher_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/dispatcher_test.go
@@ -103,6 +103,16 @@ func TestNewDispatcher(t *testing.T) {
 									},
 								},
 							}, {
+								Name: "POD_NAME",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.name",
+									},
+								},
+							}, {
+								Name:  "CONTAINER_NAME",
+								Value: "dispatcher",
+							}, {
 								Name:  "MAX_IDLE_CONNS",
 								Value: "2000",
 							}, {


### PR DESCRIPTION
Fixes #4844

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix privilege escalation error
- Fix missing env vars in namespace-scoped in-mem dispatcher. 
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
:bug: Fix bug preventing the namespace-scoped in-memory channel to become ready. 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
