### PR TITLE
Sequence: Omit empty channels and subscriptions statuses

### DIFF
--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -143,8 +143,6 @@ spec:
             properties:
               address:
                 type: object
-                required:
-                  - url
                 properties:
                   url:
                     type: string

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -3134,6 +3134,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SubscriptionStatuses is an array of corresponding Subscription statuses.
 Matches the Spec.Steps array in the order.</p>
 </td>
@@ -3148,6 +3149,7 @@ Matches the Spec.Steps array in the order.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ChannelStatuses is an array of corresponding Channel statuses.
 Matches the Spec.Steps array in the order.</p>
 </td>

--- a/pkg/apis/flows/v1/sequence_types.go
+++ b/pkg/apis/flows/v1/sequence_types.go
@@ -118,11 +118,13 @@ type SequenceStatus struct {
 
 	// SubscriptionStatuses is an array of corresponding Subscription statuses.
 	// Matches the Spec.Steps array in the order.
-	SubscriptionStatuses []SequenceSubscriptionStatus `json:"subscriptionStatuses"`
+	// +optional
+	SubscriptionStatuses []SequenceSubscriptionStatus `json:"subscriptionStatuses,omitempty"`
 
 	// ChannelStatuses is an array of corresponding Channel statuses.
 	// Matches the Spec.Steps array in the order.
-	ChannelStatuses []SequenceChannelStatus `json:"channelStatuses"`
+	// +optional
+	ChannelStatuses []SequenceChannelStatus `json:"channelStatuses,omitempty"`
 
 	// Address is the starting point to this Sequence. Sending to this
 	// will target the first subscriber.


### PR DESCRIPTION
Fixes #5069 

## Proposed Changes

- :bug: Sequence's `subscriptionStatuses` and `channelStatuses` status fileds are not required and can be empty when object from `spec.channelTemplate` is not available for any reason.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note

```


**Docs**
