### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -244,12 +244,12 @@ function unleash_duck() {
   echo "enable debug logging"
   cat test/config/config-logging.yaml | \
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" | \
-    ko apply --strict ${KO_FLAGS} -f - || return $?
+    ko apply ${KO_FLAGS} -f - || return $?
 
   echo "unleash the duck"
   cat test/config/chaosduck.yaml | \
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" | \
-    ko apply --strict ${KO_FLAGS} -f - || return $?
+    ko apply ${KO_FLAGS} -f - || return $?
 }
 
 # Teardown the Knative environment after tests finish.


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

/assign @matzew @slinkydeveloper 