### PR TITLE
:broom: Remove hard coded label and rely on config-br-defaults defaults

### DIFF
--- a/pkg/reconciler/sugar/resources/broker.go
+++ b/pkg/reconciler/sugar/resources/broker.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
@@ -29,10 +28,9 @@ const (
 func MakeBroker(namespace, name string) *v1.Broker {
 	return &v1.Broker{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Labels:      Labels(),
-			Annotations: map[string]string{eventing.BrokerClassKey: eventing.MTChannelBrokerClassValue},
+			Namespace: namespace,
+			Name:      name,
+			Labels:    Labels(),
 		},
 	}
 }

--- a/pkg/reconciler/sugar/resources/broker_test.go
+++ b/pkg/reconciler/sugar/resources/broker_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
@@ -43,10 +42,9 @@ func TestMakeBroker(t *testing.T) {
 			},
 			want: &v1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   "default",
-					Name:        "df-broker",
-					Labels:      Labels(),
-					Annotations: map[string]string{eventing.BrokerClassKey: eventing.MTChannelBrokerClassValue},
+					Namespace: "default",
+					Name:      "df-broker",
+					Labels:    Labels(),
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove hard-coded label to rely on default config in `config-br-defaults` CM - as discussed here: https://github.com/knative/eventing/issues/5958#issuecomment-985599622 
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

