### PR TITLE
Remove camel as a downstream now that is deprecated

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -30,8 +30,6 @@ jobs:
             org: knative-sandbox
           - repo: eventing-awssqs
             org: knative-sandbox
-          - repo: eventing-camel
-            org: knative-sandbox
           - repo: eventing-ceph
             org: knative-sandbox
           - repo: eventing-couchdb


### PR DESCRIPTION
https://github.com/knative-sandbox/eventing-camel/pull/97