### PR TITLE
Add securityContext to Knative Eventing core objects

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -57,6 +57,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 700Mi
         ports:
         - containerPort: 8080
           name: http
@@ -92,6 +95,11 @@ spec:
             value: "8080"
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -57,9 +57,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 700Mi
         ports:
         - containerPort: 8080
           name: http

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -57,9 +57,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
         ports:
         - containerPort: 8080
           name: http

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -57,6 +57,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
         ports:
         - containerPort: 8080
           name: http
@@ -92,6 +95,11 @@ spec:
             value: "8080"
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -57,6 +57,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
 
         env:
           - name: SYSTEM_NAMESPACE
@@ -85,6 +88,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -57,9 +57,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
 
         env:
           - name: SYSTEM_NAMESPACE

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -79,14 +79,6 @@ spec:
             drop:
             - all
 
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-
         ports:
         - name: metrics
           containerPort: 9090

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -73,6 +73,19 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -95,10 +95,3 @@ spec:
           capabilities:
             drop:
             - all
-        resources:
-          requests:
-            cpu: 100m
-            memory: 200Mi
-          limits:
-            cpu: 1000m
-            memory: 1200Mi

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -88,3 +88,17 @@ spec:
             protocol: TCP
           - containerPort: 9090
             name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+          limits:
+            cpu: 1000m
+            memory: 1200Mi

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -58,9 +58,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
 
         env:
           - name: SYSTEM_NAMESPACE

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -58,6 +58,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
 
         env:
           - name: SYSTEM_NAMESPACE
@@ -92,6 +95,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -86,4 +86,12 @@ spec:
             limits:
               cpu: 1000m
               memory: 2048Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - all
+
       serviceAccountName: pingsource-mt-adapter

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -96,6 +96,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: https-webhook

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -49,3 +49,18 @@ spec:
             - "sinkbindings.sources.knative.dev"
             - "subscriptions.messaging.knative.dev"
             - "triggers.eventing.knative.dev"
+          resources:
+            requests:
+              cpu: 60m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 400Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - all
+

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -49,13 +49,6 @@ spec:
             - "sinkbindings.sources.knative.dev"
             - "subscriptions.messaging.knative.dev"
             - "triggers.eventing.knative.dev"
-          resources:
-            requests:
-              cpu: 60m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 400Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/sugar/500-controller.yaml
+++ b/config/sugar/500-controller.yaml
@@ -56,13 +56,6 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
 
-        resources:
-          requests:
-            cpu: 60m
-            memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 800Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/config/sugar/500-controller.yaml
+++ b/config/sugar/500-controller.yaml
@@ -56,8 +56,20 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
 
+        resources:
+          requests:
+            cpu: 60m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 800Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/tools/appender/appender.yaml
+++ b/config/tools/appender/appender.yaml
@@ -27,3 +27,11 @@ spec:
         - name: MESSAGE
           value: "...your message goes here..."
         image: ko://knative.dev/eventing/cmd/appender
+        # This is needed to run under the "restricted" Pod Security Standard
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all

--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -24,3 +24,11 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/eventing/cmd/event_display
+        # This is needed to run under the "restricted" Pod Security Standard
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all

--- a/config/tools/heartbeats/heartbeats.yaml
+++ b/config/tools/heartbeats/heartbeats.yaml
@@ -27,6 +27,21 @@ spec:
               value: "heartbeats"
             - name: POD_NAMESPACE
               value: "default"
+          resources:
+            requests:
+              cpu: 30m
+              memory: 60Mi
+            limits:
+              cpu: 250m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - all
+
   sink:
     ref:
       apiVersion: serving.knative.dev/v1

--- a/config/tools/heartbeats/heartbeats.yaml
+++ b/config/tools/heartbeats/heartbeats.yaml
@@ -27,13 +27,6 @@ spec:
               value: "heartbeats"
             - name: POD_NAMESPACE
               value: "default"
-          resources:
-            requests:
-              cpu: 30m
-              memory: 60Mi
-            limits:
-              cpu: 250m
-              memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/tools/recordevents/recordevents.yaml
+++ b/config/tools/recordevents/recordevents.yaml
@@ -36,3 +36,11 @@ spec:
           value: recorder,logger
         - name: EVENT_GENERATORS
           value: receiver
+      # This is needed to run under the "restricted" Pod Security Standard
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+          - all

--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -23,13 +23,6 @@ spec:
       containers:
         - image: ko://knative.dev/eventing/cmd/websocketsource
           name: hue
-          resources:
-            requests:
-              cpu: 125m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 600Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -23,6 +23,21 @@ spec:
       containers:
         - image: ko://knative.dev/eventing/cmd/websocketsource
           name: hue
+          resources:
+            requests:
+              cpu: 125m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 600Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - all
+
   sink:
     ref:
       apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Set SecurityContext on all resources installed by core or in-memory controllers.
  - This should allow running pods under the `restricted` [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [na] **At least 80% unit test coverage**
- [na] **E2E tests** for any new behavior
- [na] **Docs PR** for any user-facing impact
- [na] **Spec PR** for any new API feature
- [na] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
All core Knative Eventing Pods should now be able to run in the restricted pod security standard profile.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

No docs impact