### PR TITLE
Add create KinD cluster script

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -65,6 +65,9 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
       ARTIFACTS: ${{ github.workspace }}/artifacts
 
+      NODE_VERSION: ${{ matrix.k8s-version }}
+      NODE_SHA: ${{ matrix.kind-image-sha }}
+
     steps:
     - name: Set up Go 1.15.x
       uses: actions/setup-go@v2
@@ -98,43 +101,9 @@ jobs:
         chmod +x ./kind
         sudo mv kind /usr/local/bin
 
-    - name: Configure KinD Cluster
-      working-directory: ./src/knative.dev/eventing
-      run: |
-        set -x
-
-        # KinD configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-
-        # This is needed in order to support projected volumes with service account tokens.
-        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        kubeadmConfigPatches:
-          - |
-            apiVersion: kubeadm.k8s.io/v1beta2
-            kind: ClusterConfiguration
-            metadata:
-              name: config
-            apiServer:
-              extraArgs:
-                "service-account-issuer": "kubernetes.default.svc"
-                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-            networking:
-              dnsDomain: "${CLUSTER_SUFFIX}"
-        nodes:
-        - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        EOF
-
     - name: Create KinD Cluster
       working-directory: ./src/knative.dev/eventing
-      run: |
-        set -x
-
-        kind create cluster --config kind.yaml
+      run: ./hack/create-kind-cluster.sh
 
     - name: Install Knative Eventing
       run: |

--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-"cluster.local"}
+NODE_VERSION=${NODE_VERSION:-"v1.20.0"}
+NODE_SHA=${NODE_SHA:-"sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040"}
+
+dir=$(mktemp -d --suffix=knative)
+
+cat >"${dir}"/kind.yaml <<EOF
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+
+# This is needed in order to support projected volumes with service account tokens.
+# See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+    networking:
+      dnsDomain: "${CLUSTER_SUFFIX}"
+nodes:
+- role: control-plane
+  image: kindest/node:${NODE_VERSION}@${NODE_SHA}
+- role: worker
+  image: kindest/node:${NODE_VERSION}@${NODE_SHA}
+EOF
+
+kind create cluster --config "${dir}/kind.yaml"
+
+rm -r "${dir}"


### PR DESCRIPTION
Every downstream eventing repo inline the creation of the KinD cluster.

- [Eventing Kafka Broker](https://github.com/knative-sandbox/eventing-kafka-broker/blob/a2ee4608aa26e6564399fe0903a0b423b9c6ef41/.github/workflows/kind-e2e.yaml#L106-L140)
- [Eventing Kafka](https://github.com/knative-sandbox/eventing-kafka/blob/12679c8ec25aa43d67493c2b71e1f0221d7d45ed/.github/workflows/kind-e2e.yaml#L95-L132)
- [Eventing RabbitMQ](https://github.com/knative-sandbox/eventing-rabbitmq/blob/454e9e34a866b492630b6dfa9e06092dabe6a56f/.github/workflows/kind-e2e.yaml#L91-L122)
- ...

Note: [Serving needs a container config patch](https://github.com/knative/serving/blob/9ee92b15428fff5db0f15dc2f50756ab1e23e311/.github/workflows/kind-e2e.yaml#L113-L114), so this isn't suitable for a repository like `pkg` or `hack`.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add create KinD cluster script