### PR TITLE
fix #4994 use trigger's namespace only when subscriber's namespace is nil

### DIFF
--- a/pkg/reconciler/mtbroker/trigger/trigger.go
+++ b/pkg/reconciler/mtbroker/trigger/trigger.go
@@ -115,9 +115,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 		t.Status.MarkBrokerFailed("MissingBrokerChannel", "Failed to get broker %q annotations: %s", t.Spec.Broker, err)
 		return fmt.Errorf("failed to find Broker's Trigger channel: %s", err)
 	}
-	if t.Spec.Subscriber.Ref != nil {
-		// To call URIFromDestination(dest apisv1alpha1.Destination, parent interface{}), dest.Ref must have a Namespace
-		// We will use the Namespace of Trigger as the Namespace of dest.Ref
+	if t.Spec.Subscriber.Ref != nil && t.Spec.Subscriber.Ref.Namespace == "" {
+		// To call URIFromDestinationV1(ctx context.Context, dest v1.Destination, parent interface{}), dest.Ref must have a Namespace
+		// If Subscriber.Ref.Namespace is nil, We will use the Namespace of Trigger as the Namespace of dest.Ref
 		t.Spec.Subscriber.Ref.Namespace = t.GetNamespace()
 	}
 


### PR DESCRIPTION
Fixes #4994 #4628



<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :bug: Fix bug #4994 #4628, Allow `Trigger` users to set another namespace's `Subscriber`, And when `Subscriber`'s namespace not been set, it will be set to  `Trigger`'s namespace 

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:


- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Allow Trigger users to set another namespace's Subscriber, And when Subscriber's namespace not been set, it will be set to  Trigger's namespace 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
