### PR TITLE
Forward prefer: reply header for brokers

### DIFF
--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -229,6 +229,10 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 	defer message.Finish(nil)
 
 	additionalHeaders := utils.PassThroughHeaders(headers)
+
+	//To follow the spec, discussion in: https://github.com/knative/eventing/issues/5771
+	additionalHeaders.Add("prefer", "reply")
+
 	err = kncloudevents.WriteHTTPRequestWithAdditionalHeaders(ctx, message, req, additionalHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write request: %w", err)

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -230,8 +230,8 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 
 	additionalHeaders := utils.PassThroughHeaders(headers)
 
-	//To follow the spec, discussion in: https://github.com/knative/eventing/issues/5771
-	additionalHeaders.Add("prefer", "reply")
+	// Following the spec https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md#derived-reply-events
+	additionalHeaders.Set("prefer", "reply")
 
 	err = kncloudevents.WriteHTTPRequestWithAdditionalHeaders(ctx, message, req, additionalHeaders)
 	if err != nil {

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -283,6 +283,31 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			returnedEvent:             makeDifferentEvent(),
 		},
+		"Maintain `Prefer: reply` header when it is provided in the original request": {
+			triggers: []*eventingv1.Trigger{
+				makeTrigger(makeTriggerFilterWithAttributes("", "")),
+			},
+			request: func() *http.Request {
+				e := makeEvent()
+				b, _ := e.MarshalJSON()
+				request := httptest.NewRequest(http.MethodPost, validPath, bytes.NewBuffer(b))
+				// Following the spec (https://github.com/knative/specs/blob/main/specs/eventing/data-plane.md#derived-reply-events)
+				//   this header should be present even if it is provided in the original request
+				request.Header.Set("Prefer", "reply")
+				// Content-Type will not pass filtering.
+				request.Header.Set(cehttp.ContentType, event.ApplicationCloudEventsJSON)
+
+				return request
+			}(),
+			expectedHeaders: http.Header{
+				// Prefer: reply must be present, even if it is provided in the original request
+				"Prefer": []string{"reply"},
+			},
+			expectedDispatch:          true,
+			expectedEventCount:        true,
+			expectedEventDispatchTime: true,
+			returnedEvent:             makeDifferentEvent(),
+		},
 		"Returned non empty non event response": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributes("", "")),

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -275,6 +275,8 @@ func TestReceiver(t *testing.T) {
 				"X-Request-Id": []string{"123"},
 				// Knative-Foo will pass as a prefix match.
 				"Knative-Foo": []string{"baz"},
+				// Prefer: reply will be added for every request as defined in the spec.
+				"Prefer": []string{"reply"},
 			},
 			expectedDispatch:          true,
 			expectedEventCount:        true,


### PR DESCRIPTION
Fixes #5771


## Proposed Changes

:gift: Add new feature

- Forward `Prefer: reply` header by default from the broker filter


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**


```release-note
By default, the `Prefer: reply` header is forwarded to Broker Triggers' subscribers
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

