### PR TITLE
Use v1 CRD clients in tests

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -45,7 +45,7 @@ import (
 type Client struct {
 	Kube          kubernetes.Interface
 	Eventing      *eventing.Clientset
-	Apiextensions *apiextensionsv1beta1.ApiextensionsV1beta1Client
+	Apiextensions *apiextensionsv1.ApiextensionsV1Client
 	Dynamic       dynamic.Interface
 	Config        *rest.Config
 
@@ -83,7 +83,7 @@ func NewClient(configPath string, clusterName string, namespace string, t *testi
 		return nil, err
 	}
 
-	client.Apiextensions, err = apiextensionsv1beta1.NewForConfig(client.Config)
+	client.Apiextensions, err = apiextensionsv1.NewForConfig(client.Config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

The tests still try to fetch `apiextensions/v1beta1` which is dropped in K8s 1.22 and makes all CRD related tests fail there. That's unnecessary since all our CRDs are `apiextensions/v1` anyway, so let's use the appropriate clients.

/assign @matzew 
