### PR TITLE
Increase defaulting test coverage a little bit for api config

### DIFF
--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -133,6 +133,20 @@ func TestDefaultsConfiguration(t *testing.T) {
 			Data: map[string]string{},
 		},
 	}, {
+		name:    "corrupt default-br-config",
+		wantErr: true,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      DefaultsConfigName,
+			},
+			Data: map[string]string{
+				"default-br-config": `
+      broken YAML
+`,
+			},
+		},
+	}, {
 		name:    "all specified values",
 		wantErr: false,
 		wantDefaults: &Defaults{

--- a/pkg/apis/messaging/config/channel_defaults_test.go
+++ b/pkg/apis/messaging/config/channel_defaults_test.go
@@ -83,6 +83,20 @@ func TestChannelDefaultsConfiguration(t *testing.T) {
 			Data: map[string]string{},
 		},
 	}, {
+		name:    "broken default-ch-config",
+		wantErr: true,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      ChannelDefaultsConfigName,
+			},
+			Data: map[string]string{
+				"default-ch-config": `
+      broken YAML
+`,
+			},
+		},
+	}, {
 		name:    "all specified values",
 		wantErr: false,
 		wantChannelDefaults: &ChannelDefaults{


### PR DESCRIPTION
Increase defaulting test coverage a little for apis/config and apis/messaging/config

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Increase defaulting test coverage a little for apis/config and apis/messaging/config
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

