### PR TITLE
setup proper schemes in the fake dynamic client used in unit tests

### DIFF
--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -37,7 +37,6 @@ import (
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/pkg/apis"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -63,11 +62,6 @@ const (
 var (
 	validPath = fmt.Sprintf("/triggers/%s/%s/%s", testNS, triggerName, triggerUID)
 )
-
-func init() {
-	// Add types to scheme.
-	_ = eventingv1.AddToScheme(scheme.Scheme)
-}
 
 func TestReceiver(t *testing.T) {
 	testCases := map[string]struct {

--- a/pkg/duck/listable_test.go
+++ b/pkg/duck/listable_test.go
@@ -31,15 +31,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1alpha1/addressable"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 )
-
-func init() {
-	// Add types to scheme
-	_ = duckv1alpha1.AddToScheme(scheme.Scheme)
-}
 
 const ns = "test-ns"
 

--- a/pkg/duck/subscriber_test.go
+++ b/pkg/duck/subscriber_test.go
@@ -24,22 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-
-	"k8s.io/client-go/kubernetes/scheme"
-
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var (
 	testNS = "testnamespace"
 )
-
-func init() {
-	// Add types to scheme
-	_ = eventingv1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestDomainToURL(t *testing.T) {
 	d := "default-broker.default.svc.cluster.local"

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -87,13 +86,6 @@ const (
 
 	generation = 1
 )
-
-func init() {
-	// Add types to scheme
-	_ = appsv1.AddToScheme(scheme.Scheme)
-	_ = corev1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -25,11 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/eventing/pkg/apis/eventing"
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
@@ -83,12 +81,6 @@ var (
 		Path:   fmt.Sprintf("/%s/%s", testNS, brokerName),
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = eventingv1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -139,12 +138,6 @@ var (
 		Path:   fmt.Sprintf("/%s/%s", testNS, brokerName),
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = eventingv1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -317,7 +317,7 @@ func channelCRD() metav1.TypeMeta {
 func channelCRDBadGvk() metav1.TypeMeta {
 	return metav1.TypeMeta{
 		APIVersion: "",
-		Kind:       "-BrokenKind",
+		Kind:       "",
 	}
 }
 

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -23,11 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/channel"
@@ -57,12 +55,6 @@ var (
 		Retry: pointer.Int32Ptr(10),
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = messagingv1.AddToScheme(scheme.Scheme)
-	_ = eventingduckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestReconcile(t *testing.T) {
 
@@ -325,7 +317,7 @@ func channelCRD() metav1.TypeMeta {
 func channelCRDBadGvk() metav1.TypeMeta {
 	return metav1.TypeMeta{
 		APIVersion: "",
-		Kind:       "",
+		Kind:       "-BrokenKind",
 	}
 }
 

--- a/pkg/reconciler/containersource/containersource_test.go
+++ b/pkg/reconciler/containersource/containersource_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/pkg/apis"
@@ -75,13 +74,6 @@ var (
 		},
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = appsv1.AddToScheme(scheme.Scheme)
-	_ = corev1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllCases(t *testing.T) {
 	table := TableTest{

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -24,9 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
-	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/eventtype"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -52,11 +50,6 @@ var (
 		Host:   "test-source",
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-}
 
 func TestReconcile(t *testing.T) {
 	table := TableTest{{

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -40,14 +40,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
@@ -66,12 +64,6 @@ const (
 
 	imcGeneration = 7
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllCases(t *testing.T) {
 	imcKey := testNS + "/" + imcName

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
@@ -100,11 +99,6 @@ var (
 
 	subscribers = []eventingduckv1.SubscriberSpec{subscriber1, subscriber2}
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllCases(t *testing.T) {
 	backoffPolicy := eventingduckv1.BackoffPolicyLinear

--- a/pkg/reconciler/parallel/parallel_test.go
+++ b/pkg/reconciler/parallel/parallel_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
@@ -65,12 +64,6 @@ var (
 		Kind:    "Subscriber",
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllBranches(t *testing.T) {
 	pKey := testNS + "/" + parallelName

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 
 	"knative.dev/pkg/apis"
@@ -91,13 +90,6 @@ const (
 	sinkName   = "testsink"
 	generation = 1
 )
-
-func init() {
-	// Add types to scheme
-	_ = appsv1.AddToScheme(scheme.Scheme)
-	_ = corev1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllCases(t *testing.T) {
 	table := TableTest{

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -63,12 +62,6 @@ var (
 		Kind:    "Subscriber",
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-}
 
 func createReplyChannel(channelName string) *duckv1.Destination {
 	return &duckv1.Destination{

--- a/pkg/reconciler/source/crd/crd_test.go
+++ b/pkg/reconciler/source/crd/crd_test.go
@@ -68,12 +68,6 @@ var crdGVK = schema.GroupVersionKind{
 	Kind:    crdKind,
 }
 
-var crdListGVK = schema.GroupVersionKind{
-	Group:   crdGroup,
-	Version: crdVersionServed,
-	Kind:    crdKind + "List",
-}
-
 func TestAllCases(t *testing.T) {
 	ctx := context.Background()
 	ctx, _ = injection.Fake.SetupInformers(ctx, &rest.Config{})

--- a/pkg/reconciler/source/crd/crd_test.go
+++ b/pkg/reconciler/source/crd/crd_test.go
@@ -53,7 +53,7 @@ const (
 	crdGroup         = "testing.sources.knative.dev"
 	crdKind          = "TestSource"
 	crdPlural        = "testsources"
-	crdVersionServed = "v1alpha1"
+	crdVersionServed = "v1"
 )
 
 var crdGVR = schema.GroupVersionResource{

--- a/pkg/reconciler/source/crd/crd_test.go
+++ b/pkg/reconciler/source/crd/crd_test.go
@@ -40,6 +40,7 @@ import (
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
+
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
 	fakeclient "knative.dev/pkg/client/injection/apiextensions/client/fake"
 	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/fake"
@@ -65,6 +66,12 @@ var crdGVK = schema.GroupVersionKind{
 	Group:   crdGroup,
 	Version: crdVersionServed,
 	Kind:    crdKind,
+}
+
+var crdListGVK = schema.GroupVersionKind{
+	Group:   crdGroup,
+	Version: crdVersionServed,
+	Kind:    crdKind + "List",
 }
 
 func TestAllCases(t *testing.T) {

--- a/pkg/reconciler/source/duck/controller_test.go
+++ b/pkg/reconciler/source/duck/controller_test.go
@@ -34,12 +34,12 @@ func TestNew(t *testing.T) {
 
 	gvr := schema.GroupVersionResource{
 		Group:    "testing.sources.knative.dev",
-		Version:  "v1alpha1",
+		Version:  "v1",
 		Resource: "testsources",
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   "testing.sources.knative.dev",
-		Version: "v1alpha1",
+		Version: "v1",
 		Kind:    "TestSource",
 	}
 	crd := "testsources.testing.sources.knative.dev"

--- a/pkg/reconciler/source/duck/controller_test.go
+++ b/pkg/reconciler/source/duck/controller_test.go
@@ -17,20 +17,27 @@ limitations under the License.
 package duck
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/configmap"
-	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
 	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/source/fake"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+
+	. "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 func TestNew(t *testing.T) {
-	ctx, _ := SetupFakeContext(t)
+	ctx, _ := SetupFakeContext(t, func(ctx context.Context) context.Context {
+		ctx, _ = fakedynamicclient.With(ctx, NewScheme())
+		return ctx
+	})
 
 	gvr := schema.GroupVersionResource{
 		Group:    "testing.sources.knative.dev",

--- a/pkg/reconciler/source/duck/duck_test.go
+++ b/pkg/reconciler/source/duck/duck_test.go
@@ -66,13 +66,13 @@ var (
 
 	gvr = schema.GroupVersionResource{
 		Group:    "testing.sources.knative.dev",
-		Version:  "v1alpha1",
+		Version:  "v1",
 		Resource: "testsources",
 	}
 
 	gvk = schema.GroupVersionKind{
 		Group:   "testing.sources.knative.dev",
-		Version: "v1alpha1",
+		Version: "v1",
 		Kind:    "TestSource",
 	}
 )

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -26,16 +26,13 @@ import (
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/network"
 
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -129,14 +126,6 @@ var (
 		Name:       channelName,
 	}
 )
-
-func init() {
-	// Add types to scheme
-	_ = eventingv1.AddToScheme(scheme.Scheme)
-	_ = duckv1.AddToScheme(scheme.Scheme)
-	_ = apiextensionsv1.AddToScheme(scheme.Scheme)
-	_ = messagingv1.AddToScheme(scheme.Scheme)
-}
 
 func TestAllCases(t *testing.T) {
 	linear := eventingduck.BackoffPolicyLinear

--- a/pkg/reconciler/sugar/namespace/namespace_test.go
+++ b/pkg/reconciler/sugar/namespace/namespace_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
@@ -42,11 +41,6 @@ import (
 const (
 	testNS = "test-namespace"
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-}
 
 func TestEnabledByDefault(t *testing.T) {
 	// Events

--- a/pkg/reconciler/sugar/trigger/trigger_test.go
+++ b/pkg/reconciler/sugar/trigger/trigger_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
@@ -42,11 +41,6 @@ const (
 	triggerName = "test-trigger"
 	brokerName  = "default"
 )
-
-func init() {
-	// Add types to scheme
-	_ = v1.AddToScheme(scheme.Scheme)
-}
 
 func TestEnabledByDefault(t *testing.T) {
 	// Events

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -23,9 +23,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apiextensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -34,26 +32,18 @@ import (
 	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
 	sourcev1beta2listers "knative.dev/eventing/pkg/client/listers/sources/v1beta2"
+	testscheme "knative.dev/eventing/pkg/reconciler/testing/scheme"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler/testing"
 )
-
-var subscriberAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.eventing.knative.dev", Version: "v1", Kind: "Subscriber"}, &unstructured.Unstructured{})
-	return nil
-}
-
-var sourceAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.sources.knative.dev", Version: "v1", Kind: "TestSource"}, &duckv1.Source{})
-	return nil
-}
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
 	fakeeventingclientset.AddToScheme,
 	fakeapiextensionsclientset.AddToScheme,
-	subscriberAddToScheme,
-	sourceAddToScheme,
+	duckv1.AddToScheme,
+	testscheme.Eventing.AddToScheme,
+	testscheme.Serving.AddToScheme,
 }
 
 type Listers struct {
@@ -102,7 +92,7 @@ func (l *Listers) GetAPIExtentionsObjects() []runtime.Object {
 }
 
 func (l *Listers) GetSubscriberObjects() []runtime.Object {
-	return l.sorter.ObjectsForSchemeFunc(subscriberAddToScheme)
+	return l.sorter.ObjectsForSchemeFunc(testscheme.SubscriberToScheme)
 }
 
 func (l *Listers) GetAllObjects() []runtime.Object {

--- a/pkg/reconciler/testing/scheme/scheme.go
+++ b/pkg/reconciler/testing/scheme/scheme.go
@@ -33,7 +33,7 @@ var Serving = runtime.SchemeBuilder{
 }
 
 func SubscriberToScheme(scheme *runtime.Scheme) error {
-	gv := schema.GroupVersion{Group: "testing.eventing.knative.dev", Version: "v1"}
+	gv := schema.GroupVersion{Group: "messaging.knative.dev", Version: "v1"}
 	scheme.AddKnownTypeWithName(gv.WithKind("Subscriber"), &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(gv.WithKind("SubscriberList"), &unstructured.UnstructuredList{})
 	return nil

--- a/pkg/reconciler/testing/scheme/scheme.go
+++ b/pkg/reconciler/testing/scheme/scheme.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var Eventing = &runtime.SchemeBuilder{
+	SubscriberToScheme,
+	TestSourceToScheme,
+}
+
+var Serving = runtime.SchemeBuilder{
+	ServingServiceToScheme,
+}
+
+func SubscriberToScheme(scheme *runtime.Scheme) error {
+	gv := schema.GroupVersion{Group: "testing.eventing.knative.dev", Version: "v1"}
+	scheme.AddKnownTypeWithName(gv.WithKind("Subscriber"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gv.WithKind("SubscriberList"), &unstructured.UnstructuredList{})
+	return nil
+}
+
+func TestSourceToScheme(scheme *runtime.Scheme) error {
+	gv := schema.GroupVersion{Group: "testing.sources.knative.dev", Version: "v1"}
+	scheme.AddKnownTypeWithName(gv.WithKind("TestSource"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gv.WithKind("TestSourceList"), &unstructured.UnstructuredList{})
+	return nil
+}
+
+func ServingServiceToScheme(scheme *runtime.Scheme) error {
+	gv := schema.GroupVersion{Group: "serving.knative.dev", Version: "v1"}
+	scheme.AddKnownTypeWithName(gv.WithKind("Service"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gv.WithKind("ServiceList"), &unstructured.UnstructuredList{})
+	scheme.AddKnownTypes(gv, &metav1.Status{})
+	metav1.AddToGroupVersion(scheme, gv)
+	return nil
+}

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -66,11 +66,6 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 		ctx, dynamicClient := fakedynamicclient.With(ctx,
 			NewScheme(), ToUnstructured(t, r.Objects)...)
 
-		dynamicScheme := runtime.NewScheme()
-		for _, addTo := range clientSetSchemes {
-			addTo(dynamicScheme)
-		}
-
 		// The dynamic client's support for patching is BS.  Implement it
 		// here via PrependReactor (this can be overridden below by the
 		// provided reactors).

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -23,9 +23,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apiextensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -43,27 +41,19 @@ import (
 	flowslisters "knative.dev/eventing/pkg/client/listers/flows/v1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	sourcelisters "knative.dev/eventing/pkg/client/listers/sources/v1"
+	testscheme "knative.dev/eventing/pkg/reconciler/testing/scheme"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler/testing"
 )
-
-var subscriberAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.eventing.knative.dev", Version: "v1", Kind: "Subscriber"}, &unstructured.Unstructured{})
-	return nil
-}
-
-var sourceAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.sources.knative.dev", Version: "v1", Kind: "TestSource"}, &duckv1.Source{})
-	return nil
-}
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
 	fakeeventingclientset.AddToScheme,
 	fakeapiextensionsclientset.AddToScheme,
-	subscriberAddToScheme,
-	sourceAddToScheme,
+	duckv1.AddToScheme,
 	eventingduck.AddToScheme,
+	testscheme.Eventing.AddToScheme,
+	testscheme.Serving.AddToScheme,
 }
 
 type Listers struct {
@@ -108,7 +98,7 @@ func (l *Listers) GetEventingObjects() []runtime.Object {
 }
 
 func (l *Listers) GetSubscriberObjects() []runtime.Object {
-	return l.sorter.ObjectsForSchemeFunc(subscriberAddToScheme)
+	return l.sorter.ObjectsForSchemeFunc(testscheme.SubscriberToScheme)
 }
 
 func (l *Listers) GetAllObjects() []runtime.Object {

--- a/pkg/reconciler/testing/v1beta1/listers.go
+++ b/pkg/reconciler/testing/v1beta1/listers.go
@@ -23,9 +23,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apiextensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -34,26 +32,18 @@ import (
 	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
 	eventingv1beta1listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	testscheme "knative.dev/eventing/pkg/reconciler/testing/scheme"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler/testing"
 )
-
-var subscriberAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.eventing.knative.dev", Version: "v1alpha1", Kind: "Subscriber"}, &unstructured.Unstructured{})
-	return nil
-}
-
-var sourceAddToScheme = func(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "testing.sources.knative.dev", Version: "v1alpha1", Kind: "TestSource"}, &duckv1.Source{})
-	return nil
-}
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
 	fakeeventingclientset.AddToScheme,
 	fakeapiextensionsclientset.AddToScheme,
-	subscriberAddToScheme,
-	sourceAddToScheme,
+	duckv1.AddToScheme,
+	testscheme.Eventing.AddToScheme,
+	testscheme.Serving.AddToScheme,
 }
 
 type Listers struct {
@@ -102,7 +92,7 @@ func (l *Listers) GetEventingObjects() []runtime.Object {
 }
 
 func (l *Listers) GetSubscriberObjects() []runtime.Object {
-	return l.sorter.ObjectsForSchemeFunc(subscriberAddToScheme)
+	return l.sorter.ObjectsForSchemeFunc(testscheme.SubscriberToScheme)
 }
 
 func (l *Listers) GetAllObjects() []runtime.Object {


### PR DESCRIPTION
I also removed some unnecessary `init` functions that modified the k8s global `scheme.Scheme` 

This should help when bumping K8s libs to 1.20