### PR TITLE
Clean up resources created by Feature tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	knative.dev/hack v0.0.0-20210325223819-b6ab329907d3
 	knative.dev/hack/schema v0.0.0-20210325223819-b6ab329907d3
 	knative.dev/pkg v0.0.0-20210420053235-1afd04993622
-	knative.dev/reconciler-test v0.0.0-20210420201836-15b4e1222865
 	knative.dev/reconciler-test v0.0.0-20210420215136-4598ca0f0602
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 )
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+
+replace knative.dev/reconciler-test => github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76

--- a/go.mod
+++ b/go.mod
@@ -44,9 +44,8 @@ require (
 	knative.dev/hack/schema v0.0.0-20210325223819-b6ab329907d3
 	knative.dev/pkg v0.0.0-20210420053235-1afd04993622
 	knative.dev/reconciler-test v0.0.0-20210420201836-15b4e1222865
+	knative.dev/reconciler-test v0.0.0-20210420215136-4598ca0f0602
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
-
-replace knative.dev/reconciler-test => github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76

--- a/go.sum
+++ b/go.sum
@@ -632,6 +632,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76 h1:emQwIpp9B9YuuToSasp/dq91NxY2DOzjlwBGwn+2kPg=
+github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76/go.mod h1:yZihS1XoBt7oxU6Jq+U2hMKmUvfKFEaj3vMqOMBt/tI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76 h1:emQwIpp9B9YuuToSasp/dq91NxY2DOzjlwBGwn+2kPg=
-github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76/go.mod h1:yZihS1XoBt7oxU6Jq+U2hMKmUvfKFEaj3vMqOMBt/tI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
@@ -1124,8 +1122,8 @@ knative.dev/hack/schema v0.0.0-20210325223819-b6ab329907d3 h1:F/pVm+rB+WpyVhH9cm
 knative.dev/hack/schema v0.0.0-20210325223819-b6ab329907d3/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/pkg v0.0.0-20210420053235-1afd04993622 h1:wSyDPp/LuOLeDCpvUHgKXqb4DfmCEPelsaYzC0Fojm0=
 knative.dev/pkg v0.0.0-20210420053235-1afd04993622/go.mod h1:UtcSLHy2XIz5blWoPTA40F87zk4O7erxkCwv+7Tsmws=
-knative.dev/reconciler-test v0.0.0-20210420201836-15b4e1222865 h1:Flf/ZPKa76ynJhHltE1+RpB+0oDum44Wlfz9ednc7l4=
-knative.dev/reconciler-test v0.0.0-20210420201836-15b4e1222865/go.mod h1:yZihS1XoBt7oxU6Jq+U2hMKmUvfKFEaj3vMqOMBt/tI=
+knative.dev/reconciler-test v0.0.0-20210420215136-4598ca0f0602 h1:+EGg+hRVnOdgBPID/ngPjjN2BCOY1xV983BKan+SDhk=
+knative.dev/reconciler-test v0.0.0-20210420215136-4598ca0f0602/go.mod h1:yZihS1XoBt7oxU6Jq+U2hMKmUvfKFEaj3vMqOMBt/tI=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -123,18 +123,3 @@ func TestBrokerConformance(t *testing.T) {
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))
 }
-
-// DO NOT CHECK IN
-func TestBrokerConformanceOneOff(t *testing.T) {
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	// Install and wait for a Ready Broker.
-	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
-	env.TestSet(ctx, t, broker.ControlPlaneConformanceOneOff("default"))
-}

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -123,3 +123,18 @@ func TestBrokerConformance(t *testing.T) {
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))
 }
+
+// DO NOT CHECK IN
+func TestBrokerConformanceOneOff(t *testing.T) {
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	// Install and wait for a Ready Broker.
+	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
+	env.TestSet(ctx, t, broker.ControlPlaneConformanceOneOff("default"))
+}

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -46,6 +46,21 @@ import (
 	"knative.dev/reconciler-test/resources/svc"
 )
 
+// DO NOT SUBMIT
+func ControlPlaneConformanceOneOff(brokerName string) *feature.FeatureSet {
+	fs := &feature.FeatureSet{
+		Name:     "VAIKAS Knative Broker Specification - Control Plane",
+		Features: []feature.Feature{},
+	}
+
+	// Add each feature of event routing and Delivery tests as a new feature
+	addControlPlaneEventRouting(fs)
+	// TODO: This is not a control plane test, or at best it is a blend with data plane.
+	// Must("Events that pass the attributes filter MUST include context or extension attributes that match all key-value pairs exactly.", todo)
+
+	return fs
+}
+
 func ControlPlaneConformance(brokerName string) *feature.FeatureSet {
 	fs := &feature.FeatureSet{
 		Name: "Knative Broker Specification - Control Plane",
@@ -364,9 +379,17 @@ func addControlPlaneDelivery(fs *feature.FeatureSet) {
 				t.Failed()
 			}
 		})
-
 		f.Stable("Conformance").Should(tt.name, assertExpectedEvents(prober, expectedEvents))
 		fs.Features = append(fs.Features, *f)
+	}
+}
+
+func deleteFeatureResources() feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		f := feature.FromContext(ctx)
+		for _, ref := range f.References() {
+			t.Logf("WOULD DELETE HERE!! : CLEANING UP for feature %q RESOURCE: %+v", f.Name, ref)
+		}
 	}
 }
 
@@ -557,6 +580,7 @@ func addControlPlaneEventRouting(fs *feature.FeatureSet) {
 		})
 
 		f.Stable("Conformance").Should(tt.name, assertExpectedRoutedEvents(prober, expectedEvents))
+		f.Teardown("DUMP RESOURCES", deleteFeatureResources())
 		fs.Features = append(fs.Features, *f)
 	}
 }

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -36,7 +37,9 @@ import (
 	brokerresources "knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/delivery"
 	triggerresources "knative.dev/eventing/test/rekt/resources/trigger"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/ptr"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
@@ -45,21 +48,6 @@ import (
 	"knative.dev/reconciler-test/pkg/state"
 	"knative.dev/reconciler-test/resources/svc"
 )
-
-// DO NOT SUBMIT
-func ControlPlaneConformanceOneOff(brokerName string) *feature.FeatureSet {
-	fs := &feature.FeatureSet{
-		Name:     "VAIKAS Knative Broker Specification - Control Plane",
-		Features: []feature.Feature{},
-	}
-
-	// Add each feature of event routing and Delivery tests as a new feature
-	addControlPlaneEventRouting(fs)
-	// TODO: This is not a control plane test, or at best it is a blend with data plane.
-	// Must("Events that pass the attributes filter MUST include context or extension attributes that match all key-value pairs exactly.", todo)
-
-	return fs
-}
 
 func ControlPlaneConformance(brokerName string) *feature.FeatureSet {
 	fs := &feature.FeatureSet{
@@ -380,15 +368,26 @@ func addControlPlaneDelivery(fs *feature.FeatureSet) {
 			}
 		})
 		f.Stable("Conformance").Should(tt.name, assertExpectedEvents(prober, expectedEvents))
+		f.Teardown("Delete feature resources", deleteFeatureResources())
 		fs.Features = append(fs.Features, *f)
 	}
 }
 
 func deleteFeatureResources() feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
+		dc := dynamicclient.Get(ctx)
 		f := feature.FromContext(ctx)
 		for _, ref := range f.References() {
-			t.Logf("WOULD DELETE HERE!! : CLEANING UP for feature %q RESOURCE: %+v", f.Name, ref)
+			gv, err := schema.ParseGroupVersion(ref.APIVersion)
+			if err != nil {
+				t.Errorf("Could not parse GroupVersion for %+v", ref.APIVersion)
+			} else {
+				resource := apis.KindToResource(gv.WithKind(ref.Kind))
+				t.Logf("Deleting %s/%s of GVR: %+v", ref.Namespace, ref.Name, resource)
+				if err := dc.Resource(resource).Namespace(ref.Namespace).Delete(ctx, ref.Name, *metav1.NewDeleteOptions(0)); err != nil {
+					t.Logf("Failed to delete during cleanup %s/%s of GVR: %+v", ref.Namespace, ref.Name, resource)
+				}
+			}
 		}
 	}
 }
@@ -580,7 +579,7 @@ func addControlPlaneEventRouting(fs *feature.FeatureSet) {
 		})
 
 		f.Stable("Conformance").Should(tt.name, assertExpectedRoutedEvents(prober, expectedEvents))
-		f.Teardown("DUMP RESOURCES", deleteFeatureResources())
+		f.Teardown("Delete feature resources", deleteFeatureResources())
 		fs.Features = append(fs.Features, *f)
 	}
 }

--- a/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
@@ -218,6 +218,7 @@ func (mr *MagicEnvironment) Test(ctx context.Context, originalT *testing.T, f *f
 		f.State = &state.KVStore{}
 	}
 	ctx = state.ContextWith(ctx, f.State)
+	ctx = feature.ContextWith(ctx, f)
 
 	steps := categorizeSteps(f.Steps)
 

--- a/vendor/knative.dev/reconciler-test/pkg/feature/context.go
+++ b/vendor/knative.dev/reconciler-test/pkg/feature/context.go
@@ -35,5 +35,5 @@ func FromContext(ctx context.Context) *Feature {
 	if e, ok := ctx.Value(envKey{}).(*Feature); ok {
 		return e
 	}
-	panic("no Store found in context")
+	panic("no Feature found in context")
 }

--- a/vendor/knative.dev/reconciler-test/pkg/feature/context.go
+++ b/vendor/knative.dev/reconciler-test/pkg/feature/context.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"context"
+)
+
+type envKey struct{}
+
+// ContextWith decorates the given context with the provided Feature, and returns
+// the resulting context.
+func ContextWith(ctx context.Context, f *Feature) context.Context {
+	return context.WithValue(ctx, envKey{}, f)
+}
+
+// FromContext returns the Feature from Context, if not found FromContext will
+// panic.
+// TODO: revisit if we really want to panic here... likely not.
+func FromContext(ctx context.Context) *Feature {
+	if e, ok := ctx.Value(envKey{}).(*Feature); ok {
+		return e
+	}
+	panic("no Store found in context")
+}

--- a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+++ b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
@@ -22,6 +22,8 @@ import (
 	"runtime"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"knative.dev/reconciler-test/pkg/state"
 )
 
@@ -30,6 +32,8 @@ type Feature struct {
 	Name  string
 	Steps []Step
 	State state.Store
+	// Contains all the resources created as part of this Feature.
+	refs []corev1.ObjectReference
 }
 
 // NewFeatureNamed creates a new feature with the provided name
@@ -81,6 +85,16 @@ func (s *Step) TestName() string {
 	default:
 		return s.Name
 	}
+}
+
+// Reference adds references to keep track of for example, for cleaning things
+// after a Feature completes.
+func (f *Feature) Reference(ref ...corev1.ObjectReference) {
+	f.refs = append(f.refs, ref...)
+}
+
+func (f *Feature) References() []corev1.ObjectReference {
+	return f.refs
 }
 
 // Setup adds a step function to the feature set at the Setup timing phase.

--- a/vendor/knative.dev/reconciler-test/pkg/manifest/installer.go
+++ b/vendor/knative.dev/reconciler-test/pkg/manifest/installer.go
@@ -28,6 +28,7 @@ import (
 
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 )
 
 // CfgFn is the function signature of configuration mutation options.
@@ -36,6 +37,7 @@ type CfgFn func(map[string]interface{})
 func InstallYaml(ctx context.Context, dir string, base map[string]interface{}) (Manifest, error) {
 	env := environment.FromContext(ctx)
 	cfg := env.TemplateConfig(base)
+	f := feature.FromContext(ctx)
 
 	yamls, err := ParseTemplates(dir, env.Images(), cfg)
 	if err != nil {
@@ -54,8 +56,9 @@ func InstallYaml(ctx context.Context, dir string, base map[string]interface{}) (
 		return manifest, err
 	}
 
-	// Save the refs.
+	// Save the refs to Environment and Feature
 	env.Reference(manifest.References()...)
+	f.Reference(manifest.References()...)
 
 	// Temp
 	refs := manifest.References()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1110,7 +1110,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20210420201836-15b4e1222865
+# knative.dev/reconciler-test v0.0.0-20210420215136-4598ca0f0602
 ## explicit
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1137,4 +1137,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit
 sigs.k8s.io/yaml
 # github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
-# knative.dev/reconciler-test => github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1137,3 +1137,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit
 sigs.k8s.io/yaml
 # github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+# knative.dev/reconciler-test => github.com/vaikas/reconciler-test v0.0.0-20210420211313-1bd73ea90a76


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :gift: Delete k8s resources created in Features. Important for some environments where we create many resources and the footprint may not be light.
- Utilizes https://github.com/knative-sandbox/reconciler-test/pull/183
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
