### PR TITLE
Validate DeliverySpec in Channels & Subscriptions

### DIFF
--- a/pkg/apis/messaging/v1/channel_validation.go
+++ b/pkg/apis/messaging/v1/channel_validation.go
@@ -49,6 +49,13 @@ func (cs *ChannelSpec) Validate(ctx context.Context) *apis.FieldError {
 	if len(cs.SubscribableSpec.Subscribers) > 0 {
 		errs = errs.Also(apis.ErrDisallowedFields("subscribers").ViaField("subscribable"))
 	}
+
+	if cs.Delivery != nil {
+		if fe := cs.Delivery.Validate(ctx); fe != nil {
+			errs = errs.Also(fe.ViaField("delivery"))
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/apis/messaging/v1/channel_validation_test.go
+++ b/pkg/apis/messaging/v1/channel_validation_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
-	"knative.dev/pkg/apis"
 )
 
 func TestChannelValidation(t *testing.T) {
@@ -95,6 +95,51 @@ func TestChannelValidation(t *testing.T) {
 			errs = errs.Also(apis.ErrDisallowedFields("spec.subscribable.subscribers"))
 			return errs
 		}(),
+	}, {
+		name: "invalid Delivery",
+		cr: &Channel{
+			Spec: ChannelSpec{
+				ChannelTemplate: &ChannelTemplateSpec{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Channel",
+						APIVersion: SchemeGroupVersion.String(),
+					},
+				},
+				ChannelableSpec: eventingduck.ChannelableSpec{
+					Delivery: getDelivery(backoffDelayInvalid),
+				},
+			},
+		},
+		want: apis.ErrInvalidValue(backoffDelayInvalid, "spec.delivery.backoffDelay"),
+	}, {
+		name: "valid Delivery",
+		cr: &Channel{
+			Spec: ChannelSpec{
+				ChannelTemplate: &ChannelTemplateSpec{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Channel",
+						APIVersion: SchemeGroupVersion.String(),
+					},
+				},
+				ChannelableSpec: eventingduck.ChannelableSpec{
+					Delivery: getDelivery(backoffDelayValid),
+				},
+			},
+		},
+		want: nil,
+	}, {
+		name: "valid minimal spec",
+		cr: &Channel{
+			Spec: ChannelSpec{
+				ChannelTemplate: &ChannelTemplateSpec{
+					TypeMeta: v1.TypeMeta{
+						Kind:       "Channel",
+						APIVersion: SchemeGroupVersion.String(),
+					},
+				},
+			},
+		},
+		want: nil,
 	}}
 
 	doValidateTest(t, tests)

--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -68,6 +68,12 @@ func (ss *SubscriptionSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
+	if ss.Delivery != nil {
+		if fe := ss.Delivery.Validate(ctx); fe != nil {
+			errs = errs.Also(fe.ViaField("delivery"))
+		}
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
Fixes #5776

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Added missing validation of `DeliverySpec` to Channel and Subscription.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [X] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior (n/a)
- [ ] **Docs PR** for any user-facing impact  (n/a)
- [ ] **Spec PR** for any new API feature  (n/a)
- [ ] **Conformance test** for any change to the spec  (n/a)

I don't see any mention of what is/isn't validated in the [Specs](https://github.com/knative/specs/blob/main/specs/eventing/overview.md) and would assume that having consistent validation of the DeliverySpec would just be expected?

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Channel and Subscription will now enforce validation of the "delivery" field.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

n/a
