### PR TITLE
Prevent teardown in ugprade tests on failure

### DIFF
--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -66,8 +66,6 @@ func (p *probeRunner) Verify(ctx pkgupgrade.Context) {
 	// use T from new test
 	p.client.T = ctx.T
 	t := ctx.T
-	defer testlib.TearDown(p.client)
-	defer p.remove()
 	p.Finish()
 	waitAfterFinished(p.prober)
 
@@ -80,6 +78,10 @@ func (p *probeRunner) Verify(ctx pkgupgrade.Context) {
 	}
 
 	p.ReportErrors(errors)
+	if !ctx.T.Failed() {
+		p.remove()
+		testlib.TearDown(p.client)
+	}
 }
 
 type prober struct {


### PR DESCRIPTION
Fixes #5623

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Tear down test resources only when the test is successful

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

