### PR TITLE
Retry install_knative_eventing on 502 errors from GitHub

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -154,7 +154,7 @@ function install_knative_eventing() {
     local EVENTING_RELEASE_YAML=${TMP_DIR}/"eventing-${LATEST_RELEASE_VERSION}.yaml"
     # Download the latest release of Knative Eventing.
     local url="https://github.com/knative/eventing/releases/download/${LATEST_RELEASE_VERSION}"
-    wget "${url}/eventing.yaml" -O "${EVENTING_RELEASE_YAML}" \
+    wget --retry-on-http-error=502 "${url}/eventing.yaml" -O "${EVENTING_RELEASE_YAML}" \
       || fail_test "Unable to download latest knative/eventing file."
 
     # Replace the default system namespace with the test's system namespace.


### PR DESCRIPTION
Fixes #5482

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Retry installing eventing when we encounter 502 errors from GitHub

We seem to have been getting a fair number of these. Wget by default does a linear retry starting from 1 second and going up to a maximum of 10 seconds, for a total of 25 retries.