### PR TITLE
Updating validation tests to follow the spec for `spec.subscriber`

### DIFF
--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -49,10 +49,10 @@ func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	missingSubscriber := isDestinationNilOrEmpty(ss.Subscriber)
-	missingReply := isDestinationNilOrEmpty(ss.Reply)
-	if missingSubscriber && missingReply {
-		fe := apis.ErrMissingField("reply", "subscriber")
-		fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+
+	if missingSubscriber {
+		fe := apis.ErrMissingField( "subscriber")
+		fe.Details = "the Subscription must reference a subscriber"
 		errs = errs.Also(fe)
 	}
 
@@ -62,6 +62,7 @@ func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
+	missingReply := isDestinationNilOrEmpty(ss.Reply)
 	if !missingReply {
 		if fe := ss.Reply.Validate(ctx); fe != nil {
 			errs = errs.Also(fe.ViaField("reply"))

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -137,8 +137,8 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			Channel: getValidChannelRef(),
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return fe
 		}(),
 	}, {
@@ -149,8 +149,8 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			Reply:      &duckv1.Destination{},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return fe
 		}(),
 	}, {
@@ -174,7 +174,11 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			Channel: getValidChannelRef(),
 			Reply:   getValidReply(),
 		},
-		want: nil,
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
+			return fe
+		}(),
 	}, {
 		name: "empty Subscriber",
 		c: &SubscriptionSpec{
@@ -182,7 +186,11 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			Subscriber: &duckv1.Destination{},
 			Reply:      getValidReply(),
 		},
-		want: nil,
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
+			return fe
+		}(),
 	}, {
 		name: "missing name in channel, and missing subscriber, reply",
 		c: &SubscriptionSpec{
@@ -192,8 +200,8 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return apis.ErrMissingField("channel.name").Also(fe)
 		}(),
 	}, {
@@ -293,8 +301,8 @@ func TestSubscriptionSpecValidationWithKRefGroupFeatureEnabled(t *testing.T) {
 			Channel: getValidChannelRef(),
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return fe
 		}(),
 	}, {
@@ -305,8 +313,8 @@ func TestSubscriptionSpecValidationWithKRefGroupFeatureEnabled(t *testing.T) {
 			Reply:      &duckv1.Destination{},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField( "subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return fe
 		}(),
 	}, {
@@ -330,7 +338,11 @@ func TestSubscriptionSpecValidationWithKRefGroupFeatureEnabled(t *testing.T) {
 			Channel: getValidChannelRef(),
 			Reply:   getValidReply(),
 		},
-		want: nil,
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
+			return fe
+		}(),
 	}, {
 		name: "empty Subscriber",
 		c: &SubscriptionSpec{
@@ -338,7 +350,11 @@ func TestSubscriptionSpecValidationWithKRefGroupFeatureEnabled(t *testing.T) {
 			Subscriber: &duckv1.Destination{},
 			Reply:      getValidReply(),
 		},
-		want: nil,
+		want: func() *apis.FieldError {
+			fe := apis.ErrMissingField("subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
+			return fe
+		}(),
 	}, {
 		name: "missing name in channel, and missing subscriber, reply",
 		c: &SubscriptionSpec{
@@ -348,8 +364,8 @@ func TestSubscriptionSpecValidationWithKRefGroupFeatureEnabled(t *testing.T) {
 			},
 		},
 		want: func() *apis.FieldError {
-			fe := apis.ErrMissingField("reply", "subscriber")
-			fe.Details = "the Subscription must reference at least one of (reply or a subscriber)"
+			fe := apis.ErrMissingField("subscriber")
+			fe.Details = "the Subscription must reference a subscriber"
 			return apis.ErrMissingField("channel.name").Also(fe)
 		}(),
 	}, {
@@ -455,36 +471,6 @@ func TestSubscriptionImmutable(t *testing.T) {
 			Spec: SubscriptionSpec{
 				Channel:    getValidChannelRef(),
 				Subscriber: newSubscriber,
-			},
-		},
-		want: nil,
-	}, {
-		name: "valid, new Reply",
-		c: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
-				Reply:   getValidReply(),
-			},
-		},
-		og: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
-				Reply:   newReply,
-			},
-		},
-		want: nil,
-	}, {
-		name: "valid, have Reply, remove and replace with Subscriber",
-		c: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel: getValidChannelRef(),
-				Reply:   getValidReply(),
-			},
-		},
-		og: &Subscription{
-			Spec: SubscriptionSpec{
-				Channel:    getValidChannelRef(),
-				Subscriber: getValidDestination(),
 			},
 		},
 		want: nil,


### PR DESCRIPTION
Fixes #5756
 
## Proposed Changes

:broom: Update or clean up current behavior
This Pull Request updates the validation of Subscription resources requiring the `spec.subscriber` to be set for all subscriptions. This is based on the spec update linked in #5756 . 

This PR removes 2 old validation tests which were creating previously valid Subscriptions without `spec.subscriber`. These tests are no longer needed. 

This PR also removes the resource validation of the `spec.reply`  property as it is no longer required by the spec. 


### Pre-review Checklist


- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note
This change brake compatibility with previous versions as it enforces the presence of `spec.subscriber` for Subscriptions resources. This is based on a change in the spec to improve the user experience when using Subscriptions. 

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

