### PR TITLE
Fix subscription re-resolving channel dlsuri when using it's channel DLS

### DIFF
--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -285,13 +285,11 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1
 			logging.FromContext(ctx).Debugw("Resolved channel deadLetterSink", zap.String("deadLetterSinkURI", channel.Status.DeadLetterSinkURI.String()))
 			subscription.Status.PhysicalSubscription.DeadLetterSinkURI = channel.Status.DeadLetterSinkURI
 			return nil
-		} else {
-			subscription.Status.PhysicalSubscription.DeadLetterSinkURI = nil
-			logging.FromContext(ctx).Warnw("Channel didn't set status.deadLetterSinkURI",
-				zap.Any("delivery.deadLetterSink", channel.Spec.Delivery.DeadLetterSink))
-			subscription.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", channel.Name)
-			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", channel.Name)
-		}
+		subscription.Status.PhysicalSubscription.DeadLetterSinkURI = nil
+		logging.FromContext(ctx).Warnw("Channel didn't set status.deadLetterSinkURI",
+			zap.Any("delivery.deadLetterSink", channel.Spec.Delivery.DeadLetterSink))
+		subscription.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", channel.Name)
+		return pkgreconciler.NewEvent(corev1.EventTypeWarning, deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", channel.Name)
 	}
 
 	// There is no DLS defined in neither Subscription nor the Channel

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -283,7 +283,7 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, s *v1.Subscripti
 			s.Status.PhysicalSubscription.DeadLetterSinkURI = c.Status.DeadLetterSinkURI
 		} else {
 			s.Status.PhysicalSubscription.DeadLetterSinkURI = nil
-			logging.FromContext(ctx).Warnw("Failed to use channel status.deadLetterSinkURI",
+			logging.FromContext(ctx).Warnw("Channel didn't set status.deadLetterSinkURI",
 				zap.Any("delivery.deadLetterSink", c.Spec.Delivery.DeadLetterSink))
 			s.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", c.Name)
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", c.Name)

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -261,7 +261,7 @@ func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1.Subscrip
 	return nil
 }
 
-func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, s *v1.Subscription, c *eventingduckv1.Channelable) pkgreconciler.Event {
+func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1.Subscription, channel *eventingduckv1.Channelable) pkgreconciler.Event {
 	// resolve the Subscription's dls first, fall back to the Channels's
 	if s.Spec.Delivery != nil && s.Spec.Delivery.DeadLetterSink != nil {
 		deadLetterSinkURI, err := r.destinationResolver.URIFromDestinationV1(ctx, *s.Spec.Delivery.DeadLetterSink, s)

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -285,6 +285,7 @@ func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, subscription *v1
 			logging.FromContext(ctx).Debugw("Resolved channel deadLetterSink", zap.String("deadLetterSinkURI", channel.Status.DeadLetterSinkURI.String()))
 			subscription.Status.PhysicalSubscription.DeadLetterSinkURI = channel.Status.DeadLetterSinkURI
 			return nil
+		}
 		subscription.Status.PhysicalSubscription.DeadLetterSinkURI = nil
 		logging.FromContext(ctx).Warnw("Channel didn't set status.deadLetterSinkURI",
 			zap.Any("delivery.deadLetterSink", channel.Spec.Delivery.DeadLetterSink))

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -183,13 +183,7 @@ func (r *Reconciler) resolveSubscriptionURIs(ctx context.Context, subscription *
 		return err
 	}
 
-	var err error
-	if subscription.Spec.Delivery == nil && channel.Spec.Delivery != nil {
-		err = r.resolveDeadLetterSink(ctx, channel.Spec.Delivery.DeadLetterSink, subscription)
-	} else if subscription.Spec.Delivery != nil {
-		err = r.resolveDeadLetterSink(ctx, subscription.Spec.Delivery.DeadLetterSink, subscription)
-	}
-	if err != nil {
+	if err := r.resolveDeadLetterSink(ctx, subscription, channel); err != nil {
 		return err
 	}
 
@@ -267,30 +261,38 @@ func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1.Subscrip
 	return nil
 }
 
-func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, deadLetterSink *duckv1.Destination, subscription *v1.Subscription) pkgreconciler.Event {
-	// Resolve DeadLetterSink.
-	if deadLetterSink != nil {
-		// Populate the namespace for the dead letter sink since it is in the namespace
-		if deadLetterSink.Ref != nil {
-			deadLetterSink.Ref.Namespace = subscription.Namespace
-		}
-
-		deadLetterSink, err := r.destinationResolver.URIFromDestinationV1(ctx, *deadLetterSink, subscription)
+func (r *Reconciler) resolveDeadLetterSink(ctx context.Context, s *v1.Subscription, c *eventingduckv1.Channelable) pkgreconciler.Event {
+	// resolve the Subscription's dls first, fall back to the Channels's
+	if s.Spec.Delivery != nil && s.Spec.Delivery.DeadLetterSink != nil {
+		deadLetterSinkURI, err := r.destinationResolver.URIFromDestinationV1(ctx, *s.Spec.Delivery.DeadLetterSink, s)
 		if err != nil {
+			s.Status.PhysicalSubscription.DeadLetterSinkURI = nil
 			logging.FromContext(ctx).Warnw("Failed to resolve spec.delivery.deadLetterSink",
 				zap.Error(err),
-				zap.Any("delivery.deadLetterSink", subscription.Spec.Delivery.DeadLetterSink))
-			subscription.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "Failed to resolve spec.delivery.deadLetterSink: %v", err)
+				zap.Any("delivery.deadLetterSink", s.Spec.Delivery.DeadLetterSink))
+			s.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "Failed to resolve spec.delivery.deadLetterSink: %v", err)
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deadLetterSinkResolveFailed, "Failed to resolve spec.delivery.deadLetterSink: %w", err)
 		}
-		// If there is a change in resolved URI, log it.
-		if subscription.Status.PhysicalSubscription.DeadLetterSinkURI == nil || subscription.Status.PhysicalSubscription.DeadLetterSinkURI.String() != deadLetterSink.String() {
-			logging.FromContext(ctx).Debugw("Resolved deadLetterSink", zap.String("deadLetterSinkURI", deadLetterSink.String()))
-			subscription.Status.PhysicalSubscription.DeadLetterSinkURI = deadLetterSink
+
+		logging.FromContext(ctx).Debugw("Resolved deadLetterSink", zap.String("deadLetterSinkURI", deadLetterSinkURI.String()))
+		s.Status.PhysicalSubscription.DeadLetterSinkURI = deadLetterSinkURI
+		// In case there is no DLS defined in the Subscription Spec, fallback to Channel's
+	} else if c.Spec.Delivery != nil && c.Spec.Delivery.DeadLetterSink != nil {
+		if c.Status.DeadLetterSinkURI != nil {
+			logging.FromContext(ctx).Debugw("Resolved channel deadLetterSink", zap.String("deadLetterSinkURI", c.Status.DeadLetterSinkURI.String()))
+			s.Status.PhysicalSubscription.DeadLetterSinkURI = c.Status.DeadLetterSinkURI
+		} else {
+			s.Status.PhysicalSubscription.DeadLetterSinkURI = nil
+			logging.FromContext(ctx).Warnw("Failed to use channel status.deadLetterSinkURI",
+				zap.Any("delivery.deadLetterSink", c.Spec.Delivery.DeadLetterSink))
+			s.Status.MarkReferencesNotResolved(deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", c.Name)
+			return pkgreconciler.NewEvent(corev1.EventTypeWarning, deadLetterSinkResolveFailed, "channel %s didn't set status.deadLetterSinkURI", c.Name)
 		}
 	} else {
-		subscription.Status.PhysicalSubscription.DeadLetterSinkURI = nil
+		// There is no DLS defined in neither Subscription nor the Channel
+		s.Status.PhysicalSubscription.DeadLetterSinkURI = nil
 	}
+
 	return nil
 }
 

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -129,6 +129,8 @@ var (
 		Namespace:  testNS,
 		Name:       channelName,
 	}
+
+	dlsURI = apis.HTTP(dlcDNS)
 )
 
 func TestAllCases(t *testing.T) {
@@ -1447,6 +1449,7 @@ func TestAllCases(t *testing.T) {
 						BackoffPolicy: &linear,
 						BackoffDelay:  pointer.StringPtr("PT1S"),
 					}),
+					WithInMemoryChannelStatusDLSURI(dlsURI),
 				),
 				NewService(serviceName, testNS),
 			},


### PR DESCRIPTION
Fixes #5860 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: When using its Channel DeadLetterSink Ref, Subscriptions are re-resolving the Channels `spec.delivery.deadLetterSink` instead of using the already resolved Channel's `status.deadLetterSinkURI` directly

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

