### PR TITLE
redo smoketests, move one broker test

### DIFF
--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -69,7 +69,7 @@ func ControlPlaneBroker(brokerName string) *feature.Feature {
 
 	f.Stable("Conformance").
 		Should("Broker objects SHOULD include a Ready condition in their status",
-			knconf.KResourceHasReadyInConditions(brokerresources.Gvr(), brokerName)).
+			knconf.KResourceHasReadyInConditions(brokerresources.GVR(), brokerName)).
 		Should("The Broker SHOULD indicate Ready=True when its ingress is available to receive events.",
 			readyBrokerHasIngressAvailable).
 		Should("While a Broker is Ready, it SHOULD be a valid Addressable and its `status.address.url` field SHOULD indicate the address of its ingress.",

--- a/test/rekt/features/broker/ingress.go
+++ b/test/rekt/features/broker/ingress.go
@@ -60,7 +60,7 @@ func brokerIngressConformanceFeature(brokerClass string, version string, enc clo
 
 	f.Setup("install source", eventshub.Install(
 		sourceName,
-		eventshub.StartSenderToResource(broker.Gvr(), brokerName),
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
 		eventshub.InputEventWithEncoding(event, enc),
 	))
 
@@ -95,7 +95,7 @@ func brokerIngressConformanceBadEvent(brokerClass string) *feature.Feature {
 	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
 
 	f.Setup("install source", eventshub.Install(sourceName,
-		eventshub.StartSenderToResource(broker.Gvr(), brokerName),
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
 		eventshub.InputHeader("ce-specversion", "9000.1"),
 		eventshub.InputHeader("ce-type", "sometype"),
 		eventshub.InputHeader("ce-source", "400.request.sender.test.knative.dev"),

--- a/test/rekt/features/broker/readyness.go
+++ b/test/rekt/features/broker/readyness.go
@@ -45,10 +45,10 @@ func TriggerGoesReady(name, brokerName string) *feature.Feature {
 	f.Setup(fmt.Sprintf("install trigger %q", name), trigger.Install(name, brokerName, cfg...))
 
 	// Wait for a ready broker.
-	f.Requirement("broker is ready", broker.IsReady(brokerName))
+	f.Requirement("Broker is ready", broker.IsReady(brokerName))
+	f.Requirement("Trigger is ready", trigger.IsReady(name))
 
-	f.Stable("trigger").
-		Must("be ready", trigger.IsReady(name))
+	f.Stable("trigger")
 
 	return f
 }
@@ -60,8 +60,9 @@ func GoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 
 	f.Setup(fmt.Sprintf("install broker %q", name), broker.Install(name, cfg...))
 
+	f.Requirement("Broker is ready", broker.IsReady(name))
+
 	f.Stable("broker").
-		Must("be ready", broker.IsReady(name)).
 		Must("be addressable", broker.IsAddressable(name))
 
 	return f

--- a/test/rekt/features/channel/data_plane.go
+++ b/test/rekt/features/channel/data_plane.go
@@ -17,7 +17,12 @@ limitations under the License.
 package channel
 
 import (
+	"context"
+
+	"knative.dev/eventing/test/rekt/features/knconf"
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/state"
 )
 
 func DataPlaneConformance(channelName string) *feature.FeatureSet {
@@ -38,7 +43,8 @@ func DataPlaneChannel(channelName string) *feature.Feature {
 
 	f.Stable("Input").
 		Must("Every Channel MUST expose either an HTTP or HTTPS endpoint.", todo).
-		Must("The endpoint(s) MUST conform to 0.3 or 1.0 CloudEvents specification.", todo).
+		Must("The endpoint(s) MUST conform to 0.3 or 1.0 CloudEvents specification.",
+			channelAcceptsCEVersions).
 		MustNot("The Channel MUST NOT perform an upgrade of the passed in version. It MUST emit the event with the same version.", todo).
 		Must("It MUST support both Binary Content Mode and Structured Content Mode of the HTTP Protocol Binding for CloudEvents.", todo).
 		May("When dispatching the event, the channel MAY use a different HTTP Message mode of the one used by the event.", todo).
@@ -90,4 +96,9 @@ func DataPlaneChannel(channelName string) *feature.Feature {
 		// messaging.message_id: the event ID
 
 	return f
+}
+
+func channelAcceptsCEVersions(ctx context.Context, t feature.T) {
+	name := state.GetStringOrFail(ctx, t, ChannelableNameKey)
+	knconf.AcceptsCEVersions(ctx, t, channel_impl.GVR(), name)
 }

--- a/test/rekt/features/channel/readyness.go
+++ b/test/rekt/features/channel/readyness.go
@@ -32,8 +32,9 @@ func GoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 
 	f.Setup(fmt.Sprintf("install a Channel named %q", name), channel.Install(name, cfg...))
 
+	f.Requirement("Channel is ready", channel.IsReady(name))
+
 	f.Stable("Channel").
-		Must("be ready", channel.IsReady(name)).
 		Must("be addressable", channel.IsAddressable(name))
 
 	return f
@@ -45,8 +46,9 @@ func ImplGoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 
 	f.Setup(fmt.Sprintf("install a %s named %q", channel_impl.GVK().Kind, name), channel_impl.Install(name, cfg...))
 
+	f.Requirement(channel_impl.GVK().Kind+" is ready", channel_impl.IsReady(name))
+
 	f.Stable("ChannelImpl").
-		Must("be ready", channel_impl.IsReady(name)).
 		Must("be addressable", channel_impl.IsAddressable(name))
 
 	return f
@@ -59,8 +61,9 @@ func SubscriptionGoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature 
 
 	f.Setup(fmt.Sprintf("install a Subscription named %q", name), subscription.Install(name, cfg...))
 
-	f.Stable("Subscription").
-		Must("be ready", subscription.IsReady(name))
+	f.Requirement("Subscription is ready", subscription.IsReady(name))
+
+	f.Stable("Subscription")
 
 	return f
 }

--- a/test/rekt/features/knconf/data_plane.go
+++ b/test/rekt/features/knconf/data_plane.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knconf
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/feature"
+	eventshubmain "knative.dev/reconciler-test/pkg/test_images/eventshub"
+)
+
+func AcceptsCEVersions(ctx context.Context, t feature.T, gvr schema.GroupVersionResource, name string) {
+	u, err := addressable.Address(ctx, gvr, name)
+	if err != nil || u == nil {
+		t.Error("failed to get the address of the resource", gvr, name, err)
+	}
+
+	opts := []eventshub.EventsHubOption{eventshub.StartSenderToResource(gvr, name)}
+
+	uuids := map[string]string{
+		uuid.New().String(): "1.0",
+		uuid.New().String(): "0.3",
+	}
+	for id, version := range uuids {
+		// We need to use a different source name, otherwise, it will try to update
+		// the pod, which is immutable.
+		source := feature.MakeRandomK8sName("source")
+		event := FullEvent()
+		event.SetID(id)
+		event.SetSpecVersion(version)
+		opts = append(opts, eventshub.InputEvent(event))
+
+		eventshub.Install(source, opts...)(ctx, t)
+		store := eventshub.StoreFromContext(ctx, source)
+		// We are looking for two events, one of them is the sent event and the other
+		// is Response, so correlate them first. We want to make sure the event was sent and that the
+		// response was what was expected.
+		events := Correlate(store.AssertAtLeast(2, SentEventMatcher(id)))
+		for _, e := range events {
+			// Make sure HTTP response code is 2XX
+			if e.Response.StatusCode < 200 || e.Response.StatusCode > 299 {
+				t.Errorf("Expected statuscode 2XX for sequence %d got %d", e.Response.Sequence, e.Response.StatusCode)
+			}
+		}
+	}
+}
+
+type EventInfoCombined struct {
+	Sent     eventshubmain.EventInfo
+	Response eventshubmain.EventInfo
+}
+
+func SentEventMatcher(uuid string) func(eventshubmain.EventInfo) error {
+	return func(ei eventshubmain.EventInfo) error {
+		if (ei.Kind == eventshubmain.EventSent || ei.Kind == eventshubmain.EventResponse) && ei.SentId == uuid {
+			return nil
+		}
+		return errors.New("no match")
+	}
+}
+
+// Correlate takes in an array of mixed Sent / Response events (matched with sentEventMatcher for example)
+// and correlates them based on the sequence into a pair.
+func Correlate(in []eventshubmain.EventInfo) []EventInfoCombined {
+	var out []EventInfoCombined
+	// not too many events, this will suffice...
+	for i, e := range in {
+		if e.Kind == eventshubmain.EventSent {
+			looking := e.Sequence
+			for j := i + 1; j <= len(in)-1; j++ {
+				if in[j].Kind == eventshubmain.EventResponse && in[j].Sequence == looking {
+					out = append(out, EventInfoCombined{Sent: e, Response: in[j]})
+				}
+			}
+		}
+	}
+	return out
+}

--- a/test/rekt/features/pingsource/readyness.go
+++ b/test/rekt/features/pingsource/readyness.go
@@ -37,10 +37,11 @@ func PingSourceGoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 		APIVersion: "v1",
 	}, ""))
 
-	f.Setup("install a pingsource", pingsource.Install(name, cfg...))
+	f.Setup("install a PingSource", pingsource.Install(name, cfg...))
 
-	f.Stable("pingsource").
-		Must("be ready", pingsource.IsReady(name))
+	f.Requirement("PingSource is ready", pingsource.IsReady(name))
+
+	f.Stable("PingSource")
 
 	return f
 }

--- a/test/rekt/features/sinkbinding/readyness.go
+++ b/test/rekt/features/sinkbinding/readyness.go
@@ -25,8 +25,9 @@ import (
 func GoesReady(name string) *feature.Feature {
 	f := feature.NewFeatureNamed("SinkBinding goes ready.")
 
-	f.Stable("sinkbinding").
-		Must("be ready", sinkbinding.IsReady(name))
+	f.Requirement("SinkBinding is ready", sinkbinding.IsReady(name))
+
+	f.Stable("sinkbinding")
 
 	return f
 }

--- a/test/rekt/resources/addressable/addressable.go
+++ b/test/rekt/resources/addressable/addressable.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addressable
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis"
+	"knative.dev/reconciler-test/pkg/k8s"
+)
+
+// Address returns a broker's address.
+func Address(ctx context.Context, gvr schema.GroupVersionResource, name string, timings ...time.Duration) (*apis.URL, error) {
+	interval, timeout := k8s.PollTimings(ctx, timings)
+	var addr *apis.URL
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		addr, err = k8s.Address(ctx, gvr, name)
+		if err == nil && addr == nil {
+			// keep polling
+			return false, nil
+		}
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// keep polling
+				return false, nil
+			}
+			// seems fatal.
+			return false, err
+		}
+		// success!
+		return true, nil
+	})
+	return addr, err
+}

--- a/test/rekt/resources/channel/channel.go
+++ b/test/rekt/resources/channel/channel.go
@@ -20,16 +20,12 @@ import (
 	"context"
 	"time"
 
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/pkg/apis"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/reconciler-test/pkg/k8s"
-
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
@@ -69,27 +65,7 @@ func IsAddressable(name string, timing ...time.Duration) feature.StepFn {
 
 // Address returns a Channel's address.
 func Address(ctx context.Context, name string, timings ...time.Duration) (*apis.URL, error) {
-	interval, timeout := k8s.PollTimings(ctx, timings)
-	var addr *apis.URL
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		var err error
-		addr, err = k8s.Address(ctx, GVR(), name)
-		if err == nil && addr == nil {
-			// keep polling
-			return false, nil
-		}
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// keep polling
-				return false, nil
-			}
-			// seems fatal.
-			return false, err
-		}
-		// success!
-		return true, nil
-	})
-	return addr, err
+	return addressable.Address(ctx, GVR(), name, timings...)
 }
 
 // AsRef returns a KRef for a Channel without namespace.

--- a/test/rekt/resources/channel_impl/channel_impl.go
+++ b/test/rekt/resources/channel_impl/channel_impl.go
@@ -22,10 +22,9 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/eventing/test/rekt/resources/addressable"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -87,27 +86,7 @@ func IsAddressable(name string, timing ...time.Duration) feature.StepFn {
 
 // Address returns a Channel's address.
 func Address(ctx context.Context, name string, timings ...time.Duration) (*apis.URL, error) {
-	interval, timeout := k8s.PollTimings(ctx, timings)
-	var addr *apis.URL
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		var err error
-		addr, err = k8s.Address(ctx, GVR(), name)
-		if err == nil && addr == nil {
-			// keep polling
-			return false, nil
-		}
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// keep polling
-				return false, nil
-			}
-			// seems fatal.
-			return false, err
-		}
-		// success!
-		return true, nil
-	})
-	return addr, err
+	return addressable.Address(ctx, GVR(), name, timings...)
 }
 
 // AsRef returns a KRef for a Channel without namespace.


### PR DESCRIPTION
Related to https://github.com/knative/eventing/issues/4935

Update smoke tests to not assert readyness of DUT, make it a requirement for the feature.

Use a test for the broker, move it to a common place so channel can use it
