### PR TITLE
Trigger defaulting webhook tests

### DIFF
--- a/test/rekt/features/trigger/client.go
+++ b/test/rekt/features/trigger/client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/rekt/features/trigger/client.go
+++ b/test/rekt/features/trigger/client.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trigger
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	eventingclientsetv1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/eventing/v1"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/state"
+)
+
+const (
+	TriggerNameKey = "triggerName"
+)
+
+func GetTrigger(ctx context.Context, t feature.T) *eventingv1.Trigger {
+	c := Client(ctx)
+	name := state.GetStringOrFail(ctx, t, TriggerNameKey)
+
+	trigger, err := c.Triggers.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("failed to get Trigger, %v", err)
+	}
+	return trigger
+}
+
+func SetTriggerName(name string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		state.SetOrFail(ctx, t, TriggerNameKey, name)
+	}
+}
+
+type EventingClient struct {
+	Brokers  eventingclientsetv1.BrokerInterface
+	Triggers eventingclientsetv1.TriggerInterface
+}
+
+func Client(ctx context.Context) *EventingClient {
+	ec := eventingclient.Get(ctx).EventingV1()
+	env := environment.FromContext(ctx)
+
+	return &EventingClient{
+		Brokers:  ec.Brokers(env.Namespace()),
+		Triggers: ec.Triggers(env.Namespace()),
+	}
+}

--- a/test/rekt/features/trigger/control_plane.go
+++ b/test/rekt/features/trigger/control_plane.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trigger
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/assert"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	triggerresources "knative.dev/eventing/test/rekt/resources/trigger"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/resources/svc"
+)
+
+func Defaulting() *feature.FeatureSet {
+	fs := &feature.FeatureSet{
+		Name: "Knative Trigger Specification - Defaulting",
+		Features: []feature.Feature{
+			*Defaulting_Filter(),
+			*Defaulting_SubscriberNamespace(),
+		},
+	}
+
+	return fs
+}
+
+func Defaulting_Filter() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker")
+
+	resourceName := feature.MakeRandomK8sName("trigger")
+
+	withSubscriber := triggerresources.WithSubscriber(svc.AsKReference("sub"), "")
+
+	f.Setup("Set Trigger name", SetTriggerName(resourceName))
+	f.Setup("Create a Trigger with empty spec.filter",
+		triggerresources.Install(resourceName, "broker", withSubscriber))
+
+	f.Stable("Conformance").
+		Must("Trigger MUST default spec.filter to empty filter",
+			defaultFilterIsSetOnTrigger)
+	return f
+}
+
+func Defaulting_SubscriberNamespace() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker")
+
+	resourceName := feature.MakeRandomK8sName("trigger")
+
+	withSubscriber := triggerresources.WithSubscriber(svc.AsKReference("sub"), "")
+
+	f.Setup("Set Trigger name", SetTriggerName(resourceName))
+	f.Setup("Create a Trigger with empty subscriber namespace",
+		triggerresources.Install(resourceName, "broker", withSubscriber))
+
+	f.Stable("Conformance").
+		Must("Trigger subscriber namespace MUST be defaulted to Trigger namespace",
+			triggerNamespaceIsSetOnSubscriber)
+	return f
+}
+
+func defaultFilterIsSetOnTrigger(ctx context.Context, t feature.T) {
+	trigger := GetTrigger(ctx, t)
+
+	assert.Equal(t, &eventingv1.TriggerFilter{}, trigger.Spec.Filter)
+}
+
+func triggerNamespaceIsSetOnSubscriber(ctx context.Context, t feature.T) {
+	trigger := GetTrigger(ctx, t)
+
+	assert.Equal(t, trigger.Namespace, trigger.Spec.Subscriber.Ref.Namespace)
+}

--- a/test/rekt/trigger_test.go
+++ b/test/rekt/trigger_test.go
@@ -1,0 +1,37 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rekt
+
+import (
+	"testing"
+
+	"knative.dev/eventing/test/rekt/features/trigger"
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+func TestTriggerDefaulting(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(environment.Managed(t))
+
+	env.TestSet(ctx, t, trigger.Defaulting())
+
+	env.Finish()
+}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add trigger defaulting webhook tests
- Move some Trigger related reusable code into trigger features package (first 2 commits)
- Check if the filter is defaulted to empty filter
- Check if subscriber namespace is defaulted to trigger namespace
- **Don't** check if [the label](https://github.com/knative/eventing/blob/d8265bb5b08f1bebe61fdecd166f43962b01a0e2/pkg/apis/eventing/v1/trigger_defaults.go#L44) is set. I can't find any usages for that label in the code.

Found some issues in the spec:
- https://github.com/knative/specs/pull/22 --> Default value of `broker` cannot exist as the field is required.
- https://github.com/knative/specs/pull/23 --> There's no mention of Trigger delivering all events if no `filter` defined.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

