### PR TITLE
Fix the link to the Working Group page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For complete Knative Eventing documentation, see
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
-[Knative WORKING-GROUPS.md](https://knative.dev/community/contributing/working-groups/working-groups/#eventing).
+[Knative working groups](https://knative.dev/community/contributing/working-groups/working-groups/#eventing).
 
 Interested users should join
 [knative-users](https://groups.google.com/forum/#!forum/knative-users),

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For complete Knative Eventing documentation, see
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md),
 [DEVELOPMENT.md](./DEVELOPMENT.md) and
-[Knative WORKING-GROUPS.md](https://www.knative.dev/contributing/working-groups/#eventing).
+[Knative WORKING-GROUPS.md](https://knative.dev/community/contributing/working-groups/working-groups/#eventing).
 
 Interested users should join
 [knative-users](https://groups.google.com/forum/#!forum/knative-users),


### PR DESCRIPTION
Fixes #5609 README: Link to the working-groups page is wrong

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :bug: Fix bug

Update a link in the README

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

This is a simple link update in the README.  No code was harmed in the creation of this PR.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The link in the README to the Working Groups page was fixed.
```


**Docs**

N/A

