### PR TITLE
Running validation for events on broker ingress

### DIFF
--- a/pkg/broker/ingress/ingress_handler.go
+++ b/pkg/broker/ingress/ingress_handler.go
@@ -132,6 +132,14 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	// run validation for the extracted event
+	validationErr := event.Validate()
+	if validationErr != nil {
+		h.Logger.Warn("failed to validate extractd event", zap.Error(validationErr))
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	brokerNamespace := nsBrokerName[1]
 	brokerName := nsBrokerName[2]
 	brokerNamespacedName := types.NamespacedName{

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -127,6 +127,18 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			name:       "invalid event",
+			method:     nethttp.MethodPost,
+			uri:        "/ns/name",
+			body:       getInvalidEvent(),
+			statusCode: nethttp.StatusBadRequest,
+			handler:    handler(),
+			reporter:   &mockReporter{},
+			brokers: []*eventingv1.Broker{
+				makeBroker("name", "ns"),
+			},
+		},
+		{
 			name:       "no TTL drop event",
 			method:     nethttp.MethodPost,
 			uri:        "/ns/name",
@@ -310,6 +322,14 @@ func getValidEvent() io.Reader {
 	e := event.New()
 	e.SetType("type")
 	e.SetSource("source")
+	e.SetID("1234")
+	b, _ := e.MarshalJSON()
+	return bytes.NewBuffer(b)
+}
+
+func getInvalidEvent() io.Reader {
+	e := event.New()
+	e.SetType("type")
 	e.SetID("1234")
 	b, _ := e.MarshalJSON()
 	return bytes.NewBuffer(b)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #5143

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- running validation of the extracted cloudevent.


<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Runnng validation for event ingress on mt broker 
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
