### PR TITLE
relax malformed ce response code to 4xx

### DIFF
--- a/test/rekt/features/broker/data_plane.go
+++ b/test/rekt/features/broker/data_plane.go
@@ -308,9 +308,9 @@ func brokerRejectsMalformedCE(ctx context.Context, t feature.T) {
 		// above, they do not get stuff into the sent/response SentId fields.
 		events := correlate(store.AssertAtLeast(2, sentEventMatcher("")))
 		for _, e := range events {
-			// Make sure HTTP response code is 400
-			if e.response.StatusCode != 400 {
-				t.Errorf("Expected statuscode 400 with missing required field %q for sequence %d got %d", k, e.response.Sequence, e.response.StatusCode)
+			// Make sure HTTP response code is 4XX
+			if e.response.StatusCode < 400 || e.response.StatusCode > 499 {
+				t.Errorf("Expected statuscode 4XX with missing required field %q for sequence %d got %d", k, e.response.Sequence, e.response.StatusCode)
 				t.Logf("Sent event was: %s\nresponse: %s\n", e.sent.String(), e.response.String())
 			}
 		}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- As per: https://github.com/knative/specs/pull/13 relax the allowed response codes when a CE is malformed.
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
