### PR TITLE
Only reconcile CRDs labeled with the duck key/value

### DIFF
--- a/pkg/reconciler/source/crd/controller.go
+++ b/pkg/reconciler/source/crd/controller.go
@@ -49,15 +49,17 @@ func NewController(
 		ogcmw:       cmw,
 		controllers: make(map[schema.GroupVersionResource]runningController),
 	}
+	filterFunc := pkgreconciler.LabelFilterFunc(sources.SourceDuckLabelKey, sources.SourceDuckLabelValue, false)
 	impl := crdreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{
-			AgentName: ReconcilerName,
+			AgentName:         ReconcilerName,
+			PromoteFilterFunc: filterFunc,
 		}
 	})
 
 	logger.Info("Setting up event handlers")
 	crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.LabelFilterFunc(sources.SourceDuckLabelKey, sources.SourceDuckLabelValue, false),
+		FilterFunc: filterFunc,
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :bug: Fix bug where we would reconcile non-duck-labelled CRDs on controller startup and controller promotion

On controller promotion (which happens on installation) the source controller is attempting to reconcile all CRDs. This change will do in-memory filtering to exclude those that do not match the filter.

Fixes #5543
xref https://github.com/knative/pkg/pull/2180