### PR TITLE
Fix broker conformance tests

### DIFF
--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -85,7 +85,8 @@ func ControlPlaneBroker(brokerName string) *feature.Feature {
 	f.Setup("Set Broker Name", setBrokerName(bName))
 
 	f.Setup("install a service", svc.Install(sink, "app", "rekt"))
-	f.Setup("update broker", broker.Install(bName, delivery.WithDeadLetterSink(svc.AsKReference(sink), "")))
+	brokerOpts := append(brokerresources.WithEnvConfig(), delivery.WithDeadLetterSink(svc.AsKReference(sink), ""))
+	f.Setup("update broker", broker.Install(bName, brokerOpts...))
 	f.Setup("broker goes ready", broker.IsReady(bName))
 
 	f.Stable("Conformance").


### PR DESCRIPTION
Create the additional broker using `WithEnvConfig()` so that it picks up the configured broker class. Otherwise we are defaulting to MTChannelBroker

Fixes #5836

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix rekt TestBrokerConformance not respecting BROKER_CLASS

/assign @pierDipi @gabo1208 