### PR TITLE
Use time encoder with human-readable timestamps for upgrade tests

### DIFF
--- a/test/upgrade/prober/wathola/config/logger.go
+++ b/test/upgrade/prober/wathola/config/logger.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Log is a default logger for wathola
@@ -24,6 +25,8 @@ var Log = newLogger()
 var logConfig = zap.NewProductionConfig()
 
 func newLogger() *zap.SugaredLogger {
+	// Get timestamps readable and comparable with wathola-fetcher
+	logConfig.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 	z, err := logConfig.Build()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Change format of logs in wathola-receiver and related components so that we can read timestamps properly and compare them with the ones in wathola-fetcher.
Initial format:
```
{"level":"info","ts":1642064145.2131953,"caller":"event/services.go:102","msg":"finish event received, expecting 1548 event ware propagated"}
```
New format:
```
{"level":"info","ts":"2022-01-13T13:34:20.075868487Z","caller":"event/services.go:102","msg":"finish event received, expecting 38560 event ware propagated"}
```

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

