### PR TITLE
drop scheduled github action e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ 'main', 'master' ]
 
-  schedule:
-  - cron: '0 */2 * * *'
-
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Trying to reduce our GitHub Action job queue times. 
