### PR TITLE
Fix kind tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -122,6 +122,8 @@ jobs:
 
         # Be KinD to these tests.
         kubectl scale -n${SYSTEM_NAMESPACE} deployment/chaosduck --replicas=0
+        # scale up the pingsource adapter now to ensure we have enough quota for it
+        kubectl scale -n${SYSTEM_NAMESPACE} deployment/pingsource-mt-adapter --replicas=1
 
     - name: Test Setup
       run: |

--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -49,8 +49,8 @@ spec:
           initialDelaySeconds: 5
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 10m
+            memory: 15Mi
         ports:
         - containerPort: 8080
           name: http

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -49,8 +49,8 @@ spec:
           initialDelaySeconds: 5
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 10m
+            memory: 20Mi
         ports:
         - containerPort: 8080
           name: http

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -49,8 +49,8 @@ spec:
 
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 10m
+            memory: 20Mi
 
         env:
           - name: SYSTEM_NAMESPACE

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -66,8 +66,8 @@ spec:
 
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 20m
+            memory: 40Mi
           limits:
             cpu: 1000m
             memory: 1000Mi

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -56,8 +56,8 @@ spec:
           initialDelaySeconds: 5
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 10m
+            memory: 20Mi
           limits:
             cpu: 1000m
             memory: 1000Mi

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -50,8 +50,8 @@ spec:
 
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 20m
+            memory: 50Mi
           limits:
             cpu: 1000m
             memory: 1000Mi

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -79,8 +79,8 @@ spec:
             readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: 125m
-              memory: 64Mi
+              cpu: 10m
+              memory: 15Mi
             limits:
               cpu: 1000m
               memory: 2048Mi

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -51,11 +51,9 @@ spec:
 
         resources:
           requests:
-            # taken from serving.
-            cpu: 100m
-            memory: 50Mi
+            cpu: 20m
+            memory: 25Mi
           limits:
-            # taken from serving.
             cpu: 200m
             memory: 200Mi
 


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Reduce resource requests that were added in #5612

**Release Note**
(backfilling some details missing from #5612 and #5611)

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Add runAsNonRoot=true and allowPrivilegeEscalation=false to pods where missing
Add readOnlyRootFilesystem=true to pods where possible
Add rough resource requests and limits to controller pods
```


They seem to have been too large, resulting in kind clusters on GitHub actions becoming unable to schedule the pingsource-mt-adapter pod, which only gets created when the first pingsource is created. This change will also scale it up when we're installing the rest of Knative, so that we'll see the failure to schedule the pod before we run the tests.