### PR TITLE
Change spec redirects to template used by docs and serving

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/README.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/README.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/README.md">
+# Knative Eventing API spec
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/README.md)

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/broker.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/broker.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/broker.md">
+# Knative Broker Specification
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/broker.md)

--- a/docs/spec/channel.md
+++ b/docs/spec/channel.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/channel.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/channel.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/channel.md">
+# Knative Channel Specification
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/channel.md)

--- a/docs/spec/data-plane.md
+++ b/docs/spec/data-plane.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md">
+# Knative Eventing Data Plane Contracts
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md)

--- a/docs/spec/helper.md
+++ b/docs/spec/helper.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/helper.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/helper.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/helper.md">
+# Implementation Helper
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/helper.md)

--- a/docs/spec/interfaces.md
+++ b/docs/spec/interfaces.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md">
+# Interface Contracts
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md)

--- a/docs/spec/motivation.md
+++ b/docs/spec/motivation.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/motivation.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/motivation.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/motivation.md">
+# Motivation
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/motivation.md)

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/overview.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/overview.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/overview.md">
+# Resource Types
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/overview.md)

--- a/docs/spec/sources.md
+++ b/docs/spec/sources.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/sources.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/sources.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/sources.md">
+# Sources
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/sources.md)

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,5 +1,3 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://github.com/knative/specs/blob/main/specs/eventing/spec.md</title>
-<meta http-equiv="refresh" content="0; URL=https://github.com/knative/specs/blob/main/specs/eventing/spec.md">
-<link rel="canonical" href="https://github.com/knative/specs/blob/main/specs/eventing/spec.md">
+# Object Model
+
+This file has been moved to the [Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/eventing/spec.md)


### PR DESCRIPTION
Fixes #https://github.com/knative/specs/issues/4

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Github UI doesn't follow redirects. So changing the spec files to follow convention used by docs by keeping the title of the document with a link to the new location.
- Serving example: https://github.com/knative/serving/blob/main/docs/spec/errors.md

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
