### PR TITLE
Add health endpoint to event_display server

### DIFF
--- a/cmd/event_display/main.go
+++ b/cmd/event_display/main.go
@@ -49,19 +49,26 @@ Data,
   }
 */
 
+// display prints the given Event in a human-readable format.
 func display(event cloudevents.Event) {
-	fmt.Printf("☁️  cloudevents.Event\n%s", event.String())
+	fmt.Printf("☁️  cloudevents.Event\n%s", event)
 }
 
 func main() {
+	run(context.Background())
+}
+
+func run(ctx context.Context) {
 	c, err := cloudevents.NewClientHTTP(
 		cehttp.WithMiddleware(healthzMiddleware()),
 	)
 	if err != nil {
-		log.Fatal("Failed to create client, ", err)
+		log.Fatal("Failed to create client: ", err)
 	}
 
-	log.Fatal(c.StartReceiver(context.Background(), display))
+	if err := c.StartReceiver(ctx, display); err != nil {
+		log.Fatal("Error during receiver's runtime: ", err)
+	}
 }
 
 // HTTP path of the health endpoint used for probing the service.

--- a/cmd/event_display/main_test.go
+++ b/cmd/event_display/main_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const ceClientURL = "http://localhost:8080"
+
+func TestRun_HealthEndpoint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	go run(ctx)
+	if err := waitForClient(ctx); err != nil {
+		t.Fatal("Error waiting for CloudEvents receiver:", err)
+	}
+
+	const healthzURL = ceClientURL + healthzPath
+	const expectStatusCode = http.StatusNoContent
+
+	// GET request
+	resp, err := http.Get(healthzURL)
+	if err != nil {
+		t.Fatal("Error sending GET request to health endpoint:", err)
+	}
+	if gotStatusCode := resp.StatusCode; gotStatusCode != expectStatusCode {
+		t.Error("Unexpected status code sending GET request to health endpoint:", gotStatusCode)
+	}
+
+	// POST request
+	resp, err = http.Post(healthzURL, "text/plain", new(bytes.Buffer))
+	if err != nil {
+		t.Fatal("Error sending POST request to health endpoint:", err)
+	}
+	if gotStatusCode := resp.StatusCode; gotStatusCode != expectStatusCode {
+		t.Error("Unexpected status code sending POST request to health endpoint:", gotStatusCode)
+	}
+}
+
+// waitForClient sends requests to the local CloudEvents receiver address until
+// a HTTP response is received, or until ctx is cancelled.
+func waitForClient(ctx context.Context) error {
+	httpClient := http.DefaultClient
+	var httpErr error
+
+	tick := time.Tick(5 * time.Millisecond)
+
+	for {
+		select {
+		case <-tick:
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, ceClientURL, nil)
+			if err != nil {
+				return fmt.Errorf("creating HTTP request: %w", err)
+			}
+
+			if _, httpErr = httpClient.Do(req); httpErr == nil {
+				// got a response from CloudEvents client's HTTP receiver
+				return nil
+			}
+
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled: %s. The last HTTP error was: %s", ctx.Err(), httpErr)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Adds a health HTTP handler to `event_display` on the `/healthz` endpoint.

This handler responds with "204 No Content" to any request, regardless of the HTTP method. It is meant to be used for probing liveness/readiness.

Background: I observed race conditions on several occasions downstream, in e2e tests that rely on event_display. E.g. an event is sent as soon as the Pod starts, but the CE client isn't started yet 🤷.

I purposely avoided using something from k8s/knative to avoid large imports ("fat binary").

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**  (⚠️ `event_display` didn't have unit tests prior to this PR. I'll add more tests in a subsequent refactoring.)
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Add a health endpoint to `event_display` for enabling readiness probes.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->