### PR TITLE
break apart rekt tests from e2e tests

### DIFF
--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -32,11 +32,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 initialize $@ --skip-istio-addon
 
-echo "Running E2E tests for: Multi Tenant Channel Based Broker, Channel (v1beta1, v1), InMemoryChannel (v1beta1, v1) , ApiServerSource (v1beta1, v1), ContainerSource (v1alpha2, v1) and PingSource (v1beta1, v1beta2)"
-go_test_e2e -timeout=30m -parallel=20 ./test/e2e \
-  -brokerclass=MTChannelBasedBroker \
-  -channels=messaging.knative.dev/v1beta1:Channel,messaging.knative.dev/v1beta1:InMemoryChannel,messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel \
-  -sources=sources.knative.dev/v1beta1:ApiServerSource,sources.knative.dev/v1alpha2:ContainerSource,sources.knative.dev/v1beta1:PingSource,sources.knative.dev/v1beta2:PingSource,sources.knative.dev/v1:ApiServerSource,sources.knative.dev/v1:ContainerSource \
-  || fail_test
+echo "Running E2E Reconciler Tests"
+go_test_e2e -timeout=30m -parallel=20 ./test/rekt || fail_test
 
 success


### PR DESCRIPTION
the flakes on e2e and rekt tests come from these taking too much time on prow. Break them apart. 