### PR TITLE
make sure the mtchannelbasedbroker uses trigger.spec.delivery

### DIFF
--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -163,7 +163,13 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *eventingv1
 		Name:       b.Name,
 		Namespace:  b.Namespace,
 	}
-	expected := resources.NewSubscription(t, brokerTrigger, brokerObjRef, uri, b.Spec.Delivery)
+
+	delivery := t.Spec.Delivery
+	if delivery == nil {
+		delivery = b.Spec.Delivery
+	}
+
+	expected := resources.NewSubscription(t, brokerTrigger, brokerObjRef, uri, delivery)
 
 	sub, err := r.subscriptionLister.Subscriptions(t.Namespace).Get(expected.Name)
 	// If the resource doesn't exist, we'll create it.

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -19,18 +19,15 @@ package mttrigger
 import (
 	"context"
 	"fmt"
-	"knative.dev/pkg/ptr"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -54,6 +51,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/resolver"
 
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -18,16 +18,16 @@ package testing
 
 import (
 	"context"
-	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	"knative.dev/pkg/ptr"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/ptr"
 )
 
 // TriggerOption enables further configuration of a Trigger.


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/5266

## Proposed Changes

- :bug: Propagate trigger.spec.delivery to subscriptions for MTChannelBasedBroker.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Bug fix: Propagate trigger.spec.delivery to subscriptions for MTChannelBasedBroker.
```

