### PR TITLE
Remove forgotten legacy sequence/parallel rule

### DIFF
--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -131,31 +131,6 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: messaging-addressable-resolver
-  labels:
-    eventing.knative.dev/release: devel
-    duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
-# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
-rules:
-- apiGroups:
-  - messaging.knative.dev
-  resources:
-  - sequences
-  - sequences/status
-  - parallels
-  - parallels/status
-  verbs:
-  - get
-  - list
-  - watch
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
   name: flows-addressable-resolver
   labels:
     eventing.knative.dev/release: devel


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Sequence/Parallel were moved to `flow` group in https://github.com/knative/eventing/pull/2168. Therefore removing this rule
-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

