### PR TITLE
Collect logs for knative-eventing-logs only when test failed

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -68,9 +68,13 @@ func TestMain(m *testing.M) {
 		// place that cleans it up. If an individual test calls this instead, then it will break other
 		// tests that need the tracing in place.
 		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
-		defer testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
 
-		return m.Run()
+		exit := m.Run()
+		// Collect logs only when test failed.
+		if exit != 0 {
+			testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
+		}
+		return exit
 	}())
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -41,7 +41,10 @@ func TestMain(m *testing.M) {
 
 	exit := m.Run()
 
-	testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
+	// Collect logs only when test failed.
+	if exit != 0 {
+		testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
+	}
 
 	os.Exit(exit)
 }


### PR DESCRIPTION
Current conformance and e2e test always collect and upload logs even when tests passed.
It takes long time to report "Test Passed!" and use a lot of strage.

This patch fixes it.