### PR TITLE
[IMC] Always consider ObservedGeneration to determine readiness

### DIFF
--- a/pkg/apis/messaging/v1/in_memory_channel_lifecycle.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_lifecycle.go
@@ -73,9 +73,12 @@ func (imcs *InMemoryChannelStatus) GetCondition(t apis.ConditionType) *apis.Cond
 	return imcCondSet.Manage(imcs).GetCondition(t)
 }
 
-// IsReady returns true if the resource is ready overall.
-func (imcs *InMemoryChannelStatus) IsReady() bool {
-	return imcCondSet.Manage(imcs).IsHappy()
+// IsReady returns true if the Status condition InMemoryChannelConditionReady
+// is true and the latest spec has been observed.
+func (imc *InMemoryChannel) IsReady() bool {
+	imcs := imc.Status
+	return imcs.ObservedGeneration == imc.Generation &&
+		imcs.GetCondition(InMemoryChannelConditionReady).IsTrue()
 }
 
 // InitializeConditions sets relevant unset conditions to Unknown state.

--- a/pkg/apis/messaging/v1/in_memory_channel_lifecycle.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_lifecycle.go
@@ -78,7 +78,7 @@ func (imcs *InMemoryChannelStatus) GetCondition(t apis.ConditionType) *apis.Cond
 func (imc *InMemoryChannel) IsReady() bool {
 	imcs := imc.Status
 	return imcs.ObservedGeneration == imc.Generation &&
-		imcs.GetCondition(InMemoryChannelConditionReady).IsTrue()
+		imcCondSet.Manage(&imcs).IsHappy()
 }
 
 // InitializeConditions sets relevant unset conditions to Unknown state.

--- a/pkg/apis/messaging/v1/in_memory_channel_lifecycle_test.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_lifecycle_test.go
@@ -286,7 +286,7 @@ func TestInMemoryChannelIsReady(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cs := &InMemoryChannelStatus{}
+			cs := InMemoryChannelStatus{}
 			cs.InitializeConditions()
 			if test.markServiceReady {
 				cs.MarkServiceTrue()
@@ -311,7 +311,8 @@ func TestInMemoryChannelIsReady(t *testing.T) {
 			} else {
 				cs.MarkDispatcherFailed("NotReadyDispatcher", "testing")
 			}
-			got := cs.IsReady()
+			imc := InMemoryChannel{Status: cs}
+			got := imc.IsReady()
 			if test.wantReady != got {
 				t.Errorf("unexpected readiness: want %v, got %v", test.wantReady, got)
 			}

--- a/pkg/apis/messaging/v1/in_memory_channel_lifecycle_test.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_lifecycle_test.go
@@ -316,6 +316,12 @@ func TestInMemoryChannelIsReady(t *testing.T) {
 			if test.wantReady != got {
 				t.Errorf("unexpected readiness: want %v, got %v", test.wantReady, got)
 			}
+
+			imc.Generation = 1
+			imc.Status.ObservedGeneration = 2
+			if imc.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -74,7 +74,7 @@ func (r *Reconciler) ObserveKind(ctx context.Context, imc *v1.InMemoryChannel) r
 func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) reconciler.Event {
 	logging.FromContext(ctx).Infow("Reconciling", zap.Any("InMemoryChannel", imc))
 
-	if !imc.Status.IsReady() {
+	if !imc.IsReady() {
 		logging.FromContext(ctx).Debug("IMC is not ready, skipping")
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Related to: https://github.com/knative/serving/issues/8004

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: consider `ObservedGeneration` for readiness

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

