### PR TITLE
Use transformers efficiently for extracting info for metrics in Kafka Channel 

### DIFF
--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -304,7 +304,6 @@ func (f *FanoutMessageHandler) makeFanoutRequest(ctx context.Context, message bi
 		sub.Reply,
 		sub.DeadLetter,
 		sub.RetryConfig,
-		nil,
 	)
 }
 

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -304,6 +304,7 @@ func (f *FanoutMessageHandler) makeFanoutRequest(ctx context.Context, message bi
 		sub.Reply,
 		sub.DeadLetter,
 		sub.RetryConfig,
+		nil,
 	)
 }
 

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -154,7 +154,7 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 		return dispatchExecutionInfo, nil
 	}
 
-	ctx, responseResponseMessage, _, dispatchExecutionInfo, err := d.executeRequest(ctx, reply, responseMessage, responseAdditionalHeaders, retriesConfig)
+	ctx, responseResponseMessage, _, dispatchExecutionInfo, err := d.executeRequest(ctx, reply, responseMessage, responseAdditionalHeaders, retriesConfig, transformers...)
 	if err != nil {
 		// If DeadLetter is configured, then send original message with knative error extensions
 		if deadLetter != nil {

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -51,7 +51,7 @@ type MessageDispatcher interface {
 	// DispatchMessageWithRetries dispatches an event to a destination over HTTP.
 	//
 	// The destination and reply are URLs.
-	DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination *url.URL, reply *url.URL, deadLetter *url.URL, config *kncloudevents.RetryConfig) (*DispatchExecutionInfo, error)
+	DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination *url.URL, reply *url.URL, deadLetter *url.URL, config *kncloudevents.RetryConfig, transformers ...binding.Transformer) (*DispatchExecutionInfo, error)
 }
 
 // MessageDispatcherImpl is the 'real' MessageDispatcher used everywhere except unit tests.
@@ -93,7 +93,7 @@ func (d *MessageDispatcherImpl) DispatchMessage(ctx context.Context, message clo
 	return d.DispatchMessageWithRetries(ctx, message, additionalHeaders, destination, reply, deadLetter, nil)
 }
 
-func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination *url.URL, reply *url.URL, deadLetter *url.URL, retriesConfig *kncloudevents.RetryConfig) (*DispatchExecutionInfo, error) {
+func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination *url.URL, reply *url.URL, deadLetter *url.URL, retriesConfig *kncloudevents.RetryConfig, transformers ...binding.Transformer) (*DispatchExecutionInfo, error) {
 	// All messages that should be finished at the end of this function
 	// are placed in this slice
 	var messagesToFinish []binding.Message


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka/pull/688 the Kafka message needs to be copied to in order to extract the event type (used for labeling metrics) with a transformer. Transformers can be used though in DispatchWithRetries via the execute method, so with this PR we can touch the msg only when we write it and get the info we need back efficiently. 
Implementation example of this can be found [here](https://github.com/openshift-knative/eventing-kafka/pull/234) downstream.

/cc @matzew 