### PR TITLE
if no kubeconfig use inclusterconfig test

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"knative.dev/pkg/test"
 	configtracing "knative.dev/pkg/tracing/config"
 
@@ -77,7 +78,11 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 	} else {
 		client.Config, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, err
+			// If no in-cluster config, try the default location in the user's home directory.
+			client.Config, err = test.BuildClientConfig(clientcmd.RecommendedHomeFile, clusterName)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	client.Kube, err = kubernetes.NewForConfig(client.Config)

--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -69,9 +69,16 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 	var err error
 
 	client := &Client{}
-	client.Config, err = test.BuildClientConfig(configPath, clusterName)
-	if err != nil {
-		return nil, err
+	if configPath != "" {
+		client.Config, err = test.BuildClientConfig(configPath, clusterName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client.Config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
 	}
 	client.Kube, err = kubernetes.NewForConfig(client.Config)
 	if err != nil {


### PR DESCRIPTION
If no kubeconfig is specified, try to use inclusterconfig.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

