### PR TITLE
Fix wrong error message

### DIFF
--- a/test/e2e/helpers/broker_test_helper.go
+++ b/test/e2e/helpers/broker_test_helper.go
@@ -213,7 +213,7 @@ func TestBrokerWithManyTriggers(ctx context.Context, t *testing.T, brokerCreator
 			if shouldLabelNamespace {
 				// Label namespace so that it creates the default broker.
 				if err := client.LabelNamespace(map[string]string{sugar.InjectionLabelKey: sugar.InjectionEnabledLabelValue}); err != nil {
-					t.Fatal("Error annotating namespace:", err)
+					t.Fatal("Error labeling namespace:", err)
 				}
 			}
 


### PR DESCRIPTION
We're labeling the namespace, not annotating.

See https://github.com/knative/eventing/pull/5925#pullrequestreview-812760471

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix wrong error message

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
None
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

```
None
```