### PR TITLE
Add permission to update namespaces/finalizer

### DIFF
--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -42,6 +42,14 @@ rules:
       - "watch"
       - "patch"
 
+  # finalizers are needed for the owner reference of the webhook
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces/finalizers"
+    verbs:
+      - "update"
+
   # For getting our Deployment so we can decorate with ownerref.
   - apiGroups:
       - "apps"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
(similar to https://github.com/knative/serving/pull/11517)

This patch adds the permission to update `namespaces/finalizers`.

Since knative/pkg#2098 added ownerRef refers to namespace for webhook,
we need this permission. Without it, cluster which has a stricter RBAC
rules gets the following error:

```
cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on:
```

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
knative-eventing-webhook cluster role has update permission for namespaces/finalizers.

```

/cc @markusthoemmes @nak3 

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

