### PR TITLE
Change default Broker delivery spec

### DIFF
--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -30,3 +30,7 @@ data:
       kind: ConfigMap
       name: config-br-default-channel
       namespace: knative-eventing
+      delivery:
+        retry: 10
+        backoffPolicy: exponential
+        backoffDelay: PT0.2S

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/trace v0.20.0
 	go.uber.org/atomic v1.9.0
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.42.0

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -28,6 +28,8 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
+	"knative.dev/reconciler-test/pkg/eventshub"
+
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/test/rekt/features/broker"
 	b "knative.dev/eventing/test/rekt/resources/broker"
@@ -104,4 +106,16 @@ func TestBrokerConformance(t *testing.T) {
 	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
 	env.TestSet(ctx, t, broker.ControlPlaneConformance("default"))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))
+}
+
+func TestBrokerDefaultDelivery(t *testing.T) {
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, broker.DefaultDeliverySpec())
 }

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -28,8 +28,6 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
-	"knative.dev/reconciler-test/pkg/eventshub"
-
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/test/rekt/features/broker"
 	b "knative.dev/eventing/test/rekt/resources/broker"

--- a/test/rekt/features/broker/delivery.go
+++ b/test/rekt/features/broker/delivery.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"knative.dev/reconciler-test/pkg/feature"
+
+	"knative.dev/eventing/test/rekt/resources/broker"
+)
+
+func DefaultDeliverySpec() *feature.Feature {
+	f := feature.NewFeatureNamed("default delivery spec")
+
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+
+	f.Requirement("broker is ready", broker.IsReady(brokerName))
+	f.Requirement("broker is addressable", broker.IsAddressable(brokerName))
+
+	f.Assert("broker has delivery spec set", broker.WaitForCondition(brokerName,
+		broker.HasDelivery().
+			And(broker.HasDeliveryRetry()).
+			And(broker.HasDeliveryBackoffDelay()).
+			And(broker.HasDeliveryBackoffPolicy()),
+	))
+
+	return f
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -369,6 +369,7 @@ go.uber.org/automaxprocs/internal/cgroups
 go.uber.org/automaxprocs/internal/runtime
 go.uber.org/automaxprocs/maxprocs
 # go.uber.org/multierr v1.6.0
+## explicit
 go.uber.org/multierr
 # go.uber.org/zap v1.19.1
 ## explicit


### PR DESCRIPTION
Our Broker delivery spec is unset by default, which means that it has literally a
fire-and-forget delivery guarantee because with don't retry.

To make our defaults stronger, we should set a reasonable delivery spec
by default when no delivery spec is specified.

**Default Delivery Spec**

The following delivery spec isn't perfect for every use case by at least
prevents events loss for normal networking errors (eg connection resets, etc)
or during upgrades.

```yaml
delivery:
  retry: 10
  backoffPolicy: exponential
  backoffDelay: PT0.2S
```
The retry period with the above configuration is ~200 seconds long

Fixes #5936

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Change default Broker delivery spec

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Change default Broker delivery spec
```


**Docs**

```
None
```
