### PR TITLE
Use in-cluster kube config as a fallback

### DIFF
--- a/test/lib/client.go
+++ b/test/lib/client.go
@@ -65,11 +65,11 @@ type Client struct {
 
 // NewClient instantiates and returns several clientsets required for making request to the
 // cluster specified by the combination of clusterName and configPath.
-func NewClient(configPath string, clusterName string, namespace string, t *testing.T) (*Client, error) {
+func NewClient(namespace string, t *testing.T) (*Client, error) {
 	var err error
 
 	client := &Client{}
-	client.Config, err = test.BuildClientConfig(configPath, clusterName)
+	client.Config, err = test.Flags.GetRESTConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -32,7 +32,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/prow"
 
 	"knative.dev/eventing/pkg/utils"
@@ -198,11 +197,7 @@ func CreateNamespacedClient(t *testing.T) (*Client, error) {
 	// development cycles when namespaces from previous runs were not cleaned properly.
 	for i := 0; i < MaxNamespaceSkip; i++ {
 		ns = NextNamespace()
-		client, err := NewClient(
-			pkgTest.Flags.Kubeconfig,
-			pkgTest.Flags.Cluster,
-			ns,
-			t)
+		client, err := NewClient(ns, t)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Makes it possible to run tests in a container within cluster without
specifying/mounting extra kubeconfig

Fixes #5996

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

