### PR TITLE
Brokers do not have conversion webhooks.

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -157,11 +157,3 @@ spec:
     - knative
     - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing


### PR DESCRIPTION
fixes https://github.com/knative/eventing/issues/4922

We do not serve any version aside from v1 in the current api. The CRD has extra config that is not used. 