### PR TITLE
Change the container name of the sugar-controller Deployment

### DIFF
--- a/config/sugar/500-controller.yaml
+++ b/config/sugar/500-controller.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: eventing-controller
       enableServiceLinks: false
       containers:
-      - name: controller
+      - name: sugar-controller
         image: ko://knative.dev/eventing/cmd/sugar_controller
         env:
           - name: CONFIG_LOGGING_NAME


### PR DESCRIPTION
## Proposed Changes

This PR changes the container name of the sugar-controller Deployment from `controller` to `sugar-controller` to support separate resource specs via knative/operator. The knative operator allows configuration of resource requests using container names (https://github.com/knative/operator/blob/master/docs/configuration.md#specresources). Because the sugar-controller and the imc-controller both currently use `controller` as the container name, it´s not possible to specify separate resource requests for the deployments. 

**Release Note**

```release-note
The container name of the sugar-controller Deployment changes from from `controller` to `sugar-controller`
```