### PR TITLE
RetryConfig.RequestTimeout to configure the timeout of a single request

### DIFF
--- a/pkg/kncloudevents/message_sender.go
+++ b/pkg/kncloudevents/message_sender.go
@@ -57,8 +57,18 @@ func (s *HTTPMessageSender) SendWithRetries(req *nethttp.Request, config *RetryC
 		return s.Send(req)
 	}
 
+	client := s.Client
+	if config.RequestTimeout != 0 {
+		client = &nethttp.Client{
+			Transport:     client.Transport,
+			CheckRedirect: client.CheckRedirect,
+			Jar:           client.Jar,
+			Timeout:       config.RequestTimeout,
+		}
+	}
+
 	retryableClient := retryablehttp.Client{
-		HTTPClient:   s.Client,
+		HTTPClient:   client,
 		RetryWaitMin: defaultRetryWaitMin,
 		RetryWaitMax: defaultRetryWaitMax,
 		RetryMax:     config.RetryMax,

--- a/pkg/kncloudevents/message_sender_test.go
+++ b/pkg/kncloudevents/message_sender_test.go
@@ -162,23 +162,22 @@ func TestHTTPMessageSenderSendWithRetriesWithSingleRequestTimeout(t *testing.T) 
 	var n int32
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		newVal := atomic.AddInt32(&n, 1)
-		if newVal == 5 {
+		if newVal >= 5 {
 			writer.WriteHeader(http.StatusOK)
 		} else {
 			// Let's add one more second
-			time.Sleep(timeout + time.Second)
+			time.Sleep(timeout)
 			writer.WriteHeader(http.StatusAccepted)
 		}
 	}))
+	defer server.Close()
 
 	sender := &HTTPMessageSender{
 		Client: getClient(),
 	}
 	config := &RetryConfig{
-		RetryMax: 5,
-		CheckRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-			return true, nil
-		},
+		RetryMax:   5,
+		CheckRetry: RetryIfGreaterThan300,
 		Backoff: func(attemptNum int, resp *http.Response) time.Duration {
 			return time.Millisecond
 		},
@@ -189,10 +188,10 @@ func TestHTTPMessageSenderSendWithRetriesWithSingleRequestTimeout(t *testing.T) 
 	require.NoError(t, err)
 
 	got, err := sender.SendWithRetries(request, config)
-	require.NoError(t, err)
 
-	require.Equal(t, http.StatusOK, got.StatusCode)
 	require.Equal(t, 5, int(atomic.LoadInt32(&n)))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, got.StatusCode)
 }
 
 func TestRetriesOnNetworkErrors(t *testing.T) {

--- a/pkg/kncloudevents/retries.go
+++ b/pkg/kncloudevents/retries.go
@@ -63,6 +63,9 @@ type RetryConfig struct {
 
 	CheckRetry CheckRetry
 	Backoff    Backoff
+
+	// RequestTimeout represents the timeout of the single request
+	RequestTimeout time.Duration
 }
 
 func NoRetries() RetryConfig {


### PR DESCRIPTION
Part of https://github.com/knative/eventing/issues/5148

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `RetryConfig.RequestTimeout` to configure the timeout of a single request when using `kncloudevents.HTTPMessageSender`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior: N/A
- [x] **Docs PR** for any user-facing impact:  N/A
- [x] **Spec PR** for any new API feature:  N/A
- [x] **Conformance test** for any change to the spec:  N/A
