### PR TITLE
Subscription.Spec.Channel now uses KReference

### DIFF
--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -41,23 +41,11 @@ spec:
                   apiVersion:
                     description: API version of the referent.
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.'
-                    type: string
                   kind:
                     description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
               delivery:
                 description: Delivery configuration

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -35,7 +35,7 @@ spec:
             type: object
             properties:
               channel:
-                description: 'Reference to a channel that will be used to create the subscription You can specify only the following fields of the ObjectReference: - Kind - APIVersion - Name The resource pointed by this ObjectReference must meet the contract to the ChannelableSpec duck type. If the resource does not meet this contract it will be reflected in the Subscription''s status.  This field is immutable. We have no good answer on what happens to the events that are currently in the channel being consumed from and what the semantics there should be. For now, you can always delete the Subscription and recreate it to point to a different channel, giving the user more control over what semantics should be used (drain the channel first, possibly have events dropped, etc.)'
+                description: 'Reference to a channel that will be used to create the subscription. You can specify only the following fields of the KReference: kind, apiVersion and name. The resource pointed by this KReference must meet the contract to the ChannelableSpec duck type. If the resource does not meet this contract it will be reflected in the Subscription''s status.  This field is immutable. We have no good answer on what happens to the events that are currently in the channel being consumed from and what the semantics there should be. For now, you can always delete the Subscription and recreate it to point to a different channel, giving the user more control over what semantics should be used (drain the channel first, possibly have events dropped, etc.)'
                 type: object
                 properties:
                   apiVersion:

--- a/pkg/apis/messaging/v1/subscribable_channelable_validation.go
+++ b/pkg/apis/messaging/v1/subscribable_channelable_validation.go
@@ -17,69 +17,25 @@ limitations under the License.
 package v1
 
 import (
-	"reflect"
+	"context"
 
-	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-func isChannelEmpty(f corev1.ObjectReference) bool {
-	return equality.Semantic.DeepEqual(f, corev1.ObjectReference{})
+func isChannelEmpty(f duckv1.KReference) bool {
+	return equality.Semantic.DeepEqual(f, duckv1.KReference{})
 }
 
 // Valid if it is a valid object reference.
-func isValidChannel(f corev1.ObjectReference) *apis.FieldError {
-	return IsValidObjectReference(f)
-}
+func isValidChannel(ctx context.Context, f duckv1.KReference) *apis.FieldError {
+	errs := f.Validate(ctx)
 
-func IsValidObjectReference(f corev1.ObjectReference) *apis.FieldError {
-	return checkRequiredObjectReferenceFields(f).
-		Also(checkDisallowedObjectReferenceFields(f))
-}
+	// Namespace field is disallowed
+	if f.Namespace != "" {
+		errs = errs.Also(apis.ErrDisallowedFields("namespace"))
+	}
 
-// Check the corev1.ObjectReference to make sure it has the required fields. They
-// are not checked for anything more except that they are set.
-func checkRequiredObjectReferenceFields(f corev1.ObjectReference) *apis.FieldError {
-	var errs *apis.FieldError
-	if f.Name == "" {
-		errs = errs.Also(apis.ErrMissingField("name"))
-	}
-	if f.APIVersion == "" {
-		errs = errs.Also(apis.ErrMissingField("apiVersion"))
-	}
-	if f.Kind == "" {
-		errs = errs.Also(apis.ErrMissingField("kind"))
-	}
 	return errs
-}
-
-// Check the corev1.ObjectReference to make sure it only has the following fields set:
-// Name, Kind, APIVersion
-// If any other fields are set and is not the Zero value, returns an apis.FieldError
-// with the fieldpaths for all those fields.
-func checkDisallowedObjectReferenceFields(f corev1.ObjectReference) *apis.FieldError {
-	disallowedFields := []string{}
-	// See if there are any fields that have been set that should not be.
-	// TODO: Hoist this kind of stuff into pkg repository.
-	s := reflect.ValueOf(f)
-	typeOf := s.Type()
-	for i := 0; i < s.NumField(); i++ {
-		field := s.Field(i)
-		fieldName := typeOf.Field(i).Name
-		if fieldName == "Name" || fieldName == "Kind" || fieldName == "APIVersion" {
-			continue
-		}
-		if !cmp.Equal(field.Interface(), reflect.Zero(field.Type()).Interface()) {
-			disallowedFields = append(disallowedFields, fieldName)
-		}
-	}
-	if len(disallowedFields) > 0 {
-		fe := apis.ErrDisallowedFields(disallowedFields...)
-		fe.Details = "only name, apiVersion and kind are supported fields"
-		return fe
-	}
-	return nil
-
 }

--- a/pkg/apis/messaging/v1/subscribable_channelable_validation.go
+++ b/pkg/apis/messaging/v1/subscribable_channelable_validation.go
@@ -34,7 +34,9 @@ func isValidChannel(ctx context.Context, f duckv1.KReference) *apis.FieldError {
 
 	// Namespace field is disallowed
 	if f.Namespace != "" {
-		errs = errs.Also(apis.ErrDisallowedFields("namespace"))
+		fe := apis.ErrDisallowedFields("namespace")
+		fe.Details = "only name, apiVersion and kind are supported fields"
+		errs = errs.Also(fe)
 	}
 
 	return errs

--- a/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
+++ b/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
@@ -56,7 +56,11 @@ var validationTests = []struct {
 			Kind:       "MyChannel",
 			Namespace:  "my-namespace",
 		},
-		want: apis.ErrDisallowedFields("namespace"),
+		want: func() *apis.FieldError {
+			fe := apis.ErrDisallowedFields("namespace")
+			fe.Details = "only name, apiVersion and kind are supported fields"
+			return fe
+		}(),
 	},
 }
 

--- a/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
+++ b/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
@@ -17,21 +17,22 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var validationTests = []struct {
 	name string
-	ref  corev1.ObjectReference
+	ref  duckv1.KReference
 	want *apis.FieldError
 }{
 	{
-		name: "valid object ref",
-		ref: corev1.ObjectReference{
+		name: "valid kref",
+		ref: duckv1.KReference{
 			Name:       "boaty-mcboatface",
 			APIVersion: "messaging.knative.dev/v1",
 			Kind:       "MyChannel",
@@ -39,20 +40,30 @@ var validationTests = []struct {
 		want: nil,
 	},
 	{
-		name: "invalid object ref",
-		ref: corev1.ObjectReference{
+		name: "missing kind",
+		ref: duckv1.KReference{
 			Name:       "boaty-mcboatface",
 			APIVersion: "messaging.knative.dev/v1",
 			Kind:       "",
 		},
 		want: apis.ErrMissingField("kind"),
 	},
+	{
+		name: "contains namespace",
+		ref: duckv1.KReference{
+			Name:       "boaty-mcboatface",
+			APIVersion: "messaging.knative.dev/v1",
+			Kind:       "MyChannel",
+			Namespace: "my-namespace",
+		},
+		want: apis.ErrDisallowedFields("namespace"),
+	},
 }
 
 func TestIsChannelEmpty(t *testing.T) {
 	name := "non empty"
 	t.Run(name, func(t *testing.T) {
-		r := corev1.ObjectReference{
+		r := duckv1.KReference{
 			Name:       "boaty-mcboatface",
 			APIVersion: "messaging.knative.dev/v1",
 			Kind:       "Channel",
@@ -64,7 +75,7 @@ func TestIsChannelEmpty(t *testing.T) {
 
 	name = "empty"
 	t.Run(name, func(t *testing.T) {
-		r := corev1.ObjectReference{}
+		r := duckv1.KReference{}
 		if !isChannelEmpty(r) {
 			t.Errorf("%s: isChannelEmpty(%s) should be true", name, r)
 		}
@@ -74,75 +85,8 @@ func TestIsChannelEmpty(t *testing.T) {
 func TestIsValidChannel(t *testing.T) {
 	for _, test := range validationTests {
 		t.Run(test.name, func(t *testing.T) {
-			got := isValidChannel(test.ref)
+			got := isValidChannel(context.TODO(), test.ref)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
-				t.Errorf("%s: validation (-want, +got) = %v", test.name, diff)
-			}
-		})
-	}
-}
-
-func TestIsValidObjectReference(t *testing.T) {
-	tests := []struct {
-		name string
-		ref  corev1.ObjectReference
-		want []*apis.FieldError
-	}{
-		{
-			name: "missing api version and kind",
-			ref: corev1.ObjectReference{
-				Name:       "boaty-mcboatface",
-				APIVersion: "",
-				Kind:       "",
-			},
-			want: []*apis.FieldError{
-				apis.ErrMissingField("apiVersion"),
-				apis.ErrMissingField("kind"),
-			},
-		},
-		{
-			name: "missing name",
-			ref: corev1.ObjectReference{
-				Name:       "",
-				APIVersion: "eventing.knative.dev/v1",
-				Kind:       "Strait",
-			},
-			want: []*apis.FieldError{
-				apis.ErrMissingField("name"),
-			},
-		},
-		{
-			name: "missing all",
-			ref: corev1.ObjectReference{
-				Name:       "",
-				APIVersion: "",
-				Kind:       "",
-			},
-			want: []*apis.FieldError{
-				apis.ErrMissingField("name"),
-				apis.ErrMissingField("apiVersion"),
-				apis.ErrMissingField("kind"),
-			},
-		},
-		{
-			name: "missing none",
-			ref: corev1.ObjectReference{
-				Name:       "kind",
-				APIVersion: "messaging.knative.dev/v1",
-				Kind:       "Channel",
-			},
-			want: []*apis.FieldError{},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			allWanted := &apis.FieldError{}
-			for _, fe := range test.want {
-				allWanted = allWanted.Also(fe)
-			}
-			got := IsValidObjectReference(test.ref)
-			if diff := cmp.Diff(allWanted.Error(), got.Error()); diff != "" {
 				t.Errorf("%s: validation (-want, +got) = %v", test.name, diff)
 			}
 		})

--- a/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
+++ b/pkg/apis/messaging/v1/subscribable_channelable_validation_test.go
@@ -54,7 +54,7 @@ var validationTests = []struct {
 			Name:       "boaty-mcboatface",
 			APIVersion: "messaging.knative.dev/v1",
 			Kind:       "MyChannel",
-			Namespace: "my-namespace",
+			Namespace:  "my-namespace",
 		},
 		want: apis.ErrDisallowedFields("namespace"),
 	},

--- a/pkg/apis/messaging/v1/subscription_types.go
+++ b/pkg/apis/messaging/v1/subscription_types.go
@@ -73,11 +73,11 @@ var (
 // channel --> reply
 type SubscriptionSpec struct {
 	// Reference to a channel that will be used to create the subscription
-	// You can specify only the following fields of the ObjectReference:
+	// You can specify only the following fields of the KReference:
 	//   - Kind
 	//   - APIVersion
 	//   - Name
-	//  The resource pointed by this ObjectReference must meet the
+	// The resource pointed by this KReference must meet the
 	// contract to the ChannelableSpec duck type. If the resource does not
 	// meet this contract it will be reflected in the Subscription's status.
 	//

--- a/pkg/apis/messaging/v1/subscription_types.go
+++ b/pkg/apis/messaging/v1/subscription_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,7 +88,7 @@ type SubscriptionSpec struct {
 	// channel, giving the user more control over what semantics should
 	// be used (drain the channel first, possibly have events dropped,
 	// etc.)
-	Channel corev1.ObjectReference `json:"channel"`
+	Channel duckv1.KReference `json:"channel"`
 
 	// Subscriber is reference to (optional) function for processing events.
 	// Events from the Channel will be delivered here and replies are

--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -44,7 +44,7 @@ func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
 		fe := apis.ErrMissingField("channel")
 		fe.Details = "the Subscription must reference a channel"
 		return fe
-	} else if fe := isValidChannel(ss.Channel); fe != nil {
+	} else if fe := isValidChannel(ctx, ss.Channel); fe != nil {
 		errs = errs.Also(fe.ViaField("channel"))
 	}
 

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -36,8 +35,8 @@ const (
 	namespace         = "namespace"
 )
 
-func getValidChannelRef() corev1.ObjectReference {
-	return corev1.ObjectReference{
+func getValidChannelRef() duckv1.KReference {
+	return duckv1.KReference{
 		Name:       channelName,
 		Kind:       channelKind,
 		APIVersion: channelAPIVersion,
@@ -70,7 +69,7 @@ func TestSubscriptionValidation(t *testing.T) {
 	name := "empty channel"
 	c := &Subscription{
 		Spec: SubscriptionSpec{
-			Channel: corev1.ObjectReference{},
+			Channel: duckv1.KReference{},
 		},
 	}
 	want := &apis.FieldError{
@@ -111,7 +110,7 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 	}, {
 		name: "empty Channel",
 		c: &SubscriptionSpec{
-			Channel: corev1.ObjectReference{},
+			Channel: duckv1.KReference{},
 		},
 		want: func() *apis.FieldError {
 			fe := apis.ErrMissingField("channel")
@@ -121,7 +120,7 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 	}, {
 		name: "missing name in Channel",
 		c: &SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				Kind:       channelKind,
 				APIVersion: channelAPIVersion,
 			},
@@ -186,7 +185,7 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 	}, {
 		name: "missing name in channel, and missing subscriber, reply",
 		c: &SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				Kind:       channelKind,
 				APIVersion: channelAPIVersion,
 			},
@@ -383,11 +382,11 @@ func TestSubscriptionImmutable(t *testing.T) {
 func TestValidChannel(t *testing.T) {
 	tests := []struct {
 		name string
-		c    corev1.ObjectReference
+		c    duckv1.KReference
 		want *apis.FieldError
 	}{{
 		name: "valid",
-		c: corev1.ObjectReference{
+		c: duckv1.KReference{
 			Name:       channelName,
 			APIVersion: channelAPIVersion,
 			Kind:       channelKind,
@@ -395,7 +394,7 @@ func TestValidChannel(t *testing.T) {
 		want: nil,
 	}, {
 		name: "missing name",
-		c: corev1.ObjectReference{
+		c: duckv1.KReference{
 			APIVersion: channelAPIVersion,
 			Kind:       channelKind,
 		},
@@ -405,7 +404,7 @@ func TestValidChannel(t *testing.T) {
 		}(),
 	}, {
 		name: "missing apiVersion",
-		c: corev1.ObjectReference{
+		c: duckv1.KReference{
 			Name: channelName,
 			Kind: channelKind,
 		},
@@ -414,7 +413,7 @@ func TestValidChannel(t *testing.T) {
 		}(),
 	}, {
 		name: "extra field, namespace",
-		c: corev1.ObjectReference{
+		c: duckv1.KReference{
 			Name:       channelName,
 			APIVersion: channelAPIVersion,
 			Kind:       channelKind,
@@ -426,23 +425,9 @@ func TestValidChannel(t *testing.T) {
 			return fe
 		}(),
 	}, {
-		name: "extra field, namespace and resourceVersion",
-		c: corev1.ObjectReference{
-			Name:            channelName,
-			APIVersion:      channelAPIVersion,
-			Kind:            channelKind,
-			Namespace:       "secretnamespace",
-			ResourceVersion: "myresourceversion",
-		},
-		want: func() *apis.FieldError {
-			fe := apis.ErrDisallowedFields("Namespace", "ResourceVersion")
-			fe.Details = "only name, apiVersion and kind are supported fields"
-			return fe
-		}(),
-	}, {
 		// Make sure that if an empty field for namespace is given, it's treated as not there.
 		name: "valid extra field, namespace empty",
-		c: corev1.ObjectReference{
+		c: duckv1.KReference{
 			Name:       channelName,
 			APIVersion: channelAPIVersion,
 			Kind:       channelKind,
@@ -453,7 +438,7 @@ func TestValidChannel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := isValidChannel(test.c)
+			got := isValidChannel(context.TODO(), test.c)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Error("isValidChannel (-want, +got) =", diff)
 			}

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -420,7 +420,7 @@ func TestValidChannel(t *testing.T) {
 			Namespace:  "secretnamespace",
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrDisallowedFields("Namespace")
+			fe := apis.ErrDisallowedFields("namespace")
 			fe.Details = "only name, apiVersion and kind are supported fields"
 			return fe
 		}(),

--- a/pkg/reconciler/broker/resources/subscription.go
+++ b/pkg/reconciler/broker/resources/subscription.go
@@ -44,7 +44,7 @@ func NewSubscription(t *eventingv1.Trigger, brokerTrigger, brokerRef *corev1.Obj
 			Labels: SubscriptionLabels(t),
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				APIVersion: brokerTrigger.APIVersion,
 				Kind:       brokerTrigger.Kind,
 				Name:       brokerTrigger.Name,

--- a/pkg/reconciler/broker/resources/subscription_test.go
+++ b/pkg/reconciler/broker/resources/subscription_test.go
@@ -75,7 +75,7 @@ func TestNewSubscription(t *testing.T) {
 			},
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				Name:       "tc-name",
 				Kind:       "tc-kind",
 				APIVersion: "tc-apiVersion",

--- a/pkg/reconciler/parallel/resources/subscription.go
+++ b/pkg/reconciler/parallel/resources/subscription.go
@@ -22,7 +22,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -51,7 +50,7 @@ func NewFilterSubscription(branchNumber int, p *v1.Parallel) *messagingv1.Subscr
 			},
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				APIVersion: p.Spec.ChannelTemplate.APIVersion,
 				Kind:       p.Spec.ChannelTemplate.Kind,
 				Name:       ParallelChannelName(p.Name),
@@ -90,7 +89,7 @@ func NewSubscription(branchNumber int, p *v1.Parallel) *messagingv1.Subscription
 			},
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				APIVersion: p.Spec.ChannelTemplate.APIVersion,
 				Kind:       p.Spec.ChannelTemplate.Kind,
 				Name:       ParallelBranchChannelName(p.Name, branchNumber),

--- a/pkg/reconciler/sequence/resources/subscription.go
+++ b/pkg/reconciler/sequence/resources/subscription.go
@@ -21,7 +21,6 @@ import (
 
 	"knative.dev/pkg/kmeta"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -47,7 +46,7 @@ func NewSubscription(stepNumber int, s *v1.Sequence) *messagingv1.Subscription {
 			},
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: corev1.ObjectReference{
+			Channel: duckv1.KReference{
 				APIVersion: s.Spec.ChannelTemplate.APIVersion,
 				Kind:       s.Spec.ChannelTemplate.Kind,
 				Name:       SequenceChannelName(s.Name, stepNumber),

--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -118,7 +117,7 @@ func WithSubscriptionLabels(labels map[string]string) SubscriptionOption {
 
 func WithSubscriptionChannel(gvk metav1.GroupVersionKind, name string) SubscriptionOption {
 	return func(s *v1.Subscription) {
-		s.Spec.Channel = corev1.ObjectReference{
+		s.Spec.Channel = duckv1.KReference{
 			APIVersion: apiVersion(gvk),
 			Kind:       gvk.Kind,
 			Name:       name,

--- a/test/lib/resources/eventing.go
+++ b/test/lib/resources/eventing.go
@@ -46,9 +46,9 @@ type DeliveryOption func(*eventingduckv1beta1.DeliverySpec)
 // channelRef returns an ObjectReference for a given Channel name.
 func channelRef(name string, typemeta *metav1.TypeMeta) duckv1.KReference {
 	return duckv1.KReference{
-		Kind: typemeta.Kind,
+		Kind:       typemeta.Kind,
 		APIVersion: typemeta.APIVersion,
-		Name: name,
+		Name:       name,
 	}
 }
 

--- a/test/lib/resources/eventing.go
+++ b/test/lib/resources/eventing.go
@@ -23,14 +23,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	pkgTest "knative.dev/pkg/test"
-
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 // BrokerOption enables further configuration of a v1 Broker.
@@ -46,8 +44,12 @@ type SubscriptionOption func(*messagingv1.Subscription)
 type DeliveryOption func(*eventingduckv1beta1.DeliverySpec)
 
 // channelRef returns an ObjectReference for a given Channel name.
-func channelRef(name string, typemeta *metav1.TypeMeta) *corev1.ObjectReference {
-	return pkgTest.CoreV1ObjectReference(typemeta.Kind, typemeta.APIVersion, name)
+func channelRef(name string, typemeta *metav1.TypeMeta) duckv1.KReference {
+	return duckv1.KReference{
+		Kind: typemeta.Kind,
+		APIVersion: typemeta.APIVersion,
+		Name: name,
+	}
 }
 
 func KnativeRefForService(name, namespace string) *duckv1.KReference {
@@ -124,7 +126,7 @@ func Subscription(
 			Name: name,
 		},
 		Spec: messagingv1.SubscriptionSpec{
-			Channel: *channelRef(channelName, channelTypeMeta),
+			Channel: channelRef(channelName, channelTypeMeta),
 		},
 	}
 	for _, option := range options {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #5411

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Subscription.Spec.Channel now uses KReference.
- :bug: Now the spec.channel CRD schema is less permissive and matches the supported usage of KReference fields.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
- :broom: Subscription.Spec.Channel now uses KReference and the spec.channel CRD schema is less permissive and matches the supported usage of KReference fields. Subscription's users creating their resources with YAMLs are not affected.
```