### PR TITLE
Remove KafkaChannel upgrade hack

### DIFF
--- a/pkg/apis/messaging/v1/subscription_defaults.go
+++ b/pkg/apis/messaging/v1/subscription_defaults.go
@@ -24,10 +24,4 @@ func (s *Subscription) SetDefaults(ctx context.Context) {
 	s.Spec.SetDefaults(ctx)
 }
 
-func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {
-	// HACK if a channel ref is a kafka channel ref, we need to hack it around to use only v1beta1
-	//  TODO(slinkydeveloper) REMOVE AFTER 0.22 release
-	if ss.Channel.Kind == "KafkaChannel" && ss.Channel.APIVersion == "messaging.knative.dev/v1alpha1" {
-		ss.Channel.APIVersion = "messaging.knative.dev/v1beta1"
-	}
-}
+func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {}

--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -80,16 +80,8 @@ func (s *Subscription) CheckImmutableFields(ctx context.Context, original *Subsc
 		return nil
 	}
 
-	// TODO(slinkydeveloper)
-	//  HACK around the immutability check to make sure the update script can upgrade the api version
-	//  REMOVE AFTER 0.22 release
-	ignoredFields := []string{"Subscriber", "Reply"}
-	if original.Spec.Channel.Kind == "KafkaChannel" && original.Spec.Channel.APIVersion == "messaging.knative.dev/v1alpha1" && s.Spec.Channel.APIVersion == "messaging.knative.dev/v1beta1" {
-		ignoredFields = append(ignoredFields, "Channel.APIVersion")
-	}
-
 	// Only Subscriber and Reply are mutable.
-	ignoreArguments := cmpopts.IgnoreFields(SubscriptionSpec{}, ignoredFields...)
+	ignoreArguments := cmpopts.IgnoreFields(SubscriptionSpec{}, "Subscriber", "Reply")
 	if diff, err := kmp.ShortDiff(original.Spec, s.Spec, ignoreArguments); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff Subscription",

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -330,29 +330,6 @@ func TestSubscriptionImmutable(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "valid, kafkachannel hack",
-		c: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel: corev1.ObjectReference{
-					Name:       channelName,
-					Kind:       "KafkaChannel",
-					APIVersion: "messaging.knative.dev/v1beta1",
-				},
-				Subscriber: getValidDestination(),
-			},
-		},
-		og: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel: corev1.ObjectReference{
-					Name:       channelName,
-					Kind:       "KafkaChannel",
-					APIVersion: "messaging.knative.dev/v1alpha1",
-				},
-				Subscriber: getValidDestination(),
-			},
-		},
-		want: nil,
-	}, {
 		name: "Channel changed",
 		c: &Subscription{
 			Spec: SubscriptionSpec{


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Reverts https://github.com/knative/eventing/pull/5085, which was required in 0.22 release to upgrade kafka channel