### PR TITLE
[PingSource] disable @every

### DIFF
--- a/pkg/apis/sources/v1/ping_validation.go
+++ b/pkg/apis/sources/v1/ping_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -37,8 +38,10 @@ func (c *PingSource) Validate(ctx context.Context) *apis.FieldError {
 
 func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-
 	schedule := cs.Schedule
+
+	errs = validateDescriptor(schedule)
+
 	if cs.Timezone != "" {
 		schedule = "CRON_TZ=" + cs.Timezone + " " + schedule
 	}
@@ -97,4 +100,16 @@ func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 func validateJSON(str string) error {
 	var objmap map[string]interface{}
 	return json.Unmarshal([]byte(str), &objmap)
+}
+
+func validateDescriptor(spec string) *apis.FieldError {
+	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
+		i := strings.Index(spec, " ")
+		spec = strings.TrimSpace(spec[i:])
+	}
+
+	if strings.HasPrefix(spec, "@every") {
+		return apis.ErrInvalidValue(errors.New("unsupported descriptor @every"), "schedule")
+	}
+	return nil
 }

--- a/pkg/apis/sources/v1/ping_validation.go
+++ b/pkg/apis/sources/v1/ping_validation.go
@@ -103,12 +103,7 @@ func validateJSON(str string) error {
 }
 
 func validateDescriptor(spec string) *apis.FieldError {
-	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
-		i := strings.Index(spec, " ")
-		spec = strings.TrimSpace(spec[i:])
-	}
-
-	if strings.HasPrefix(spec, "@every") {
+	if strings.Contains(spec, "@every") {
 		return apis.ErrInvalidValue(errors.New("unsupported descriptor @every"), "schedule")
 	}
 	return nil

--- a/pkg/apis/sources/v1/ping_validation_test.go
+++ b/pkg/apis/sources/v1/ping_validation_test.go
@@ -362,6 +362,51 @@ func TestPingSourceValidation(t *testing.T) {
 				},
 			},
 			want: nil,
+		}, {
+			name: "unsupported @every descriptor",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "@every 2h",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				fe := apis.ErrInvalidValue("unsupported descriptor @every", "spec.schedule")
+				errs = errs.Also(fe)
+				return errs
+			}(),
+		}, {
+			name: "unsupported @every descriptor with TZ",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "@every 2h",
+					Timezone: "Europe/Paris",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				fe := apis.ErrInvalidValue("unsupported descriptor @every", "spec.schedule")
+				errs = errs.Also(fe)
+				return errs
+			}(),
 		},
 	}
 

--- a/pkg/apis/sources/v1beta2/ping_validation.go
+++ b/pkg/apis/sources/v1beta2/ping_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -37,8 +38,10 @@ func (c *PingSource) Validate(ctx context.Context) *apis.FieldError {
 
 func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-
 	schedule := cs.Schedule
+
+	errs = validateDescriptor(schedule)
+
 	if cs.Timezone != "" {
 		schedule = "CRON_TZ=" + cs.Timezone + " " + schedule
 	}
@@ -97,4 +100,16 @@ func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 func validateJSON(str string) error {
 	var objmap map[string]interface{}
 	return json.Unmarshal([]byte(str), &objmap)
+}
+
+func validateDescriptor(spec string) *apis.FieldError {
+	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
+		i := strings.Index(spec, " ")
+		spec = strings.TrimSpace(spec[i:])
+	}
+
+	if strings.HasPrefix(spec, "@every") {
+		return apis.ErrInvalidValue(errors.New("unsupported descriptor @every"), "schedule")
+	}
+	return nil
 }

--- a/pkg/apis/sources/v1beta2/ping_validation.go
+++ b/pkg/apis/sources/v1beta2/ping_validation.go
@@ -103,12 +103,7 @@ func validateJSON(str string) error {
 }
 
 func validateDescriptor(spec string) *apis.FieldError {
-	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
-		i := strings.Index(spec, " ")
-		spec = strings.TrimSpace(spec[i:])
-	}
-
-	if strings.HasPrefix(spec, "@every") {
+	if strings.Contains(spec, "@every") {
 		return apis.ErrInvalidValue(errors.New("unsupported descriptor @every"), "schedule")
 	}
 	return nil

--- a/pkg/apis/sources/v1beta2/ping_validation_test.go
+++ b/pkg/apis/sources/v1beta2/ping_validation_test.go
@@ -362,6 +362,51 @@ func TestPingSourceValidation(t *testing.T) {
 				},
 			},
 			want: nil,
+		}, {
+			name: "unsupported @every descriptor",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "@every 2h",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				fe := apis.ErrInvalidValue("unsupported descriptor @every", "spec.schedule")
+				errs = errs.Also(fe)
+				return errs
+			}(),
+		}, {
+			name: "unsupported @every descriptor with TZ",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "@every 2h",
+					Timezone: "Europe/Paris",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				fe := apis.ErrInvalidValue("unsupported descriptor @every", "spec.schedule")
+				errs = errs.Also(fe)
+				return errs
+			}(),
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/5584

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-  :bug: reject non-standard @every schedule.
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
:bug: PingSource schedules starting with `@every` are now properly rejected.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

