### PR TITLE
Add test for default deadLetterSink namespace in generic Channel

### DIFF
--- a/pkg/apis/messaging/v1/channel_defaults_test.go
+++ b/pkg/apis/messaging/v1/channel_defaults_test.go
@@ -22,6 +22,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/messaging/config"
 
 	"github.com/google/go-cmp/cmp"
@@ -87,6 +90,41 @@ func TestChannelSetDefaults(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		"deadLetterSink.ref.namespace gets defaulted": {
+			initial: Channel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "imc",
+					Namespace:   "custom",
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1"},
+				},
+				Spec: ChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Name: "foo",
+							},
+						},
+					},
+				}},
+			},
+			expected: Channel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "imc",
+					Namespace:   "custom",
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1"},
+				},
+				Spec: ChannelSpec{ChannelableSpec: eventingduckv1.ChannelableSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							Ref: &duckv1.KReference{
+								Name:      "foo",
+								Namespace: "custom",
+							},
+						},
+					},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
See https://github.com/knative/eventing/pull/5906#pullrequestreview-805953656

Fixes https://github.com/knative/eventing/pull/5906#pullrequestreview-805953656

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add test for default deadLetterSink namespace in generic Channel

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
None
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```

/assign @odacremolbap 
