### PR TITLE
IMC status propagation respects dispatcher scaling

### DIFF
--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -24,11 +24,6 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-eventing
 spec:
-  strategy:
-    rollingUpdate:
-      maxSurge: 50%
-      maxUnavailable: 75%
-    type: RollingUpdate
   selector:
     matchLabels: &labels
       messaging.knative.dev/channel: in-memory-channel


### PR DESCRIPTION
Fixes #5828

## Proposed Changes

- :broom: If IMC dispatcher `Available` status is `False`, check `Reason` and `availableReplicas` before switch channels status to "unavaialble". 

### Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note

```

**Docs**