### PR TITLE
Clarify meaning of `default-br-config`

### DIFF
--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting brokers that do not specify a spec.config or broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker


### PR DESCRIPTION
A simple rewording requested by @snneji in https://github.com/knative/docs/pull/4182.

We want the docs and the actual config to be in sync, so I'm submitting this here as well.

/assign @matzew 
(sorry for requiring two PRs for this simple change)