### PR TITLE
apiServerSource now retries sending events

### DIFF
--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	kncloudevents "knative.dev/eventing/pkg/adapter/v2"
 
@@ -133,6 +134,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 		ResourceGroup: resourceGroup,
 	}
 	ctx = kncloudevents.ContextWithMetricTag(ctx, metricTag)
+	ctx = cloudevents.ContextWithRetriesExponentialBackoff(ctx, 50*time.Millisecond, 5)
 
 	return ctx, event, nil
 }

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -103,3 +103,17 @@ func TestApiServerSourceDataPlane_ResourceMatching(t *testing.T) {
 
 	env.TestSet(ctx, t, apiserversourcefeatures.DataPlane_ResourceMatching())
 }
+
+func TestApiServerSourceDataPlane_EventsRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, apiserversourcefeatures.SendsEventsWithRetries())
+}


### PR DESCRIPTION
Signed-off-by: XinYang <xinydev@gmail.com>

Fixes https://github.com/knative/eventing/issues/2980

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

* apiServerSource now retries sending events using exponential backoff, 5 times. same as [PingSource](https://github.com/knative/eventing/blob/main/pkg/adapter/mtping/runner.go#L88)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

