### PR TITLE
Handful more cleanups

### DIFF
--- a/pkg/adapter/mtping/controller.go
+++ b/pkg/adapter/mtping/controller.go
@@ -63,7 +63,6 @@ func NewController(ctx context.Context, adapter adapter.Adapter) *controller.Imp
 		}
 	})
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	pingsourceinformer.Get(ctx).Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    impl.Enqueue,

--- a/pkg/adapter/v2/main_injection_test.go
+++ b/pkg/adapter/v2/main_injection_test.go
@@ -54,7 +54,7 @@ func TestMain_WithController_DisableHA(t *testing.T) {
 
 	ctx = WithController(ctx, func(ctx context.Context, adapter Adapter) *controller.Impl {
 		r := &myAdapter{}
-		return controller.NewImplFull(r, controller.ControllerOptions{
+		return controller.NewContext(ctx, r, controller.ControllerOptions{
 			WorkQueueName: "foo",
 			Logger:        logging.FromContext(ctx),
 		})
@@ -113,7 +113,7 @@ func TestMain_WithControllerHA(t *testing.T) {
 
 	ctx = WithController(ctx, func(ctx context.Context, adapter Adapter) *controller.Impl {
 		r := &myAdapter{}
-		return controller.NewImplFull(r, controller.ControllerOptions{
+		return controller.NewContext(ctx, r, controller.ControllerOptions{
 			WorkQueueName: "foo",
 			Logger:        logging.FromContext(ctx),
 		})

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -479,7 +479,7 @@ func TestSinkBindingDo(t *testing.T) {
 			got := test.in
 			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, got)
 			ctx = addressable.WithDuck(ctx)
-			r := resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+			r := resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 			ctx = WithURIResolver(context.Background(), r)
 
 			sb := &SinkBinding{Spec: SinkBindingSpec{

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -44,6 +44,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/tracker"
 
 	rttesting "knative.dev/eventing/pkg/reconciler/testing"
 	rttestingv1 "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -663,7 +664,7 @@ func TestReconcile(t *testing.T) {
 			kubeClientSet:       fakekubeclient.Get(ctx),
 			ceSource:            source,
 			receiveAdapterImage: image,
-			sinkResolver:        resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
+			sinkResolver:        resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 			configs:             &reconcilersource.EmptyVarsGenerator{},
 		}
 		return apiserversource.NewReconciler(ctx, logger,

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -69,11 +69,10 @@ func NewController(
 
 	r.sinkResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	apiServerSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1.Kind("ApiServerSource")),
+		FilterFunc: controller.FilterController(&v1.ApiServerSource{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -84,8 +84,6 @@ func NewController(
 	}
 	impl := brokerreconciler.NewImpl(ctx, r, eventing.MTChannelBrokerClassValue)
 
-	logger.Info("Setting up event handlers")
-
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 
 	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.MTChannelBrokerClassValue, false /*allowUnset*/)

--- a/pkg/reconciler/broker/trigger/controller.go
+++ b/pkg/reconciler/broker/trigger/controller.go
@@ -66,8 +66,6 @@ func NewController(
 	impl := triggerreconciler.NewImpl(ctx, r)
 	r.impl = impl
 
-	logger.Info("Setting up event handlers")
-
 	r.sourceTracker = duck.NewListableTrackerFromTracker(ctx, source.Get, impl.Tracker)
 	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
@@ -88,7 +86,7 @@ func NewController(
 
 	// Reconcile Trigger when my Subscription changes
 	subscriptionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(eventingv1.Kind("Trigger")),
+		FilterFunc: controller.FilterController(&eventingv1.Trigger{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -947,7 +947,7 @@ func TestReconcile(t *testing.T) {
 			brokerLister:    listers.GetBrokerLister(),
 			configmapLister: listers.GetConfigMapLister(),
 			sourceTracker:   duck.NewListableTrackerFromTracker(ctx, source.Get, tracker.New(func(types.NamespacedName) {}, 0)),
-			uriResolver:     resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
+			uriResolver:     resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 		}
 		return trigger.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetTriggerLister(),

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -22,7 +22,6 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
-	"knative.dev/pkg/logging"
 
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
@@ -45,8 +44,6 @@ func NewController(
 	impl := channelreconciler.NewImpl(ctx, r)
 
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
-
-	logging.FromContext(ctx).Info("Setting up event handlers")
 
 	channelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 

--- a/pkg/reconciler/containersource/controller.go
+++ b/pkg/reconciler/containersource/controller.go
@@ -29,7 +29,6 @@ import (
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 )
 
 // NewController creates a Reconciler for ContainerSource and returns the result of NewImpl.
@@ -53,7 +52,6 @@ func NewController(
 	}
 	impl := v1containersource.NewImpl(ctx, r)
 
-	logging.FromContext(ctx).Info("Setting up event handlers.")
 	containersourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -62,7 +60,7 @@ func NewController(
 	})
 
 	sinkbindingInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1.Kind("ContainerSource")),
+		FilterFunc: controller.FilterController(&v1.ContainerSource{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/eventtype/controller.go
+++ b/pkg/reconciler/eventtype/controller.go
@@ -19,8 +19,6 @@ package eventtype
 import (
 	"context"
 
-	"knative.dev/pkg/logging"
-
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
@@ -46,7 +44,6 @@ func NewController(
 	}
 	impl := eventtypereconciler.NewImpl(ctx, r)
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	eventTypeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Tracker is used to notify us that a EventType's Broker has changed so that

--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -83,7 +83,6 @@ func NewController(
 
 	impl := inmemorychannelreconciler.NewImpl(ctx, r)
 
-	logger.Info("Setting up event handlers")
 	inmemorychannelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Set up watches for dispatcher resources we care about, since any changes to these

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -123,8 +123,6 @@ func NewController(
 		return controller.Options{SkipStatusUpdates: true, FinalizerName: finalizerName}
 	})
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
-
 	// Watch for inmemory channels.
 	inmemorychannelInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/pingsource/controller.go
+++ b/pkg/reconciler/pingsource/controller.go
@@ -74,7 +74,6 @@ func NewController(
 
 	r.sinkResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
-	logger.Info("Setting up event handlers")
 	pingSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Tracker is used to notify us that the pingsource-mt-adapter Deployment has changed so that

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -365,7 +365,7 @@ func TestAllCases(t *testing.T) {
 			kubeClientSet: fakekubeclient.Get(ctx),
 			tracker:       tracker.New(func(types.NamespacedName) {}, 0),
 		}
-		r.sinkResolver = resolver.NewURIResolver(ctx, func(types.NamespacedName) {})
+		r.sinkResolver = resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 
 		return pingsource.NewReconciler(ctx, logging.FromContext(ctx),
 			fakeeventingclient.Get(ctx), listers.GetPingSourceLister(),

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -19,8 +19,6 @@ package sequence
 import (
 	"context"
 
-	"knative.dev/pkg/logging"
-
 	"k8s.io/client-go/tools/cache"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
 	"knative.dev/eventing/pkg/duck"
@@ -53,15 +51,13 @@ func NewController(
 	}
 	impl := sequencereconciler.NewImpl(ctx, r)
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
-
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 	sequenceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Register handler for Subscriptions that are owned by Sequence, so that
 	// we get notified if they change.
 	subscriptionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGK(v1.Kind("Sequence")),
+		FilterFunc: controller.FilterController(&v1.Sequence{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -87,9 +87,10 @@ func NewController(
 			scheme.Scheme, corev1.EventSource{Component: controllerAgentName}),
 		NamespaceLister: namespaceInformer.Lister(),
 	}
-	impl := controller.NewImpl(c, logger, "SinkBindings")
-
-	logger.Info("Setting up event handlers")
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "SinkBindings",
+		Logger:        logger,
+	})
 
 	sbInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 	namespaceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/source/crd/controller.go
+++ b/pkg/reconciler/source/crd/controller.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/eventing/pkg/apis/sources"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
 	crdinfomer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition"
@@ -41,7 +40,6 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	logger := logging.FromContext(ctx)
 	crdInformer := crdinfomer.Get(ctx)
 
 	r := &Reconciler{
@@ -57,7 +55,6 @@ func NewController(
 		}
 	})
 
-	logger.Info("Setting up event handlers")
 	crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: filterFunc,
 		Handler:    controller.HandleAll(impl.Enqueue),

--- a/pkg/reconciler/source/duck/controller.go
+++ b/pkg/reconciler/source/duck/controller.go
@@ -66,7 +66,6 @@ func NewController(crd string, gvr schema.GroupVersionResource, gvk schema.Group
 		}
 		impl := controller.NewImpl(r, logger, ReconcilerName)
 
-		logger.Info("Setting up event handlers")
 		sourceInformer.AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		eventTypeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/subscription/controller.go
+++ b/pkg/reconciler/subscription/controller.go
@@ -61,7 +61,6 @@ func NewController(
 		}
 	})
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	subscriptionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Trackers used to notify us when the resources Subscription depends on change, so that the

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -1703,7 +1703,7 @@ func TestAllCases(t *testing.T) {
 			subscriptionLister:  listers.GetSubscriptionLister(),
 			channelLister:       listers.GetMessagingChannelLister(),
 			channelableTracker:  duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
-			destinationResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
+			destinationResolver: resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 			kreferenceResolver:  kref.NewKReferenceResolver(listers.GetCustomResourceDefinitionLister()),
 			tracker:             &FakeTracker{},
 		}

--- a/pkg/reconciler/sugar/namespace/controller.go
+++ b/pkg/reconciler/sugar/namespace/controller.go
@@ -53,11 +53,10 @@ func NewController(
 		}
 	})
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	namespaceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 	brokerInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGVK(corev1.SchemeGroupVersion.WithKind("Namespace")),
+			FilterFunc: controller.FilterControllerGK(corev1.SchemeGroupVersion.WithKind("Namespace").GroupKind()),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 

--- a/pkg/reconciler/sugar/trigger/controller.go
+++ b/pkg/reconciler/sugar/trigger/controller.go
@@ -57,7 +57,6 @@ func NewController(
 		}
 	})
 
-	logging.FromContext(ctx).Info("Setting up event handlers")
 	triggerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Watch brokers.


### PR DESCRIPTION
This spiraled a bit, but overall didn't seem to grow big enough to warrant breaking it up.  The changes:

1. `controller.NewImpl[Full]` -> `controller.NewContext`
1. `resolver.NewURIResolver` -> `resolver.NewURIResolverFromTracker`
1. Remove a dumb log statement we've been copy/pasting around forever.
1. Use `GK` instead of `GVK` filter because it's more versioning tolerant
1. Replace more `GK`-based filters with new-ish strongly typed variant

/kind cleanup

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

