### PR TITLE
Remove outdated GCP channel from test flag example listing text

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -31,7 +31,7 @@ import (
 const (
 	ChannelUsage = "The names of the channel type metas, separated by comma. " +
 		`Example: "messaging.knative.dev/v1:InMemoryChannel,` +
-		`messaging.cloud.google.com/v1alpha1:Channel,messaging.knative.dev/v1beta1:KafkaChannel".`
+		`messaging.knative.dev/v1beta1:KafkaChannel".`
 	BrokerClassUsage = "Which brokerclass to test, requires the proper Broker " +
 		"implementation to have been installed, and only one value. brokerclass " +
 		"must be (for now) 'MTChannelBasedBroker'."


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title

/assign @pierDipi 