### PR TITLE
[release-1.0] Fix channel template spec type for Sequence channel template field

### DIFF
--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -50,7 +50,8 @@ spec:
                     type: string
                   spec:
                     description: Spec defines the Spec to use for each channel created. Passed in verbatim to the Channel CRD as Spec section.
-                    type: string
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
               reply:
                 description: Reply is a Reference to where the result of the last Subscriber gets sent to.
                 type: object

--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -27,15 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
+
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 
-	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
-	"knative.dev/eventing/pkg/client/injection/reconciler/flows/v1/sequence"
-	"knative.dev/eventing/pkg/duck"
-	"knative.dev/eventing/pkg/reconciler/sequence/resources"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
@@ -45,8 +41,15 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/tracker"
 
-	. "knative.dev/eventing/pkg/reconciler/testing/v1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
+	"knative.dev/eventing/pkg/client/injection/reconciler/flows/v1/sequence"
+	"knative.dev/eventing/pkg/duck"
+	"knative.dev/eventing/pkg/reconciler/sequence/resources"
+
 	. "knative.dev/pkg/reconciler/testing"
+
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 )
 
 const (
@@ -226,7 +229,7 @@ func TestAllCases(t *testing.T) {
 			InduceFailure("create", "inmemorychannels"),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile channel resource for step: 0 : inducing failure for create inmemorychannels"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to reconcile channel test-sequence-kn-sequence-0 at step 0: failed to create channel {InMemoryChannel test-namespace test-sequence-kn-sequence-0  messaging.knative.dev/v1  }: inducing failure for create inmemorychannels"),
 		},
 		WantCreates: []runtime.Object{
 			createChannel(sequenceName, 0),
@@ -236,7 +239,7 @@ func TestAllCases(t *testing.T) {
 				WithInitSequenceConditions,
 				WithSequenceChannelTemplateSpec(imc),
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(0)}}),
-				WithSequenceChannelsNotReady("ChannelsNotReady", "Failed to reconcile channels, step: 0")),
+				WithSequenceChannelsNotReady("ChannelsNotReady", "failed to reconcile channel test-sequence-kn-sequence-0 at step 0: failed to create channel {InMemoryChannel test-namespace test-sequence-kn-sequence-0  messaging.knative.dev/v1  }: inducing failure for create inmemorychannels")),
 		}},
 	}, {
 		Name: "singlestep-subscriptioncreatefails",
@@ -267,7 +270,7 @@ func TestAllCases(t *testing.T) {
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(0)}}),
 				WithSequenceAddressableNotReady("emptyAddress", "addressable is nil"),
 				WithSequenceChannelsNotReady("ChannelsNotReady", "Channels are not ready yet, or there are none"),
-				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "Failed to reconcile subscriptions, step: 0"),
+				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "failed to reconcile subscription resource for step: 0 : inducing failure for create subscriptions"),
 				WithSequenceChannelStatuses([]v1.SequenceChannelStatus{
 					{
 						Channel: corev1.ObjectReference{
@@ -319,7 +322,7 @@ func TestAllCases(t *testing.T) {
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(0)}}),
 				WithSequenceAddressableNotReady("emptyAddress", "addressable is nil"),
 				WithSequenceChannelsNotReady("ChannelsNotReady", "Channels are not ready yet, or there are none"),
-				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "Failed to reconcile subscriptions, step: 0"),
+				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "failed to reconcile subscription resource for step: 0 : inducing failure for delete subscriptions"),
 				WithSequenceChannelStatuses([]v1.SequenceChannelStatus{
 					{
 						Channel: corev1.ObjectReference{
@@ -376,7 +379,7 @@ func TestAllCases(t *testing.T) {
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(0)}}),
 				WithSequenceAddressableNotReady("emptyAddress", "addressable is nil"),
 				WithSequenceChannelsNotReady("ChannelsNotReady", "Channels are not ready yet, or there are none"),
-				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "Failed to reconcile subscriptions, step: 0"),
+				WithSequenceSubscriptionsNotReady("SubscriptionsNotReady", "failed to reconcile subscription resource for step: 0 : inducing failure for create subscriptions"),
 				WithSequenceChannelStatuses([]v1.SequenceChannelStatus{
 					{
 						Channel: corev1.ObjectReference{

--- a/test/rekt/features/parallel/readyness.go
+++ b/test/rekt/features/parallel/readyness.go
@@ -19,10 +19,11 @@ package parallel
 import (
 	"strconv"
 
-	"knative.dev/eventing/test/rekt/resources/parallel"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/resources/svc"
+
+	"knative.dev/eventing/test/rekt/resources/parallel"
 )
 
 // GoesReady returns a feature testing if a Parallel becomes ready with 3 branches.

--- a/test/rekt/features/sequence/readyness.go
+++ b/test/rekt/features/sequence/readyness.go
@@ -19,15 +19,16 @@ package sequence
 import (
 	"strconv"
 
-	"knative.dev/eventing/test/rekt/resources/sequence"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/resources/svc"
+
+	"knative.dev/eventing/test/rekt/resources/sequence"
 )
 
 // GoesReady returns a feature testing if a Sequence becomes ready with 3 steps.
 func GoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
-	f := feature.NewFeatureNamed("Parallel goes ready.")
+	f := feature.NewFeatureNamed("Sequence goes ready.")
 
 	{
 		reply := feature.MakeRandomK8sName("reply")

--- a/test/rekt/resources/delivery/delivery.go
+++ b/test/rekt/resources/delivery/delivery.go
@@ -17,9 +17,10 @@ limitations under the License.
 package delivery
 
 import (
-	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
 )
 
 // WithDeadLetterSink adds the dead letter sink related config to the config.
@@ -59,10 +60,10 @@ func WithRetry(count int32, backoffPolicy *eventingv1.BackoffPolicyType, backoff
 
 		delivery["retry"] = count
 		if backoffPolicy != nil {
-			delivery["backoffPolicy"] = backoffPolicy
+			delivery["backoffPolicy"] = *backoffPolicy
 		}
 		if backoffDelay != nil {
-			delivery["backoffDelay"] = backoffDelay
+			delivery["backoffDelay"] = *backoffDelay
 		}
 	}
 }

--- a/test/rekt/resources/parallel/parallel.go
+++ b/test/rekt/resources/parallel/parallel.go
@@ -21,13 +21,15 @@ import (
 	"embed"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/test/rekt/resources/addressable"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/resources/addressable"
 )
 
 //go:embed *.yaml
@@ -214,5 +216,26 @@ func WithReply(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			rref["namespace"] = ref.Namespace
 			rref["name"] = ref.Name
 		}
+	}
+}
+
+type ChannelTemplate struct {
+	metav1.TypeMeta
+
+	Spec map[string]interface{}
+}
+
+// WithChannelTemplate adds the top level channel references.
+func WithChannelTemplate(template ChannelTemplate) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["channelTemplate"]; !set {
+			cfg["channelTemplate"] = map[string]interface{}{}
+		}
+		channelTemplate := cfg["channelTemplate"].(map[string]interface{})
+
+		channelTemplate["kind"] = template.Kind
+		channelTemplate["apiVersion"] = template.APIVersion
+
+		channelTemplate["spec"] = template.Spec
 	}
 }

--- a/test/rekt/resources/parallel/parallel.yaml
+++ b/test/rekt/resources/parallel/parallel.yaml
@@ -27,7 +27,14 @@ spec:
     {{ if .channelTemplate.spec }}
     spec:
       {{ range $key, $value := .channelTemplate.spec }}
+      {{ if ne (printf "%T" $value) "string" }}
+      {{ $key }}:
+        {{ range $k, $v := $value }}
+        {{ $k }}: {{ $v }}
+        {{ end }}
+      {{ else }}
       {{ $key }}: {{ $value }}
+      {{ end }}
       {{ end }}
     {{ end }}
   {{ end }}

--- a/test/rekt/resources/parallel/parallel_test.go
+++ b/test/rekt/resources/parallel/parallel_test.go
@@ -19,9 +19,10 @@ package parallel_test
 import (
 	"os"
 
-	"knative.dev/eventing/test/rekt/resources/parallel"
 	v1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/resources/parallel"
 )
 
 // The following examples validate the processing of the With* helper methods
@@ -50,6 +51,161 @@ func Example_min() {
 	//   branches:
 }
 
+func Example_fullDelivery() {
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"channelTemplate": map[string]interface{}{
+			"apiVersion": "channelimpl/v1",
+			"kind":       "mychannel",
+			"spec": map[string]interface{}{
+				"delivery": map[string]interface{}{
+					"retry": 8,
+				},
+				"thing2": "value2",
+			},
+		},
+		"branches": []map[string]interface{}{{
+			"filter": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "filter1-api",
+					"kind":       "filter1-kind",
+					"name":       "filter1",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			},
+			"subscriber": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "subscriber1-api",
+					"kind":       "subscriber1-kind",
+					"name":       "subscriber1",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			},
+			"reply": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "reply1-api",
+					"kind":       "reply1-kind",
+					"name":       "reply1",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			}}, {
+			"filter": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "filter2-api",
+					"kind":       "filter2-kind",
+					"name":       "filter2",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			},
+			"subscriber": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "subscriber2-api",
+					"kind":       "subscriber2-kind",
+					"name":       "subscriber2",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			},
+			"reply": map[string]interface{}{
+				"ref": map[string]string{
+					"apiVersion": "reply2-api",
+					"kind":       "reply2-kind",
+					"name":       "reply2",
+					"namespace":  "bar",
+				},
+				"uri": "/extra/path",
+			}},
+		},
+		"reply": map[string]interface{}{
+			"ref": map[string]string{
+				"apiVersion": "reply1-api",
+				"kind":       "reply1-kind",
+				"name":       "reply1",
+				"namespace":  "bar",
+			},
+			"uri": "/extra/path",
+		},
+	}
+
+	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: flows.knative.dev/v1
+	// kind: Parallel
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   channelTemplate:
+	//     apiVersion: channelimpl/v1
+	//     kind: mychannel
+	//     spec:
+	//       delivery:
+	//         retry: 8
+	//       thing2: value2
+	//   branches:
+	//     -
+	//       filter:
+	//         ref:
+	//           kind: filter1-kind
+	//           namespace: bar
+	//           name: filter1
+	//           apiVersion: filter1-api
+	//         uri: /extra/path
+	//       subscriber:
+	//         ref:
+	//           kind: subscriber1-kind
+	//           namespace: bar
+	//           name: subscriber1
+	//           apiVersion: subscriber1-api
+	//         uri: /extra/path
+	//       reply:
+	//         ref:
+	//           kind: reply1-kind
+	//           namespace: bar
+	//           name: reply1
+	//           apiVersion: reply1-api
+	//         uri: /extra/path
+	//     -
+	//       filter:
+	//         ref:
+	//           kind: filter2-kind
+	//           namespace: bar
+	//           name: filter2
+	//           apiVersion: filter2-api
+	//         uri: /extra/path
+	//       subscriber:
+	//         ref:
+	//           kind: subscriber2-kind
+	//           namespace: bar
+	//           name: subscriber2
+	//           apiVersion: subscriber2-api
+	//         uri: /extra/path
+	//       reply:
+	//         ref:
+	//           kind: reply2-kind
+	//           namespace: bar
+	//           name: reply2
+	//           apiVersion: reply2-api
+	//         uri: /extra/path
+	//   reply:
+	//     ref:
+	//       kind: reply1-kind
+	//       namespace: bar
+	//       name: reply1
+	//       apiVersion: reply1-api
+	//     uri: /extra/path
+}
 func Example_full() {
 	images := map[string]string{}
 	cfg := map[string]interface{}{

--- a/test/rekt/resources/sequence/sequence.go
+++ b/test/rekt/resources/sequence/sequence.go
@@ -21,13 +21,15 @@ import (
 	"embed"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/test/rekt/resources/addressable"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/resources/addressable"
 )
 
 //go:embed *.yaml
@@ -132,5 +134,26 @@ func WithReply(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			rref["namespace"] = ref.Namespace
 			rref["name"] = ref.Name
 		}
+	}
+}
+
+type ChannelTemplate struct {
+	metav1.TypeMeta
+
+	Spec map[string]interface{}
+}
+
+// WithChannelTemplate adds the top level channel references.
+func WithChannelTemplate(template ChannelTemplate) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["channelTemplate"]; !set {
+			cfg["channelTemplate"] = map[string]interface{}{}
+		}
+		channelTemplate := cfg["channelTemplate"].(map[string]interface{})
+
+		channelTemplate["kind"] = template.Kind
+		channelTemplate["apiVersion"] = template.APIVersion
+
+		channelTemplate["spec"] = template.Spec
 	}
 }

--- a/test/rekt/resources/sequence/sequence.yaml
+++ b/test/rekt/resources/sequence/sequence.yaml
@@ -27,7 +27,14 @@ spec:
     {{ if .channelTemplate.spec }}
     spec:
       {{ range $key, $value := .channelTemplate.spec }}
+      {{ if ne (printf "%T" $value) "string" }}
+      {{ $key }}:
+        {{ range $k, $v := $value }}
+        {{ $k }}: {{ $v }}
+        {{ end }}
+        {{ else }}
       {{ $key }}: {{ $value }}
+      {{ end }}
       {{ end }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
Cherry-pick of #5955

```
The Sequence type accepts any Channel spec field in the `spec.channelTemplate.spec` field.
```