### PR TITLE
Using SetTTL API instead of direct access to EventContext's SetExtension

### DIFF
--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -84,7 +84,7 @@ func TTLDefaulter(logger *zap.Logger, defaultTTL int32) client.EventDefaulter {
 			}
 		}
 		// Overwrite the TTL into the event.
-		if err := event.Context.SetExtension(TTLAttribute, ttl); err != nil {
+		if err := SetTTL(event.Context, ttl); err != nil {
 			logger.Error("Failed to set TTL on outbound event.",
 				zap.String("event.id", event.ID()),
 				zap.Int32(TTLAttribute, ttl),


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Using own `SetTTL` API, instead of direct access

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

