### PR TITLE
Update schema of Channel via the schema tool.

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -44,7 +44,7 @@ spec:
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
     schema:
       openAPIV3Schema:
-        description: 'Channel represents a generic Channel. It is normally used when we want a Channel, but don''t need a specific Channel implementation.'
+        description: 'Channel represents a generic Channel. It is normally used when we want a Channel, but do not need a specific Channel implementation.'
         type: object
         properties:
           spec:
@@ -52,81 +52,54 @@ spec:
             type: object
             properties:
               channelTemplate:
-                description: ChannelTemplate specifies which Channel CRD to use to
-                    create the CRD Channel backing this Channel. This is immutable
-                    after creation. Normally this is set by the Channel defaulter,
-                    not directly by the user.
+                description: ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel. This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.
                 type: object
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST
-                        resource this object represents. Servers may infer this
-                        from the endpoint the client submits requests to. Cannot
-                        be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   spec:
-                    description: Spec defines the Spec to use for each channel
-                        created. Passed in verbatim to the Channel CRD as Spec
-                        section.
+                    description: Spec defines the Spec to use for each channel created. Passed in verbatim to the Channel CRD as Spec section.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-              delivery: &deliverySpec
-                description: DeliverySpec contains options controlling the event delivery
+              delivery:
+                description: DeliverySpec contains the default delivery spec for each subscription to this Channelable. Each subscription delivery spec, if any, overrides this global delivery spec.
                 type: object
                 properties:
                   backoffDelay:
-                    description: 'BackoffDelay is the delay before retrying. More
-                        information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
-                        - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
-                        backoff delay is backoffDelay*<numberOfRetries>. For
-                        exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
                     type: string
                   backoffPolicy:
-                    description: BackoffPolicy is the retry backoff policy (linear,
-                        exponential).
+                    description: BackoffPolicy is the retry backoff policy (linear, exponential).
                     type: string
                   deadLetterSink:
-                    description: DeadLetterSink is the sink receiving event that
-                        could not be sent to a destination.
+                    description: DeadLetterSink is the sink receiving event that could not be sent to a destination.
                     type: object
                     properties:
                       ref:
                         description: Ref points to an Addressable.
                         type: object
-                        properties: &referentProperties
+                        properties:
                           apiVersion:
                             description: API version of the referent.
                             type: string
                           kind:
-                            description: 'Kind of the referent. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           name:
-                            description: 'Name of the referent. More info:
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           namespace:
-                            description: 'Namespace of the referent. More
-                                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                                This is optional field, it gets defaulted
-                                to the object holding it if left out.'
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                             type: string
                       uri:
-                        description: URI can be an absolute URL(non-empty
-                            scheme and non-empty host) pointing to the target
-                            or a relative URI. Relative URIs will be resolved
-                            using the base URI retrieved from Ref.
+                        description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
                         type: string
                   retry:
-                    description: Retry is the minimum number of retries the sender
-                        should attempt when sending an event before moving it
-                        to the dead letter sink.
+                    description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
                     type: integer
                     format: int32
               subscribers:
@@ -136,10 +109,44 @@ spec:
                   type: object
                   properties:
                     delivery:
-                      <<: *deliverySpec
+                      description: DeliverySpec contains options controlling the event delivery
+                      type: object
+                      properties:
+                        backoffDelay:
+                          description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                          type: string
+                        backoffPolicy:
+                          description: BackoffPolicy is the retry backoff policy (linear, exponential).
+                          type: string
+                        deadLetterSink:
+                          description: DeadLetterSink is the sink receiving event that could not be sent to a destination.
+                          type: object
+                          properties:
+                            ref:
+                              description: Ref points to an Addressable.
+                              type: object
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                                  type: string
+                            uri:
+                              description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                              type: string
+                        retry:
+                          description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
+                          type: integer
+                          format: int32
                     generation:
-                      description: Generation of the origin of the subscriber
-                          with uid:UID.
+                      description: Generation of the origin of the subscriber with uid:UID.
                       type: integer
                       format: int64
                     replyUri:
@@ -149,93 +156,102 @@ spec:
                       description: SubscriberURI is the endpoint for the subscriber
                       type: string
                     uid:
-                      description: UID is used to understand the origin of the
-                          subscriber.
+                      description: UID is used to understand the origin of the subscriber.
                       type: string
           status:
-            description: Status represents the current state of the Channel. This data
-                may be out of date.
+            description: Status represents the current state of the Channel. This data may be out of date.
             type: object
             properties:
               address:
                 type: object
                 properties:
-                    url:
-                        type: string
+                  url:
+                    type: string
               annotations:
-                description: Annotations is additional Status fields for the Resource
-                    to save some additional State as well as convey more information
-                    to the user. This is roughly akin to Annotations on any k8s resource,
-                    just the reconciler conveying richer information outwards.
+                description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               channel:
-                description: Channel is an KReference to the Channel CRD backing this
-                    Channel.
+                description: Channel is an KReference to the Channel CRD backing this Channel.
                 type: object
                 properties:
-                  <<: *referentProperties
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                    type: string
               conditions:
-                description: Conditions the latest available observations of a resource's
-                    current state.
+                description: Conditions the latest available observations of a resource's current state.
                 type: array
                 items:
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
+                  required:
+                    - type
+                    - status
                   properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                      type: string
                     message:
-                      description: A human readable message indicating details
-                          about the transition.
+                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
                       type: string
                     severity:
-                      description: Severity with which to treat failures of
-                          this type of condition. When this is not specified,
-                          it defaults to Error.
+                      description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False,
-                          Unknown.
+                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       description: Type of condition.
                       type: string
               deadLetterChannel:
-                description: DeadLetterChannel is a KReference and is set by the channel
-                    when it supports native error handling via a channel Failed messages
-                    are delivered here.
+                description: DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel Failed messages are delivered here.
                 type: object
                 properties:
-                  <<: *referentProperties
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                    type: string
               observedGeneration:
-                description: ObservedGeneration is the 'Generation' of the Service
-                    that was last processed by the controller.
+                description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer
                 format: int64
               subscribers:
-                description: This is the list of subscription's statuses for this
-                    channel.
+                description: This is the list of subscription's statuses for this channel.
                 type: array
                 items:
                   type: object
                   properties:
                     message:
-                      description: A human readable message indicating details
-                          of Ready status.
+                      description: A human readable message indicating details of Ready status.
                       type: string
                     observedGeneration:
-                      description: Generation of the origin of the subscriber
-                          with uid:UID.
+                      description: Generation of the origin of the subscriber with uid:UID.
                       type: integer
                       format: int64
                     ready:
                       description: Status of the subscriber.
                       type: string
                     uid:
-                      description: UID is used to understand the origin of the
-                          subscriber.
+                      description: UID is used to understand the origin of the subscriber.
                       type: string
   names:
     kind: Channel
@@ -249,11 +265,3 @@ spec:
     shortNames:
       - ch
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/pkg/apis/duck/v1/channelable_types.go
+++ b/pkg/apis/duck/v1/channelable_types.go
@@ -59,6 +59,7 @@ type ChannelableStatus struct {
 	// * Conditions - the latest available observations of a resource's current state.
 	duckv1.Status `json:",inline"`
 	// AddressStatus is the part where the Channelable fulfills the Addressable contract.
+	// +optional
 	duckv1.AddressStatus `json:",inline"`
 	// Subscribers is populated with the statuses of each of the Channelable's subscribers.
 	SubscribableStatus `json:",inline"`

--- a/pkg/apis/eventing/v1/broker_types.go
+++ b/pkg/apis/eventing/v1/broker_types.go
@@ -90,6 +90,7 @@ type BrokerStatus struct {
 
 	// Broker is Addressable. It exposes the endpoint as an URI to get events
 	// delivered into the Broker mesh.
+	// +optional
 	Address duckv1.Addressable `json:"address,omitempty"`
 }
 

--- a/pkg/apis/messaging/v1/channel_types.go
+++ b/pkg/apis/messaging/v1/channel_types.go
@@ -29,7 +29,8 @@ import (
 // +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Channel represents a generic Channel. It is normally used when we want a Channel, but don't need a specific Channel implementation.
+// Channel represents a generic Channel. It is normally used when we want a
+// Channel, but do not need a specific Channel implementation.
 type Channel struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -38,8 +39,8 @@ type Channel struct {
 	// Spec defines the desired state of the Channel.
 	Spec ChannelSpec `json:"spec,omitempty"`
 
-	// Status represents the current state of the Channel. This data may be out of
-	// date.
+	// Status represents the current state of the Channel. This data may be out
+	// of date.
 	// +optional
 	Status ChannelStatus `json:"status,omitempty"`
 }
@@ -61,11 +62,13 @@ var (
 	_ duckv1.KRShaped = (*Channel)(nil)
 )
 
-// ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
-// It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.
+// ChannelSpec defines which subscribers have expressed interest in receiving
+// events from this Channel. It also defines the ChannelTemplate to use in
+// order to create the CRD Channel backing this Channel.
 type ChannelSpec struct {
-	// ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
-	// This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.
+	// ChannelTemplate specifies which Channel CRD to use to create the CRD
+	// Channel backing this Channel. This is immutable after creation.
+	// Normally this is set by the Channel defaulter, not directly by the user.
 	// +optional
 	ChannelTemplate *ChannelTemplateSpec `json:"channelTemplate"`
 
@@ -93,7 +96,8 @@ type ChannelList struct {
 	Items           []Channel `json:"items"`
 }
 
-// GetStatus retrieves the status of the Channel. Implements the KRShaped interface.
+// GetStatus retrieves the status of the Channel. Implements the KRShaped
+// interface.
 func (t *Channel) GetStatus() *duckv1.Status {
 	return &t.Status.Status
 }

--- a/pkg/apis/messaging/v1/channel_types.go
+++ b/pkg/apis/messaging/v1/channel_types.go
@@ -66,6 +66,7 @@ var (
 type ChannelSpec struct {
 	// ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
 	// This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.
+	// +optional
 	ChannelTemplate *ChannelTemplateSpec `json:"channelTemplate"`
 
 	// Channel conforms to ChannelableSpec
@@ -78,6 +79,7 @@ type ChannelStatus struct {
 	eventingduckv1.ChannelableStatus `json:",inline"`
 
 	// Channel is an KReference to the Channel CRD backing this Channel.
+	// +optional
 	Channel *duckv1.KReference `json:"channel,omitempty"`
 }
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/4923

- Update the schema of Channel to the (mostly) unedited version of the schema tool.
- Drop conversion webhook config (an oversight), Channels no longer have conversion webhooks at v1.