### PR TITLE
Subscription Channel ref without api version

### DIFF
--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -47,7 +47,7 @@ func NewController(
 
 	r := &Reconciler{
 		dynamicClientSet:   dynamicclient.Get(ctx),
-		crdLister: customresourcedefinition.Get(ctx).Lister(),
+		crdLister:          customresourcedefinition.Get(ctx).Lister(),
 		subscriptionLister: subscriptionInformer.Lister(),
 		channelLister:      channelInformer.Lister(),
 	}

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -19,6 +19,7 @@ package subscription
 import (
 	"context"
 
+	"knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -46,6 +47,7 @@ func NewController(
 
 	r := &Reconciler{
 		dynamicClientSet:   dynamicclient.Get(ctx),
+		crdLister: customresourcedefinition.Get(ctx).Lister(),
 		subscriptionLister: subscriptionInformer.Lister(),
 		channelLister:      channelInformer.Lister(),
 	}

--- a/pkg/reconciler/subscription/controller_test.go
+++ b/pkg/reconciler/subscription/controller_test.go
@@ -23,10 +23,12 @@ import (
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
+	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/fake"
+	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -120,8 +120,8 @@ var (
 	}
 
 	imcGVK = metav1.GroupVersionKind{
-		Group:   "messaging.knative.dev",
-		Kind:    "InMemoryChannel",
+		Group: "messaging.knative.dev",
+		Kind:  "InMemoryChannel",
 	}
 
 	channelV1GVK = metav1.GroupVersionKind{
@@ -276,10 +276,10 @@ func TestAllCases(t *testing.T) {
 				// IMC CRD
 				pkgtesting.NewCustomResourceDefinition(messaging.InMemoryChannelsResource.String(),
 					pkgtesting.WithCustomResourceDefinitionVersions([]apiextensionsv1.CustomResourceDefinitionVersion{{
-						Name: "v1beta1",
+						Name:    "v1beta1",
 						Storage: false,
 					}, {
-						Name: "v1",
+						Name:    "v1",
 						Storage: true,
 					}}),
 				),

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -26,10 +26,6 @@ import (
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/network"
 
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
-
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +41,12 @@ import (
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/resolver"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/apis/messaging"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
+	pkgtesting "knative.dev/eventing/pkg/reconciler/testing"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -114,6 +116,11 @@ var (
 	imcV1GVK = metav1.GroupVersionKind{
 		Group:   "messaging.knative.dev",
 		Version: "v1",
+		Kind:    "InMemoryChannel",
+	}
+
+	imcGVK = metav1.GroupVersionKind{
+		Group:   "messaging.knative.dev",
 		Kind:    "InMemoryChannel",
 	}
 
@@ -207,6 +214,82 @@ func TestAllCases(t *testing.T) {
 				Object: NewSubscription(subscriptionName, testNS,
 					WithSubscriptionUID(subscriptionUID),
 					WithSubscriptionChannel(imcV1GVK, channelName),
+					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
+					WithSubscriptionReply(imcV1GVK, replyName, testNS),
+					WithInitSubscriptionConditions,
+					WithSubscriptionFinalizers(finalizerName),
+					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					// - Status Update -
+					MarkSubscriptionReady,
+				),
+			}},
+		}, {
+			Name: "subscription goes ready without api version",
+			Objects: []runtime.Object{
+				NewSubscription(subscriptionName, testNS,
+					WithSubscriptionUID(subscriptionUID),
+					WithSubscriptionChannel(imcGVK, channelName),
+					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
+					WithSubscriptionReply(imcV1GVK, replyName, testNS),
+					WithInitSubscriptionConditions,
+					WithSubscriptionFinalizers(finalizerName),
+					MarkReferencesResolved,
+					MarkAddedToChannel,
+					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+				),
+				// Subscriber
+				NewUnstructured(subscriberGVK, subscriberName, testNS,
+					WithUnstructuredAddressable(subscriberDNS),
+				),
+				// Reply
+				NewInMemoryChannel(replyName, testNS,
+					WithInitInMemoryChannelConditions,
+					WithInMemoryChannelAddress(replyDNS),
+				),
+				// Channel
+				NewInMemoryChannel(channelName, testNS,
+					WithInitInMemoryChannelConditions,
+					WithInMemoryChannelReady(channelDNS),
+					WithInMemoryChannelSubscribers([]eventingduck.SubscriberSpec{{
+						UID:           subscriptionUID,
+						Generation:    0,
+						SubscriberURI: subscriberURI,
+						ReplyURI:      replyURI,
+					}, {
+						UID:           "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+						Generation:    1,
+						SubscriberURI: apis.HTTP("call2"),
+						ReplyURI:      apis.HTTP("sink2"),
+					}}),
+					WithInMemoryChannelStatusSubscribers([]eventingduck.SubscriberStatus{{
+						UID:                subscriptionUID,
+						ObservedGeneration: 0,
+						Ready:              "True",
+					}, {
+						UID:                "34c5aec8-deb6-11e8-9f32-f2801f1b9fd1",
+						ObservedGeneration: 1,
+						Ready:              "True",
+					}}),
+				),
+				// IMC CRD
+				pkgtesting.NewCustomResourceDefinition(messaging.InMemoryChannelsResource.String(),
+					pkgtesting.WithCustomResourceDefinitionVersions([]apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name: "v1beta1",
+						Storage: false,
+					}, {
+						Name: "v1",
+						Storage: true,
+					}}),
+				),
+			},
+			Key:     testNS + "/" + subscriptionName,
+			WantErr: false,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewSubscription(subscriptionName, testNS,
+					WithSubscriptionUID(subscriptionUID),
+					WithSubscriptionChannel(imcGVK, channelName),
 					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
@@ -1374,6 +1457,7 @@ func TestAllCases(t *testing.T) {
 		ctx = addressable.WithDuck(ctx)
 		r := &Reconciler{
 			dynamicClientSet:    dynamicclient.Get(ctx),
+			crdLister:           listers.GetCustomResourceDefinitionLister(),
 			subscriptionLister:  listers.GetSubscriptionLister(),
 			channelLister:       listers.GetMessagingChannelLister(),
 			channelableTracker:  duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),

--- a/pkg/reconciler/testing/v1/unstructured.go
+++ b/pkg/reconciler/testing/v1/unstructured.go
@@ -60,6 +60,9 @@ func WithUnstructuredAddressable(hostname string) UnstructuredOption {
 }
 
 func apiVersion(gvk metav1.GroupVersionKind) string {
+	if gvk.Version == "" {
+		return gvk.Group
+	}
 	groupVersion := gvk.Version
 	if gvk.Group != "" {
 		groupVersion = gvk.Group + "/" + gvk.Version


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #5086

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Refer to channels without specifying api version

## Additional context

The idea of this PR is described here: https://github.com/knative/eventing/issues/5086#issuecomment-804196548
In short, when the "concrete api version" of a CRD is missing, it queries the resource definition to check what's the storage version and, using the storage version, it performs the reconciliation.

Example log creating a subscription:

```
{"level":"info","ts":"2021-03-23T12:53:58.733Z","logger":"controller","caller":"subscription/subscription.go:330","msg":"Getting channel","commit":"c039526","knative.dev/pod":"eventing-controller-69df4cd754-hgjwr","knative.dev/controller":"knative.dev.eventing.pkg.reconciler.subscription.Reconciler","knative.dev/kind":"messaging.knative.dev.Subscription","knative.dev/traceid":"9f407704-fd86-4c80-a0b9-b3bcea8121a2","knative.dev/key":"default/with-dead-letter-sink","channel":{"kind":"InMemoryChannel","name":"my-channel","apiVersion":"messaging.knative.dev"}}
{"level":"info","ts":"2021-03-23T12:53:58.733Z","logger":"controller","caller":"subscription/subscription.go:337","msg":"Resolved channel ref","commit":"c039526","knative.dev/pod":"eventing-controller-69df4cd754-hgjwr","knative.dev/controller":"knative.dev.eventing.pkg.reconciler.subscription.Reconciler","knative.dev/kind":"messaging.knative.dev.Subscription","knative.dev/traceid":"9f407704-fd86-4c80-a0b9-b3bcea8121a2","knative.dev/key":"default/with-dead-letter-sink","channel":{"kind":"InMemoryChannel","name":"my-channel","apiVersion":"messaging.knative.dev/v1"}}
```

This PR is a working PoC and can be merged as is, although I prefer to refactor https://github.com/knative/eventing/pull/5131/files#diff-f4ab96e0544e474732f224fa784e19598eacbbecd9db8944a4eebbc72c785d35R532 to a more proper place where we can use the same logic for whatever other place we use refs: maybe somewhere in pkg?
 