### PR TITLE
[DUMMY] Why are roundtrip tests failing when adding this field? 

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -1603,6 +1603,16 @@ DeliverySpec
 <p>Delivery contains the delivery spec for this specific trigger.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>tags</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1835,6 +1845,16 @@ DeliverySpec
 <td>
 <em>(Optional)</em>
 <p>Delivery contains the delivery spec for this specific trigger.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tags</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -90,6 +90,8 @@ type TriggerSpec struct {
 	// Delivery contains the delivery spec for this specific trigger.
 	// +optional
 	Delivery *eventingduckv1.DeliverySpec `json:"delivery,omitempty"`
+
+	Tags *[]string `json:"tags,omitempty"`
 }
 
 type TriggerFilter struct {

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -252,6 +252,15 @@ func (in *TriggerSpec) DeepCopyInto(out *TriggerSpec) {
 		*out = new(apisduckv1.DeliverySpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
+	}
 	return
 }
 

--- a/vendor/github.com/google/go-cmp/cmp/options.go
+++ b/vendor/github.com/google/go-cmp/cmp/options.go
@@ -241,7 +241,8 @@ func (validator) apply(s *state, vx, vy reflect.Value) {
 			}
 			name = fmt.Sprintf("%q.(%v)", pkgPath, t.String()) // e.g., "path/to/package".(struct { a int })
 		}
-		panic(fmt.Sprintf("cannot handle unexported field at %#v:\n\t%v\n%s", s.curPath, name, help))
+		fmt.Sprintf("%s%s",help, name)
+		return
 	}
 
 	panic("not reachable")


### PR DESCRIPTION
This is a dummy PR to show case a failure in `pkg/apis/eventing/v1/roundtip_test.go` I faced while working on #5715 . 

### Root Causing
- If I change the added field in `TriggerSpec` from `Tags *[]string` to `Tags []string`, the roundtrip tests succeed.
- Root causing is initially clouded by the test crashing when the failure path is detected while trying to log the failure using cmp because of an unexported field in `{*v1.Trigger}.Spec.Subscriber.URI.User.username` . 

```
    --- FAIL: TestEventingRoundTripTypesToJSON/eventing.knative.dev.v1.Trigger (0.01s)
panic: cannot handle unexported field at {*v1.Trigger}.Spec.Subscriber.URI.User.username:
	"net/url".Userinfo
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported [recovered]
	panic: cannot handle unexported field at {*v1.Trigger}.Spec.Subscriber.URI.User.username:
	"net/url".Userinfo
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported

goroutine 12 [running]:
testing.tRunner.func1.2(0xd71e80, 0xc0002b3390)
	/usr/lib/golang/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc0001b9680)
	/usr/lib/golang/src/testing/testing.go:1146 +0x4b6
panic(0xd71e80, 0xc0002b3390)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
github.com/google/go-cmp/cmp.validator.apply(0xc0000fa000, 0xd71e80, 0xc000481cb0, 0x1b8, 0xd71e80, 0xc00051a360, 0x1b8)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/options.go:244 +0x6b0
github.com/google/go-cmp/cmp.(*state).tryOptions(0xc0000fa000, 0xfda388, 0xd71e80, 0xd71e80, 0xc000481cb0, 0x1b8, 0xd71e80, 0xc00051a360, 0x1b8, 0x47b4a5)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:303 +0x132
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc92d0, 0xc000272d00)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:258 +0x2f2
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc0000fa000, 0xfda388, 0xdf7c40, 0xdf7c40, 0xc000481cb0, 0x199, 0xdf7c40, 0xc00051a360, 0x199)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:427 +0x685
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc9240, 0xc0002b0800)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:286 +0xe38
github.com/google/go-cmp/cmp.(*state).comparePtr(0xc0000fa000, 0xfda388, 0xdc0100, 0xdc0100, 0xc000520da0, 0x196, 0xdc0100, 0xc000521100, 0x196)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:579 +0x333
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc92d0, 0xc000272c00)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:292 +0xcbe
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc0000fa000, 0xfda388, 0xe54e20, 0xe54e20, 0xc000520d80, 0x199, 0xe54e20, 0xc0005210e0, 0x199)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:427 +0x685
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc9240, 0xc0002b07c0)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:286 +0xe38
github.com/google/go-cmp/cmp.(*state).comparePtr(0xc0000fa000, 0xfda388, 0xe15400, 0xe15400, 0xc0005a3178, 0x196, 0xe15400, 0xc0005a3cd8, 0x196)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:579 +0x333
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc92d0, 0xc000272a00)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:292 +0xcbe
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc0000fa000, 0xfda388, 0xdddf20, 0xdddf20, 0xc0005a3170, 0x199, 0xdddf20, 0xc0005a3cd0, 0x199)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:427 +0x685
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc92d0, 0xc000272800)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:286 +0xe38
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc0000fa000, 0xfda388, 0xe1fac0, 0xe1fac0, 0xc0005a3158, 0x199, 0xe1fac0, 0xc0005a3cb8, 0x199)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:427 +0x685
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc92d0, 0xc000272200)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:286 +0xe38
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc0000fa000, 0xfda388, 0xe119c0, 0xe119c0, 0xc0005a3040, 0x199, 0xe119c0, 0xc0005a3ba0, 0x199)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:427 +0x685
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc9240, 0xc0002b0280)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:286 +0xe38
github.com/google/go-cmp/cmp.(*state).comparePtr(0xc0000fa000, 0xfda388, 0xe853a0, 0xe853a0, 0xc0005a3040, 0x16, 0xe853a0, 0xc0005a3ba0, 0x16)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:579 +0x333
github.com/google/go-cmp/cmp.(*state).compareAny(0xc0000fa000, 0xfc54c0, 0xc0002b0240)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:292 +0xcbe
github.com/google/go-cmp/cmp.Diff(0xe853a0, 0xc0005a3040, 0xe853a0, 0xc0005a3ba0, 0x0, 0x0, 0x0, 0xfb99c0, 0xc0005a3ba0)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/github.com/google/go-cmp/cmp/compare.go:119 +0xab
k8s.io/apimachinery/pkg/util/diff.legacyDiff(...)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/util/diff/diff.go:51
k8s.io/apimachinery/pkg/util/diff.ObjectReflectDiff(...)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/util/diff/diff.go:72
k8s.io/apimachinery/pkg/api/apitesting/roundtrip.roundTrip(0xc0001b9680, 0xc000241dc0, 0xfc8e20, 0xc0004b6c30, 0xfb99c0, 0xc0005a3040)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go:361 +0x1b0a
k8s.io/apimachinery/pkg/api/apitesting/roundtrip.roundTripOfExternalType(0xc0001b9680, 0xc000241dc0, 0xc000241dc0, 0xfb42a0, 0xc00000ee58, 0xc0001b8a80, 0x3, 0x4, 0xfc8e50, 0xc000033d60, ...)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go:282 +0x265
k8s.io/apimachinery/pkg/api/apitesting/roundtrip.roundTripSpecificKind(0xc0001b9680, 0xe9f6ab, 0x14, 0xe9406d, 0x2, 0xd0df25, 0x7, 0xc000241dc0, 0xc000241dc0, 0xfb42a0, ...)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go:199 +0x186
k8s.io/apimachinery/pkg/api/apitesting/roundtrip.RoundTripSpecificKindWithoutProtobuf(...)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go:181
knative.dev/pkg/apis/testing/roundtrip.ExternalTypesViaJSON.func1(0xc0001b9680)
	/home/abd4lla/Workspace/redhat/src/knative.dev/eventing/vendor/knative.dev/pkg/apis/testing/roundtrip/roundtrip.go:109 +0x11e
testing.tRunner(0xc0001b9680, 0xc0003dbf80)
	/usr/lib/golang/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/lib/golang/src/testing/testing.go:1238 +0x2b3
```