### PR TITLE
Triggers do not have conversion webhooks, drop config from CRD

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -174,11 +174,3 @@ spec:
     - knative
     - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing


### PR DESCRIPTION
fixes https://github.com/knative/eventing/issues/4932

Minor leftover config that is invalid for the trigger CRD.