### PR TITLE
Enable to scale chaosduck down to zero for prow test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -61,6 +61,9 @@ If you have set up a running environment that meets
 with
 `test/e2e-tests.sh --run-tests --skip-knative-setup --gcp-project-id=$PROJECT_ID`.
 
+If you want to turn off the [`chaosduck`](config/chaosduck/chaosduck.yaml) during the test,
+you can set `$SCALE_CHAOSDUCK_TO_ZERO` to 1.
+
 ## Running tests with `go test` command
 
 ### Running unit tests

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -58,6 +58,8 @@ readonly REPLICAS=3
 # Should deploy a Knative Monitoring as well
 readonly DEPLOY_KNATIVE_MONITORING="${DEPLOY_KNATIVE_MONITORING:-1}"
 
+readonly SCALE_CHAOSDUCK_TO_ZERO="${SCALE_CHAOSDUCK_TO_ZERO:-0}"
+
 TMP_DIR=$(mktemp -d -t "ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX")
 readonly TMP_DIR
 readonly KNATIVE_DEFAULT_NAMESPACE="knative-eventing"
@@ -170,6 +172,8 @@ function install_knative_eventing() {
   kubectl replace -f ${TMP_CONFIG_TRACING_CONFIG}
 
   scale_controlplane eventing-webhook eventing-controller
+
+  if (( SCALE_CHAOSDUCK_TO_ZERO )); then kubectl -n "${SYSTEM_NAMESPACE}" scale deployment/chaosduck --replicas=0; fi
 
   wait_until_pods_running ${SYSTEM_NAMESPACE} || fail_test "Knative Eventing did not come up"
 


### PR DESCRIPTION
Fixes #5292 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- If an environment variable (e.g. `SCALE_CHAOSDUCK_TO_ZERO`) is set to 1 when running the `test/e2e-tests.sh`, the chaosduck deployment scales the corresponding pod down to 0.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

