### PR TITLE
[Broker] Always consider ObservedGeneration to determine readiness

### DIFF
--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -84,8 +84,10 @@ func (bs *BrokerStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 }
 
 // IsReady returns true if the resource is ready overall.
-func (bs *BrokerStatus) IsReady() bool {
-	return bs.GetConditionSet().Manage(bs).IsHappy()
+func (b *Broker) IsReady() bool {
+	bs := b.Status
+	return bs.ObservedGeneration == b.Generation &&
+		b.GetConditionSet().Manage(&bs).IsHappy()
 }
 
 // InitializeConditions sets relevant unset conditions to Unknown state.

--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -83,7 +83,7 @@ func (bs *BrokerStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return bs.GetConditionSet().Manage(bs).GetCondition(t)
 }
 
-// IsReady returns true if the resource is ready overall.
+// IsReady returns true if the resource is ready overall and the latest spec has been observed.
 func (b *Broker) IsReady() bool {
 	bs := b.Status
 	return bs.ObservedGeneration == b.Generation &&

--- a/pkg/apis/eventing/v1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle_test.go
@@ -351,7 +351,7 @@ func TestBrokerIsReady(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			bs := &BrokerStatus{}
+			bs := BrokerStatus{}
 			if test.markIngressReady != nil {
 				var ep *corev1.Endpoints
 				if *test.markIngressReady {
@@ -381,11 +381,17 @@ func TestBrokerIsReady(t *testing.T) {
 			}
 			bs.SetAddress(test.address)
 
-			got := bs.IsReady()
+			b := Broker{Status: bs}
+			got := b.IsReady()
 			if test.wantReady != got {
 				t.Errorf("unexpected readiness: want %v, got %v", test.wantReady, got)
 			}
 
+			b.Generation = 1
+			b.Status.ObservedGeneration = 2
+			if b.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -106,7 +106,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 	t.Status.PropagateBrokerCondition(b.Status.GetTopLevelCondition())
 
 	// If Broker is not ready, we're done, but once it becomes ready, we'll get requeued.
-	if !b.Status.IsReady() {
+	if !b.IsReady() {
 		logging.FromContext(ctx).Errorw("Broker is not ready", zap.Any("Broker", b))
 		return nil
 	}

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -582,7 +582,7 @@ func readyBrokerHasIngressAvailable(ctx context.Context, t feature.T) {
 func readyBrokerIsAddressable(ctx context.Context, t feature.T) {
 	broker := getBroker(ctx, t)
 
-	if broker.Status.IsReady() {
+	if broker.IsReady() {
 		if broker.Status.Address.URL == nil {
 			t.Errorf("broker is not addressable")
 		}


### PR DESCRIPTION
Related to: https://github.com/knative/serving/issues/8004

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: consider `ObservedGeneration` for readiness
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

