### PR TITLE
Add tracing support to eventdisplay and heartbeats

### DIFF
--- a/cmd/event_display/main_test.go
+++ b/cmd/event_display/main_test.go
@@ -61,7 +61,7 @@ func TestRun_HealthEndpoint(t *testing.T) {
 // waitForClient sends requests to the local CloudEvents receiver address until
 // a HTTP response is received, or until ctx is cancelled.
 func waitForClient(ctx context.Context) error {
-	httpClient := http.DefaultClient
+	httpClient := http.Client{}
 	var httpErr error
 
 	tick := time.Tick(5 * time.Millisecond)


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Event Display and Heartbeats sample programs will emit traces to a trace endpoint if it's configured


**Release Note**

```release-note
Event Display and Heartbeats sample programs will emit traces to a trace endpoint if it's configured
```

I refactored the healthz endpoint that @antoineco added to the event display as well, since now `next` is an `ochttp.Handler` and not a `http.ServeMux`. It seems cleaner this way.