### PR TITLE
Increase MaxNamespaceSkip in test runner

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -48,7 +48,7 @@ import (
 const (
 	podLogsDir         = "pod-logs"
 	testPullSecretName = "kn-eventing-test-pull-secret"
-	MaxNamespaceSkip   = 50
+	MaxNamespaceSkip   = 100
 	MaxRetries         = 5
 	RetrySleepDuration = 2 * time.Second
 )


### PR DESCRIPTION
The error was:
```
test_runner.go:163: Couldn't initialize clients: unable to find available namespace
```
Changes tested in https://github.com/knative-sandbox/eventing-kafka-broker/pull/1227

Fixes #5700

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Increase MaxNamespaceSkip in test runner

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec


