### PR TITLE
Run conformance tests as project admin

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -44,13 +44,12 @@ Running the conformance tests then consists of these steps:
     ```shell
     NUM_NAMESPACES=40 ./create-namespace-rbac.sh
     ```
-   Note: There are currently slightly over 30 tests. but the number will grow. So the number of namespaces
-   needs to be adjusted.
+   Note: The number of required namespaces might grow over time.
 1. The project admin runs the test suite with specific flags:
     ```shell
     go test -v -tags=e2e,project_admin -count=1 ./test/conformance \
       -reusenamespace \
       -kubeconfig=$PROJECT_ADMIN_KUBECONFIG
     ```
-   It is expected that the $PROJECT_ADMIN_KUBECONFIG's user is a project admin for all the
+   The $PROJECT_ADMIN_KUBECONFIG's user is expected to be a project admin for all the
    created namespaces.

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -4,7 +4,7 @@ Conformance tests verifies knative eventing implementation for expected behavior
 described in
 [specification](https://github.com/knative/eventing/tree/main/docs/spec).
 
-## Running performance tests
+## Running conformance tests
 
 Run test with e2e tag and optionally select conformance test
 
@@ -31,3 +31,26 @@ can specify:
 go test -v -tags e2e knative.dev/eventing/test/conformance -brokername=foo -brokernamespace=bar -run TestBrokerV1Beta1DataPlaneIngress
 
 ```
+
+## Running conformance tests as a project admin
+
+It is possible to run the conformance tests by a user with reduced privileges, e.g. project admin.
+Some tests require cluster-admin privileges and those tests are excluded from execution in this case.
+Running the conformance tests then consists of these steps:
+1. The cluster admin creates test namespaces and required RBAC. Each test requires a separate namespace.
+   By default, the namespace names consist of `eventing-e2e` prefix and numeric suffix starting from 0:
+   `eventing-e2e0`, `eventing-e2e1`, etc. The prefix can be configured using the EVENTING_E2E_NAMESPACE env
+  variable. There's a helper script in the current folder that will create all the required resources:
+    ```shell
+    NUM_NAMESPACES=40 ./create-namespace-rbac.sh
+    ```
+   Note: There are currently slightly over 30 tests. but the number will grow. So the number of namespaces
+   needs to be adjusted.
+1. The project admin runs the test suite with specific flags:
+    ```shell
+    go test -v -tags=e2e,project_admin -count=1 ./test/conformance \
+      -reusenamespace \
+      -kubeconfig=$PROJECT_ADMIN_KUBECONFIG
+    ```
+   It is expected that the $PROJECT_ADMIN_KUBECONFIG's user is a project admin for all the
+   created namespaces.

--- a/test/conformance/broker_tracing_test.go
+++ b/test/conformance/broker_tracing_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2019 The Knative Authors

--- a/test/conformance/channel_addressable_resolver_cluster_role_test.go
+++ b/test/conformance/channel_addressable_resolver_cluster_role_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/conformance/channel_channelable_manipulator_cluster_role_test.go
+++ b/test/conformance/channel_channelable_manipulator_cluster_role_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/conformance/channel_crd_metadata_test.go
+++ b/test/conformance/channel_crd_metadata_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/conformance/channel_tracing_test.go
+++ b/test/conformance/channel_tracing_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2019 The Knative Authors

--- a/test/conformance/create-namespace-rbac.sh
+++ b/test/conformance/create-namespace-rbac.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script creates test namespaces together with ServiceAccounts, Roles,
+# RoleBindings for conformance tests. This script is useful when tests are
+# run with --reusenamespace option in restricted environments. See README.md
+# for more information.
+
+set -Eeuo pipefail
+
+NUM_NAMESPACES=${NUM_NAMESPACES:?"Pass the NUM_NAMESPACES env variable"}
+EVENTING_E2E_NAMESPACE="${EVENTING_E2E_NAMESPACE:-eventing-e2e}"
+
+for i in $(seq 0 "$(("$NUM_NAMESPACES" - 1))"); do
+  cat <<EOF | sed "s/__NAME__/${EVENTING_E2E_NAMESPACE}${i}/" | kubectl apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: __NAME__
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: __NAME__
+  namespace: __NAME__
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: __NAME__
+  namespace: __NAME__
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __NAME__
+  namespace: __NAME__
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: __NAME__
+subjects:
+- kind: ServiceAccount
+  name: __NAME__
+  namespace: __NAME__
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: __NAME__-eventwatcher
+  namespace: __NAME__
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __NAME__-eventwatcher
+  namespace: __NAME__
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __NAME__-eventwatcher
+  namespace: __NAME__
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: __NAME__-eventwatcher
+subjects:
+- kind: ServiceAccount
+  name: __NAME__-eventwatcher
+  namespace: __NAME__
+EOF
+done

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 const (
-	roleName                = "event-watcher-r"
-	serviceAccountName      = "event-watcher-sa"
 	recordEventsAPIPodName  = "api-server-source-logger-pod"
 	recordEventsPingPodName = "ping-source-logger-pod"
 )
@@ -89,7 +87,7 @@ func addSourcesInitializers() {
 		testlib.ApiServerSourceTypeMeta,
 		setupclientoptions.ApiServerSourceV1ClientSetupOption(
 			ctx, apiSrcName, "Reference",
-			recordEventsAPIPodName, roleName, serviceAccountName),
+			recordEventsAPIPodName),
 	)
 	sourcesTestRunner.AddComponentSetupClientOption(
 		testlib.PingSourceTypeMeta,

--- a/test/conformance/source_crd_metadata_test.go
+++ b/test/conformance/source_crd_metadata_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/conformance/source_crd_rbac_test.go
+++ b/test/conformance/source_crd_rbac_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2021 The Knative Authors

--- a/test/conformance/source_crd_registry_test.go
+++ b/test/conformance/source_crd_registry_test.go
@@ -1,4 +1,5 @@
 // +build e2e
+// +build !project_admin
 
 /*
 Copyright 2020 The Knative Authors

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -515,8 +515,8 @@ func (c *Client) CreateServiceAccountOrFail(saName string) {
 	sa := resources.ServiceAccount(saName, namespace)
 	sas := c.Kube.CoreV1().ServiceAccounts(namespace)
 	c.T.Logf("Creating service account %+v", sa)
-	if _, err := sas.Create(context.Background(), sa, metav1.CreateOptions{}); err != nil {
-		c.T.Fatalf("Failed to create service account %q: %v", saName, err)
+	if _, err := sas.Create(context.Background(), sa, metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
+	  	c.T.Fatalf("Failed to create service account %q: %v", saName, err)
 	}
 	c.Tracker.Add(coreAPIGroup, coreAPIVersion, "serviceaccounts", namespace, saName)
 

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -516,7 +516,7 @@ func (c *Client) CreateServiceAccountOrFail(saName string) {
 	sas := c.Kube.CoreV1().ServiceAccounts(namespace)
 	c.T.Logf("Creating service account %+v", sa)
 	if _, err := sas.Create(context.Background(), sa, metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
-	  	c.T.Fatalf("Failed to create service account %q: %v", saName, err)
+		c.T.Fatalf("Failed to create service account %q: %v", saName, err)
 	}
 	c.Tracker.Add(coreAPIGroup, coreAPIVersion, "serviceaccounts", namespace, saName)
 

--- a/test/lib/creation.go
+++ b/test/lib/creation.go
@@ -552,7 +552,7 @@ func (c *Client) CreateRoleOrFail(r *rbacv1.Role) {
 }
 
 const (
-	RoleKind        = "Role"
+	RoleKind = "Role"
 )
 
 // CreateRoleBindingOrFail will create a RoleBinding or fail the test if there is an error.

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -19,8 +19,9 @@ package recordevents
 import (
 	"context"
 	"encoding/json"
-	"knative.dev/eventing/test"
 	"strings"
+
+	"knative.dev/eventing/test"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/pkg/errors"

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -139,10 +139,6 @@ func serializeHeaders(headers map[string]string) string {
 // This allows creating the namespaces, SAs, Roles, RoleBindings in advance by the
 // admin user.
 func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name string, options ...EventRecordOption) *corev1.Pod {
-	if !test.EventingFlags.ReuseNamespace {
-		testlib.CreateRBACPodsGetEventsAll(client, client.Namespace)
-	}
-
 	options = append(
 		options,
 		testlib.WithService(name),

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"knative.dev/eventing/test"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -135,9 +133,6 @@ func serializeHeaders(headers map[string]string) string {
 }
 
 // DeployEventRecordOrFail deploys the recordevents image with necessary sa, roles, rb to execute the image
-// By convention, all resources are named according to the client's namespace.
-// This allows creating the namespaces, SAs, Roles, RoleBindings in advance by the
-// admin user.
 func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name string, options ...EventRecordOption) *corev1.Pod {
 	options = append(
 		options,
@@ -157,10 +152,6 @@ func DeployEventRecordOrFail(ctx context.Context, client *testlib.Client, name s
 
 // DeployEventSenderOrFail deploys the recordevents image with necessary sa, roles, rb to execute the image
 func DeployEventSenderOrFail(ctx context.Context, client *testlib.Client, name string, sink string, options ...EventRecordOption) *corev1.Pod {
-	if !test.EventingFlags.ReuseNamespace {
-		testlib.CreateRBACPodsGetEventsAll(client, client.Namespace)
-	}
-
 	options = append(
 		options,
 		envOption("EVENT_GENERATORS", "sender"),

--- a/test/lib/setupclientoptions/sources.go
+++ b/test/lib/setupclientoptions/sources.go
@@ -19,11 +19,10 @@ package setupclientoptions
 import (
 	"context"
 	"fmt"
-	"knative.dev/eventing/test"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"knative.dev/eventing/test"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"

--- a/test/lib/setupclientoptions/sources.go
+++ b/test/lib/setupclientoptions/sources.go
@@ -22,8 +22,6 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"knative.dev/eventing/test"
-
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
 	eventingtestingv1 "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -41,11 +39,6 @@ import (
 func ApiServerSourceV1ClientSetupOption(ctx context.Context, name string, mode string,
 	recordEventsPodName string) testlib.SetupClientOption {
 	return func(client *testlib.Client) {
-		sa := client.Namespace + "-eventwatcher"
-		if !test.EventingFlags.ReuseNamespace {
-			testlib.CreateRBACPodsEventsGetListWatch(client, sa)
-		}
-
 		// create event record
 		recordevents.StartEventRecordOrFail(ctx, client, recordEventsPodName)
 
@@ -55,7 +48,7 @@ func ApiServerSourceV1ClientSetupOption(ctx context.Context, name string, mode s
 				Kind:       "Event",
 			}},
 			EventMode:          mode,
-			ServiceAccountName: sa,
+			ServiceAccountName: client.Namespace + "-eventwatcher",
 		}
 		spec.Sink = duckv1.Destination{Ref: resources.ServiceKRef(recordEventsPodName)}
 

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -167,7 +167,7 @@ func Setup(t *testing.T, runInParallel bool, options ...SetupClientOption) *Clie
 		SetupServiceAccount(t, client)
 		SetupPullSecret(t, client)
 		CreateRBACPodsGetEventsAll(client, client.Namespace)
-		CreateRBACPodsEventsGetListWatch(client, client.Namespace + "-eventwatcher")
+		CreateRBACPodsEventsGetListWatch(client, client.Namespace+"-eventwatcher")
 	}
 
 	// Run the test case in parallel if needed.

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -166,6 +166,8 @@ func Setup(t *testing.T, runInParallel bool, options ...SetupClientOption) *Clie
 	if !ReuseNamespace {
 		SetupServiceAccount(t, client)
 		SetupPullSecret(t, client)
+		CreateRBACPodsGetEventsAll(client, client.Namespace)
+		CreateRBACPodsEventsGetListWatch(client, client.Namespace + "-eventwatcher")
 	}
 
 	// Run the test case in parallel if needed.


### PR DESCRIPTION
This partially fixes https://github.com/knative/eventing/issues/5357 but the user is able to run only conformance tests so far.
With the current changes, and by following the readme below, there are 48 tests passing in the conformance test suite.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

* move RBAC creation to a common place
* use RBAC that is named according to the test namespace (one set for event logger, and one set for tests using ApiServerSource)
* add `!project_admin` build tag to tests that require cluster-admin permissions (this is mostly because they manipulate CRDs or read configs from knative-eventing namespace and try to do port-forwarding to a pod in Knative Eventing namespace (Tracing))
* helper script for creating NS, SA, Role, RoleBinding
* instructions in readme
* remove unused CreateRBACResourcesForBrokers function

Just for reference, we already have similar instructions in Knative Serving and Knative Client:
* https://github.com/knative/serving/blob/main/test/README.md#running-conformance-as-a-project-admin
* https://github.com/knative/client/tree/main/test#running-e2e-tests-as-a-project-admin



This PR doesn't include:
* changes to REKT test suite
* changes to E2E test suite - not sure it's worth as this one requires cluster-admin privileges in most tests

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

