### PR TITLE
Change webhook PodDisruptionBudget.minAvailable to 1

### DIFF
--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -43,7 +43,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: eventing-webhook


### PR DESCRIPTION
Matches the absolute minReplicas value of the hpa

## Proposed Changes
- Change the minimum available pods to absolute (1) value instead of percentage
￼- :wastebasket: Update or clean up current behavior

```release-note
The eventing-webhook's PodDisruptionBudget.minAvailable has been changed from 80% to an absolute value of 1
```

