### PR TITLE
[PingSource] Degrade warning to normal event

### DIFF
--- a/pkg/adapter/mtping/pingsource_test.go
+++ b/pkg/adapter/mtping/pingsource_test.go
@@ -18,11 +18,11 @@ package mtping
 
 import (
 	"context"
-
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
@@ -88,6 +88,10 @@ func TestAllCases(t *testing.T) {
 				),
 			},
 			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "PingSourceSynchronized",
+					`PingSource adapter is synchronized`),
+			},
 		}, {
 			Name: "valid schedule without contentType, data and dataBase64",
 			Key:  pingsourceKey,
@@ -107,6 +111,10 @@ func TestAllCases(t *testing.T) {
 				),
 			},
 			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "PingSourceSynchronized",
+					`PingSource adapter is synchronized`),
+			},
 		}, {
 			Name: "valid schedule with dataBase64",
 			Key:  pingsourceKey,
@@ -128,6 +136,10 @@ func TestAllCases(t *testing.T) {
 				),
 			},
 			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "PingSourceSynchronized",
+					`PingSource adapter is synchronized`),
+			},
 		}, {
 			Name: "valid schedule, with finalizer",
 			Key:  pingsourceKey,
@@ -149,6 +161,10 @@ func TestAllCases(t *testing.T) {
 				),
 			},
 			WantErr: false,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "PingSourceSynchronized",
+					`PingSource adapter is synchronized`),
+			},
 		}, {
 			Name: "valid schedule, deleted with finalizer",
 			Key:  pingsourceKey,

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -148,7 +148,7 @@ func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, source *source
 	d, err := r.kubeClientSet.AppsV1().Deployments(system.Namespace()).Get(ctx, mtadapterName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			logging.FromContext(ctx).Errorw("pingsource adapter deployment doesn't exist", zap.Error(err))
+			logging.FromContext(ctx).Errorw("PingSource adapter deployment doesn't exist", zap.Error(err))
 			return nil, err
 		}
 		return nil, fmt.Errorf("error getting mt adapter deployment %v", err)
@@ -162,7 +162,7 @@ func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, source *source
 		if d, err = r.kubeClientSet.AppsV1().Deployments(system.Namespace()).Update(ctx, d, metav1.UpdateOptions{}); err != nil {
 			return d, err
 		}
-		controller.GetEventRecorder(ctx).Event(source, corev1.EventTypeNormal, pingSourceDeploymentUpdated, "pingsource adapter deployment updated")
+		controller.GetEventRecorder(ctx).Event(source, corev1.EventTypeNormal, pingSourceDeploymentUpdated, "PingSource adapter deployment updated")
 		return d, nil
 	} else {
 		logging.FromContext(ctx).Debugw("Reusing existing cluster-scoped deployment", zap.Any("deployment", d))

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -245,7 +245,7 @@ func TestAllCases(t *testing.T) {
 			},
 			Key: testNS + "/" + sourceName,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, pingSourceDeploymentUpdated, `pingsource adapter deployment updated`),
+				Eventf(corev1.EventTypeNormal, pingSourceDeploymentUpdated, `PingSource adapter deployment updated`),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: rtv1.NewPingSource(sourceName, testNS,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: The PingSource adapter now generates a normal event instead of a warning when the source is not ready. Rename event to PingSourceSkipped 
- :broom: The PingSource adapter now generates a normal event when it has been synchronized 
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
- :broom: The PingSource adapter now generates a normal event instead of a warning when the source is not ready. Rename the event to PingSourceSkipped 
- :broom: The PingSource adapter now generates the normal event PingSourceSynchronized when it has been synchronized. 
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

