### PR TITLE
Bump downstream job to go 1.16

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -55,10 +55,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-    - name: Set up Go 1.15.x
+    - name: Set up Go 1.16.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
     - name: Install Dependencies
       run: |
         go get github.com/google/go-licenses


### PR DESCRIPTION
Fixes failing downstream tests from #5447

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: bump go in downstream test job to 1.16