### PR TITLE
tracing fix for APIServerSource and PingSource

### DIFF
--- a/pkg/adapter/v2/cloudevents.go
+++ b/pkg/adapter/v2/cloudevents.go
@@ -83,7 +83,7 @@ func newCloudEventsClientCRStatus(env EnvConfigAccessor, ceOverrides *duckv1.Clo
 	// Make sure that explicitly set options have priority
 	opts = append(pOpts, opts...)
 
-	ceClient, err := newClientHTTPObserved(pOpts, nil)
+	ceClient, err := newClientHTTPObserved(opts, nil)
 
 	if crStatusEventClient == nil {
 		crStatusEventClient = crstatusevent.GetDefaultClient()

--- a/pkg/adapter/v2/cloudevents.go
+++ b/pkg/adapter/v2/cloudevents.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"time"
 
+	cloudeventsobsclient "github.com/cloudevents/sdk-go/observability/opencensus/v2/client"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol"
@@ -33,6 +34,8 @@ import (
 	"knative.dev/pkg/source"
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 )
+
+var newClientHTTPObserved = cloudeventsobsclient.NewClientHTTP
 
 // NewCloudEventsClient returns a client that will apply the ceOverrides to
 // outbound events and report outbound event counts.
@@ -80,12 +83,7 @@ func newCloudEventsClientCRStatus(env EnvConfigAccessor, ceOverrides *duckv1.Clo
 	// Make sure that explicitly set options have priority
 	opts = append(pOpts, opts...)
 
-	p, err := cloudevents.NewHTTP(opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	ceClient, err := cloudevents.NewClient(p, cloudevents.WithTimeNow(), cloudevents.WithUUIDs())
+	ceClient, err := newClientHTTPObserved(pOpts, nil)
 
 	if crStatusEventClient == nil {
 		crStatusEventClient = crstatusevent.GetDefaultClient()

--- a/pkg/adapter/v2/cloudevents_test.go
+++ b/pkg/adapter/v2/cloudevents_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	v2client "github.com/cloudevents/sdk-go/v2/client"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/source"
@@ -127,7 +128,7 @@ func TestNewCloudEventsClient_send(t *testing.T) {
 
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			restoreHTTP := cloudevents.NewHTTP
+			restoreHTTP := newClientHTTPObserved
 			restoreEnv, setEnv := os.LookupEnv("K_SINK_TIMEOUT")
 			if tc.timeout != 0 {
 				if err := os.Setenv("K_SINK_TIMEOUT", strconv.Itoa(tc.timeout)); err != nil {
@@ -135,8 +136,8 @@ func TestNewCloudEventsClient_send(t *testing.T) {
 				}
 			}
 
-			defer func(restoreHTTP func(opts ...http.Option) (*http.Protocol, error), restoreEnv string, setEnv bool) {
-				cloudevents.NewHTTP = restoreHTTP
+			defer func(restoreHTTP func(topt []http.Option, copt []v2client.Option) (v2client.Client, error), restoreEnv string, setEnv bool) {
+				newClientHTTPObserved = restoreHTTP
 				if setEnv {
 					if err := os.Setenv("K_SINK_TIMEOUT", restoreEnv); err != nil {
 						t.Error(err)
@@ -150,8 +151,8 @@ func TestNewCloudEventsClient_send(t *testing.T) {
 			}(restoreHTTP, restoreEnv, setEnv)
 
 			sendOptions := []http.Option{}
-			cloudevents.NewHTTP = func(opts ...http.Option) (*http.Protocol, error) {
-				sendOptions = append(sendOptions, opts...)
+			newClientHTTPObserved = func(topt []http.Option, copt []v2client.Option) (v2client.Client, error) {
+				sendOptions = append(sendOptions, topt...)
 				return nil, nil
 			}
 			envConfigAccessor := ConstructEnvOrDie(func() EnvConfigAccessor {


### PR DESCRIPTION
Fixes #
Due to some refactoring in the v2.4 of cloudevents go sdk, traces were not being generated because of the method thats used to generate the ceClient. I noticed the issue after eventing's v0.22 release when the changes were also done in the cloudevents sdk.
Reference: cloudevents/sdk-go#682
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
In cloudevents go sdk, opencensus dependencies are removed from v2 (and future releases), so I am using here a method suggested in the issue linked above,  to generate a client with the tracing options.

https://github.com/cloudevents/sdk-go/blob/main/observability/opencensus/v2/client/client.go#L14

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug:

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

This is an example of a scenario when the cloudevent flow is: pingsource -> imc channel -> a ksvc which sends back 503 -> goes to deadletter sink which gives 200:

![](https://user-images.githubusercontent.com/48708039/122799566-7f499200-d2df-11eb-87f1-b75697b77579.png)

