### PR TITLE
Fix cloudevent adapter panic

### DIFF
--- a/pkg/adapter/v2/cloudevents.go
+++ b/pkg/adapter/v2/cloudevents.go
@@ -181,8 +181,9 @@ func (c *client) reportMetrics(ctx context.Context, event cloudevents.Event, res
 			var res *http.Result
 			if !cloudevents.ResultAs(retryResult, &res) {
 				c.reportError(reportArgs, result)
+			} else {
+				c.reporter.ReportRetryEventCount(reportArgs, res.StatusCode)
 			}
-			c.reporter.ReportRetryEventCount(reportArgs, res.StatusCode)
 		}
 	}
 }

--- a/pkg/adapter/v2/test/test_client.go
+++ b/pkg/adapter/v2/test/test_client.go
@@ -86,6 +86,10 @@ func (c *TestCloudEventsClient) Send(ctx context.Context, out event.Event) proto
 		return errors.New("totally not an http result")
 	} else if eventData.Type == "unit.sendFail" {
 		return http.NewResult(400, "%w", protocol.ResultNACK)
+	} else if eventData.Type == "unit.nonHttpRetry" {
+		var attempts []protocol.Result
+		attempts = append(attempts, errors.New("totally not an http result"))
+		return http.NewRetriesResult(http.NewResult(200, "%w", protocol.ResultACK), 1, time.Now(), attempts)
 	}
 	return http.NewResult(200, "%w", protocol.ResultACK)
 }


### PR DESCRIPTION
Fixes #5421

## Proposed Changes

- :bug: Fix NPE in the cloudevents adapter

We were testing whether this `protocol.Result` was a `*http.Result` but then even if it wasn't still calling `res.StatusCode`, resulting in a NPE. I don't have enough context on this to understand how this happens *in the wild*, but we are at least seeing it in CI envs.