### PR TITLE
adding ping source smoke test

### DIFF
--- a/test/rekt/README.md
+++ b/test/rekt/README.md
@@ -8,3 +8,9 @@ To run the tests on an existing cluster:
 ```bash
 SYSTEM_NAMESPACE=knative-eventing go test -count=1 -v -tags=e2e ./test/rekt/...
 ```
+
+To run just one test:
+
+```bash
+SYSTEM_NAMESPACE=knative-eventing go test -count=1 -v -tags=e2e -run Smoke_PingSource ./test/rekt/...
+```

--- a/test/rekt/features/pingsource/readyness.go
+++ b/test/rekt/features/pingsource/readyness.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingsource
+
+import (
+	"knative.dev/eventing/test/rekt/resources/pingsource"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"knative.dev/reconciler-test/pkg/feature"
+
+	"knative.dev/eventing/test/rekt/features"
+	"knative.dev/eventing/test/rekt/resources/svc"
+)
+
+// PingSourceGoesReady returns a feature testing if a pingsource becomes ready.
+func PingSourceGoesReady(name string) *feature.Feature {
+	f := feature.NewFeatureNamed("PingSource goes ready.")
+
+	sink := feature.MakeRandomK8sName("sink")
+	f.Setup("install a service", svc.Install(sink, "app", "rekt"))
+
+	f.Setup("install a pingsource", pingsource.Install(name, pingsource.WithSink(&duckv1.KReference{
+		Kind:       "Service",
+		Name:       sink,
+		APIVersion: "v1",
+	}, "")))
+
+	f.Stable("pingsource").
+		Must("be ready", pingsource.IsReady(name, features.Interval, features.Timeout))
+
+	return f
+}

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingsource
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/k8s"
+
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+type CfgFn func(map[string]interface{})
+
+func Gvr() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1beta2", Resource: "pingsources"}
+}
+
+// Install will create a Broker resource, augmented with the config fn options.
+func Install(name string, opts ...CfgFn) feature.StepFn {
+	cfg := map[string]interface{}{
+		"name": name,
+	}
+	for _, fn := range opts {
+		fn(cfg)
+	}
+	return func(ctx context.Context, t feature.T) {
+		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// IsReady tests to see if a PingSource becomes ready within the time given.
+func IsReady(name string, interval, timeout time.Duration) feature.StepFn {
+	return k8s.IsReady(Gvr(), name, interval, timeout)
+}
+
+// WithSink adds the sink related config to a PingSource spec.
+func WithSink(ref *duckv1.KReference, uri string) CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["sink"]; !set {
+			cfg["sink"] = map[string]interface{}{}
+		}
+		sink := cfg["sink"].(map[string]interface{})
+
+		if uri != "" {
+			sink["uri"] = uri
+		}
+		if ref != nil {
+			if _, set := sink["ref"]; !set {
+				sink["ref"] = map[string]interface{}{}
+			}
+			sref := sink["ref"].(map[string]interface{})
+			sref["apiVersion"] = ref.APIVersion
+			sref["kind"] = ref.Kind
+			// skip namespace
+			sref["name"] = ref.Name
+		}
+	}
+}

--- a/test/rekt/resources/pingsource/pingsource.yaml
+++ b/test/rekt/resources/pingsource/pingsource.yaml
@@ -1,0 +1,36 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: sources.knative.dev/v1beta2
+kind: PingSource
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+spec:
+  schedule: "*/1 * * * *"
+  contentType: "application/json"
+  data: '{"message": "Hello world!"}'
+  {{if .sink }}
+  sink:
+    {{ if .sink.ref }}
+    ref:
+      kind: {{ .sink.ref.kind }}
+      namespace: {{ .namespace }}
+      name: {{ .sink.ref.name }}
+      apiVersion: {{ .sink.ref.apiVersion }}
+    {{ end }}
+    {{ if .sink.uri }}
+    uri: {{ .sink.uri }}
+    {{ end }}
+  {{ end }}

--- a/test/rekt/resources/pingsource/pingsource_test.go
+++ b/test/rekt/resources/pingsource/pingsource_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingsource_test
+
+import (
+	"os"
+
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+// The following examples validate the processing of the With* helper methods
+// applied to config and go template parser.
+
+func Example_min() {
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":       "foo",
+		"namespace":  "bar",
+		"brokerName": "baz",
+	}
+
+	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: sources.knative.dev/v1beta2
+	// kind: PingSource
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   schedule: "*/1 * * * *"
+	//   contentType: "application/json"
+	//   data: '{"message": "Hello world!"}'
+}
+
+func Example_full() {
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"sink": map[string]interface{}{
+			"ref": map[string]string{
+				"kind":       "sinkkind",
+				"namespace":  "sinknamespace",
+				"name":       "sinkname",
+				"apiVersion": "sinkversion",
+			},
+			"uri": "uri/parts",
+		},
+	}
+
+	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: sources.knative.dev/v1beta2
+	// kind: PingSource
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   schedule: "*/1 * * * *"
+	//   contentType: "application/json"
+	//   data: '{"message": "Hello world!"}'
+	//   sink:
+	//     ref:
+	//       kind: sinkkind
+	//       namespace: bar
+	//       name: sinkname
+	//       apiVersion: sinkversion
+	//     uri: uri/parts
+}

--- a/test/rekt/smoke_test.go
+++ b/test/rekt/smoke_test.go
@@ -24,6 +24,7 @@ import (
 	_ "knative.dev/pkg/system/testing"
 
 	"knative.dev/eventing/test/rekt/features/broker"
+	"knative.dev/eventing/test/rekt/features/pingsource"
 )
 
 // TestSmoke_Broker
@@ -31,6 +32,7 @@ func TestSmoke_Broker(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
 
 	names := []string{
 		"default",
@@ -43,8 +45,6 @@ func TestSmoke_Broker(t *testing.T) {
 	for _, name := range names {
 		env.Test(ctx, t, broker.BrokerGoesReady(name, "MTChannelBroker"))
 	}
-
-	env.Finish()
 }
 
 // TestSmoke_Trigger
@@ -52,6 +52,7 @@ func TestSmoke_Trigger(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
 
 	names := []string{
 		"default",
@@ -67,6 +68,23 @@ func TestSmoke_Trigger(t *testing.T) {
 	for _, name := range names {
 		env.Test(ctx, t, broker.TriggerGoesReady(name, brokerName))
 	}
+}
 
-	env.Finish()
+// TestSmoke_PingSource
+func TestSmoke_PingSource(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
+
+	names := []string{
+		"customname",
+		"name-with-dash",
+		"name1with2numbers3",
+		"name63-01234567890123456789012345678901234567890123456789012345",
+	}
+
+	for _, name := range names {
+		env.Test(ctx, t, pingsource.PingSourceGoesReady(name))
+	}
 }


### PR DESCRIPTION
Related to https://github.com/knative/eventing/issues/4952

Adds a simple smoke test in the reconciler testing framework for PingSource v1beta2