### PR TITLE
sugar uses v1 versions of broker / trigger

### DIFF
--- a/pkg/reconciler/sugar/namespace/controller.go
+++ b/pkg/reconciler/sugar/namespace/controller.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
+	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
 	"knative.dev/eventing/pkg/reconciler/sugar"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 	namespacereconciler "knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"

--- a/pkg/reconciler/sugar/namespace/controller_test.go
+++ b/pkg/reconciler/sugar/namespace/controller_test.go
@@ -24,7 +24,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/client/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace/fake"
 )
 

--- a/pkg/reconciler/sugar/namespace/namespace.go
+++ b/pkg/reconciler/sugar/namespace/namespace.go
@@ -29,7 +29,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
-	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/reconciler/sugar"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 )
@@ -61,7 +61,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {
-		_, err = r.eventingClientSet.EventingV1beta1().Brokers(ns.Name).Create(
+		_, err = r.eventingClientSet.EventingV1().Brokers(ns.Name).Create(
 			ctx, resources.MakeBroker(ns.Name, resources.DefaultBrokerName), metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create Broker: %w", err)

--- a/pkg/reconciler/sugar/namespace/namespace_test.go
+++ b/pkg/reconciler/sugar/namespace/namespace_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -35,7 +35,7 @@ import (
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 
-	. "knative.dev/eventing/pkg/reconciler/testing"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	. "knative.dev/pkg/reconciler/testing"
 )
 
@@ -45,7 +45,7 @@ const (
 
 func init() {
 	// Add types to scheme
-	_ = v1beta1.AddToScheme(scheme.Scheme)
+	_ = v1.AddToScheme(scheme.Scheme)
 }
 
 func TestEnabledByDefault(t *testing.T) {
@@ -126,7 +126,7 @@ func TestEnabledByDefault(t *testing.T) {
 			NewNamespace(testNS,
 				WithNamespaceLabeled(sugar.InjectionDisabledLabels()),
 			),
-			&v1beta1.Broker{
+			&v1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNS,
 					Name:      resources.DefaultBrokerName,
@@ -143,7 +143,7 @@ func TestEnabledByDefault(t *testing.T) {
 		r := &Reconciler{
 			eventingClientSet: fakeeventingclient.Get(ctx),
 			isEnabled:         sugar.OnByDefault,
-			brokerLister:      listers.GetV1Beta1BrokerLister(),
+			brokerLister:      listers.GetBrokerLister(),
 		}
 
 		return namespacereconciler.NewReconciler(ctx, logger,
@@ -224,7 +224,7 @@ func TestDisabledByDefault(t *testing.T) {
 			NewNamespace(testNS,
 				WithNamespaceLabeled(sugar.InjectionDisabledLabels()),
 			),
-			&v1beta1.Broker{
+			&v1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testNS,
 					Name:      resources.DefaultBrokerName,
@@ -241,7 +241,7 @@ func TestDisabledByDefault(t *testing.T) {
 		r := &Reconciler{
 			eventingClientSet: fakeeventingclient.Get(ctx),
 			isEnabled:         sugar.OffByDefault,
-			brokerLister:      listers.GetV1Beta1BrokerLister(),
+			brokerLister:      listers.GetBrokerLister(),
 		}
 
 		return namespacereconciler.NewReconciler(ctx, logger,

--- a/pkg/reconciler/sugar/resources/broker_test.go
+++ b/pkg/reconciler/sugar/resources/broker_test.go
@@ -22,7 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
 func TestMakeBroker(t *testing.T) {
@@ -33,7 +33,7 @@ func TestMakeBroker(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *v1beta1.Broker
+		want *v1.Broker
 	}{
 		{
 			name: "ok",
@@ -41,7 +41,7 @@ func TestMakeBroker(t *testing.T) {
 				namespace: "default",
 				name:      "df-broker",
 			},
-			want: &v1beta1.Broker{
+			want: &v1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "default",
 					Name:        "df-broker",

--- a/pkg/reconciler/sugar/trigger/controller.go
+++ b/pkg/reconciler/sugar/trigger/controller.go
@@ -30,9 +30,9 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker"
-	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/trigger"
-	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/trigger"
+	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
+	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
+	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/reconciler/sugar"
 )
 

--- a/pkg/reconciler/sugar/trigger/controller_test.go
+++ b/pkg/reconciler/sugar/trigger/controller_test.go
@@ -23,12 +23,12 @@ import (
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/broker/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/trigger/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/sugar/trigger/trigger.go
+++ b/pkg/reconciler/sugar/trigger/trigger.go
@@ -23,10 +23,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
-	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/trigger"
-	listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
+	listers "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/reconciler/sugar"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 	"knative.dev/pkg/logging"
@@ -48,7 +48,7 @@ type Reconciler struct {
 // Check that our Reconciler implements triggerreconciler.Interface
 var _ triggerreconciler.Interface = (*Reconciler)(nil)
 
-func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1beta1.Trigger) reconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1.Trigger) reconciler.Event {
 	if !r.isEnabled(t.GetAnnotations()) {
 		logging.FromContext(ctx).Debug("Injection for Trigger not enabled.")
 		return nil
@@ -58,7 +58,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *v1beta1.Trigger) reco
 
 	// If the resource doesn't exist, we'll create it.
 	if k8serrors.IsNotFound(err) {
-		_, err = r.eventingClientSet.EventingV1beta1().Brokers(t.Namespace).Create(
+		_, err = r.eventingClientSet.EventingV1().Brokers(t.Namespace).Create(
 			ctx, resources.MakeBroker(t.Namespace, t.Spec.Broker), metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("Unable to create Broker: %w", err)

--- a/pkg/reconciler/sugar/trigger/trigger_test.go
+++ b/pkg/reconciler/sugar/trigger/trigger_test.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/trigger"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/reconciler/sugar"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 
-	. "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	. "knative.dev/pkg/reconciler/testing"
 )
 

--- a/pkg/reconciler/testing/v1/namespace.go
+++ b/pkg/reconciler/testing/v1/namespace.go
@@ -14,25 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package testing
 
 import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
-	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
-const (
-	DefaultBrokerName = "default"
-)
+// NamespaceOption enables further configuration of a Namespace.
+type NamespaceOption func(*corev1.Namespace)
 
-func MakeBroker(namespace, name string) *v1.Broker {
-	return &v1.Broker{
+// NewNamespace creates a Namespace with NamespaceOptions
+func NewNamespace(name string, o ...NamespaceOption) *corev1.Namespace {
+	s := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Labels:      Labels(),
-			Annotations: map[string]string{eventing.BrokerClassKey: eventing.MTChannelBrokerClassValue},
+			Name: name,
 		},
+	}
+	for _, opt := range o {
+		opt(s)
+	}
+	return s
+}
+
+func WithNamespaceDeleted(n *corev1.Namespace) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	n.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+func WithNamespaceLabeled(labels map[string]string) NamespaceOption {
+	return func(n *corev1.Namespace) {
+		n.Labels = labels
 	}
 }


### PR DESCRIPTION
Addresses #4836 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Have sugar controller use v1 resources instead of v1beta1.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
