### PR TITLE
CR's name in metrics' label for APIServerSource

### DIFF
--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -64,12 +64,12 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 	resyncPeriod := 10 * time.Hour
 
 	var delegate cache.Store = &resourceDelegate{
-		ce:     a.ce,
-		source: a.source,
-		logger: a.logger,
-		ref:    a.config.EventMode == v1.ReferenceMode,
+		ce:                  a.ce,
+		source:              a.source,
+		logger:              a.logger,
+		ref:                 a.config.EventMode == v1.ReferenceMode,
+		apiServerSourceName: a.name,
 	}
-
 	if a.config.ResourceOwner != nil {
 		a.logger.Infow("will be filtered",
 			zap.String("APIVersion", a.config.ResourceOwner.APIVersion),

--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -39,6 +39,8 @@ import (
 	pkgtesting "knative.dev/pkg/reconciler/testing"
 )
 
+const apiServerSourceNameTest = "test-apiserversource"
+
 func TestAdapter_StartRef(t *testing.T) {
 	ce := adaptertest.NewTestClient()
 
@@ -288,18 +290,20 @@ func validateNotSent(t *testing.T, ce *adaptertest.TestCloudEventsClient, want s
 func makeResourceAndTestingClient() (*resourceDelegate, *adaptertest.TestCloudEventsClient) {
 	ce := adaptertest.NewTestClient()
 	return &resourceDelegate{
-		ce:     ce,
-		source: "unit-test",
-		logger: zap.NewExample().Sugar(),
+		ce:                  ce,
+		source:              "unit-test",
+		apiServerSourceName: apiServerSourceNameTest,
+		logger:              zap.NewExample().Sugar(),
 	}, ce
 }
 
 func makeRefAndTestingClient() (*resourceDelegate, *adaptertest.TestCloudEventsClient) {
 	ce := adaptertest.NewTestClient()
 	return &resourceDelegate{
-		ce:     ce,
-		source: "unit-test",
-		logger: zap.NewExample().Sugar(),
-		ref:    true,
+		ce:                  ce,
+		source:              "unit-test",
+		apiServerSourceName: apiServerSourceNameTest,
+		logger:              zap.NewExample().Sugar(),
+		ref:                 true,
 	}, ce
 }

--- a/pkg/adapter/apiserver/delegate.go
+++ b/pkg/adapter/apiserver/delegate.go
@@ -27,9 +27,10 @@ import (
 )
 
 type resourceDelegate struct {
-	ce     cloudevents.Client
-	source string
-	ref    bool
+	ce                  cloudevents.Client
+	source              string
+	ref                 bool
+	apiServerSourceName string
 
 	logger *zap.SugaredLogger
 }
@@ -37,7 +38,7 @@ type resourceDelegate struct {
 var _ cache.Store = (*resourceDelegate)(nil)
 
 func (a *resourceDelegate) Add(obj interface{}) error {
-	ctx, event, err := events.MakeAddEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeAddEvent(a.source, a.apiServerSourceName, obj, a.ref)
 	if err != nil {
 		a.logger.Infow("event creation failed", zap.Error(err))
 		return err
@@ -47,7 +48,7 @@ func (a *resourceDelegate) Add(obj interface{}) error {
 }
 
 func (a *resourceDelegate) Update(obj interface{}) error {
-	ctx, event, err := events.MakeUpdateEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeUpdateEvent(a.source, a.apiServerSourceName, obj, a.ref)
 	if err != nil {
 		a.logger.Info("event creation failed", zap.Error(err))
 		return err
@@ -57,7 +58,7 @@ func (a *resourceDelegate) Update(obj interface{}) error {
 }
 
 func (a *resourceDelegate) Delete(obj interface{}) error {
-	ctx, event, err := events.MakeDeleteEvent(a.source, obj, a.ref)
+	ctx, event, err := events.MakeDeleteEvent(a.source, a.apiServerSourceName, obj, a.ref)
 	if err != nil {
 		a.logger.Info("event creation failed", zap.Error(err))
 		return err

--- a/pkg/adapter/apiserver/events/events.go
+++ b/pkg/adapter/apiserver/events/events.go
@@ -36,7 +36,7 @@ const (
 )
 
 // MakeAddEvent returns a cloudevent when a k8s api event is created.
-func MakeAddEvent(source string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
+func MakeAddEvent(source string, apiServerSourceName string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
 	if obj == nil {
 		return nil, cloudevents.Event{}, fmt.Errorf("resource can not be nil")
 	}
@@ -52,11 +52,11 @@ func MakeAddEvent(source string, obj interface{}, ref bool) (context.Context, cl
 		eventType = sources.ApiServerSourceAddEventType
 	}
 
-	return makeEvent(source, eventType, object, data)
+	return makeEvent(source, apiServerSourceName, eventType, object, data)
 }
 
 // MakeUpdateEvent returns a cloudevent when a k8s api event is updated.
-func MakeUpdateEvent(source string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
+func MakeUpdateEvent(source string, apiServerSourceName string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
 	if obj == nil {
 		return nil, cloudevents.Event{}, fmt.Errorf("resource can not be nil")
 	}
@@ -72,11 +72,11 @@ func MakeUpdateEvent(source string, obj interface{}, ref bool) (context.Context,
 		eventType = sources.ApiServerSourceUpdateEventType
 	}
 
-	return makeEvent(source, eventType, object, data)
+	return makeEvent(source, apiServerSourceName, eventType, object, data)
 }
 
 // MakeDeleteEvent returns a cloudevent when a k8s api event is deleted.
-func MakeDeleteEvent(source string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
+func MakeDeleteEvent(source string, apiServerSourceName string, obj interface{}, ref bool) (context.Context, cloudevents.Event, error) {
 	if obj == nil {
 		return nil, cloudevents.Event{}, fmt.Errorf("resource can not be nil")
 	}
@@ -92,7 +92,7 @@ func MakeDeleteEvent(source string, obj interface{}, ref bool) (context.Context,
 		eventType = sources.ApiServerSourceDeleteEventType
 	}
 
-	return makeEvent(source, eventType, object, data)
+	return makeEvent(source, apiServerSourceName, eventType, object, data)
 }
 
 func getRef(object *unstructured.Unstructured) corev1.ObjectReference {
@@ -104,7 +104,7 @@ func getRef(object *unstructured.Unstructured) corev1.ObjectReference {
 	}
 }
 
-func makeEvent(source, eventType string, obj *unstructured.Unstructured, data interface{}) (context.Context, cloudevents.Event, error) {
+func makeEvent(source, apiServerSourceName, eventType string, obj *unstructured.Unstructured, data interface{}) (context.Context, cloudevents.Event, error) {
 	resourceName := obj.GetName()
 	kind := obj.GetKind()
 	namespace := obj.GetNamespace()
@@ -130,7 +130,7 @@ func makeEvent(source, eventType string, obj *unstructured.Unstructured, data in
 	ctx := context.Background()
 	metricTag := &kncloudevents.MetricTag{
 		Namespace:     namespace,
-		Name:          resourceName,
+		Name:          apiServerSourceName,
 		ResourceGroup: resourceGroup,
 	}
 	ctx = kncloudevents.ContextWithMetricTag(ctx, metricTag)

--- a/pkg/adapter/apiserver/events/events_test.go
+++ b/pkg/adapter/apiserver/events/events_test.go
@@ -31,6 +31,8 @@ import (
 
 var contentType = "application/json"
 
+const apiServerSourceNameTest = "test-apiserversource"
+
 func simplePod(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -84,7 +86,7 @@ func TestMakeAddEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeAddEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeAddEvent(tc.source, apiServerSourceNameTest, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -125,7 +127,7 @@ func TestMakeUpdateEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeUpdateEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeUpdateEvent(tc.source, apiServerSourceNameTest, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -166,7 +168,7 @@ func TestMakeDeleteEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeDeleteEvent(tc.source, tc.obj, false)
+			_, got, err := events.MakeDeleteEvent(tc.source, apiServerSourceNameTest, tc.obj, false)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -207,7 +209,7 @@ func TestMakeAddRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeAddEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeAddEvent(tc.source, apiServerSourceNameTest, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -248,7 +250,7 @@ func TestMakeUpdateRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeUpdateEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeUpdateEvent(tc.source, apiServerSourceNameTest, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}
@@ -289,7 +291,7 @@ func TestMakeDeleteRefEvent(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-			_, got, err := events.MakeDeleteEvent(tc.source, tc.obj, true)
+			_, got, err := events.MakeDeleteEvent(tc.source, apiServerSourceNameTest, tc.obj, true)
 			validate(t, got, err, tc.want, tc.wantData, tc.wantErr)
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/5942

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- add `apiServerSourceName` in the `resourseDelegate` struct
- using this new field to replace the value of `name` label in the metrics from the objects name to CR's name

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

