### PR TITLE
Use embed package for rekt resource templates

### DIFF
--- a/test/rekt/resources/account_role/role.go
+++ b/test/rekt/resources/account_role/role.go
@@ -18,6 +18,7 @@ package account_role
 
 import (
 	"context"
+	"embed"
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -25,6 +26,9 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // Install will create a channelable-manipulator bound service account,
 // augmented with the config fn options.
@@ -36,7 +40,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/apiserversource/apiserversource.go
+++ b/test/rekt/resources/apiserversource/apiserversource.go
@@ -18,6 +18,7 @@ package apiserversource
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,9 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "apiserversources"}
@@ -57,7 +61,7 @@ func InstallLocalYaml(ctx context.Context, name string, opts ...manifest.CfgFn) 
 	for _, fn := range opts {
 		fn(cfg)
 	}
-	return manifest.InstallLocalYaml(ctx, cfg)
+	return manifest.InstallYamlFS(ctx, yaml, cfg)
 }
 
 // WithServiceAccountName sets the service account name on the ApiServerSource spec.

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -18,6 +18,7 @@ package broker
 
 import (
 	"context"
+	"embed"
 	"log"
 	"os"
 	"time"
@@ -31,6 +32,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 var EnvCfg EnvConfig
 
@@ -106,7 +110,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		}
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/channel/channel.go
+++ b/test/rekt/resources/channel/channel.go
@@ -18,6 +18,7 @@ package channel
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "channels"}
@@ -46,7 +50,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/channel_impl/channel_impl.go
+++ b/test/rekt/resources/channel_impl/channel_impl.go
@@ -18,6 +18,7 @@ package channel_impl
 
 import (
 	"context"
+	"embed"
 	"log"
 	"time"
 
@@ -32,6 +33,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func GVR() schema.GroupVersionResource {
 	gvr, _ := meta.UnsafeGuessKindToResource(GVK())
@@ -68,7 +72,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/containersource/containersource.go
+++ b/test/rekt/resources/containersource/containersource.go
@@ -18,6 +18,7 @@ package containersource
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,8 +28,11 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
+//go:embed *.yaml
+var yaml embed.FS
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+	environment.RegisterPackage(manifest.ImagesFromFS(yaml)...)
 }
 
 func Gvr() schema.GroupVersionResource {
@@ -50,7 +54,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/deployment/deployment.go
+++ b/test/rekt/resources/deployment/deployment.go
@@ -18,12 +18,16 @@ package deployment
 
 import (
 	"context"
+	"embed"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/tracker"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // Install will create a Deployment with defaults that can be overwritten by
 // the With* methods.
@@ -36,7 +40,7 @@ func Install(name string) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/eventlibrary/eventlibrary.go
+++ b/test/rekt/resources/eventlibrary/eventlibrary.go
@@ -18,6 +18,7 @@ package eventlibrary
 
 import (
 	"context"
+	"embed"
 	"log"
 	"path"
 	"runtime"
@@ -30,8 +31,11 @@ import (
 	"knative.dev/reconciler-test/resources/svc"
 )
 
+//go:embed *.yaml
+var yaml embed.FS
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+	environment.RegisterPackage(manifest.ImagesFromFS(yaml)...)
 }
 
 // Install
@@ -41,7 +45,7 @@ func Install(name string) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/flaker/flaker.go
+++ b/test/rekt/resources/flaker/flaker.go
@@ -18,6 +18,7 @@ package flaker
 
 import (
 	"context"
+	"embed"
 
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -25,8 +26,11 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
+//go:embed *.yaml
+var yaml embed.FS
+
 func init() {
-	environment.RegisterPackage(manifest.ImagesLocalYaml()...)
+	environment.RegisterPackage(manifest.ImagesFromFS(yaml)...)
 }
 
 // Install
@@ -37,7 +41,7 @@ func Install(name, sink string) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/parallel/parallel.go
+++ b/test/rekt/resources/parallel/parallel.go
@@ -18,6 +18,7 @@ package parallel
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "flows.knative.dev", Version: "v1", Resource: "parallels"}
@@ -46,7 +50,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -18,6 +18,7 @@ package pingsource
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,9 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "pingsources"}
@@ -41,7 +45,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err, cfg)
 		}
 	}

--- a/test/rekt/resources/pod/pod.go
+++ b/test/rekt/resources/pod/pod.go
@@ -18,10 +18,14 @@ package pod
 
 import (
 	"context"
+	"embed"
 
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // Install will create a Pod with defaults that can be overwritten by
 // the With* methods.
@@ -38,7 +42,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/sequence/sequence.go
+++ b/test/rekt/resources/sequence/sequence.go
@@ -18,6 +18,7 @@ package sequence
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "flows.knative.dev", Version: "v1", Resource: "sequences"}
@@ -46,7 +50,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/sinkbinding/sinkbinding.go
+++ b/test/rekt/resources/sinkbinding/sinkbinding.go
@@ -18,6 +18,7 @@ package sinkbinding
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "sinkbindings"}
@@ -76,7 +80,7 @@ func Install(name string, sink *duckv1.Destination, subject *tracker.Reference, 
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/subscription/subscription.go
+++ b/test/rekt/resources/subscription/subscription.go
@@ -18,6 +18,7 @@ package subscription
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "subscriptions"}
@@ -112,7 +116,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/svc/service.go
+++ b/test/rekt/resources/svc/service.go
@@ -18,6 +18,7 @@ package svc
 
 import (
 	"context"
+	"embed"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
@@ -28,6 +29,9 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/resources/svc"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // Deprecated, use reconciler-test/resources/svc
 func Gvr() schema.GroupVersionResource {
@@ -45,7 +49,7 @@ func Install(name, selectorKey, selectorValue string) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -18,6 +18,7 @@ package trigger
 
 import (
 	"context"
+	"embed"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "eventing.knative.dev", Version: "v1", Resource: "triggers"}
@@ -102,7 +106,7 @@ func Install(name, brokerName string, opts ...manifest.CfgFn) feature.StepFn {
 		fn(cfg)
 	}
 	return func(ctx context.Context, t feature.T) {
-		if _, err := manifest.InstallLocalYaml(ctx, cfg); err != nil {
+		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This gets us a little closer to being able to make redistributable test binaries. I think what remains is a better story around producing test images, since that's still tied to shelling out to `ko` and relative filepath references.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug

- :wastebasket: Remove feature or internal logic
-->

- :broom: Switch to using Go 1.16's `embed` package for including yaml templates in the rekt suite

