### PR TITLE
Add a readiness probe to recordevents receiver

### DIFF
--- a/test/lib/recordevents/receiver/receiver.go
+++ b/test/lib/recordevents/receiver/receiver.go
@@ -123,8 +123,13 @@ func (o *Receiver) Start(ctx context.Context, handlerFuncs ...func(handler http.
 	for _, dec := range handlerFuncs {
 		handler = dec(handler)
 	}
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 
-	server := &http.Server{Addr: fmt.Sprintf(":%d", recordevents.EventRecordReceivePort), Handler: handler}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", recordevents.EventRecordReceivePort), Handler: mux}
 
 	var err error
 	go func() {

--- a/test/lib/recordevents/resources.go
+++ b/test/lib/recordevents/resources.go
@@ -122,6 +122,7 @@ func recordEventsPod(imageName string, name string, serviceAccountName string, r
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Port: intstr.FromString("receive"),
+					Path: "/healthz",
 				},
 			},
 		}


### PR DESCRIPTION
This might be the cause of test flakiness. Hard to prove, but it's
always possible. With an artificial sleep added to the program and
without the readiness probe, it does cause the test to consistently
fail.

Maybe fixes #5578

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Add readiness probe to recordevents test program to try to eliminate a race causing test flakes
