### PR TITLE
Add Eventing 1.0 to the roadmap

### DIFF
--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -2,12 +2,12 @@
 
 ## Next 3 Months (Short-term)
 
-### Knative Eventing 1.0
-Releasing Knative Eventing v1.0.
+### Knative Eventing 1.0 Ready 
+Make the current feature set of Eventing ready for a 1.0 release.
 
 **GitHub Issue** https://github.com/knative/eventing/issues/5039
 
-**Owner:** Scott Nichols
+**Owner:** Ville Aikas
 
 ### Event Discovery
 

--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -2,6 +2,13 @@
 
 ## Next 3 Months (Short-term)
 
+### Knative Eventing 1.0
+Releasing Knative Eventing v1.0.
+
+**GitHub Issue** https://github.com/knative/eventing/issues/5039
+
+**Owner:** Scott Nichols
+
 ### Event Discovery
 
 Event discovery have been a needed feature with many attempts to implement it.


### PR DESCRIPTION
With work starting on getting the Eventing v1.0 out, it only makes sense to have it as the top priority item on our roadmap
## Proposed Changes

- Add Eventing 1.0 to the roadmap 
