### PR TITLE
[Rekt] adding more polling for channel tests

### DIFF
--- a/test/rekt/features/channel/data_plane.go
+++ b/test/rekt/features/channel/data_plane.go
@@ -41,6 +41,8 @@ func DataPlaneChannel(channelName string) *feature.Feature {
 
 	f.Setup("Set Channel Name", setChannelableName(channelName))
 
+	f.Requirement("Channel is Ready", channel_impl.IsReady(channelName))
+
 	f.Stable("Input").
 		Must("Every Channel MUST expose either an HTTP or HTTPS endpoint.", todo).
 		Must("The endpoint(s) MUST conform to 0.3 or 1.0 CloudEvents specification.",


### PR DESCRIPTION
Fixing some more race conditions. It is a bit too easy to write tests that fail based on racing. We will look into how to fix this more generally.