### PR TITLE
Add missing singular resource names to sources/sinkbinding crds

### DIFF
--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -558,6 +558,7 @@ spec:
      - sources
     kind: ApiServerSource
     plural: apiserversources
+    singular: apiserversource
   scope: Namespaced
   conversion:
     strategy: Webhook

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -425,6 +425,7 @@ spec:
       - sources
     kind: ContainerSource
     plural: containersources
+    singular: containersource
   scope: Namespaced
   conversion:
     strategy: Webhook

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -472,6 +472,7 @@ spec:
     - sources
     kind: PingSource
     plural: pingsources
+    singular: pingsource
   scope: Namespaced
   conversion:
     strategy: Webhook

--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -257,6 +257,7 @@ spec:
       - bindings
     kind: SinkBinding
     plural: sinkbindings
+    singular: sinkbinding
   scope: Namespaced
   conversion:
     strategy: Webhook


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add missing explicit singular names for some CRDs that were missing them (no behaviour change since these get filled by default with lowercased kind value)
