### PR TITLE
Use a readiness probe to check apiserver adapter readiness

### DIFF
--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -118,8 +119,17 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		}
 	}
 
+	srv := &http.Server{
+		Addr: ":8080",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	go srv.ListenAndServe()
+
 	<-stopCh
 	stop <- struct{}{}
+	srv.Shutdown(ctx)
 	return nil
 }
 

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"knative.dev/eventing/pkg/adapter/apiserver"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -88,7 +89,17 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
 								ContainerPort: 9090,
+							}, {
+								Name:          "health",
+								ContainerPort: 8080,
 							}},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Port: intstr.FromString("health"),
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -117,6 +118,9 @@ func TestMakeReceiveAdapters(t *testing.T) {
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
 								ContainerPort: 9090,
+							}, {
+								Name:          "health",
+								ContainerPort: 8080,
 							}},
 							Env: []corev1.EnvVar{
 								{
@@ -150,6 +154,13 @@ func TestMakeReceiveAdapters(t *testing.T) {
 								}, {
 									Name:  source.EnvTracingCfg,
 									Value: "",
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Port: intstr.FromString("health"),
+									},
 								},
 							},
 						},


### PR DESCRIPTION
(Hopefully) fixes a flakiness we have been seeing in the apiserversource rekt tests where the apiserversource receives 0 events.

My theory is that the apiserversource will report ready when the Deployment is ready, but that is no guarantee that the pod has started watching for events, just that it has started. Therefore there's a race where we might trigger an event in our tests (via creating a dummy pod) and expect to see it, but it might have been missed by the source.

By inserting a sleep in the beginning of the main method of the apiserver adapter I'm able to reproduce what we're seeing on GitHub Actions, and this fix works with the sleep in place, so I'm hoping that's faithfully reproducing the issue we're seeing in CI.

**Release Note**

```release-note
Fix a race condition with apiserversources reported ready before they have begun listening for events
```

Recent failures:
- https://github.com/knative/eventing/runs/2688555356?check_suite_focus=true#step:11:6300
- https://github.com/knative/eventing/runs/2687475974?check_suite_focus=true#step:11:6128
- https://github.com/knative/eventing/runs/2686118804?check_suite_focus=true#step:11:6303
- https://github.com/knative/eventing/runs/2685047362?check_suite_focus=true#step:11:5985
- https://github.com/knative/eventing/runs/2678110719?check_suite_focus=true#step:11:5977