### PR TITLE
Fix DeadLetterSink on Trigger status

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -158,6 +158,9 @@ spec:
                     type:
                       description: 'Type of condition.'
                       type: string
+              deadLetterSinkUri:
+                description: DeadLetterSinkURI is the resolved URI of the dead letter sink for this Trigger.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -1889,7 +1889,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>deadLetterUri</code><br/>
+<code>deadLetterSinkUri</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
@@ -1898,7 +1898,7 @@ knative.dev/pkg/apis.URL
 </td>
 <td>
 <em>(Optional)</em>
-<p>DeadLetterURI is the resolved URI of the dead letter sink for this Trigger.</p>
+<p>DeadLetterSinkURI is the resolved URI of the dead letter sink for this Trigger.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -120,9 +120,9 @@ type TriggerStatus struct {
 	// +optional
 	SubscriberURI *apis.URL `json:"subscriberUri,omitempty"`
 
-	// DeadLetterURI is the resolved URI of the dead letter sink for this Trigger.
+	// DeadLetterSinkURI is the resolved URI of the dead letter sink for this Trigger.
 	// +optional
-	DeadLetterURI *apis.URL `json:"deadLetterUri,omitempty"`
+	DeadLetterSinkURI *apis.URL `json:"deadLetterSinkUri,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -274,8 +274,8 @@ func (in *TriggerStatus) DeepCopyInto(out *TriggerStatus) {
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DeadLetterURI != nil {
-		in, out := &in.DeadLetterURI, &out.DeadLetterURI
+	if in.DeadLetterSinkURI != nil {
+		in, out := &in.DeadLetterSinkURI, &out.DeadLetterSinkURI
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -159,10 +159,10 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, b *eventingv1.Br
 			if err != nil {
 				logging.FromContext(ctx).Errorw("Unable to get the dead letter sink's URI", zap.Error(err))
 				t.Status.MarkDeadLetterSinkResolvedFailed("Unable to get the dead letter sink's URI", "%v", err)
-				t.Status.DeadLetterURI = nil
+				t.Status.DeadLetterSinkURI = nil
 				return err
 			}
-			t.Status.DeadLetterURI = dlqURI
+			t.Status.DeadLetterSinkURI = dlqURI
 			t.Status.MarkDeadLetterSinkResolvedSucceeded()
 			return nil
 		}

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -192,7 +192,7 @@ func WithTriggerStatusSubscriberURI(uri string) TriggerOption {
 func WithTriggerStatusDeadLetterSinkURI(uri string) TriggerOption {
 	return func(t *v1.Trigger) {
 		u, _ := apis.ParseURL(uri)
-		t.Status.DeadLetterURI = u
+		t.Status.DeadLetterSinkURI = u
 	}
 }
 


### PR DESCRIPTION
I mistakenly hadn't added it to the CRD, so it was just getting dropped by the apiserver as an unknown field.

Semi-fixes #5639, I think there still remains the problem that Broker doesn't have a `status.deadLetterSinkUri` as referenced by the spec

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix DeadLetterSinkURI not persisting to Trigger status

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
:page_facing_up: Fix DeadLetterSinkURI not persisting to Trigger status
```