### PR TITLE
Try to fix more flaky tests

### DIFF
--- a/test/rekt/features/broker/source_to_sink.go
+++ b/test/rekt/features/broker/source_to_sink.go
@@ -160,6 +160,8 @@ func SourceToTwoSinksWithDLQ(brokerName string) *feature.Feature {
 
 	// After we have finished sending.
 	f.Requirement("sender is finished", prober.SenderDone("source"))
+	f.Requirement("receiver 1 is finished", prober.ReceiverDone("source", "sink1"))
+	f.Requirement("receiver 2 is finished", prober.ReceiverDone("source", "sink2"))
 
 	// Assert events ended up where we expected.
 	f.Stable("broker with DLQ").

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -137,6 +137,7 @@ func EventTransformation() *feature.Feature {
 	f.Setup("event library is ready", eventlibrary.IsReady(lib))
 
 	f.Requirement("sender is finished", prober.SenderDone("source"))
+	f.Requirement("receiver is finished", prober.ReceiverDone("source", "sink"))
 
 	f.Assert("sink receives events", prober.AssertReceivedAll("source", "sink"))
 	f.Assert("events have passed through transform service", func(ctx context.Context, t feature.T) {
@@ -177,6 +178,7 @@ func SingleEventWithEncoding(encoding binding.Encoding) *feature.Feature {
 	f.Setup("install source", prober.SenderInstall("source", eventshub.InputEventWithEncoding(event, encoding)))
 
 	f.Requirement("sender is finished", prober.SenderDone("source"))
+	f.Requirement("receiver is finished", prober.ReceiverDone("source", "sink"))
 
 	f.Assert("sink receives events", prober.AssertReceivedAll("source", "sink"))
 


### PR DESCRIPTION
Lots of flakiness recently, which hopefully this can address.

The idea of this change being that `prober.ReceiverDone()` will poll for the receiver to have received all the sender's events, whereas before we were just doing `prober.AssertReceivedAll`. The latter works fine as long as the time between `SenderDone` and `ReceiverDone` is close to 0, which it seems to be on my machine. However if there's enough of a delay (as I think might be the case in a GitHub Action kind env), the assert will kick in before the receiver and it immediately will fail.

https://github.com/knative/eventing/runs/2817796102?check_suite_focus=true#step:12:4213
https://github.com/knative/eventing/runs/2818732715?check_suite_focus=true#step:12:5736
https://github.com/knative/eventing/runs/2820524189?check_suite_focus=true#step:12:4820
https://github.com/knative/eventing/runs/2821565820?check_suite_focus=true#step:12:4827
https://github.com/knative/eventing/runs/2821629829?check_suite_focus=true#step:12:5384
https://github.com/knative/eventing/runs/2822529840?check_suite_focus=true#step:12:4251
