### PR TITLE
DeliverySpec.Timeout on Broker and Trigger

### DIFF
--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -58,6 +58,7 @@ spec:
               delivery:
                 description: Delivery contains the delivery spec for this specific trigger.
                 type: object
+                x-kubernetes-preserve-unknown-fields: true # This is necessary to enable the experimental feature delivery-timeout
                 properties:
                   backoffDelay:
                     description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'

--- a/test/experimental/delivery_timeout_test.go
+++ b/test/experimental/delivery_timeout_test.go
@@ -21,9 +21,14 @@ package experimental
 import (
 	"testing"
 
+	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/test/experimental/features/delivery_timeout"
+	"knative.dev/eventing/test/rekt/features/broker"
+	b "knative.dev/eventing/test/rekt/resources/broker"
+	rt "knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 )
@@ -40,4 +45,22 @@ func TestDeliveryTimeout(t *testing.T) {
 	)
 
 	env.Test(ctx, t, delivery_timeout.ChannelToSink())
+}
+
+func TestBrokerTriggerWithDeliveryTimeout(t *testing.T) {
+	class := eventing.MTChannelBrokerClassValue
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	triggerName := feature.MakeRandomK8sName("trigger")
+
+	env.Test(ctx, t, broker.GoesReady(brokerName, b.WithBrokerClass(class), b.WithTimeout("PT1S")))
+	env.Test(ctx, t, broker.TriggerGoesReady(triggerName, brokerName, rt.WithTimeout("PT10S")))
 }

--- a/test/rekt/features/broker/readyness.go
+++ b/test/rekt/features/broker/readyness.go
@@ -29,15 +29,14 @@ import (
 
 // TriggerGoesReady returns a feature that tests after the creation of a
 // Trigger, it becomes ready. This feature assumes the Broker already exists.
-func TriggerGoesReady(name, brokerName string) *feature.Feature {
-	cfg := []manifest.CfgFn(nil)
-
+func TriggerGoesReady(name, brokerName string, cfg ...manifest.CfgFn) *feature.Feature {
 	f := new(feature.Feature)
 
 	// The test needs a subscriber.
 	sub := feature.MakeRandomK8sName("sub")
 	f.Setup("install a service", svc.Install(sub, "app", "rekt"))
-	cfg = append(cfg, trigger.WithSubscriber(svc.AsKReference(sub), ""))
+	// Append user-provided cfg to the end, in case they are providing their own subscriber.
+	cfg = append([]manifest.CfgFn{trigger.WithSubscriber(svc.AsKReference(sub), "")}, cfg...)
 
 	// Install the trigger
 	f.Setup(fmt.Sprintf("install trigger %q", name), trigger.Install(name, brokerName, cfg...))

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -93,6 +93,9 @@ var WithDeadLetterSink = delivery.WithDeadLetterSink
 // WithRetry adds the retry related config to a Broker spec.
 var WithRetry = delivery.WithRetry
 
+// WithTimeout adds the timeout related config to the config.
+var WithTimeout = delivery.WithTimeout
+
 // Install will create a Broker resource, augmented with the config fn options.
 func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{

--- a/test/rekt/resources/broker/broker.yaml
+++ b/test/rekt/resources/broker/broker.yaml
@@ -31,6 +31,9 @@ spec:
   {{ end }}
   {{ if .delivery }}
   delivery:
+    {{ if .delivery.timeout }}
+    timeout: {{ .delivery.timeout }}
+    {{ end }}
     {{ if .delivery.deadLetterSink }}
     deadLetterSink:
       {{ if .delivery.deadLetterSink.ref }}

--- a/test/rekt/resources/delivery/delivery.go
+++ b/test/rekt/resources/delivery/delivery.go
@@ -66,3 +66,15 @@ func WithRetry(count int32, backoffPolicy *eventingv1.BackoffPolicyType, backoff
 		}
 	}
 }
+
+// WithTimeout adds the timeout related config to the config.
+func WithTimeout(timeout string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["delivery"]; !set {
+			cfg["delivery"] = map[string]interface{}{}
+		}
+		delivery := cfg["delivery"].(map[string]interface{})
+
+		delivery["timeout"] = timeout
+	}
+}

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -94,6 +94,9 @@ var WithDeadLetterSink = delivery.WithDeadLetterSink
 // WithRetry adds the retry related config to a Trigger spec.
 var WithRetry = delivery.WithRetry
 
+// WithTimeout adds the timeout related config to the config.
+var WithTimeout = delivery.WithTimeout
+
 // Install will create a Trigger resource, augmented with the config fn options.
 func Install(name, brokerName string, opts ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{

--- a/test/rekt/resources/trigger/trigger.yaml
+++ b/test/rekt/resources/trigger/trigger.yaml
@@ -49,6 +49,9 @@ spec:
   {{ end }}
   {{ if .delivery }}
   delivery:
+    {{ if .delivery.timeout }}
+    timeout: {{ .delivery.timeout }}
+    {{ end }}
     {{ if .delivery.deadLetterSink }}
     deadLetterSink:
       {{ if .delivery.deadLetterSink.ref }}


### PR DESCRIPTION
Fixes #5654

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Preserve unknown fields on `trigger.spec.delivery`
- Add test for broker and trigger using `spec.delivery.timeout`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Trigger accepts a timeout field in its delivery parameters `spec.delivery.timeout`
```
