### PR TITLE
Default dead letter sink namespace to the object namespace

### DIFF
--- a/pkg/apis/duck/v1/delivery_defaults.go
+++ b/pkg/apis/duck/v1/delivery_defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,23 +16,13 @@ limitations under the License.
 
 package v1
 
-import (
-	"context"
+import "context"
 
-	"knative.dev/pkg/apis"
-)
-
-func (s *Subscription) SetDefaults(ctx context.Context) {
-	if s == nil {
+func (ds *DeliverySpec) SetDefaults(ctx context.Context) {
+	if ds == nil {
 		return
 	}
-	ctx = apis.WithinParent(ctx, s.ObjectMeta)
-	s.Spec.SetDefaults(ctx)
-}
-
-func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {
-	if ss == nil {
-		return
+	if ds.DeadLetterSink != nil {
+		ds.DeadLetterSink.SetDefaults(ctx)
 	}
-	ss.Delivery.SetDefaults(ctx)
 }

--- a/pkg/apis/duck/v1/delivery_defaults_test.go
+++ b/pkg/apis/duck/v1/delivery_defaults_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestDeliverySpecSetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name  string
+		given *DeliverySpec
+		want  *DeliverySpec
+		ctx   context.Context
+	}{
+		{
+			name: "nil",
+			ctx:  context.Background(),
+		},
+		{
+			name:  "deadLetterSink nil",
+			ctx:   context.Background(),
+			given: &DeliverySpec{},
+			want:  &DeliverySpec{},
+		},
+		{
+			name:  "deadLetterSink.ref nil",
+			ctx:   context.Background(),
+			given: &DeliverySpec{DeadLetterSink: &duckv1.Destination{}},
+			want:  &DeliverySpec{DeadLetterSink: &duckv1.Destination{}},
+		},
+		{
+			name: "deadLetterSink.ref.namespace empty string",
+			ctx:  apis.WithinParent(context.Background(), metav1.ObjectMeta{Name: "b", Namespace: "custom"}),
+			given: &DeliverySpec{DeadLetterSink: &duckv1.Destination{
+				Ref: &duckv1.KReference{
+					Kind:       "Service",
+					Namespace:  "",
+					Name:       "svc",
+					APIVersion: "v1",
+				},
+			}},
+			want: &DeliverySpec{DeadLetterSink: &duckv1.Destination{
+				Ref: &duckv1.KReference{
+					Kind:       "Service",
+					Namespace:  "custom",
+					Name:       "svc",
+					APIVersion: "v1",
+				},
+			}},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tc.given.SetDefaults(tc.ctx)
+			if diff := cmp.Diff(tc.want, tc.given); diff != "" {
+				t.Error("(-want, +got)", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/eventing/v1/broker_defaults.go
+++ b/pkg/apis/eventing/v1/broker_defaults.go
@@ -21,9 +21,10 @@ import (
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 
+	"knative.dev/pkg/apis"
+
 	"knative.dev/eventing/pkg/apis/config"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/pkg/apis"
 )
 
 func (b *Broker) SetDefaults(ctx context.Context) {
@@ -53,4 +54,5 @@ func (bs *BrokerSpec) SetDefaults(ctx context.Context) {
 	if bs.Config != nil {
 		bs.Config.SetDefaults(ctx)
 	}
+	bs.Delivery.SetDefaults(ctx)
 }

--- a/pkg/apis/eventing/v1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1/trigger_defaults.go
@@ -39,6 +39,7 @@ func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
 	}
 	// Default the Subscriber namespace
 	ts.Subscriber.SetDefaults(ctx)
+	ts.Delivery.SetDefaults(ctx)
 }
 
 func setLabels(t *Trigger) {

--- a/pkg/apis/eventing/v1/trigger_defaults_test.go
+++ b/pkg/apis/eventing/v1/trigger_defaults_test.go
@@ -25,6 +25,8 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"github.com/google/go-cmp/cmp"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
 var (
@@ -76,6 +78,50 @@ func TestTriggerDefaults(t *testing.T) {
 						Ref: &duckv1.KReference{
 							Name:      "foo",
 							Namespace: namespace,
+						},
+					},
+				}},
+		},
+		"deadLetterSink, ns defaulted": {
+			initial: Trigger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+				},
+				Spec: TriggerSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Name: "foo",
+							},
+						},
+					},
+					Broker: otherBroker,
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Name:      "foo",
+							Namespace: "custom1",
+						},
+					}}},
+			expected: Trigger{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "custom",
+					Labels:    map[string]string{brokerLabel: otherBroker},
+				},
+				Spec: TriggerSpec{
+					Broker: otherBroker,
+					Filter: emptyTriggerFilter,
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Name:      "foo",
+								Namespace: "custom",
+							},
+						},
+					},
+					Subscriber: duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Name:      "foo",
+							Namespace: "custom1",
 						},
 					},
 				}},

--- a/pkg/apis/messaging/v1/channel_defaults.go
+++ b/pkg/apis/messaging/v1/channel_defaults.go
@@ -19,9 +19,10 @@ package v1
 import (
 	"context"
 
+	"knative.dev/pkg/apis"
+
 	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/eventing/pkg/apis/messaging/config"
-	"knative.dev/pkg/apis"
 )
 
 func (c *Channel) SetDefaults(ctx context.Context) {
@@ -48,6 +49,7 @@ func (cs *ChannelSpec) SetDefaults(ctx context.Context) {
 			c.Spec,
 		}
 	}
+	cs.Delivery.SetDefaults(ctx)
 }
 
 // ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not

--- a/pkg/apis/messaging/v1/in_memory_channel_defaults.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_defaults.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 
+	"knative.dev/pkg/apis"
+
 	"knative.dev/eventing/pkg/apis/messaging"
 )
 
@@ -35,9 +37,10 @@ func (imc *InMemoryChannel) SetDefaults(ctx context.Context) {
 		imc.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
 	}
 
+	ctx = apis.WithinParent(ctx, imc.ObjectMeta)
 	imc.Spec.SetDefaults(ctx)
 }
 
 func (imcs *InMemoryChannelSpec) SetDefaults(ctx context.Context) {
-	// TODO: Nothing to default here...
+	imcs.Delivery.SetDefaults(ctx)
 }

--- a/pkg/apis/messaging/v1/subscription_defaults_test.go
+++ b/pkg/apis/messaging/v1/subscription_defaults_test.go
@@ -19,10 +19,100 @@ package v1
 import (
 	"context"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
-// No-op test because method does nothing.
 func TestSubscriptionDefaults(t *testing.T) {
 	s := Subscription{}
 	s.SetDefaults(context.TODO())
+
+	tt := []struct {
+		name  string
+		given *Subscription
+		want  *Subscription
+	}{
+		{
+			name: "subscription empty",
+		},
+		{
+			name:  "subscription.spec nil",
+			given: &Subscription{},
+			want:  &Subscription{},
+		},
+		{
+			name: "subscription.spec empty",
+			given: &Subscription{
+				Spec: SubscriptionSpec{},
+			},
+			want: &Subscription{
+				Spec: SubscriptionSpec{},
+			},
+		},
+		{
+			name: "subscription.spec.delivery empty",
+			given: &Subscription{
+				Spec: SubscriptionSpec{
+					Delivery: &eventingduckv1.DeliverySpec{},
+				},
+			},
+			want: &Subscription{
+				Spec: SubscriptionSpec{
+					Delivery: &eventingduckv1.DeliverySpec{},
+				},
+			},
+		},
+		{
+			name: "subscription.spec.delivery.deadLetterSink.ref.namespace empty",
+			given: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Kind:       "Service",
+								Name:       "svc",
+								APIVersion: "v1",
+							},
+						},
+					},
+				},
+			},
+			want: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Kind:       "Service",
+								Namespace:  "custom",
+								Name:       "svc",
+								APIVersion: "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tc.given.SetDefaults(context.Background())
+			if diff := cmp.Diff(tc.want, tc.given); diff != "" {
+				t.Error("(-want, +got)", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Dead letter sink namespace is not defaulted to the object namespace for:

- Broker
- Trigger
- Channel
- Subscription

Forcing every implementation to define the logic:

"If `spec.delivery.deadLetterSink.ref.namespace` is empty, use `metadata.namespace`"

Fixes #5747

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Default dead letter sink namespace to the object namespace

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The field `spec.delivery.deadLetterSink.ref.namespace` for Broker, Trigger, Channel and Subscription if not specified is defaulted to `metadata.namespace`.
```

