### PR TITLE
Drop unused conversion webhook config

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -218,33 +218,12 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 		// Specify the types of custom resource definitions that should be converted
 		map[schema.GroupKind]conversion.GroupKindConversion{
 			// Sources
-			sourcesv1.Kind("ApiServerSource"): {
-				DefinitionName: sources.ApiServerSourceResource.String(),
-				HubVersion:     sourcesv1_,
-				Zygotes: map[string]conversion.ConvertibleObject{
-					sourcesv1_: &sourcesv1.ApiServerSource{},
-				},
-			},
 			sourcesv1.Kind("PingSource"): {
 				DefinitionName: sources.PingSourceResource.String(),
 				HubVersion:     sourcesv1beta2_,
 				Zygotes: map[string]conversion.ConvertibleObject{
 					sourcesv1beta2_: &sourcesv1beta2.PingSource{},
 					sourcesv1_:      &sourcesv1.PingSource{},
-				},
-			},
-			sourcesv1.Kind("SinkBinding"): {
-				DefinitionName: sources.SinkBindingResource.String(),
-				HubVersion:     sourcesv1_,
-				Zygotes: map[string]conversion.ConvertibleObject{
-					sourcesv1_: &sourcesv1.SinkBinding{},
-				},
-			},
-			sourcesv1.Kind("ContainerSource"): {
-				DefinitionName: sources.ContainerSourceResource.String(),
-				HubVersion:     sourcesv1_,
-				Zygotes: map[string]conversion.ConvertibleObject{
-					sourcesv1_: &sourcesv1.ContainerSource{},
 				},
 			},
 		},

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -269,11 +269,3 @@ spec:
     plural: apiserversources
     singular: apiserversource
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -249,11 +249,3 @@ spec:
     shortNames:
       - ch
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -410,11 +410,3 @@ spec:
     plural: containersources
     singular: containersource
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -143,11 +143,3 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -329,11 +329,3 @@ spec:
     - knative
     - flows
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -278,11 +278,3 @@ spec:
     - knative
     - flows
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -295,11 +295,3 @@ spec:
     shortNames:
     - sub
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing


### PR DESCRIPTION
It turns out there was still some config in the webhook that was preventing it from starting after I dropped the conversion config from SinkBinding. This PR just does a pass and cleans just the extra conversion problems up for the release.

Thanks to Ben for finding the problem while writing e2e tests 😄 

/assign @benmoss 