### PR TITLE
Only upload pod logs logs on failure

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -214,7 +214,7 @@ func TearDown(client *Client) {
 
 	// If the test is run by CI, export the pod logs in the namespace to the artifacts directory,
 	// which will then be uploaded to GCS after the test job finishes.
-	if prow.IsCI() {
+	if prow.IsCI() && client.T.Failed() {
 		dir := filepath.Join(prow.GetLocalArtifactsDir(), podLogsDir)
 		client.T.Logf("Export logs in %q to %q", client.Namespace, dir)
 		if err := client.ExportLogs(dir); err != nil {


### PR DESCRIPTION
Fixes #5388

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Only upload pod logs on test failures