### PR TITLE
Make apiserversource test watch for update events

### DIFF
--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -327,7 +327,7 @@ func SendsEventsForLabelMatchingResources() *feature.Feature {
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events",
 			eventasssert.OnStore(sink).MatchEvent(
-				test.HasType("dev.knative.apiserver.ref.add"),
+				test.HasType("dev.knative.apiserver.ref.update"),
 				test.DataContains(`"kind":"Pod"`),
 				test.DataContains(fmt.Sprintf(`"name":"%s"`, examplePodName)),
 			).AtLeast(1))


### PR DESCRIPTION
It seems like there's a race in pod creation and the apiserversource listening for it that we sometimes miss it, but we'll always get subsequent update events.

Fixes #5562