### PR TITLE
IMC should work independently of core knative eventing

### DIFF
--- a/cmd/in_memory/channel_controller/main.go
+++ b/cmd/in_memory/channel_controller/main.go
@@ -97,7 +97,7 @@ func main() {
 		SecretName: "inmemorychannel-webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(ctx, webhook.NameFromEnv(),
+	sharedmain.MainWithContext(ctx, webhook.NameFromEnv(),
 		certificates.NewController,
 		NewValidationAdmissionController,
 		NewDefaultingAdmissionController,

--- a/cmd/in_memory/channel_controller/main.go
+++ b/cmd/in_memory/channel_controller/main.go
@@ -20,13 +20,88 @@ import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"knative.dev/pkg/injection/sharedmain"
+	"context"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/certificates"
+	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
+
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	inmemorychannel "knative.dev/eventing/pkg/reconciler/inmemorychannel/controller"
 )
 
+var ourTypes = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	// For group messaging.knative.dev.
+	// v1
+	messagingv1.SchemeGroupVersion.WithKind("InMemoryChannel"): &messagingv1.InMemoryChannel{},
+}
+
+var callbacks = map[schema.GroupVersionKind]validation.Callback{}
+
+func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return defaulting.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"inmemorychannel.eventing.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/defaulting",
+
+		// The resources to default.
+		ourTypes,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		nil,
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return validation.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"validation.inmemorychannel.eventing.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/resource-validation",
+
+		// The resources to validate.
+		ourTypes,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		nil,
+
+		// Whether to disallow unknown fields.
+		true,
+
+		// Extra validating callbacks to be applied to resources.
+		callbacks,
+	)
+}
+
 func main() {
-	sharedmain.Main("inmemorychannel-controller",
+	// Set up a signal context with our webhook options
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		ServiceName: webhook.NameFromEnv(),
+		Port:        webhook.PortFromEnv(8443),
+		// SecretName must match the name of the Secret created in the configuration.
+		SecretName: "inmemorychannel-webhook-certs",
+	})
+
+	sharedmain.WebhookMainWithContext(ctx, webhook.NameFromEnv(),
+		certificates.NewController,
+		NewValidationAdmissionController,
+		NewDefaultingAdmissionController,
+
 		inmemorychannel.NewController,
 	)
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -63,9 +63,8 @@ var ourTypes = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 
 	// For group messaging.knative.dev.
 	// v1
-	messagingv1.SchemeGroupVersion.WithKind("InMemoryChannel"): &messagingv1.InMemoryChannel{},
-	messagingv1.SchemeGroupVersion.WithKind("Channel"):         &messagingv1.Channel{},
-	messagingv1.SchemeGroupVersion.WithKind("Subscription"):    &messagingv1.Subscription{},
+	messagingv1.SchemeGroupVersion.WithKind("Channel"):      &messagingv1.Channel{},
+	messagingv1.SchemeGroupVersion.WithKind("Subscription"): &messagingv1.Subscription{},
 
 	// For group sources.knative.dev.
 	// v1beta2

--- a/config/channels/in-memory-channel/100-config-event-dispatcher.yaml
+++ b/config/channels/in-memory-channel/100-config-event-dispatcher.yaml
@@ -1,1 +1,0 @@
-configmaps/event-dispatcher.yaml

--- a/config/channels/in-memory-channel/100-namespace.yaml
+++ b/config/channels/in-memory-channel/100-namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
-kind: ServiceAccount
+kind: Namespace
 metadata:
-  name: imc-controller
-  namespace: knative-eventing
+  name: knative-eventing
   labels:
     eventing.knative.dev/release: devel

--- a/config/channels/in-memory-channel/200-addressable-resolver-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-addressable-resolver-clusterrole.yaml
@@ -1,1 +1,0 @@
-roles/addressable-resolver-clusterrole.yaml

--- a/config/channels/in-memory-channel/200-channelable-manipulator-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-channelable-manipulator-clusterrole.yaml
@@ -1,1 +1,0 @@
-roles/channelable-manipulator-clusterrole.yaml

--- a/config/channels/in-memory-channel/200-controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-controller-clusterrole.yaml
@@ -1,1 +1,0 @@
-roles/controller-clusterrole.yaml

--- a/config/channels/in-memory-channel/200-dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/200-dispatcher-clusterrole.yaml
@@ -1,1 +1,0 @@
-roles/dispatcher-clusterrole.yaml

--- a/config/channels/in-memory-channel/200-dispatcher-service.yaml
+++ b/config/channels/in-memory-channel/200-dispatcher-service.yaml
@@ -1,1 +1,0 @@
-deployments/dispatcher-service.yaml

--- a/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
@@ -1,0 +1,52 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imc-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: imc-controller
+  labels:
+    eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: imc-controller
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: imc-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: knative-eventing
+  name: imc-controller
+  labels:
+    eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: imc-controller
+    namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: knative-inmemorychannel-webhook
+  apiGroup: rbac.authorization.k8s.io

--- a/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,17 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imc-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: imc-controller
+  name: imc-dispatcher
   labels:
     eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
-    name: imc-controller
+    name: imc-dispatcher
     namespace: knative-eventing
 roleRef:
   kind: ClusterRole
-  name: imc-controller
+  name: imc-dispatcher
   apiGroup: rbac.authorization.k8s.io

--- a/config/channels/in-memory-channel/300-in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/300-in-memory-channel.yaml
@@ -1,1 +1,0 @@
-resources/in-memory-channel.yaml

--- a/config/channels/in-memory-channel/500-controller.yaml
+++ b/config/channels/in-memory-channel/500-controller.yaml
@@ -1,1 +1,0 @@
-deployments/controller.yaml

--- a/config/channels/in-memory-channel/500-dispatcher.yaml
+++ b/config/channels/in-memory-channel/500-dispatcher.yaml
@@ -1,1 +1,0 @@
-deployments/dispatcher.yaml

--- a/config/channels/in-memory-channel/README.md
+++ b/config/channels/in-memory-channel/README.md
@@ -16,25 +16,26 @@ characteristics:
   - When a subscriber rejects a message, this message is sent to the dead letter
     sink, if present, otherwise it is dropped.
 
-### Deployment steps:
+## Deployment steps:
 
-1. Setup [Knative Eventing](../../../DEVELOPMENT.md).
 1. Apply the `InMemoryChannel` CRD, Controller, and cluster-scoped Dispatcher.
+
    ```shell
-   ko apply -f config/channels/in-memory-channel/
+   ko apply -Rf config/channels/in-memory-channel/
    ```
+
 1. Create InMemoryChannels
 
    ```shell
-   kubectl apply --filename - << END
-   apiVersion: messaging.knative.dev/v1beta1
+   kubectl apply --filename - << EOF
+   apiVersion: messaging.knative.dev/v1
    kind: InMemoryChannel
    metadata:
-     name: foo
-   END
+    name: foo
+   EOF
    ```
 
-### Components
+## Components
 
 The major components are:
 
@@ -54,19 +55,178 @@ kubectl get deployment -n knative-eventing imc-dispatcher
 
 ### Namespace Dispatchers
 
-By default events are received and dispatched by a single cluster-scoped
+By default, events will be received and dispatched by a single cluster-scoped
 dispatcher components. You can also specify whether events should be received
 and dispatched by the dispatcher in the same namespace as the channel definition
 by adding the `eventing.knative.dev/scope: namespace` annotation. For instance:
 
 ```shell
-kubectl apply --filename - << END
-apiVersion: messaging.knative.dev/v1beta1
+kubectl apply --filename - << EOF
+apiVersion: messaging.knative.dev/v1
 kind: InMemoryChannel
 metadata:
   name: foo-ns
   namespace: default
   annotations:
     eventing.knative.dev/scope: namespace
-END
+EOF
+```
+
+## Demo
+
+InMemoryChannel should work without core eventing installed.
+
+> Warning: `Subscriptions` are provided with Eventing Core.
+
+1. Install a channel.
+
+   ```shell
+   kubectl apply --filename - << EOF
+   apiVersion: messaging.knative.dev/v1
+   kind: InMemoryChannel
+   metadata:
+    name: demo
+   EOF
+   ```
+
+1. Install event display:
+
+   ```shell
+   ko apply -f - << EOF
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: event-display
+   spec:
+     replicas: 1
+     selector:
+       matchLabels: &labels
+         app: event-display
+     template:
+       metadata:
+         labels: *labels
+       spec:
+         containers:
+           - name: display
+             image: ko://knative.dev/eventing/cmd/event_display
+   ---
+   kind: Service
+   apiVersion: v1
+   metadata:
+     name: event-display
+   spec:
+     selector:
+       app: event-display
+     ports:
+       - protocol: TCP
+         port: 80
+         targetPort: 8080
+   EOF
+   ```
+
+1. Add event-display as a subscriber of the channel.
+
+   ```shell
+   kubectl patch InMemoryChannel demo --type merge --patch '{"spec":{"subscribers":[{"subscriberUri":"http://event-display.default.svc.cluster.local","uid":"abc-123"}]}}'
+   ```
+
+1. Create a heartbeats pod:
+
+   ```shell
+   ko apply --filename - << EOF
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: heartbeats
+   spec:
+     containers:
+       - name: heartbeats
+         image: ko://knative.dev/eventing/cmd/heartbeats
+         env:
+           - name: "K_SINK"
+             value: "http://demo-kn-channel.default.svc.cluster.local"
+           - name: POD_NAMESPACE
+             valueFrom:
+               fieldRef:
+                 fieldPath: metadata.namespace
+           - name: POD_NAME
+             valueFrom:
+               fieldRef:
+                 fieldPath: metadata.name
+   EOF
+   ```
+
+### Results
+
+The `demo` channel should end up looking like this:
+
+```
+$ kubectl get channel demo -oyaml
+apiVersion: messaging.knative.dev/v1
+kind: InMemoryChannel
+metadata:
+    messaging.knative.dev/creator: kubernetes-admin
+    messaging.knative.dev/lastModifier: kubernetes-admin
+    messaging.knative.dev/subscribable: v1
+  creationTimestamp: "2021-05-05T18:45:25Z"
+  generation: 2
+  name: demo
+  namespace: default
+  resourceVersion: "20083"
+  uid: a3c67f17-ebe6-4906-ba8d-7d8497346629
+spec:
+  subscribers:
+  - subscriberUri: http://event-display.default.svc.cluster.local
+    uid: abc-123
+status:
+  address:
+    url: http://demo-kn-channel.default.svc.cluster.local
+  conditions:
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: Addressable
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: ChannelServiceReady
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: DispatcherReady
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: EndpointsReady
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2021-05-05T18:45:26Z"
+    status: "True"
+    type: ServiceReady
+  observedGeneration: 2
+  subscribers:
+  - ready: "True"
+    uid: abc-123
+```
+
+And a `stern` output would look like this:
+
+```shell
+$ stern ".*"
+heartbeats heartbeats 2021/05/05 19:26:15 sending cloudevent to http://demo-kn-channel.default.svc.cluster.local
+event-display-5d859f98d7-b79d7 display ☁️  cloudevents.Event
+event-display-5d859f98d7-b79d7 display Validation: valid
+event-display-5d859f98d7-b79d7 display Context Attributes,
+event-display-5d859f98d7-b79d7 display   specversion: 1.0
+event-display-5d859f98d7-b79d7 display   type: dev.knative.eventing.samples.heartbeat
+event-display-5d859f98d7-b79d7 display   source: https://knative.dev/eventing-contrib/cmd/heartbeats/#default/heartbeats
+event-display-5d859f98d7-b79d7 display   id: a6a36488-028f-4fd0-9c2c-31afc389ef73
+event-display-5d859f98d7-b79d7 display   time: 2021-05-05T19:26:15.452991106Z
+event-display-5d859f98d7-b79d7 display   datacontenttype: application/json
+event-display-5d859f98d7-b79d7 display Extensions,
+event-display-5d859f98d7-b79d7 display   beats: true
+event-display-5d859f98d7-b79d7 display   heart: yes
+event-display-5d859f98d7-b79d7 display   the: 42
+event-display-5d859f98d7-b79d7 display Data,
+event-display-5d859f98d7-b79d7 display   {
+event-display-5d859f98d7-b79d7 display     "id": 11,
+event-display-5d859f98d7-b79d7 display     "label": ""
+event-display-5d859f98d7-b79d7 display   }
 ```

--- a/config/channels/in-memory-channel/configmaps/observability.yaml
+++ b/config/channels/in-memory-channel/configmaps/observability.yaml
@@ -1,0 +1,73 @@
+# Copyright 2021 The Knative Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+  annotations:
+    knative.dev/example-checksum: "f46cf09d"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. If non-empty, it enables queue proxy to send request metrics.
+    # Currently supported values: prometheus, stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_broker", "knative_trigger", and "knative_source" resource types.
+    # Setting this flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Eventing pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+
+    # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
+    # a failure to send a cloud event to the sink.
+    sink-event-error-reporting.enable: "false"

--- a/config/channels/in-memory-channel/configmaps/tracing.yaml
+++ b/config/channels/in-memory-channel/configmaps/tracing.yaml
@@ -1,0 +1,59 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+  annotations:
+    knative.dev/example-checksum: "4002b4c2"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -25,6 +25,7 @@ spec:
     matchLabels: &labels
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: controller
+      role: inmemorychannel-webhook
   template:
     metadata:
       labels: *labels
@@ -35,6 +36,10 @@ spec:
       - name: controller
         image: ko://knative.dev/eventing/cmd/in_memory/channel_controller
         env:
+          - name: WEBHOOK_NAME
+            value: inmemorychannel-webhook
+          - name: WEBHOOK_PORT
+            value: "8443"
           - name: CONFIG_LOGGING_NAME
             value: config-logging
           - name: CONFIG_OBSERVABILITY_NAME
@@ -60,3 +65,39 @@ spec:
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+              - name: k-kubelet-probe
+                value: "webhook"
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20
+
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    eventing.knative.dev/release: devel
+    role: inmemorychannel-webhook
+  name: inmemorychannel-webhook
+  namespace: knative-eventing
+spec:
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    role: inmemorychannel-webhook

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -25,7 +25,6 @@ spec:
     matchLabels: &labels
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: controller
-      role: inmemorychannel-webhook
   template:
     metadata:
       labels: *labels
@@ -91,7 +90,6 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/release: devel
-    role: inmemorychannel-webhook
   name: inmemorychannel-webhook
   namespace: knative-eventing
 spec:
@@ -100,4 +98,5 @@ spec:
       port: 443
       targetPort: 8443
   selector:
-    role: inmemorychannel-webhook
+    messaging.knative.dev/channel: in-memory-channel
+    messaging.knative.dev/role: controller

--- a/config/channels/in-memory-channel/resources/in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/resources/in-memory-channel.yaml
@@ -148,6 +148,9 @@ spec:
                 type: array
                 items:
                   type: object
+                  required:
+                    - type
+                    - status
                   properties:
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
@@ -206,7 +209,6 @@ spec:
                     uid:
                       description: UID is used to understand the origin of the subscriber.
                       type: string
-
     additionalPrinterColumns:
     - name: URL
       type: string
@@ -232,11 +234,3 @@ spec:
     shortNames:
     - imc
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -101,3 +101,31 @@ rules:
     resources:
       - leases
     verbs: *everything
+
+  # For actually registering our webhook.
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - "mutatingwebhookconfigurations"
+      - "validatingwebhookconfigurations"
+    verbs: &everything
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"

--- a/config/channels/in-memory-channel/roles/webhook-role.yaml
+++ b/config/channels/in-memory-channel/roles/webhook-role.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: knative-eventing
+  name: knative-inmemorychannel-webhook
+  labels:
+    eventing.knative.dev/release: devel
+rules:
+  # For manipulating certs into secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"
+      - "watch"
+      - "patch"

--- a/config/channels/in-memory-channel/webhooks/defaulting.yaml
+++ b/config/channels/in-memory-channel/webhooks/defaulting.yaml
@@ -1,10 +1,10 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
 metadata:
-  name: imc-dispatcher
+  name: inmemorychannel.eventing.knative.dev
   labels:
     eventing.knative.dev/release: devel
-subjects:
-  - kind: ServiceAccount
-    name: imc-dispatcher
-    namespace: knative-eventing
-roleRef:
-  kind: ClusterRole
-  name: imc-dispatcher
-  apiGroup: rbac.authorization.k8s.io
-
+webhooks:
+- admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: inmemorychannel-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: inmemorychannel.eventing.knative.dev
+  timeoutSeconds: 10

--- a/config/channels/in-memory-channel/webhooks/placeholder.go
+++ b/config/channels/in-memory-channel/webhooks/placeholder.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/config/channels/in-memory-channel/webhooks/placeholder.go
+++ b/config/channels/in-memory-channel/webhooks/placeholder.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package webhooks

--- a/config/channels/in-memory-channel/webhooks/resource-validation.yaml
+++ b/config/channels/in-memory-channel/webhooks/resource-validation.yaml
@@ -1,10 +1,10 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
 metadata:
-  name: imc-dispatcher
-  namespace: knative-eventing
+  name: validation.inmemorychannel.eventing.knative.dev
   labels:
     eventing.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions: ["v1"]
+  clientConfig:
+    service:
+      name: inmemorychannel-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: validation.inmemorychannel.eventing.knative.dev
+  timeoutSeconds: 10

--- a/config/channels/in-memory-channel/webhooks/resource-validation.yaml
+++ b/config/channels/in-memory-channel/webhooks/resource-validation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/channels/in-memory-channel/webhooks/secret.yaml
+++ b/config/channels/in-memory-channel/webhooks/secret.yaml
@@ -1,0 +1,22 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: inmemorychannel-webhook-certs
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+# The data is populated at install time.

--- a/config/channels/in-memory-channel/webhooks/secret.yaml
+++ b/config/channels/in-memory-channel/webhooks/secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -100,7 +100,7 @@ ko resolve ${KO_YAML_FLAGS} -f config/sugar/ | "${LABEL_YAML_CMD[@]}" > "${EVENT
 ko resolve ${KO_YAML_FLAGS} -f config/brokers/mt-channel-broker/ | "${LABEL_YAML_CMD[@]}" > "${EVENTING_MT_CHANNEL_BROKER_YAML}"
 
 # Create in memory channel yaml
-ko resolve ${KO_YAML_FLAGS} -f config/channels/in-memory-channel/ | "${LABEL_YAML_CMD[@]}" > "${EVENTING_IN_MEMORY_CHANNEL_YAML}"
+ko resolve ${KO_YAML_FLAGS} -Rf config/channels/in-memory-channel/ | "${LABEL_YAML_CMD[@]}" > "${EVENTING_IN_MEMORY_CHANNEL_YAML}"
 
 # Create the tools
 ko resolve ${KO_YAML_FLAGS} -f config/tools/appender/ | "${LABEL_YAML_CMD[@]}" > "${APPENDER_YAML}"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -202,9 +202,15 @@ function install_head {
 function install_latest_release() {
   header ">> Installing Knative Eventing latest public release"
 
+  # Delete InMemoryController Webhook for downgrade 0.22 from 0.23.
+  kubectl delete ValidatingWebhookConfiguration validation.inmemorychannel.eventing.knative.dev
+  kubectl delete MutatingWebhookConfiguration inmemorychannel.eventing.knative.dev
+
   install_knative_eventing \
     "latest-release" || \
     fail_test "Knative latest release installation failed"
+
+
 }
 
 function install_mt_broker() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -203,8 +203,8 @@ function install_latest_release() {
   header ">> Installing Knative Eventing latest public release"
 
   # Delete InMemoryController Webhook for downgrade 0.22 from 0.23.
-  kubectl delete ValidatingWebhookConfiguration validation.inmemorychannel.eventing.knative.dev
-  kubectl delete MutatingWebhookConfiguration inmemorychannel.eventing.knative.dev
+  kubectl delete ValidatingWebhookConfiguration validation.inmemorychannel.eventing.knative.dev || true
+  kubectl delete MutatingWebhookConfiguration inmemorychannel.eventing.knative.dev || true
 
   install_knative_eventing \
     "latest-release" || \


### PR DESCRIPTION
Fixes to https://github.com/knative/eventing/issues/4926

- Move webhook for IMC out of core eventing and into the controller for IMC.
- Add a demo for solo demo of IMC without eventing core.

```release-note
InMemoryController can be used independent of Eventing Core.

To downgrade InMemoryController from release 0.23 to 0.22,  the new to v0.23 webhook configuration:
  - `kubectl delete ValidatingWebhookConfiguration validation.inmemorychannel.eventing.knative.dev`
  - `kubectl delete MutatingWebhookConfiguration inmemorychannel.eventing.knative.dev`
```