### PR TITLE
Check SCALE_CHAOSDUCK_TO_ZERO after the chaosduck is deployed

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -173,8 +173,6 @@ function install_knative_eventing() {
 
   scale_controlplane eventing-webhook eventing-controller
 
-  if (( SCALE_CHAOSDUCK_TO_ZERO )); then kubectl -n "${SYSTEM_NAMESPACE}" scale deployment/chaosduck --replicas=0; fi
-
   wait_until_pods_running ${SYSTEM_NAMESPACE} || fail_test "Knative Eventing did not come up"
 
   echo "check the config map"
@@ -254,6 +252,7 @@ function unleash_duck() {
   cat test/config/chaosduck.yaml | \
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" | \
     ko apply ${KO_FLAGS} -f - || return $?
+    if (( SCALE_CHAOSDUCK_TO_ZERO )); then kubectl -n "${SYSTEM_NAMESPACE}" scale deployment/chaosduck --replicas=0; fi
 }
 
 # Teardown the Knative environment after tests finish.


### PR DESCRIPTION
The current location of checking `$SCALE_CHAOSDUCK_TO_ZERO` is wrongly placed.  If the env variable is set to 1, an error occurs during the test as follows:

```
Error from server (NotFound): deployments.apps "chaosduck" not found
```

This PR is to relocate the code to get called after the `chaosduck` is deployed. The change is tested via the local `phaino` test. If the env variable is set to 1, the `chaosduck` gets scaled to 0 and the following messages are logged as expected.

```
deployment.apps/chaosduck created
deployment.apps/chaosduck scaled
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Relocate the code after the `chaosduck` is deployed

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

