### PR TITLE
Delete non used Step resources at Sequence

### DIFF
--- a/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
@@ -33,3 +33,4 @@ rules:
       - watch
       - update
       - patch
+      - delete

--- a/config/core/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/core/roles/channelable-manipulator-clusterrole.yaml
@@ -48,3 +48,4 @@ rules:
   - watch
   - update
   - patch
+  - delete

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -121,7 +121,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, s *v1.Sequence) pkgrecon
 		return err
 	}
 
-	return r.removeUnwantedSubscriptions(ctx, s, channels)
+	return r.removeUnwantedSubscriptions(ctx, s, subs)
 }
 
 func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, s *v1.Sequence, channelObjRef corev1.ObjectReference) (*eventingduckv1.Channelable, error) {
@@ -254,7 +254,7 @@ func (r *Reconciler) removeUnwantedChannels(ctx context.Context, channelResource
 	for _, c := range exists {
 		ch, err := kmeta.DeletionHandlingAccessor(c)
 		if err != nil {
-			logging.FromContext(ctx).Errorw("Failed to get get channel", zap.Any("channel", c), zap.Error(err))
+			logging.FromContext(ctx).Errorw("Failed to get channel", zap.Any("channel", c), zap.Error(err))
 			return err
 		}
 
@@ -283,7 +283,7 @@ func (r *Reconciler) removeUnwantedChannels(ctx context.Context, channelResource
 	return nil
 }
 
-func (r *Reconciler) removeUnwantedSubscriptions(ctx context.Context, seq *v1.Sequence, wanted []*eventingduckv1.Channelable) error {
+func (r *Reconciler) removeUnwantedSubscriptions(ctx context.Context, seq *v1.Sequence, wanted []*messagingv1.Subscription) error {
 	subs, err := r.subscriptionLister.Subscriptions(seq.Namespace).List(labels.Everything())
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Error listing Subscriptions", zap.Any("namespace", seq.Namespace), zap.Error(err))
@@ -297,8 +297,8 @@ func (r *Reconciler) removeUnwantedSubscriptions(ctx context.Context, seq *v1.Se
 		}
 
 		used := false
-		for _, ch := range wanted {
-			if sub.Spec.Channel.Name == ch.Name {
+		for _, sw := range wanted {
+			if sub.Name == sw.Name {
 				used = true
 				break
 			}

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -26,6 +26,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"knative.dev/pkg/kmeta"
@@ -42,7 +43,7 @@ import (
 	listers "knative.dev/eventing/pkg/client/listers/flows/v1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	"knative.dev/eventing/pkg/duck"
-	ducklib "knative.dev/eventing/pkg/duck"
+
 	"knative.dev/eventing/pkg/reconciler/sequence/resources"
 )
 
@@ -99,6 +100,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, s *v1.Sequence) pkgrecon
 		channels = append(channels, channelable)
 		logging.FromContext(ctx).Infof("Reconciled Channel Object: %s/%s %+v", s.Namespace, ingressChannelName, channelable)
 	}
+
 	s.Status.PropagateChannelStatuses(channels)
 
 	subs := make([]*messagingv1.Subscription, 0, len(s.Spec.Steps))
@@ -113,7 +115,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, s *v1.Sequence) pkgrecon
 	}
 	s.Status.PropagateSubscriptionStatuses(subs)
 
-	return nil
+	// If a sequence is modified resulting in the number of steps decreasing, there will be
+	// leftover channels and subscriptions that need to be removed.
+	if err := r.removeUnwantedChannels(ctx, channelResourceInterface, s, channels); err != nil {
+		return err
+	}
+
+	return r.removeUnwantedSubscriptions(ctx, s, channels)
 }
 
 func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, s *v1.Sequence, channelObjRef corev1.ObjectReference) (*eventingduckv1.Channelable, error) {
@@ -121,7 +129,7 @@ func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterf
 	c, err := r.trackAndFetchChannel(ctx, s, channelObjRef)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
-			newChannel, err := ducklib.NewPhysicalChannel(
+			newChannel, err := duck.NewPhysicalChannel(
 				s.Spec.ChannelTemplate.TypeMeta,
 				metav1.ObjectMeta{
 					Name:      channelObjRef.Name,
@@ -130,7 +138,7 @@ func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterf
 						*kmeta.NewControllerRef(s),
 					},
 				},
-				ducklib.WithPhysicalChannelSpec(s.Spec.ChannelTemplate.Spec),
+				duck.WithPhysicalChannelSpec(s.Spec.ChannelTemplate.Spec),
 			)
 			logger.Infof("Creating Channel Object: %+v", newChannel)
 			if err != nil {
@@ -148,7 +156,7 @@ func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterf
 			err = duckapis.FromUnstructured(created, channelable)
 			if err != nil {
 				logger.Errorw("Failed to convert to channelable", zap.Any("channel", created), zap.Error(err))
-				return nil, fmt.Errorf("Failed to convert created channel to channelable: %s", err)
+				return nil, fmt.Errorf("failed to convert created channel to channelable: %s", err)
 			}
 			return channelable, nil
 		}
@@ -159,7 +167,7 @@ func (r *Reconciler) reconcileChannel(ctx context.Context, channelResourceInterf
 	channelable, ok := c.(*eventingduckv1.Channelable)
 	if !ok {
 		logger.Errorw("Failed to convert to Channelable Object", zap.Any("channel", c), zap.Error(err))
-		return nil, fmt.Errorf("Failed to convert to Channelable Object: %+v", c)
+		return nil, fmt.Errorf("failed to convert to Channelable Object: %+v", c)
 	}
 	return channelable, nil
 }
@@ -223,4 +231,88 @@ func (r *Reconciler) trackAndFetchChannel(ctx context.Context, seq *v1.Sequence,
 		return nil, err
 	}
 	return obj, err
+}
+
+func (r *Reconciler) removeUnwantedChannels(ctx context.Context, channelResourceInterface dynamic.ResourceInterface, seq *v1.Sequence, wanted []*eventingduckv1.Channelable) error {
+	channelObjRef := corev1.ObjectReference{
+		Kind:       seq.Spec.ChannelTemplate.Kind,
+		APIVersion: seq.Spec.ChannelTemplate.APIVersion,
+	}
+
+	l, err := r.channelableTracker.ListerFor(channelObjRef)
+	if err != nil {
+		logging.FromContext(ctx).Errorw("Error getting lister for Channel", zap.Any("channelRef", channelObjRef), zap.Error(err))
+		return err
+	}
+
+	exists, err := l.ByNamespace(seq.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		logging.FromContext(ctx).Errorw("Error listing Channels", zap.Any("namespace", seq.Namespace), zap.Any("channelRef", channelObjRef), zap.Error(err))
+		return err
+	}
+
+	for _, c := range exists {
+		channelable, ok := c.(*eventingduckv1.Channelable)
+		if !ok {
+			logging.FromContext(ctx).Errorw("Failed to convert to Channelable Object", zap.Any("channel", c), zap.Error(err))
+			return fmt.Errorf("failed to convert to Channelable Object: %+v", c)
+		}
+
+		if !channelable.GetDeletionTimestamp().IsZero() ||
+			!metav1.IsControlledBy(channelable, seq) {
+			continue
+		}
+
+		used := false
+		for _, ch := range wanted {
+			if equality.Semantic.DeepDerivative(ch, channelable) {
+				used = true
+				break
+			}
+		}
+
+		if !used {
+			err = channelResourceInterface.Delete(ctx, channelable.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logging.FromContext(ctx).Errorw("Failed to delete Channel", zap.Any("channel", channelable), zap.Error(err))
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) removeUnwantedSubscriptions(ctx context.Context, seq *v1.Sequence, wanted []*eventingduckv1.Channelable) error {
+	subs, err := r.subscriptionLister.Subscriptions(seq.Namespace).List(labels.Everything())
+	if err != nil {
+		logging.FromContext(ctx).Errorw("Error listing Subscriptions", zap.Any("namespace", seq.Namespace), zap.Error(err))
+		return err
+	}
+
+	for _, sub := range subs {
+		if !sub.GetDeletionTimestamp().IsZero() ||
+			!metav1.IsControlledBy(sub, seq) {
+			continue
+		}
+
+		used := false
+		for _, ch := range wanted {
+			if sub.Spec.Channel.APIVersion == ch.APIVersion &&
+				sub.Spec.Channel.Name == ch.Name {
+				used = true
+				break
+			}
+		}
+
+		if !used {
+			err = r.eventingClientSet.MessagingV1().Subscriptions(seq.Namespace).Delete(ctx, sub.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logging.FromContext(ctx).Infow("Failed to delete Subscription", zap.Any("subscription", sub), zap.Error(err))
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
+++ b/test/conformance/helpers/channel_channelable_manipulator_cluster_role_test_helper.go
@@ -38,7 +38,7 @@ func TestChannelChannelableManipulatorClusterRoleTestRunner(
 ) {
 
 	const aggregationClusterRoleName = "channelable-manipulator"
-	var permissionTestCaseVerbs = []string{"get", "list", "watch", "update", "patch"}
+	var permissionTestCaseVerbs = []string{"get", "list", "watch", "update", "patch", "delete"}
 
 	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
 		client := testlib.Setup(st, true, options...)

--- a/test/rekt/features/channel/control_plane.go
+++ b/test/rekt/features/channel/control_plane.go
@@ -59,7 +59,7 @@ func ControlPlaneChannel(channelName string) *feature.Feature {
 
 	f.Stable("Aggregated Channelable Manipulator ClusterRole").
 		Must("Every CRD MUST create a corresponding ClusterRole, that will be aggregated into the channelable-manipulator ClusterRole."+
-			"This ClusterRole MUST include permissions to create, get, list, watch, patch, and update the CRD's custom objects and their status. "+
+			"This ClusterRole MUST include permissions to create, get, list, watch, patch, update and delete the CRD's custom objects and their status. "+
 			"Each channel MUST have the duck.knative.dev/channelable: \"true\" label on its channelable-manipulator ClusterRole.",
 			serviceAccountIsChannelableManipulator(sacmName))
 
@@ -111,7 +111,7 @@ func ControlPlaneChannel(channelName string) *feature.Feature {
 func serviceAccountIsChannelableManipulator(name string) feature.StepFn {
 	return func(ctx context.Context, t feature.T) {
 		gvr := channel_impl.GVR()
-		for _, verb := range []string{"get", "list", "watch", "update", "patch"} {
+		for _, verb := range []string{"get", "list", "watch", "update", "patch", "delete"} {
 			ServiceAccountSubjectAccessReviewAllowedOrFail(ctx, t, gvr, "", name, verb)
 			ServiceAccountSubjectAccessReviewAllowedOrFail(ctx, t, gvr, "status", name, verb)
 		}


### PR DESCRIPTION
Fixes #2005

Sequence reconciliation now checks for owned and not deleting channels and subscriptions:
- If a channel is found that is not part of the current used ones, it is deleted.
- If a subscription is found that is not linked to any of the used channels, it is deleted.

## Proposed Changes

- :bug: Fix leaking resources when updating Sequence.
- `channelable-manipulator` roles aggregated using `duck.knative.dev/channelable` need to add `delete` verb so that eventing controller can remove Sequence's non used Channels.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

```release-note
Fix issue with Sequence updates leaked resources. In order for the fix to work the provided Channel must include the `delete` verb at the ClusterRole labeled `duck.knative.dev/channelable`.
```

