### PR TITLE
Create a new ListableTracker ctor taking a tracker.Interface

### DIFF
--- a/pkg/duck/listable.go
+++ b/pkg/duck/listable.go
@@ -58,10 +58,16 @@ type Track func(corev1.ObjectReference) error
 type TrackKReference func(duckv1.KReference) error
 
 // NewListableTracker creates a new ListableTracker, backed by a TypedInformerFactory.
+// Deprecated: use NewListableTrackerFromTracker instead.
 func NewListableTracker(ctx context.Context, getter func(context.Context) duck.InformerFactory, callback func(types.NamespacedName), lease time.Duration) ListableTracker {
+	return NewListableTrackerFromTracker(ctx, getter, tracker.New(callback, lease))
+}
+
+// NewListableTrackerFromTracker creates a new ListableTracker, backed by a TypedInformerFactory.
+func NewListableTrackerFromTracker(ctx context.Context, getter func(context.Context) duck.InformerFactory, t tracker.Interface) ListableTracker {
 	return &listableTracker{
 		informerFactory: getter(ctx),
-		tracker:         tracker.New(callback, lease),
+		tracker:         t,
 		concrete:        map[schema.GroupVersionResource]informerListerPair{},
 	}
 }

--- a/pkg/duck/listable_test.go
+++ b/pkg/duck/listable_test.go
@@ -33,6 +33,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1alpha1/addressable"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+	"knative.dev/pkg/tracker"
 )
 
 const ns = "test-ns"
@@ -83,7 +84,7 @@ func TestResourceTracker(t *testing.T) {
 			}
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme)
 			ctx = addressable.WithDuck(ctx)
-			tr := NewListableTracker(ctx, addressable.Get, func(types.NamespacedName) {}, time.Minute)
+			tr := NewListableTrackerFromTracker(ctx, addressable.Get, tracker.New(func(types.NamespacedName) {}, time.Minute))
 			rt, _ := tr.(*listableTracker)
 			rt.informerFactory = fif
 			track := rt.TrackInNamespace(context.Background(),
@@ -142,7 +143,7 @@ func TestResourceTrackerForKReference(t *testing.T) {
 			}
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme)
 			ctx = addressable.WithDuck(ctx)
-			tr := NewListableTracker(ctx, addressable.Get, func(types.NamespacedName) {}, time.Minute)
+			tr := NewListableTrackerFromTracker(ctx, addressable.Get, tracker.New(func(types.NamespacedName) {}, time.Minute))
 			rt, _ := tr.(*listableTracker)
 			rt.informerFactory = fif
 			track := rt.TrackInNamespaceKReference(
@@ -202,7 +203,7 @@ func TestResourceListerForKReference(t *testing.T) {
 			}
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme)
 			ctx = addressable.WithDuck(ctx)
-			tr := NewListableTracker(ctx, addressable.Get, func(types.NamespacedName) {}, time.Minute)
+			tr := NewListableTrackerFromTracker(ctx, addressable.Get, tracker.New(func(types.NamespacedName) {}, time.Minute))
 			rt, _ := tr.(*listableTracker)
 			rt.informerFactory = fif
 			track := rt.TrackInNamespaceKReference(
@@ -259,7 +260,7 @@ func TestResourceInformerForKReference(t *testing.T) {
 			}
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme)
 			ctx = addressable.WithDuck(ctx)
-			tr := NewListableTracker(ctx, addressable.Get, func(types.NamespacedName) {}, time.Minute)
+			tr := NewListableTrackerFromTracker(ctx, addressable.Get, tracker.New(func(types.NamespacedName) {}, time.Minute))
 			rt, _ := tr.(*listableTracker)
 			rt.informerFactory = fif
 			track := rt.TrackInNamespaceKReference(

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -42,6 +42,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
+	"knative.dev/pkg/tracker"
 
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -375,7 +376,7 @@ func TestReconcile(t *testing.T) {
 			subscriptionLister: listers.GetSubscriptionLister(),
 			endpointsLister:    listers.GetEndpointsLister(),
 			configmapLister:    listers.GetConfigMapLister(),
-			channelableTracker: duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
+			channelableTracker: duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 		}
 		return broker.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetBrokerLister(),

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracker"
 )
 
 const (
@@ -86,7 +87,7 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 
 	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.MTChannelBrokerClassValue, false /*allowUnset*/)
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/broker/trigger/controller.go
+++ b/pkg/reconciler/broker/trigger/controller.go
@@ -40,6 +40,7 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/tracker"
 )
 
 // NewController initializes the controller and is called by the generated code
@@ -68,7 +69,7 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 
-	r.sourceTracker = duck.NewListableTracker(ctx, source.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.sourceTracker = duck.NewListableTrackerFromTracker(ctx, source.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 	r.uriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -52,6 +52,7 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/tracker"
 
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -945,7 +946,7 @@ func TestReconcile(t *testing.T) {
 
 			brokerLister:    listers.GetBrokerLister(),
 			configmapLister: listers.GetConfigMapLister(),
-			sourceTracker:   duck.NewListableTracker(ctx, source.Get, func(types.NamespacedName) {}, 0),
+			sourceTracker:   duck.NewListableTrackerFromTracker(ctx, source.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 			uriResolver:     resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 		}
 		return trigger.NewReconciler(ctx, logger,

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -40,6 +40,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
 	. "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/tracker"
 )
 
 const (
@@ -297,7 +298,7 @@ func TestReconcile(t *testing.T) {
 		r := &Reconciler{
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
 			channelLister:      listers.GetMessagingChannelLister(),
-			channelableTracker: &fakeListableTracker{duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0)},
+			channelableTracker: &fakeListableTracker{duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0))},
 		}
 		return channelreconciler.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetMessagingChannelLister(),

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/tracker"
 
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
@@ -44,7 +45,7 @@ func NewController(
 	}
 	impl := channelreconciler.NewImpl(ctx, r)
 
-	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 

--- a/pkg/reconciler/parallel/controller.go
+++ b/pkg/reconciler/parallel/controller.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/tracker"
 
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
@@ -54,7 +55,7 @@ func NewController(
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 	parallelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Parallel, so that

--- a/pkg/reconciler/parallel/parallel_test.go
+++ b/pkg/reconciler/parallel/parallel_test.go
@@ -23,6 +23,7 @@ import (
 
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+	"knative.dev/pkg/tracker"
 
 	"knative.dev/eventing/pkg/client/injection/reconciler/flows/v1/parallel"
 
@@ -465,7 +466,7 @@ func TestAllBranches(t *testing.T) {
 		ctx = channelable.WithDuck(ctx)
 		r := &Reconciler{
 			parallelLister:     listers.GetParallelLister(),
-			channelableTracker: duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
+			channelableTracker: duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/tracker"
 
 	"k8s.io/client-go/tools/cache"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
@@ -55,7 +56,7 @@ func NewController(
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 	sequenceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Sequence, so that

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -43,6 +43,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/tracker"
 
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	. "knative.dev/pkg/reconciler/testing"
@@ -873,7 +874,7 @@ func TestAllCases(t *testing.T) {
 		ctx = channelable.WithDuck(ctx)
 		r := &Reconciler{
 			sequenceLister:     listers.GetSequenceLister(),
-			channelableTracker: duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
+			channelableTracker: duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -67,7 +67,7 @@ func NewController(
 
 	// Trackers used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
-	r.channelableTracker = duck.NewListableTracker(ctx, channelable.Get, impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
 	r.destinationResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
 
 	// Track changes to Channels.

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/kref"
 	"knative.dev/pkg/network"
+	"knative.dev/pkg/tracker"
 
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
@@ -1701,7 +1702,7 @@ func TestAllCases(t *testing.T) {
 			dynamicClientSet:    dynamicclient.Get(ctx),
 			subscriptionLister:  listers.GetSubscriptionLister(),
 			channelLister:       listers.GetMessagingChannelLister(),
-			channelableTracker:  duck.NewListableTracker(ctx, channelable.Get, func(types.NamespacedName) {}, 0),
+			channelableTracker:  duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 			destinationResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
 			kreferenceResolver:  kref.NewKReferenceResolver(listers.GetCustomResourceDefinitionLister()),
 			tracker:             &FakeTracker{},


### PR DESCRIPTION
I noticed in a few places downstream that reconcilers were creating multiple trackers, which seems superfluous. As part of examining the way we use the tracker, I'm experimenting with changing this to just take a tracker.

/kind cleanup

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note
NewListableTracker is deprecated, use NewListableTrackerFromTracker instead.
```

**Docs**
