### PR TITLE
broker changes come from the env.

### DIFF
--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -113,14 +113,8 @@ func TestBrokerWithFlakyDLQ(t *testing.T) {
 func TestBrokerConformance(t *testing.T) {
 	ctx, env := global.Environment(environment.Managed(t))
 
-	cfg := []b.CfgFn{b.WithBrokerClass(eventingGlobal.BrokerClass)}
-
-	if eventingGlobal.BrokerTemplatesDir != "" {
-		cfg = append(cfg, b.WithBrokerTemplateFiles(eventingGlobal.BrokerTemplatesDir))
-	}
-
 	// Install and wait for a Ready Broker.
-	env.Prerequisite(ctx, t, broker.GoesReady("default", cfg...))
+	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))
 }

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -154,7 +154,7 @@ func ControlPlaneTrigger_WithBrokerLifecycle() *feature.Feature {
 			triggerHasOneBroker).
 		Should("A Trigger SHOULD progress to Ready when its assigned Broker exists and is Ready.",
 			func(ctx context.Context, t feature.T) {
-				brokerresources.Install(brokerName)(ctx, t) // Default broker.
+				brokerresources.Install(brokerName, brokerresources.WithEnvConfig()...)(ctx, t) // Default broker from Env.
 				brokerresources.IsReady(brokerName)(ctx, t)
 				triggerresources.IsReady(triggerName)(ctx, t)
 			})

--- a/test/rekt/main_test.go
+++ b/test/rekt/main_test.go
@@ -20,12 +20,8 @@ package rekt
 
 import (
 	"flag"
-	"log"
 	"os"
 	"testing"
-
-	"github.com/kelseyhightower/envconfig"
-	"go.uber.org/zap"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -40,21 +36,10 @@ import (
 // the testing config for the test run. The config will specify the cluster
 // config as well as the parsing level and state flags.
 var global environment.GlobalEnvironment
-var eventingGlobal EventingGlobal
-
-type EventingGlobal struct {
-	BrokerClass        string `envconfig:"BROKER_CLASS" default:"MTChannelBasedBroker" required:"true"`
-	BrokerTemplatesDir string `envconfig:"BROKER_TEMPLATES"`
-}
 
 func init() {
 	// environment.InitFlags registers state and level filter flags.
 	environment.InitFlags(flag.CommandLine)
-
-	// Process EventingGlobal.
-	if err := envconfig.Process("", &eventingGlobal); err != nil {
-		log.Fatal("Failed to process env var", zap.Error(err))
-	}
 }
 
 // TestMain is the first entry point for `go test`.

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -18,8 +18,10 @@ package broker
 
 import (
 	"context"
+	"log"
 	"time"
 
+	"github.com/kelseyhightower/envconfig"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -30,6 +32,29 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+var EnvCfg EnvConfig
+
+type EnvConfig struct {
+	BrokerClass        string `envconfig:"BROKER_CLASS" default:"MTChannelBasedBroker" required:"true"`
+	BrokerTemplatesDir string `envconfig:"BROKER_TEMPLATES"`
+}
+
+func init() {
+	// Process EventingGlobal.
+	if err := envconfig.Process("", &EnvCfg); err != nil {
+		log.Fatal("Failed to process env var", err)
+	}
+}
+
+func WithEnvConfig() []CfgFn {
+	cfg := []CfgFn{WithBrokerClass(EnvCfg.BrokerClass)}
+
+	if EnvCfg.BrokerTemplatesDir != "" {
+		cfg = append(cfg, WithBrokerTemplateFiles(EnvCfg.BrokerTemplatesDir))
+	}
+	return cfg
+}
 
 type CfgFn func(map[string]interface{})
 


### PR DESCRIPTION
Relates to #4934

Downstream conformance testers need just configure the env flags and produce new brokers.