### PR TITLE
Pass through b3 tracing headers

### DIFF
--- a/pkg/utils/headers.go
+++ b/pkg/utils/headers.go
@@ -36,8 +36,8 @@ var (
 	// Then the SDK will set them as ce- headers when sending them through HTTP. Otherwise, when using replies we would
 	// duplicate ce- headers.
 	forwardPrefixes = []string{
-		// knative
-		"knative-",
+		"knative-", // Knative
+		"x-b3-",    // Zipkin (Istio) B3
 	}
 )
 

--- a/pkg/utils/headers_test.go
+++ b/pkg/utils/headers_test.go
@@ -29,7 +29,7 @@ func TestPassThroughHeaders(t *testing.T) {
 		additionalHeaders            http.Header
 		expectedPassedThroughHeaders http.Header
 	}{
-		"pass through of three values": {
+		"valid headers pass through": {
 			additionalHeaders: map[string][]string{
 				"not":                       {"passed", "through"},
 				"x-requEst-id":              {"1234"},

--- a/pkg/utils/headers_test.go
+++ b/pkg/utils/headers_test.go
@@ -19,38 +19,44 @@ package utils
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPassThroughHeaders(t *testing.T) {
 
 	testCases := map[string]struct {
 		additionalHeaders            http.Header
-		expectedPassedThroughHeaders int
+		expectedPassedThroughHeaders http.Header
 	}{
-		"pass through of two values": {
+		"pass through of three values": {
 			additionalHeaders: map[string][]string{
 				"not":                       {"passed", "through"},
+				"x-requEst-id":              {"1234"},
 				"nor":                       {"this-one"},
+				"knatIve-will-pass-through": {"true", "always"},
+				"nope":                      {"nada"},
+				"X-B3-Spanid":               {"5678"},
+			},
+			expectedPassedThroughHeaders: map[string][]string{
 				"x-requEst-id":              {"1234"},
 				"knatIve-will-pass-through": {"true", "always"},
+				"X-B3-Spanid":               {"5678"},
 			},
-			expectedPassedThroughHeaders: 2,
 		},
 		"nothing passes through": {
 			additionalHeaders: map[string][]string{
-				"not": {"passed", "through"},
-				"nor": {"this-one"},
+				"not":  {"passed", "through"},
+				"nor":  {"this-one"},
+				"nope": {"nada"},
 			},
-			expectedPassedThroughHeaders: 0,
+			expectedPassedThroughHeaders: map[string][]string{},
 		},
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			headers := PassThroughHeaders(tc.additionalHeaders)
-			if len(headers) != tc.expectedPassedThroughHeaders {
-				t.Errorf("Not matching the expected number of passed through headers")
-			}
+			assert.Equal(t, tc.expectedPassedThroughHeaders, headers)
 		})
 	}
 }


### PR DESCRIPTION
Tracing events using Zipkin/Istio "B3" headers is not possible via the `MessageReceiver` (pkg/channel) which relies on the `PassThroughHeaders()` function (pkg/utils).  This function is filtering them out which makes end-to-end tracing impossible when using Istio/Zipkin.

## Proposed Changes

- :gift: Pass all Zipkin `x-b3-` tracing headers through.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [X] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

I'm wondering how much of the above might apply as this is internal logic that makes the headers available to Channels/Brokers to choose if/how to handle....

- I think we might want to add it to `SingleEventWithKnativeHeaderHelperForChannelTestHelper()` in `test/conformance/helpers/channel_header_single_event_helper.go` similar to the "knative-xxx" headers?  I've never worked on the Conformance Tests before, though and could use some guidance ; )
- I didn't see specific headers/prefixes called out in the Dos/Spec but my searching might be suspect.

