### PR TITLE
Adjust resources.requests of eventing-webhook

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -52,8 +52,8 @@ spec:
         resources:
           requests:
             # taken from serving.
-            cpu: 20m
-            memory: 20Mi
+            cpu: 100m
+            memory: 50Mi
           limits:
             # taken from serving.
             cpu: 200m


### PR DESCRIPTION
Fixes #4987

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Adjust resources.requests of eventing-webhook
    - Respond to the fact that the eventing-webhook is set to HorizontalPodAutoscaler, which may scale the pod extra if CPU requests are too low.
    - Memory resources were also adjusted, as their usage is clearly higher than the current Requests.

<img width="1815" alt="eventing-webhook-resource" src="https://user-images.githubusercontent.com/4508359/111900450-f91a7700-8a75-11eb-90ca-38973a46f36e.png">

(Intel(R) Core(TM) i3-10110U CPU @ 2.10GHz)

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Fix excessive number of Replicas for eventing-webhook
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
