### PR TITLE
Add podAntiAffinity labels to remaining HA control plane pods

### DIFF
--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -29,6 +29,14 @@ spec:
     metadata:
       labels: *labels
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels: *labels
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: imc-controller
       enableServiceLinks: false
       containers:

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -23,16 +23,23 @@ spec:
   # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
   replicas: 0
   selector:
-    matchLabels:
+    matchLabels: &labels
       eventing.knative.dev/source: ping-source-controller
       sources.knative.dev/role: adapter
   template:
     metadata:
       labels:
-        eventing.knative.dev/source: ping-source-controller
-        sources.knative.dev/role: adapter
+        <<: *labels
         eventing.knative.dev/release: devel
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels: *labels
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       enableServiceLinks: false
       containers:
         - name: dispatcher

--- a/config/sugar/500-controller.yaml
+++ b/config/sugar/500-controller.yaml
@@ -27,6 +27,14 @@ spec:
     metadata:
       labels: *labels
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels: *labels
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       serviceAccountName: eventing-controller
       enableServiceLinks: false
       containers:


### PR DESCRIPTION
Fixes: #5347

Add podAntiAffinity to:
- [x] eventing-controller
- [x] pingsource-mt-adapter
- [x] sugar-controller

- :broom: Update or clean up current behavior


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

```release-note
Remaining HA Control Plane pods (via the operator) are now labelled with podAntiAffinity to ensure there isn't a single point of failure.
```

