### PR TITLE
Add trace exporting to mt broker

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -19,6 +19,7 @@ package broker
 import (
 	"context"
 
+	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
@@ -38,6 +39,8 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
+	"knative.dev/pkg/tracing"
+	tracingconfig "knative.dev/pkg/tracing/config"
 )
 
 const (
@@ -59,6 +62,10 @@ func NewController(
 	subscriptionInformer := subscriptioninformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 	configmapInformer := configmapinformer.Get(ctx)
+
+	if err := tracing.SetupDynamicPublishing(logger, cmw, "mt-broker-controller", tracingconfig.ConfigName); err != nil {
+		logger.Fatal("Error setting up trace publishing", zap.Error(err))
+	}
 
 	eventingv1.RegisterAlternateBrokerConditionSet(apis.NewLivingConditionSet(
 		BrokerConditionIngress,

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -36,7 +36,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := NewController(ctx, &configmap.ManualWatcher{})
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")


### PR DESCRIPTION
The MT Broker controller wasn't exporting traces, so downstream components would get trace span parents that never show up in your tracing system. 

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Export traces generated by the mtbroker controller

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Traces are exported by the mtbroker controller
```

Before:
<img width="1280" alt="Screen Shot 2021-08-16 at 11 55 04 AM" src="https://user-images.githubusercontent.com/239754/129593059-1d215205-e70e-4348-8d92-1f85092f4ed3.png">

After:
<img width="1279" alt="Screen Shot 2021-08-16 at 11 55 12 AM" src="https://user-images.githubusercontent.com/239754/129593088-552a01ae-a866-4ad1-98e1-7189320ae85b.png">
