### PR TITLE
Bump go to 1.16

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -69,10 +69,10 @@ jobs:
       NODE_SHA: ${{ matrix.kind-image-sha }}
 
     steps:
-    - name: Set up Go 1.15.x
+    - name: Set up Go 1.16.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
 
     - name: Install Dependencies
       working-directory: ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing
 
-go 1.15
+go 1.16
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect


### PR DESCRIPTION
The reconciler-test package is moving to rely on the [1.16 embed package](https://golang.org/pkg/embed/), so we'll need to update to bring in those changes.

## Proposed Changes

- :broom: Update go to 1.16

xref
https://github.com/knative-sandbox/reconciler-test/pull/196
https://github.com/knative-sandbox/.github/pull/108