### PR TITLE
[WIP] Add retries to test event senders to mitigate networking errors

### DIFF
--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	nethttp "net/http"
 	"strconv"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/plugin/ochttp"
+	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -124,7 +124,12 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 		RetryMax:     10,
 		CheckRetry: retryablehttp.CheckRetry(func(ctx context.Context, resp *nethttp.Response, err error) (bool, error) {
 			// Retry only errors
-			return err != nil, nil
+			if err == nil {
+				return false, nil
+			}
+
+			logging.FromContext(ctx).Warnw("Retrying after error", zap.Error(err))
+			return true, nil
 		}),
 		Backoff: retryablehttp.DefaultBackoff,
 		ErrorHandler: func(resp *nethttp.Response, err error, numTries int) (*nethttp.Response, error) {

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -128,7 +128,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 		}),
 		Backoff: retryablehttp.DefaultBackoff,
 		ErrorHandler: func(resp *nethttp.Response, err error, numTries int) (*nethttp.Response, error) {
-			log.Println("Error handler", err)
+			logging.FromContext(ctx).Errorw("Failed sending request", zap.Int("retries", numTries), zap.Error(err))
 			return resp, err
 		},
 	}

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -184,7 +184,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 
 		r, err := retryablehttp.FromRequest(req)
 		if err != nil {
-			log.Fatal("Failed to create request", err)
+			logging.FromContext(ctx).Fatalw("Failed to create request", zap.Error(err))
 		}
 
 		res, err := httpClient.Do(r)

--- a/test/test_images/event-sender/main.go
+++ b/test/test_images/event-sender/main.go
@@ -28,6 +28,7 @@ import (
 	obsclient "github.com/cloudevents/sdk-go/observability/opencensus/v2/client"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/client"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.opencensus.io/plugin/ochttp"
 	"go.uber.org/zap"
@@ -76,7 +77,11 @@ func main() {
 		log.Printf("awake, continuing")
 	}
 
-	ctx := context.Background()
+	ctx := cecontext.WithRetryParams(context.Background(), &cecontext.RetryParams{
+		Strategy: cecontext.BackoffStrategyExponential,
+		MaxTries: 10,
+		Period:   200 * time.Millisecond,
+	})
 	switch eventEncoding {
 	case "binary":
 		ctx = cloudevents.WithEncodingBinary(ctx)


### PR DESCRIPTION
A common and recurring error I've seen in failed E2E tests is 
`Connection reset by peer`.

This patch adds retries to test event senders so that we mitigate
networking errors.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add retries to test event senders to mitigate networking errors

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
None
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
```
None
```
