### PR TITLE
Enhance DLQ CloudEvents with destination

### DIFF
--- a/pkg/channel/attributes/knative_error.go
+++ b/pkg/channel/attributes/knative_error.go
@@ -30,7 +30,7 @@ const (
 	KnativeErrorDataExtensionMaxLength = 1024
 )
 
-// KnativeErrorTransformers returns Transformers which add the specified error code and data extensions.
+// KnativeErrorTransformers returns Transformers which add the specified destination and error code/data extensions.
 func KnativeErrorTransformers(destination url.URL, code int, data string) binding.Transformers {
 	destTransformer := transformer.AddExtension(KnativeErrorDestExtensionKey, destination)
 	codeTransformer := transformer.AddExtension(KnativeErrorCodeExtensionKey, code)

--- a/pkg/channel/attributes/knative_error.go
+++ b/pkg/channel/attributes/knative_error.go
@@ -17,22 +17,26 @@ limitations under the License.
 package attributes
 
 import (
+	"net/url"
+
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/binding/transformer"
 )
 
 const (
+	KnativeErrorDestExtensionKey       = "knativeerrordest"
 	KnativeErrorCodeExtensionKey       = "knativeerrorcode"
 	KnativeErrorDataExtensionKey       = "knativeerrordata"
 	KnativeErrorDataExtensionMaxLength = 1024
 )
 
 // KnativeErrorTransformers returns Transformers which add the specified error code and data extensions.
-func KnativeErrorTransformers(code int, data string) binding.Transformers {
+func KnativeErrorTransformers(destination url.URL, code int, data string) binding.Transformers {
+	destTransformer := transformer.AddExtension(KnativeErrorDestExtensionKey, destination)
 	codeTransformer := transformer.AddExtension(KnativeErrorCodeExtensionKey, code)
 	if len(data) > KnativeErrorDataExtensionMaxLength {
 		data = data[:KnativeErrorDataExtensionMaxLength] // Truncate data to max length
 	}
 	dataTransformer := transformer.AddExtension(KnativeErrorDataExtensionKey, data)
-	return binding.Transformers{codeTransformer, dataTransformer}
+	return binding.Transformers{destTransformer, codeTransformer, dataTransformer}
 }

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -30,6 +30,7 @@ import (
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"knative.dev/eventing/pkg/channel/attributes"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/tracing"
@@ -71,7 +72,7 @@ type DispatchExecutionInfo struct {
 	ResponseBody []byte
 }
 
-// NewMessageDispatcherFromConfig creates a new Message dispatcher based on config.
+// NewMessageDispatcher creates a new Message dispatcher based on config.
 func NewMessageDispatcher(logger *zap.Logger) *MessageDispatcherImpl {
 	sender, err := kncloudevents.NewHTTPMessageSenderWithTarget("")
 	if err != nil {
@@ -80,7 +81,7 @@ func NewMessageDispatcher(logger *zap.Logger) *MessageDispatcherImpl {
 	return NewMessageDispatcherFromSender(logger, sender)
 }
 
-// NewMessageDispatcherFromConfig creates a new event dispatcher.
+// NewMessageDispatcherFromSender creates a new Message dispatcher with specified sender.
 func NewMessageDispatcherFromSender(logger *zap.Logger, sender *kncloudevents.HTTPMessageSender) *MessageDispatcherImpl {
 	return &MessageDispatcherImpl{
 		sender:           sender,
@@ -122,7 +123,7 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 		if err != nil {
 			// If DeadLetter is configured, then send original message with knative error extensions
 			if deadLetter != nil {
-				dispatchTransformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
+				dispatchTransformers := d.dispatchExecutionInfoTransformers(destination, dispatchExecutionInfo)
 				_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, additionalHeaders, retriesConfig, append(transformers, dispatchTransformers)...)
 				if deadLetterErr != nil {
 					return dispatchExecutionInfo, fmt.Errorf("unable to complete request to either %s (%v) or %s (%v)", destination, err, deadLetter, deadLetterErr)
@@ -158,7 +159,7 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 	if err != nil {
 		// If DeadLetter is configured, then send original message with knative error extensions
 		if deadLetter != nil {
-			dispatchTransformers := d.dispatchExecutionInfoTransformers(dispatchExecutionInfo)
+			dispatchTransformers := d.dispatchExecutionInfoTransformers(reply, dispatchExecutionInfo)
 			_, deadLetterResponse, _, dispatchExecutionInfo, deadLetterErr := d.executeRequest(ctx, deadLetter, message, responseAdditionalHeaders, retriesConfig, append(transformers, dispatchTransformers)...)
 			if deadLetterErr != nil {
 				return dispatchExecutionInfo, fmt.Errorf("failed to forward reply to %s (%v) and failed to send it to the dead letter sink %s (%v)", reply, err, deadLetter, deadLetterErr)
@@ -263,12 +264,16 @@ func (d *MessageDispatcherImpl) sanitizeURL(u *url.URL) *url.URL {
 }
 
 // dispatchExecutionTransformer returns Transformers based on the specified DispatchExecutionInfo
-func (d *MessageDispatcherImpl) dispatchExecutionInfoTransformers(dispatchExecutionInfo *DispatchExecutionInfo) binding.Transformers {
+func (d *MessageDispatcherImpl) dispatchExecutionInfoTransformers(destination *url.URL, dispatchExecutionInfo *DispatchExecutionInfo) binding.Transformers {
+	if destination == nil {
+		destination = &url.URL{}
+	}
+	destination = d.sanitizeURL(destination)
 	// Unprintable control characters are not allowed in header values
 	// and cause HTTP requests to fail if not removed.
 	// https://pkg.go.dev/golang.org/x/net/http/httpguts#ValidHeaderFieldValue
 	httpBody := sanitizeHTTPBody(dispatchExecutionInfo.ResponseBody)
-	return attributes.KnativeErrorTransformers(dispatchExecutionInfo.ResponseCode, httpBody)
+	return attributes.KnativeErrorTransformers(*destination, dispatchExecutionInfo.ResponseCode, httpBody)
 }
 
 func sanitizeHTTPBody(body []byte) string {

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -263,7 +263,7 @@ func (d *MessageDispatcherImpl) sanitizeURL(u *url.URL) *url.URL {
 	}
 }
 
-// dispatchExecutionTransformer returns Transformers based on the specified DispatchExecutionInfo
+// dispatchExecutionTransformer returns Transformers based on the specified destination and DispatchExecutionInfo
 func (d *MessageDispatcherImpl) dispatchExecutionInfoTransformers(destination *url.URL, dispatchExecutionInfo *DispatchExecutionInfo) binding.Transformers {
 	if destination == nil {
 		destination = &url.URL{}

--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -799,6 +799,11 @@ func TestDispatchMessage(t *testing.T) {
 				assertEquality(t, replyServer.URL, *tc.expectedReplyRequest, rv)
 			}
 			if tc.expectedDeadLetterRequest != nil {
+				if tc.sendToReply {
+					tc.expectedDeadLetterRequest.Headers.Set("ce-knativeerrordest", replyServer.URL+"/")
+				} else if tc.sendToDestination {
+					tc.expectedDeadLetterRequest.Headers.Set("ce-knativeerrordest", destServer.URL+"/")
+				}
 				rv := deadLetterSinkHandler.popRequest(t)
 				assertEquality(t, deadLetterSinkServer.URL, *tc.expectedDeadLetterRequest, rv)
 			}


### PR DESCRIPTION
Fixes #5726 

## Proposed Changes

- :gift: Enhance DLQ CloudEvents with `destination` or `reply` URL in new `knativeerrordest` extension attribute.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [X] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior (N/A)
- [X] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature. (N/A)
- [ ] **Conformance test** for any change to the spec (N/A)

**Release Note**

```release-note
Dead Letter Sink CloudEvents from certain Channels will include the "ce-knativeerrordest" extension attribute indicating the original destination URL of the failed event.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
See documentation [PR #4228](https://github.com/knative/docs/pull/4228)
