### PR TITLE
Call runCleanup() after collecting logs

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -185,10 +185,6 @@ func makeK8sNamespace(baseFuncName string) string {
 
 // TearDown will delete created names using clients.
 func TearDown(client *Client) {
-	if err := client.runCleanup(); err != nil {
-		client.T.Logf("Cleanup error: %+v", err)
-	}
-
 	// Dump the events in the namespace
 	el, err := client.Kube.CoreV1().Events(client.Namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -224,6 +220,10 @@ func TearDown(client *Client) {
 		if err := client.ExportLogs(dir); err != nil {
 			client.T.Logf("Error in exporting logs: %v", err)
 		}
+	}
+
+	if err := client.runCleanup(); err != nil {
+		client.T.Logf("Cleanup error: %+v", err)
 	}
 
 	client.Tracker.Clean(true)


### PR DESCRIPTION
Current TearDown() calls runCleanup() before collecting logs.
This could miss some logs and event logs will contains the deletion
logs.

This patch changes to call runCleanup() after collecting logs.
