### PR TITLE
Disable chaosduck on the webhook

### DIFF
--- a/test/config/chaosduck/chaosduck.yaml
+++ b/test/config/chaosduck/chaosduck.yaml
@@ -78,8 +78,10 @@ spec:
         image: ko://knative.dev/pkg/leaderelection/chaosduck
 
         args: [
-          # TODO(https://github.com/knative/eventing/issues/3590): Enable once IMC chaos issues are fixed.
-          "-disable=imc-controller", "-disable=imc-dispatcher",
+          # TODO(https://github.com/knative/eventing/issues/3590,
+          # https://github.com/knative/pkg/issues/1509): Enable once chaos
+          # issues are fixed.
+          "-disable=imc-controller", "-disable=imc-dispatcher", "-disable=eventing-webhook",
         ]
 
         env:


### PR DESCRIPTION
Serving has done this as well, the chaosduck killing the webhook causes errors being tracked in https://github.com/knative/pkg/issues/1509

ref: https://github.com/knative/serving/pull/8772

Fixes #5416, probably lots of others 😄 