### PR TITLE
drop use of upstream knative.dev/pkg/metric eventing keys

### DIFF
--- a/pkg/broker/filter/stats_reporter.go
+++ b/pkg/broker/filter/stats_reporter.go
@@ -27,6 +27,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	broker "knative.dev/eventing/pkg/broker"
+	eventingmetrics "knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
 )
@@ -66,9 +67,9 @@ var (
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	triggerFilterTypeKey = tag.MustNewKey(metricskey.LabelFilterType)
-	responseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
-	responseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
+	triggerFilterTypeKey = tag.MustNewKey(eventingmetrics.LabelFilterType)
+	responseCodeKey      = tag.MustNewKey(eventingmetrics.LabelResponseCode)
+	responseCodeClassKey = tag.MustNewKey(eventingmetrics.LabelResponseCodeClass)
 )
 
 type ReportArgs struct {
@@ -172,11 +173,11 @@ func (r *reporter) ReportEventProcessingTime(args *ReportArgs, d time.Duration) 
 
 func (r *reporter) generateTag(args *ReportArgs, tags ...tag.Mutator) (context.Context, error) {
 	ctx := metricskey.WithResource(emptyContext, resource.Resource{
-		Type: metricskey.ResourceTypeKnativeTrigger,
+		Type: eventingmetrics.ResourceTypeKnativeTrigger,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName: args.ns,
-			metricskey.LabelBrokerName:    args.broker,
-			metricskey.LabelTriggerName:   args.trigger,
+			eventingmetrics.LabelNamespaceName: args.ns,
+			eventingmetrics.LabelBrokerName:    args.broker,
+			eventingmetrics.LabelTriggerName:   args.trigger,
 		},
 	})
 	// Note that filterType and filterSource can be empty strings, so they need a special treatment.

--- a/pkg/broker/filter/stats_reporter_test.go
+++ b/pkg/broker/filter/stats_reporter_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opencensus.io/resource"
 	broker "knative.dev/eventing/pkg/broker"
-	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 )
@@ -40,24 +40,24 @@ func TestStatsReporter(t *testing.T) {
 	r := NewStatsReporter("testcontainer", "testpod")
 
 	wantTags := map[string]string{
-		metricskey.LabelFilterType: "testeventtype",
-		broker.LabelContainerName:  "testcontainer",
-		broker.LabelUniqueName:     "testpod",
+		metrics.LabelFilterType:   "testeventtype",
+		broker.LabelContainerName: "testcontainer",
+		broker.LabelUniqueName:    "testpod",
 	}
 
 	wantAllTags := map[string]string{}
 	for k, v := range wantTags {
 		wantAllTags[k] = v
 	}
-	wantAllTags[metricskey.LabelResponseCode] = "202"
-	wantAllTags[metricskey.LabelResponseCodeClass] = "2xx"
+	wantAllTags[metrics.LabelResponseCode] = "202"
+	wantAllTags[metrics.LabelResponseCodeClass] = "2xx"
 
 	resource := resource.Resource{
-		Type: metricskey.ResourceTypeKnativeTrigger,
+		Type: metrics.ResourceTypeKnativeTrigger,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName: "testns",
-			metricskey.LabelTriggerName:   "testtrigger",
-			metricskey.LabelBrokerName:    "testbroker",
+			metrics.LabelNamespaceName: "testns",
+			metrics.LabelTriggerName:   "testtrigger",
+			metrics.LabelBrokerName:    "testbroker",
 		},
 	}
 
@@ -105,19 +105,19 @@ func TestReporterEmptySourceAndTypeFilter(t *testing.T) {
 	r := NewStatsReporter("testcontainer", "testpod")
 
 	wantTags := map[string]string{
-		metricskey.LabelFilterType:        anyValue,
-		metricskey.LabelResponseCode:      "202",
-		metricskey.LabelResponseCodeClass: "2xx",
-		broker.LabelContainerName:         "testcontainer",
-		broker.LabelUniqueName:            "testpod",
+		metrics.LabelFilterType:        anyValue,
+		metrics.LabelResponseCode:      "202",
+		metrics.LabelResponseCodeClass: "2xx",
+		broker.LabelContainerName:      "testcontainer",
+		broker.LabelUniqueName:         "testpod",
 	}
 
 	resource := resource.Resource{
-		Type: metricskey.ResourceTypeKnativeTrigger,
+		Type: metrics.ResourceTypeKnativeTrigger,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName: "testns",
-			metricskey.LabelTriggerName:   "testtrigger",
-			metricskey.LabelBrokerName:    "testbroker",
+			metrics.LabelNamespaceName: "testns",
+			metrics.LabelTriggerName:   "testtrigger",
+			metrics.LabelBrokerName:    "testbroker",
 		},
 	}
 

--- a/pkg/broker/ingress/stats_reporter.go
+++ b/pkg/broker/ingress/stats_reporter.go
@@ -27,6 +27,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	broker "knative.dev/eventing/pkg/broker"
+	eventingmetrics "knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
 )
@@ -53,9 +54,9 @@ var (
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	eventTypeKey         = tag.MustNewKey(metricskey.LabelEventType)
-	responseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
-	responseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
+	eventTypeKey         = tag.MustNewKey(eventingmetrics.LabelEventType)
+	responseCodeKey      = tag.MustNewKey(eventingmetrics.LabelResponseCode)
+	responseCodeClassKey = tag.MustNewKey(eventingmetrics.LabelResponseCodeClass)
 )
 
 type ReportArgs struct {
@@ -142,10 +143,10 @@ func (r *reporter) ReportEventDispatchTime(args *ReportArgs, responseCode int, d
 
 func (r *reporter) generateTag(args *ReportArgs, responseCode int) (context.Context, error) {
 	ctx := metricskey.WithResource(emptyContext, resource.Resource{
-		Type: metricskey.ResourceTypeKnativeBroker,
+		Type: eventingmetrics.ResourceTypeKnativeBroker,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName: args.ns,
-			metricskey.LabelBrokerName:    args.broker,
+			eventingmetrics.LabelNamespaceName: args.ns,
+			eventingmetrics.LabelBrokerName:    args.broker,
 		},
 	})
 	return tag.New(

--- a/pkg/broker/ingress/stats_reporter_test.go
+++ b/pkg/broker/ingress/stats_reporter_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opencensus.io/resource"
 	broker "knative.dev/eventing/pkg/broker"
-	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 )
@@ -40,18 +40,18 @@ func TestStatsReporter(t *testing.T) {
 	r := NewStatsReporter("testcontainer", "testpod")
 
 	wantTags := map[string]string{
-		metricskey.LabelEventType:         "testeventtype",
-		metricskey.LabelResponseCode:      "202",
-		metricskey.LabelResponseCodeClass: "2xx",
-		broker.LabelUniqueName:            "testpod",
-		broker.LabelContainerName:         "testcontainer",
+		metrics.LabelEventType:         "testeventtype",
+		metrics.LabelResponseCode:      "202",
+		metrics.LabelResponseCodeClass: "2xx",
+		broker.LabelUniqueName:         "testpod",
+		broker.LabelContainerName:      "testcontainer",
 	}
 
 	resource := resource.Resource{
-		Type: metricskey.ResourceTypeKnativeBroker,
+		Type: metrics.ResourceTypeKnativeBroker,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName: "testns",
-			metricskey.LabelBrokerName:    "testbroker",
+			metrics.LabelNamespaceName: "testns",
+			metrics.LabelBrokerName:    "testbroker",
 		},
 	}
 

--- a/pkg/broker/metrics.go
+++ b/pkg/broker/metrics.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package broker
 
-import "go.opencensus.io/tag"
+import (
+	"go.opencensus.io/tag"
+	"knative.dev/eventing/pkg/metrics"
+)
 
 const (
 	// EventArrivalTime is used to access the metadata stored on a
@@ -29,7 +32,7 @@ const (
 	LabelUniqueName = "unique_name"
 
 	// LabelContainerName is the label for the immutable name of the container.
-	LabelContainerName = "container_name"
+	LabelContainerName = metrics.LabelContainerName
 )
 
 var (

--- a/pkg/channel/metrics.go
+++ b/pkg/channel/metrics.go
@@ -16,14 +16,17 @@ limitations under the License.
 
 package channel
 
-import "go.opencensus.io/tag"
+import (
+	"go.opencensus.io/tag"
+	"knative.dev/eventing/pkg/metrics"
+)
 
 const (
 	// LabelUniqueName is the label for the unique name per stats_reporter instance.
 	LabelUniqueName = "unique_name"
 
 	// LabelContainerName is the label for the immutable name of the container.
-	LabelContainerName = "container_name"
+	LabelContainerName = metrics.LabelContainerName
 )
 
 var (

--- a/pkg/channel/stats_reporter.go
+++ b/pkg/channel/stats_reporter.go
@@ -25,8 +25,9 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+
+	eventingmetrics "knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics"
-	"knative.dev/pkg/metrics/metricskey"
 )
 
 var (
@@ -51,10 +52,10 @@ var (
 	// go.opencensus.io/tag/validate.go. Currently those restrictions are:
 	// - length between 1 and 255 inclusive
 	// - characters are printable US-ASCII
-	namespaceKey         = tag.MustNewKey(metricskey.LabelNamespaceName)
-	eventTypeKey         = tag.MustNewKey(metricskey.LabelEventType)
-	responseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
-	responseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
+	namespaceKey         = tag.MustNewKey(eventingmetrics.LabelNamespaceName)
+	eventTypeKey         = tag.MustNewKey(eventingmetrics.LabelEventType)
+	responseCodeKey      = tag.MustNewKey(eventingmetrics.LabelResponseCode)
+	responseCodeClassKey = tag.MustNewKey(eventingmetrics.LabelResponseCodeClass)
 )
 
 type ReportArgs struct {

--- a/pkg/channel/stats_reporter_test.go
+++ b/pkg/channel/stats_reporter_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/eventing/pkg/metrics"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 )
@@ -36,12 +36,12 @@ func TestStatsReporter(t *testing.T) {
 	r := NewStatsReporter("testcontainer", "testpod")
 
 	wantTags := map[string]string{
-		metricskey.LabelNamespaceName:     "testns",
-		metricskey.LabelEventType:         "testeventtype",
-		metricskey.LabelResponseCode:      "202",
-		metricskey.LabelResponseCodeClass: "2xx",
-		LabelUniqueName:                   "testpod",
-		LabelContainerName:                "testcontainer",
+		metrics.LabelNamespaceName:     "testns",
+		metrics.LabelEventType:         "testeventtype",
+		metrics.LabelResponseCode:      "202",
+		metrics.LabelResponseCodeClass: "2xx",
+		LabelUniqueName:                "testpod",
+		LabelContainerName:             "testcontainer",
 	}
 
 	// test ReportEventCount

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package metrics

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package metrics
+
+import (
+	"knative.dev/pkg/metrics/metricskey"
+)
+
+const (
+	// ResourceTypeKnativeTrigger is the Stackdriver resource type for Knative Triggers.
+	ResourceTypeKnativeTrigger = "knative_trigger"
+
+	// ResourceTypeKnativeBroker is the Stackdriver resource type for Knative Brokers.
+	ResourceTypeKnativeBroker = "knative_broker"
+
+	// ResourceTypeKnativeSource is the Stackdriver resource type for Knative Sources.
+	ResourceTypeKnativeSource = "knative_source"
+
+	// LabelName is the label for the name of the resource.
+	LabelName = "name"
+
+	// LabelResourceGroup is the name of the resource CRD.
+	LabelResourceGroup = "resource_group"
+
+	// LabelTriggerName is the label for the name of the Trigger.
+	LabelTriggerName = "trigger_name"
+
+	// LabelBrokerName is the label for the name of the Broker.
+	LabelBrokerName = "broker_name"
+
+	// LabelEventType is the label for the name of the event type.
+	LabelEventType = "event_type"
+
+	// LabelEventSource is the label for the name of the event source.
+	LabelEventSource = "event_source"
+
+	// LabelFilterType is the label for the Trigger filter attribute "type".
+	LabelFilterType = "filter_type"
+
+	// LabelResponseCode is the label for the HTTP response status code.
+	LabelResponseCode = metricskey.LabelResponseCode
+
+	// LabelResponseCodeClass is the label for the HTTP response status code class. For example, "2xx", "3xx", etc.
+	LabelResponseCodeClass = metricskey.LabelResponseCodeClass
+
+	// LabelNamespaceName is the label for immutable name of the namespace that the service is deployed
+	LabelNamespaceName = metricskey.LabelNamespaceName
+
+	// ContainerName is the container for which the metric is reported.
+	LabelContainerName = metricskey.ContainerName
+)


### PR DESCRIPTION
Part of: https://github.com/knative/pkg/issues/608

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: moves eventing metric constants in knative.dev/pkg to here

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

~- [ ] **At least 80% unit test coverage**~ N/A
~- [ ] **E2E tests** for any new behavior~ N/A
~- [ ] **Docs PR** for any user-facing impact~ N/A
~- [ ] **Spec PR** for any new API feature~  N/A
~- [ ] **Conformance test** for any change to the spec~ -  N/A

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
NONE
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

