### PR TITLE
remove v1beta1 task as it has been done

### DIFF
--- a/docs/roadmap-2021.md
+++ b/docs/roadmap-2021.md
@@ -71,18 +71,6 @@ with the developer thinking about fewer resources
 
 **Owner:** Scott Nichols
 
-### Remove v1beta1 API [eventing, flows, messaging]
-
-Removal of v1beta1 APIs as per
-[our deprecation policy](https://knative.dev/community/contributing/mechanics/release-versioning-principles/).
-We guarantee 9 months of support for v1beta1 APIs. This makes the release
-18/05/2021 the earliest release where we can remove v1beta1 API, and we want to
-target that release.
-
-**GitHub Issue:** https://github.com/knative/eventing/issues/4836
-
-**Owner:** Ville Aikas
-
 ## Next 6 Months (Midterm)
 
 ### Protocol negotiation contract


### PR DESCRIPTION
We have completed this task #4836 (removal of v1beta1 for {eventing, flows, messaging}), so remove it from the roadmap
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

