### PR TITLE
Fix flakiness & slowness of imc dispatcher test

### DIFF
--- a/pkg/inmemorychannel/message_dispatcher.go
+++ b/pkg/inmemorychannel/message_dispatcher.go
@@ -57,6 +57,11 @@ func (d *InMemoryMessageDispatcher) Start(ctx context.Context) error {
 	return d.httpBindingsReceiver.StartListen(kncloudevents.WithShutdownTimeout(ctx, d.writeTimeout), d.handler)
 }
 
+// WaitReady blocks until the dispatcher's server is ready to receive requests.
+func (d *InMemoryMessageDispatcher) WaitReady() {
+	<-d.httpBindingsReceiver.Ready
+}
+
 func NewMessageDispatcher(args *InMemoryMessageDispatcherArgs) *InMemoryMessageDispatcher {
 	// TODO set read timeouts?
 	bindingsReceiver := kncloudevents.NewHTTPMessageReceiver(args.Port)

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -86,6 +86,7 @@ func TestDispatcher_close(t *testing.T) {
 	}
 
 	dispatcher := NewMessageDispatcher(dispatcherArgs)
+	kncloudevents.WithDrainQuietPeriod(time.Nanosecond)(dispatcher.httpBindingsReceiver)
 
 	serverCtx, cancel := context.WithCancel(context.Background())
 
@@ -254,6 +255,7 @@ func TestDispatcher_dispatch(t *testing.T) {
 			t.Error(err)
 		}
 	}()
+	dispatcher.WaitReady()
 
 	// Ok now everything should be ready to send the event
 	httpsender, err := kncloudevents.NewHTTPMessageSenderWithTarget(channelAProxy.URL)


### PR DESCRIPTION
There was a race where the dispatcher was not ready to receive messages
by the time we sent the request. Surfacing the message receiver's Ready
channel helps solve this.

The default quiet period for draining the receiver is 45s, this means
that the TestDispatcher_close test always took 45s.