### PR TITLE
Plumb through using the `controller.Impl` tracker.

### DIFF
--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -67,7 +67,7 @@ func NewController(
 
 	impl := apiserversourcereconciler.NewImpl(ctx, r)
 
-	r.sinkResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
+	r.sinkResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 	apiServerSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -41,7 +41,6 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
-	"knative.dev/pkg/tracker"
 )
 
 const (
@@ -87,7 +86,7 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 
 	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.MTChannelBrokerClassValue, false /*allowUnset*/)
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/broker/trigger/controller.go
+++ b/pkg/reconciler/broker/trigger/controller.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
-	"knative.dev/pkg/tracker"
 )
 
 // NewController initializes the controller and is called by the generated code
@@ -69,8 +68,8 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 
-	r.sourceTracker = duck.NewListableTrackerFromTracker(ctx, source.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
-	r.uriResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
+	r.sourceTracker = duck.NewListableTrackerFromTracker(ctx, source.Get, impl.Tracker)
+	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -23,7 +23,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
@@ -45,7 +44,7 @@ func NewController(
 	}
 	impl := channelreconciler.NewImpl(ctx, r)
 
-	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 

--- a/pkg/reconciler/eventtype/controller.go
+++ b/pkg/reconciler/eventtype/controller.go
@@ -23,7 +23,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/tracker"
 
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
@@ -52,7 +51,7 @@ func NewController(
 
 	// Tracker is used to notify us that a EventType's Broker has changed so that
 	// we can reconcile.
-	r.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.tracker = impl.Tracker
 	brokerInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			r.tracker.OnChanged,

--- a/pkg/reconciler/parallel/controller.go
+++ b/pkg/reconciler/parallel/controller.go
@@ -26,7 +26,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
@@ -55,7 +54,7 @@ func NewController(
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 	parallelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Parallel, so that

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 
 	"k8s.io/client-go/tools/cache"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
@@ -56,7 +55,7 @@ func NewController(
 
 	logging.FromContext(ctx).Info("Setting up event handlers")
 
-	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 	sequenceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Sequence, so that

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -26,7 +26,6 @@ import (
 	"knative.dev/pkg/kref"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/resolver"
-	"knative.dev/pkg/tracker"
 
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
@@ -67,11 +66,11 @@ func NewController(
 
 	// Trackers used to notify us when the resources Subscription depends on change, so that the
 	// Subscription needs to reconcile again.
-	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx)))
-	r.destinationResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)
+	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
+	r.destinationResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	// Track changes to Channels.
-	r.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+	r.tracker = impl.Tracker
 	channelInformer.Informer().AddEventHandler(controller.HandleAll(
 		// Call the tracker's OnChanged method, but we've seen the objects
 		// coming through this path missing TypeMeta, so ensure it is properly


### PR DESCRIPTION
This tries to make everything that can use the tracker set up on the `controller.Impl`.  In the most extreme case, I think this will consolidate 3 trackers used by one reconciler down to just one.

/kind cleanup

- :broom: Update or clean up current behavior


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

/assign @n3wscott 
