### PR TITLE
Removing the tweak for downgrade 0.22 from 0.23 

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -202,15 +202,9 @@ function install_head {
 function install_latest_release() {
   header ">> Installing Knative Eventing latest public release"
 
-  # Delete InMemoryController Webhook for downgrade 0.22 from 0.23.
-  kubectl delete ValidatingWebhookConfiguration validation.inmemorychannel.eventing.knative.dev || true
-  kubectl delete MutatingWebhookConfiguration inmemorychannel.eventing.knative.dev || true
-
   install_knative_eventing \
     "latest-release" || \
     fail_test "Knative latest release installation failed"
-
-
 }
 
 function install_mt_broker() {


### PR DESCRIPTION
following up on this comment: https://github.com/knative/eventing/pull/5355#discussion_r627091288