### PR TITLE
Cleanup of some redundant tests for the broker's filter handler

### DIFF
--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -127,19 +127,7 @@ func TestReceiver(t *testing.T) {
 			},
 			expectedEventCount: false,
 		},
-		"Wrong type with attribs": {
-			triggers: []*eventingv1.Trigger{
-				makeTrigger(makeTriggerFilterWithAttributes("some-other-type", "")),
-			},
-			expectedEventCount: false,
-		},
 		"Wrong source": {
-			triggers: []*eventingv1.Trigger{
-				makeTrigger(makeTriggerFilterWithAttributes("", "some-other-source")),
-			},
-			expectedEventCount: false,
-		},
-		"Wrong source with attribs": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributes("", "some-other-source")),
 			},
@@ -147,7 +135,7 @@ func TestReceiver(t *testing.T) {
 		},
 		"Wrong extension": {
 			triggers: []*eventingv1.Trigger{
-				makeTrigger(makeTriggerFilterWithAttributes("", "some-other-source")),
+				makeTrigger(makeTriggerFilterWithAttributesAndExtension("", "", "some-other-extension")),
 			},
 			expectedEventCount: false,
 		},
@@ -177,15 +165,7 @@ func TestReceiver(t *testing.T) {
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
 		},
-		"Dispatch succeeded - Any with attribs": {
-			triggers: []*eventingv1.Trigger{
-				makeTrigger(makeTriggerFilterWithAttributes("", "")),
-			},
-			expectedDispatch:          true,
-			expectedEventCount:        true,
-			expectedEventDispatchTime: true,
-		},
-		"Dispatch succeeded - Specific": {
+		"Dispatch succeeded - Source with type": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributes(eventType, eventSource)),
 			},
@@ -193,15 +173,7 @@ func TestReceiver(t *testing.T) {
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
 		},
-		"Dispatch succeeded - Specific with attribs": {
-			triggers: []*eventingv1.Trigger{
-				makeTrigger(makeTriggerFilterWithAttributes(eventType, eventSource)),
-			},
-			expectedDispatch:          true,
-			expectedEventCount:        true,
-			expectedEventDispatchTime: true,
-		},
-		"Dispatch succeeded - Extension with attribs": {
+		"Dispatch succeeded - Source, type and extensions": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributesAndExtension(eventType, eventSource, extensionValue)),
 			},
@@ -210,7 +182,7 @@ func TestReceiver(t *testing.T) {
 			expectedEventCount:        true,
 			expectedEventDispatchTime: true,
 		},
-		"Dispatch succeeded - Any with attribs - Arrival extension": {
+		"Dispatch succeeded - Any - Arrival extension": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributes("", "")),
 			},
@@ -220,7 +192,7 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime:   true,
 			expectedEventProcessingTime: true,
 		},
-		"Wrong Extension with attribs": {
+		"Wrong Extension with correct source and type": {
 			triggers: []*eventingv1.Trigger{
 				makeTrigger(makeTriggerFilterWithAttributesAndExtension(eventType, eventSource, "some-other-extension-value")),
 			},


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Cleanup of some broker's filter handler tests which became redundant after dropping the `sourceAndType` field in Trigger v1beta1 APIs. 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

