### PR TITLE
Improve performance of eventfilter lookups

### DIFF
--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -163,3 +163,41 @@ func attributesWithSubject(t, s, sub string) map[string]string {
 		"subject": sub,
 	}
 }
+
+func TestAllSupportedAttributeFieldsV1(t *testing.T) {
+	e := cloudevents.NewEvent(cloudevents.VersionV1)
+	e.SetType(eventType)
+	e.SetSource(eventSource)
+	e.SetID("1234")
+	e.SetDataSchema("wow")
+	e.SetSubject("cool")
+	e.SetDataContentType("cheers;mate")
+
+	attributes := map[string]string{
+		"specversion":     e.SpecVersion(),
+		"type":            e.Type(),
+		"source":          e.Source(),
+		"subject":         e.Subject(),
+		"id":              e.ID(),
+		"time":            e.Time().String(),
+		"dataschema":      e.DataSchema(),
+		"schemaurl":       e.DataSchema(),
+		"datacontenttype": e.DataContentType(),
+		"datamediatype":   e.DataMediaType(),
+	}
+	if result := NewAttributesFilter(attributes).Filter(context.TODO(), e); result != eventfilter.PassFilter {
+		t.Errorf("Expected pass, got %v", result)
+	}
+}
+
+func TestV03Event(t *testing.T) {
+	e := cloudevents.NewEvent(cloudevents.VersionV03)
+	e.SetDataContentEncoding("perfect")
+
+	attributes := map[string]string{
+		"datacontentencoding": e.DeprecatedDataContentEncoding(),
+	}
+	if result := NewAttributesFilter(attributes).Filter(context.TODO(), e); result != eventfilter.PassFilter {
+		t.Errorf("Expected pass, got %v", result)
+	}
+}


### PR DESCRIPTION
Only do event field lookups as needed, don't pre-emptively cache them into a map

Fixes #5277 

Previous:
```
$ go test -benchtime 10s -bench=. ./pkg/eventfilter/benchmarks/
goos: linux
goarch: amd64
pkg: knative.dev/eventing/pkg/eventfilter/benchmarks
cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_id-12              1000000000               2.699 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_id-12                    1675917              7419 ns/op
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)-12            1000000000               2.697 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)-12                  1697353              7299 ns/op
BenchmarkAttributesFilter/Creation:_No_pass_with_exact_match_of_id_and_source-12                                1000000000               2.683 ns/op
BenchmarkAttributesFilter/Run:_No_pass_with_exact_match_of_id_and_source-12                                      1570285              6987 ns/op
```

Now:
```
$ go test -benchtime 10s -bench=. ./pkg/eventfilter/benchmarks/
goos: linux
goarch: amd64
pkg: knative.dev/eventing/pkg/eventfilter/benchmarks
cpu: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_id-12              1000000000               2.686 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_id-12                   143855318               82.71 ns/op
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)-12            1000000000               2.689 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)-12                 14394333               999.9 ns/op
BenchmarkAttributesFilter/Creation:_No_pass_with_exact_match_of_id_and_source-12                                1000000000               2.733 ns/op
BenchmarkAttributesFilter/Run:_No_pass_with_exact_match_of_id_and_source-12                                     39759967               563.0 ns/op
```

**Release Note**

```release-note
:page_facing_up: MTChannelBasedBrokers will see improved filter performance for triggers with few or no trigger filters
```
