### PR TITLE
Sink URI resolver tests update

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -21,14 +21,20 @@ import (
 	"reflect"
 	"testing"
 
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+
 	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
+	"knative.dev/pkg/injection"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
@@ -477,7 +483,8 @@ func TestSinkBindingDo(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.in
-			ctx, _ := fakedynamicclient.With(context.Background(), scheme.Scheme, got)
+			ctx, _ := injection.Fake.SetupInformers(context.Background(), &rest.Config{})
+			ctx, _ = fakedynamicclient.With(ctx, scheme.Scheme, got)
 			ctx = addressable.WithDuck(ctx)
 			r := resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 			ctx = WithURIResolver(context.Background(), r)

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -27,8 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubeinformers "k8s.io/client-go/informers"
-	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -41,7 +39,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -660,13 +657,8 @@ func TestReconcile(t *testing.T) {
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 	}}
 
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(
-		fakekubeclientset.NewSimpleClientset(), 0)
-	svcInformerIface := kubeInformerFactory.Core().V1().Services()
-
 	logger := logtesting.TestLogger(t)
 	table.Test(t, rttestingv1.MakeFactory(func(ctx context.Context, listers *rttestingv1.Listers, cmw configmap.Watcher) controller.Reconciler {
-		ctx = context.WithValue(ctx, service.Key{}, svcInformerIface)
 		ctx = addressable.WithDuck(ctx)
 		r := &Reconciler{
 			kubeClientSet:       fakekubeclient.Get(ctx),

--- a/pkg/reconciler/apiserversource/controller_test.go
+++ b/pkg/reconciler/apiserversource/controller_test.go
@@ -33,6 +33,7 @@ import (
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/apiserversource/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	. "knative.dev/pkg/reconciler/testing"
 )
 

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -22,8 +22,6 @@ import (
 	"strconv"
 	"testing"
 
-	_ "knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable/fake"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -40,7 +38,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1addr "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
+	serviceinformers "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
@@ -460,10 +458,10 @@ func TestAllCases(t *testing.T) {
 		}, {},
 	}
 
-	svcInformer := v1ServiceInformer(context.Background(), k8sServices())
 	logger := logtesting.TestLogger(t)
+	svcInformer := v1ServiceInformer(context.Background(), k8sServices())
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
-		ctx = context.WithValue(ctx, service.Key{}, svcInformer)
+		ctx = context.WithValue(ctx, serviceinformers.Key{}, svcInformer)
 		ctx = v1addr.WithDuck(ctx)
 		r := &Reconciler{
 			kubeClientSet:    fakekubeclient.Get(ctx),
@@ -559,12 +557,12 @@ func TestInNamespace(t *testing.T) {
 		},
 	}
 
-	svcInformer := v1ServiceInformer(context.Background(), k8sServices())
 	logger := logtesting.TestLogger(t)
+	svcInformer := v1ServiceInformer(context.Background(), k8sServices())
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		eventDispatcherConfigStore := config.NewEventDispatcherConfigStore(logger)
 		eventDispatcherConfigStore.WatchConfigs(cmw)
-		ctx = context.WithValue(ctx, service.Key{}, svcInformer)
+		ctx = context.WithValue(ctx, serviceinformers.Key{}, svcInformer)
 		ctx = v1addr.WithDuck(ctx)
 		r := &Reconciler{
 			kubeClientSet:              fakekubeclient.Get(ctx),

--- a/pkg/reconciler/pingsource/controller_test.go
+++ b/pkg/reconciler/pingsource/controller_test.go
@@ -33,6 +33,7 @@ import (
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/pingsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	. "knative.dev/pkg/reconciler/testing"

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -28,15 +28,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubeinformers "k8s.io/client-go/informers"
-	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -360,13 +357,8 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(
-		fakekubeclientset.NewSimpleClientset(), 0)
-	svcInformerIface := kubeInformerFactory.Core().V1().Services()
-
 	logger := logtesting.TestLogger(t)
 	table.Test(t, rtv1.MakeFactory(func(ctx context.Context, listers *rtv1.Listers, cmw configmap.Watcher) controller.Reconciler {
-		ctx = context.WithValue(ctx, service.Key{}, svcInformerIface)
 		ctx = addressable.WithDuck(ctx)
 		r := &Reconciler{
 			configAcc:     &reconcilersource.EmptyVarsGenerator{},

--- a/pkg/reconciler/pingsource/pingsource_test.go
+++ b/pkg/reconciler/pingsource/pingsource_test.go
@@ -28,12 +28,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubeinformers "k8s.io/client-go/informers"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	"knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -357,15 +360,20 @@ func TestAllCases(t *testing.T) {
 		},
 	}
 
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(
+		fakekubeclientset.NewSimpleClientset(), 0)
+	svcInformerIface := kubeInformerFactory.Core().V1().Services()
+
 	logger := logtesting.TestLogger(t)
 	table.Test(t, rtv1.MakeFactory(func(ctx context.Context, listers *rtv1.Listers, cmw configmap.Watcher) controller.Reconciler {
+		ctx = context.WithValue(ctx, service.Key{}, svcInformerIface)
 		ctx = addressable.WithDuck(ctx)
 		r := &Reconciler{
 			configAcc:     &reconcilersource.EmptyVarsGenerator{},
 			kubeClientSet: fakekubeclient.Get(ctx),
 			tracker:       tracker.New(func(types.NamespacedName) {}, 0),
+			sinkResolver:  resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 		}
-		r.sinkResolver = resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0))
 
 		return pingsource.NewReconciler(ctx, logging.FromContext(ctx),
 			fakeeventingclient.Get(ctx), listers.GetPingSourceLister(),

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 
 	"go.uber.org/zap"
@@ -66,6 +68,7 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 		}
 		ctx = logging.WithLogger(ctx, logger)
 
+		ctx, _ = injection.Fake.SetupInformers(ctx, &rest.Config{})
 		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
 		ctx, client := fakeeventingclient.With(ctx, ls.GetEventingObjects()...)
 		ctx, dynamicClient := fakedynamicclient.With(ctx,


### PR DESCRIPTION
Sink resolver updated behavior introduced in knative/pkg#2322 requires `v1.Service` Informer injection to retrieve destination port details.

`v1.Service` informers manually injected and prepopulated with objects if they are required in the tests.