### PR TITLE
Improve security-related config in yaml files

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -52,6 +52,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
 
         env:
           - name: SYSTEM_NAMESPACE
@@ -86,6 +89,8 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
 
         ports:
         - name: metrics

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -73,6 +73,10 @@ spec:
             - containerPort: 9090
               name: metrics
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
           resources:
             requests:
               cpu: 125m

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -88,6 +88,8 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
 
         ports:
         - name: https-webhook


### PR DESCRIPTION
Just a few security-related tidy-ups from running a [linting tool](https://github.com/stackrox/kube-linter) against the config.

- :broom: set runAsNonRoot=true and allowPrivilegeEscalation=false where missing
- :broom: set readOnlyRootFilesystem=true where possible
- :broom: Add limits to controller (copied the limits from serving controller)
