### PR TITLE
[post jobs] Like serving use generatedName

### DIFF
--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -15,15 +15,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # Adding a prefix to avoid naming conflict with previous version's post-install jobs,
-  # we cannot use `generateName` here as it's not supported by `kubectl apply -f`
-  #
-  # If `ttlSecondsAfterFinished` feature gate becomes generally available in the future,
-  # we can rely on that and keep using the same Job name.
-  name: v0.23-storage-version-migration
+  generateName: storage-version-migration-eventing-
   namespace: knative-eventing
   labels:
-    app: "storage-version-migration"
+    app: "storage-version-migration-eventing"
     eventing.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
@@ -31,7 +26,7 @@ spec:
   template:
     metadata:
       labels:
-        app: "storage-version-migration"
+        app: "storage-version-migration-eventing"
         eventing.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Like Serving, using the `generatedName` for the upgrade job. See: https://github.com/knative/serving/pull/8514/files#r447739231.  Also updating the job name and the labels, like: https://github.com/knative/serving/pull/8580
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The post job is now having a generated name, instead of an unmaintained versioned name.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

