### PR TITLE
IMC dispatcher custom readiness probe

### DIFF
--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -24,6 +24,11 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-eventing
 spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 75%
+    type: RollingUpdate
   selector:
     matchLabels: &labels
       messaging.knative.dev/channel: in-memory-channel

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
@@ -42,6 +42,7 @@ type MultiChannelMessageHandler interface {
 	SetChannelHandler(host string, handler fanout.MessageHandler)
 	DeleteChannelHandler(host string)
 	GetChannelHandler(host string) fanout.MessageHandler
+	CountChannelHandlers() int
 }
 
 // makeChannelKeyFromConfig creates the channel key for a given channelConfig. It is a helper around
@@ -107,6 +108,12 @@ func (h *MessageHandler) GetChannelHandler(host string) fanout.MessageHandler {
 	h.handlersLock.RLock()
 	defer h.handlersLock.RUnlock()
 	return h.handlers[host]
+}
+
+func (h *MessageHandler) CountChannelHandlers() int {
+	h.handlersLock.RLock()
+	defer h.handlersLock.RUnlock()
+	return len(h.handlers)
 }
 
 // ServeHTTP delegates the actual handling of the request to a fanout.MessageHandler, based on the

--- a/pkg/inmemorychannel/message_dispatcher.go
+++ b/pkg/inmemorychannel/message_dispatcher.go
@@ -38,11 +38,12 @@ type InMemoryMessageDispatcher struct {
 }
 
 type InMemoryMessageDispatcherArgs struct {
-	Port         int
-	ReadTimeout  time.Duration
-	WriteTimeout time.Duration
-	Handler      multichannelfanout.MultiChannelMessageHandler
-	Logger       *zap.Logger
+	Port                       int
+	ReadTimeout                time.Duration
+	WriteTimeout               time.Duration
+	Handler                    multichannelfanout.MultiChannelMessageHandler
+	Logger                     *zap.Logger
+	HTTPMessageReceiverOptions []kncloudevents.HTTPMessageReceiverOption
 }
 
 // GetHandler gets the current multichannelfanout.MessageHandler to delegate all HTTP
@@ -64,7 +65,10 @@ func (d *InMemoryMessageDispatcher) WaitReady() {
 
 func NewMessageDispatcher(args *InMemoryMessageDispatcherArgs) *InMemoryMessageDispatcher {
 	// TODO set read timeouts?
-	bindingsReceiver := kncloudevents.NewHTTPMessageReceiver(args.Port)
+	bindingsReceiver := kncloudevents.NewHTTPMessageReceiver(
+		args.Port,
+		args.HTTPMessageReceiverOptions...,
+	)
 
 	dispatcher := &InMemoryMessageDispatcher{
 		handler:              args.Handler,

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -559,3 +559,7 @@ func (f *fakeMultiChannelHandler) DeleteChannelHandler(host string) {
 func (f *fakeMultiChannelHandler) GetChannelHandler(host string) fanout.MessageHandler {
 	return f.handlers[host]
 }
+
+func (f *fakeMultiChannelHandler) CountChannelHandlers() int {
+	return len(f.handlers)
+}

--- a/pkg/reconciler/inmemorychannel/dispatcher/readiness.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/readiness.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/labels"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/pkg/channel/multichannelfanout"
+	messaginglistersv1 "knative.dev/eventing/pkg/client/listers/messaging/v1"
+)
+
+const (
+	readinessProbeReady    = http.StatusNoContent
+	readinessProbeNotReady = http.StatusServiceUnavailable
+	readinessProbeError    = http.StatusInternalServerError
+)
+
+// ReadinessChecker can assert the readiness of a component.
+type ReadinessChecker interface {
+	IsReady() (bool, error)
+}
+
+// DispatcherReadyChecker asserts the readiness of a dispatcher for in-memory Channels.
+type DispatcherReadyChecker struct {
+	// Allows listing observed Channels.
+	chLister messaginglistersv1.InMemoryChannelLister
+
+	// Allows listing/counting the handlers which have already been registered.
+	chMsgHandler multichannelfanout.MultiChannelMessageHandler
+
+	// Allows safe concurrent read/write of 'isReady'.
+	sync.Mutex
+
+	// Minor perf tweak, bypass check if we already observed readiness once.
+	isReady bool
+}
+
+// IsReady implements ReadinessChecker.
+// It checks whether the dispatcher has registered a handler for all observed in-memory Channels.
+func (c *DispatcherReadyChecker) IsReady() (bool, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	// readiness already observed at an earlier point in time, short-circuit the check
+	if c.isReady {
+		return true, nil
+	}
+
+	channels, err := c.chLister.List(labels.Everything())
+	if err != nil {
+		return false, fmt.Errorf("listing cached InMemoryChannels: %w", err)
+	}
+
+	readyChannels := make([]*messagingv1.InMemoryChannel, 0, len(channels))
+	for _, channel := range channels {
+		if channel.IsReady() {
+			readyChannels = append(readyChannels, channel)
+		}
+	}
+
+	c.isReady = c.chMsgHandler.CountChannelHandlers() >= len(readyChannels)
+	return c.isReady, nil
+}
+
+// readinessCheckerHTTPHandler returns a http.Handler which executes the given ReadinessChecker.
+func readinessCheckerHTTPHandler(c ReadinessChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		isReady, err := c.IsReady()
+		switch {
+		case err != nil:
+			w.WriteHeader(readinessProbeError)
+		case isReady:
+			w.WriteHeader(readinessProbeReady)
+		default:
+			w.WriteHeader(readinessProbeNotReady)
+		}
+	}
+}

--- a/pkg/reconciler/inmemorychannel/dispatcher/readiness_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/readiness_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing/pkg/channel/fanout"
+
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
+)
+
+func TestReadinessChecker(t *testing.T) {
+	// Lister with one in-memory channel.
+	ls := NewListers([]runtime.Object{
+		NewInMemoryChannel("imc-channel", testNS,
+			WithInMemoryChannelDeploymentReady(),
+			WithInMemoryChannelServiceReady(),
+			WithInMemoryChannelEndpointsReady(),
+			WithInMemoryChannelChannelServiceReady(),
+			WithInMemoryChannelAddress("fake-address"),
+		),
+	})
+
+	// Multi-channel handler with 0 handlers.
+	hander := newFakeMultiChannelHandler()
+
+	rc := &DispatcherReadyChecker{
+		chLister:     ls.GetInMemoryChannelLister(),
+		chMsgHandler: hander,
+	}
+
+	ts := httptest.NewServer(readinessCheckerHTTPHandler(rc))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1 imc and 0 handlers - dispatcher is not ready to handle events.
+	if res.StatusCode != readinessProbeNotReady {
+		t.Errorf("Unexpected Readiness probe status. Expected %v. Actual %v.", readinessProbeNotReady, res.StatusCode)
+	}
+
+	// Add one handler
+	hander.SetChannelHandler("foo", &fanout.FanoutMessageHandler{})
+
+	res, err = http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1 imc and 1 handler - dispatcher is ready.
+	if res.StatusCode != readinessProbeReady {
+		t.Errorf("Unexpected Readiness probe status. Expected %v. Actual %v.", readinessProbeReady, res.StatusCode)
+	}
+}


### PR DESCRIPTION
Fixes #5422

## Description

In-memory Channels are losing messages during dispatchers scaling under load. The cause - dispatcher [goroutine](https://github.com/knative/eventing/blob/release-0.26/pkg/reconciler/inmemorychannel/dispatcher/controller.go#L137-L142) starts a few commands before actual message handlers [reconciliation](https://github.com/knative/eventing/blob/release-0.26/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go#L90-L102). IMC dispatcher deployment scale up operation creates new pods that are receiving events but cannot handle them as handlers are not ready yet; events are lost with following log message:

```
 {"level":"info","ts":"2021-05-20T14:57:34.332Z","logger":"inmemorychannel-dispatcher","caller":"multichannelfanout/multi_channel_fanout_message_handler.go:118","msg":"Unable to find a       handler for request","commit":"200e54c","knative.dev/pod":"imc-dispatcher-6f6c79785-m9lqm","channelKey":"ch-273-kn-channel.channel.svc.cluster.local"}
``` 

## Proposed Changes

- :bug: employ kncloudevents.WithChecker(https://github.com/knative/eventing/blob/release-0.26/pkg/kncloudevents/message_receiver.go#L68-L72) HTTP message receiver option to set dispatcher's pod ready status only after initial reconciliation.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

