### PR TITLE
Update k8s app labels

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-filter
+    app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,9 +31,9 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: filter
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: broker-filter
+        app.kubernetes.io/component: broker-filter
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
       enableServiceLinks: false
@@ -106,9 +106,9 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-filter
+    app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
 spec:

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-ingress
+    app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,9 +31,9 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: ingress
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: broker-ingress
+        app.kubernetes.io/component: broker-ingress
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
       enableServiceLinks: false
@@ -106,9 +106,9 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-ingress
+    app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
 spec:

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: mt-broker-controller
+    app.kubernetes.io/component: mt-broker-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -31,9 +31,9 @@ spec:
       labels:
         app: mt-broker-controller
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: broker-controller
+        app.kubernetes.io/component: broker-controller
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:

--- a/config/brokers/mt-channel-broker/deployments/hpa.yaml
+++ b/config/brokers/mt-channel-broker/deployments/hpa.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-ingress
+    app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -44,9 +44,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: broker-filter
+    app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/config/brokers/mt-channel-broker/roles/controller-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/controller-clusterrole.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   # Configs resources and status we care about.
   - apiGroups:

--- a/config/brokers/mt-channel-broker/roles/controller-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/controller-clusterrolebinding.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller

--- a/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - eventing.knative.dev

--- a/config/brokers/mt-channel-broker/roles/filter-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrolebinding.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: mt-broker-filter

--- a/config/brokers/mt-channel-broker/roles/filter-serviceaccount.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-serviceaccount.yaml
@@ -19,4 +19,4 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - eventing.knative.dev

--- a/config/brokers/mt-channel-broker/roles/ingress-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-clusterrolebinding.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: mt-broker-ingress

--- a/config/brokers/mt-channel-broker/roles/ingress-serviceaccount.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-serviceaccount.yaml
@@ -19,4 +19,4 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/100-namespace.yaml
+++ b/config/channels/in-memory-channel/100-namespace.yaml
@@ -19,4 +19,4 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -29,7 +29,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: imc-controller
@@ -47,7 +47,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: imc-controller
@@ -64,7 +64,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: imc-controller

--- a/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -29,7 +29,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: imc-dispatcher

--- a/config/channels/in-memory-channel/configmaps/event-dispatcher.yaml
+++ b/config/channels/in-memory-channel/configmaps/event-dispatcher.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: imc-controller
+    app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
   MaxIdleConnectionsPerHost: "100"

--- a/config/channels/in-memory-channel/configmaps/observability.yaml
+++ b/config/channels/in-memory-channel/configmaps/observability.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
 data:

--- a/config/channels/in-memory-channel/configmaps/tracing.yaml
+++ b/config/channels/in-memory-channel/configmaps/tracing.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "c8f8c47b"
 data:

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -20,9 +20,9 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
-    app.kubernetes.io/name: imc-controller
+    app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels: &labels
@@ -32,9 +32,9 @@ spec:
     metadata:
       labels:
         <<: *labels
-        app.kubernetes.io/name: imc-controller
+        app.kubernetes.io/component: imc-controller
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
         podAntiAffinity:
@@ -109,9 +109,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: imc-controller
+    app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
     eventing.knative.dev/release: devel
   name: inmemorychannel-webhook
   namespace: knative-eventing

--- a/config/channels/in-memory-channel/deployments/dispatcher-service.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher-service.yaml
@@ -20,9 +20,9 @@ metadata:
     eventing.knative.dev/release: devel
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
-    app.kubernetes.io/name: imc-dispatcher
+    app.kubernetes.io/component: imc-dispatcher
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
       messaging.knative.dev/channel: in-memory-channel

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -20,9 +20,9 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
-    app.kubernetes.io/name: imc-dispatcher
+    app.kubernetes.io/component: imc-dispatcher
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels: &labels
@@ -32,9 +32,9 @@ spec:
     metadata:
       labels:
         <<: *labels
-        app.kubernetes.io/name: imc-dispatcher
+        app.kubernetes.io/component: imc-dispatcher
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
         podAntiAffinity:

--- a/config/channels/in-memory-channel/resources/in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/resources/in-memory-channel.yaml
@@ -21,7 +21,7 @@ metadata:
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
   versions:

--- a/config/channels/in-memory-channel/roles/addressable-resolver-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/addressable-resolver-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:

--- a/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
   - apiGroups:

--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/config/channels/in-memory-channel/roles/webhook-role.yaml
+++ b/config/channels/in-memory-channel/roles/webhook-role.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   # For manipulating certs into secrets.
   - apiGroups:

--- a/config/channels/in-memory-channel/webhooks/defaulting.yaml
+++ b/config/channels/in-memory-channel/webhooks/defaulting.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1"]
   clientConfig:

--- a/config/channels/in-memory-channel/webhooks/resource-validation.yaml
+++ b/config/channels/in-memory-channel/webhooks/resource-validation.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1"]
   clientConfig:

--- a/config/channels/in-memory-channel/webhooks/secret.yaml
+++ b/config/channels/in-memory-channel/webhooks/secret.yaml
@@ -20,5 +20,5 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.

--- a/config/core/100-namespace.yaml
+++ b/config/core/100-namespace.yaml
@@ -18,4 +18,4 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing

--- a/config/core/200-eventing-serviceaccount.yaml
+++ b/config/core/200-eventing-serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 
 ---
 
@@ -31,7 +31,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -50,7 +50,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -69,7 +69,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -88,7 +88,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller
@@ -107,7 +107,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-controller

--- a/config/core/200-pingsource-mt-adapter-serviceaccount.yaml
+++ b/config/core/200-pingsource-mt-adapter-serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: pingsource-mt-adapter

--- a/config/core/200-webhook-serviceaccount.yaml
+++ b/config/core/200-webhook-serviceaccount.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +30,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook
@@ -50,7 +50,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook
@@ -69,7 +69,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook
@@ -88,7 +88,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: eventing-webhook

--- a/config/core/configmaps/default-broker-channel.yaml
+++ b/config/core/configmaps/default-broker-channel.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   channelTemplateSpec: |
     apiVersion: messaging.knative.dev/v1

--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |

--- a/config/core/configmaps/default-channel.yaml
+++ b/config/core/configmaps/default-channel.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-ch-config: |

--- a/config/core/configmaps/default-pingsource.yaml
+++ b/config/core/configmaps/default-pingsource.yaml
@@ -22,7 +22,7 @@ metadata:
   annotations:
     knative.dev/example-checksum: "f8e5a744"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   _example: |
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   # ALPHA feature: The kreference-group allows you to use the Group field in KReferences.
   # For more details: https://github.com/knative/eventing/issues/5086

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 data:
   # Common configuration for all Knative codebase
   zap-logger-config: |

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
 data:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -22,7 +22,7 @@ metadata:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
 data:

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -20,9 +20,9 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
-    app.kubernetes.io/name: eventing-controller
+    app.kubernetes.io/component: eventing-controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:
@@ -32,9 +32,9 @@ spec:
       labels:
         app: eventing-controller
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: eventing-autoscaler
+        app.kubernetes.io/component: eventing-autoscaler
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: pingsource-mt-adapter
+    app.kubernetes.io/component: pingsource-mt-adapter
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
   replicas: 0
@@ -34,9 +34,9 @@ spec:
       labels:
         <<: *labels
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: pingsource-mt-adapter
+        app.kubernetes.io/component: pingsource-mt-adapter
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
         podAntiAffinity:

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: eventing-webhook
+    app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -45,9 +45,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: eventing-webhook
+    app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
   selector:

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-    app.kubernetes.io/name: eventing-webhook
+    app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels: &labels
@@ -32,9 +32,9 @@ spec:
       labels:
         <<: *labels
         eventing.knative.dev/release: devel
-        app.kubernetes.io/name: eventing-webhook
+        app.kubernetes.io/component: eventing-webhook
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-eventing
+        app.kubernetes.io/name: knative-eventing
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -133,9 +133,9 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     role: eventing-webhook
-    app.kubernetes.io/name: eventing-webhook
+    app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
 spec:

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -22,7 +22,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
     registry.knative.dev/eventTypes: |

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -21,7 +21,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
   versions:

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -22,7 +22,7 @@ metadata:
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
   versions:

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -21,7 +21,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
   group: sources.knative.dev

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -19,7 +19,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
   versions:

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -20,7 +20,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
   versions:

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -21,7 +21,7 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   annotations:
     # TODO add schemas and descriptions
     registry.knative.dev/eventTypes: |

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -20,7 +20,7 @@ metadata:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
   versions:

--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -22,7 +22,7 @@ metadata:
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
   group: sources.knative.dev

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -19,7 +19,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
   versions:

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -20,7 +20,7 @@ metadata:
     eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
   versions:

--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -37,7 +37,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -59,7 +59,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -84,7 +84,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -113,7 +113,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:
@@ -136,7 +136,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
 - apiGroups:

--- a/config/core/roles/broker-clusterrole.yaml
+++ b/config/core/roles/broker-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""
@@ -48,7 +48,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""
@@ -68,7 +68,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""

--- a/config/core/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/core/roles/channelable-manipulator-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -37,7 +37,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
 - apiGroups:

--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -20,7 +20,7 @@ metadata:
     eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
     resources: ["*"]
@@ -34,7 +34,7 @@ metadata:
     eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
     resources: ["*"]
@@ -48,7 +48,7 @@ metadata:
     eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
     resources: ["*"]
@@ -62,7 +62,7 @@ metadata:
     eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
     resources: ["*"]
@@ -76,7 +76,7 @@ metadata:
     eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
     resources: ["*"]
@@ -90,7 +90,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
     resources: ["*"]
@@ -104,7 +104,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
     resources: ["*"]

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""

--- a/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
+++ b/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""

--- a/config/core/roles/podspecable-binding-clusterrole.yaml
+++ b/config/core/roles/podspecable-binding-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -37,7 +37,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/podspecable: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "podspecable-binding role.
 rules:
 

--- a/config/core/roles/source-observer-clusterrole.yaml
+++ b/config/core/roles/source-observer-clusterrole.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -37,7 +37,7 @@ metadata:
     eventing.knative.dev/release: devel
     duck.knative.dev/source: "true"
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # Do not use this role directly. These rules will be added to the "source-observer" role.
 rules:
   - apiGroups:

--- a/config/core/roles/sources-controller-clusterroles.yaml
+++ b/config/core/roles/sources-controller-clusterroles.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
       - ""

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/config/core/roles/webhook-role.yaml
+++ b/config/core/roles/webhook-role.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 rules:
   # For manipulating certs into secrets.
   - apiGroups:

--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/secret.yaml
+++ b/config/core/webhooks/secret.yaml
@@ -20,5 +20,5 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.

--- a/config/core/webhooks/sinkbindings.yaml
+++ b/config/core/webhooks/sinkbindings.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-eventing
+    app.kubernetes.io/name: knative-eventing
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:


### PR DESCRIPTION
We use /name=eventing for all resources and use the /component to
designate different eventing components

Different resources with the same /component label contribute to
the function of that component - ie. broker-filter

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


(came across this via the PR https://github.com/knative/serving/pull/12247  from @dprotaso ) 