### PR TITLE
Use test namespaces with numeric suffix

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -47,6 +47,7 @@ var brokerClass string
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeEventingFlags()
+		testlib.ReuseNamespace = test.EventingFlags.ReuseNamespace
 		channelTestRunner = testlib.ComponentsTestRunner{
 			ComponentFeatureMap: testlib.ChannelFeatureMap,
 			ComponentsToTest:    test.EventingFlags.Channels,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -33,6 +33,7 @@ var brokerClass string
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
+	testlib.ReuseNamespace = test.EventingFlags.ReuseNamespace
 	channelTestRunner = testlib.ComponentsTestRunner{
 		ComponentFeatureMap: testlib.ChannelFeatureMap,
 		ComponentsToTest:    test.EventingFlags.Channels,

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -60,6 +60,9 @@ func InitializeEventingFlags() {
 	flag.Var(&EventingFlags.Brokers, "brokers", BrokerUsage)
 	flag.StringVar(&EventingFlags.BrokerName, "brokername", "", BrokerNameUsage)
 	flag.StringVar(&EventingFlags.BrokerNamespace, "brokernamespace", "", BrokerNamespaceUsage)
+	// Might be useful in restricted environments where namespaces need to be
+	// created by a user with increased privileges (admin).
+	flag.BoolVar(&EventingFlags.ReuseNamespace, "reusenamespace", false, "Whether to re-use namespace for a test if it already exists.")
 	flag.Parse()
 
 	// If no channel is passed through the flag, initialize it as the DefaultChannel.

--- a/test/flags/eventing_environment.go
+++ b/test/flags/eventing_environment.go
@@ -26,4 +26,5 @@ type EventingEnvironmentFlags struct {
 	ReadyFile       string
 	BrokerName      string
 	BrokerNamespace string
+	ReuseNamespace  bool
 }

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -57,6 +57,7 @@ var (
 	nsMutex sync.Mutex
 	serviceCount int
 	namespaceCount int
+	ReuseNamespace bool
 )
 
 // ComponentsTestRunner is used to run tests against different eventing components.
@@ -162,9 +163,10 @@ func Setup(t *testing.T, runInParallel bool, options ...SetupClientOption) *Clie
 	if err != nil {
 		t.Fatal("Couldn't initialize clients:", err)
 	}
-	SetupServiceAccount(t, client)
+
 	// If namespaces are re-used the pull-secret is supposed to be created in advance.
-	if !test.EventingFlags.ReuseNamespace {
+	if !ReuseNamespace {
+		SetupServiceAccount(t, client)
 		SetupPullSecret(t, client)
 	}
 

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -205,7 +205,7 @@ func CreateNamespacedClient(t *testing.T) (*Client, error) {
 		} else {
 			// The test is supposed to create a new test namespace for itself.
 			// Keep trying until we find a namespace that doesn't exist yet.
-			if err := CreateNamespace(client, ns); err != nil {
+			if err := CreateNamespaceWithRetry(client, ns); err != nil {
 				if apierrs.IsAlreadyExists(err) {
 					continue
 				}
@@ -235,16 +235,8 @@ func GetNextNamespaceId() int {
 	return current
 }
 
-// CreateNamespace creates the given namespace.
-func CreateNamespace(client *Client, namespace string) error {
-	err := createNamespaceWithRetry(client, namespace)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func createNamespaceWithRetry(client *Client, namespace string) error {
+// CreateNamespaceWithRetry creates the given namespace with retries.
+func CreateNamespaceWithRetry(client *Client, namespace string) error {
 	var (
 		retries int
 		err     error

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/eventing/test"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -201,7 +199,7 @@ func CreateNamespacedClient(t *testing.T) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		if test.EventingFlags.ReuseNamespace {
+		if ReuseNamespace {
 			// Re-using existing namespace, no need to create it.
 			// The namespace is supposed to be created in advance.
 			return client, nil

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -48,8 +48,8 @@ const (
 	podLogsDir         = "pod-logs"
 	testPullSecretName = "kn-eventing-test-pull-secret"
 	MaxNamespaceSkip   = 20
-	MaxRetries         = 10
-	RetrySleepDuration = 5 * time.Second
+	MaxRetries         = 5
+	RetrySleepDuration = 2 * time.Second
 )
 
 var (
@@ -239,7 +239,7 @@ func GetNextNamespaceId() int {
 func CreateNamespace(client *Client, namespace string) error {
 	err := createNamespaceWithRetry(client, namespace)
 	if err != nil {
-		return fmt.Errorf("could not create namespace %s: %w", namespace, err)
+		return err
 	}
 	return nil
 }

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -54,8 +54,8 @@ const (
 )
 
 var (
-	nsMutex sync.Mutex
-	serviceCount int
+	nsMutex        sync.Mutex
+	serviceCount   int
 	namespaceCount int
 	ReuseNamespace bool
 )
@@ -193,10 +193,10 @@ func CreateNamespacedClient(t *testing.T) (*Client, error) {
 	for i := 0; i < MaxNamespaceSkip; i++ {
 		ns = NextNamespace()
 		client, err := NewClient(
-				pkgTest.Flags.Kubeconfig,
-				pkgTest.Flags.Cluster,
-				ns,
-				t)
+			pkgTest.Flags.Kubeconfig,
+			pkgTest.Flags.Cluster,
+			ns,
+			t)
 		if err != nil {
 			return nil, err
 		}

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -305,8 +305,11 @@ func TearDown(client *Client) {
 	}
 
 	client.Tracker.Clean(true)
-	if err := DeleteNameSpace(client); err != nil {
-		client.T.Logf("Could not delete the namespace %q: %v", client.Namespace, err)
+	// If we're reusing existing namespaces leave the deletion to the creator.
+	if !ReuseNamespace {
+		if err := DeleteNameSpace(client); err != nil {
+			client.T.Logf("Could not delete the namespace %q: %v", client.Namespace, err)
+		}
 	}
 }
 

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -54,7 +54,6 @@ const (
 
 var (
 	nsMutex        sync.Mutex
-	serviceCount   int
 	namespaceCount int
 	ReuseNamespace bool
 )

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"knative.dev/eventing/test"
 	"os"
 	"path/filepath"
 	"sort"
@@ -28,6 +27,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"knative.dev/eventing/test"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Fixes #2776

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:

-->

- Append numeric suffix to a common namespace name so as to make the namespace names predictable
- Skip namespaces that already exist until we find a free one (similar to what is used in knative-client repo)
- If ReuseNamespace flag is passed re-use the next namespace which is supposed to exist

The individual tests still create some resources that require admin privileges. This would be resolved in the next PR. Related discussion in https://github.com/knative/eventing/issues/5357

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

