### PR TITLE
Adding finalizers/status subresources to NOOP migrator

### DIFF
--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -36,9 +36,17 @@ rules:
       - "sources.knative.dev"
     resources:
       - "apiserversources"
+      - "apiserversources/finalizers"
+      - "apiserversources/status"
       - "containersources"
+      - "containersources/finalizers"
+      - "containersources/status"
       - "pingsources"
+      - "pingsources/finalizers"
+      - "pingsources/status"
       - "sinkbindings"
+      - "sinkbindings/finalizers"
+      - "sinkbindings/status"
     verbs:
       - "get"
       - "list"
@@ -50,8 +58,14 @@ rules:
       - "eventing.knative.dev"
     resources:
       - "brokers"
+      - "brokers/finalizers"
+      - "brokers/status"
       - "eventtypes"
+      - "eventtypes/finalizers"
+      - "eventtypes/status"
       - "triggers"
+      - "triggers/finalizers"
+      - "triggers/status"
     verbs:
       - "get"
       - "list"
@@ -63,8 +77,14 @@ rules:
       - "messaging.knative.dev"
     resources:
       - "channels"
+      - "channels/finalizers"
+      - "channels/status"
       - "inmemorychannels"
+      - "inmemorychannels/finalizers"
+      - "inmemorychannels/status"
       - "subscriptions"
+      - "subscriptions/finalizers"
+      - "subscriptions/status"
     verbs:
       - "get"
       - "list"
@@ -76,7 +96,11 @@ rules:
       - "flows.knative.dev"
     resources:
       - "parallels"
+      - "parallels/finalizers"
+      - "parallels/status"
       - "sequences"
+      - "sequences/finalizers"
+      - "sequences/status"
     verbs:
       - "get"
       - "list"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

related to https://github.com/knative-sandbox/eventing-kafka/pull/908

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Adding finalizers and status subresources for storage-version migrator
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

