### PR TITLE
Set missing event type on CloudEvent in a test helper

### DIFF
--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -23,6 +23,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/test"
+	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/containersource"
 	"knative.dev/eventing/test/rekt/resources/delivery"
@@ -165,6 +166,7 @@ func SingleEventWithEncoding(encoding binding.Encoding) *feature.Feature {
 
 	event := cloudevents.NewEvent()
 	event.SetID(feature.MakeRandomK8sName("test"))
+	event.SetType(testlib.DefaultEventType)
 	event.SetSource("http://sender.svc/")
 	prober.ExpectEvents([]string{event.ID()})
 

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -19,6 +19,7 @@ package channel
 import (
 	"context"
 	"fmt"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/test"

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -19,11 +19,9 @@ package channel
 import (
 	"context"
 	"fmt"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/test"
-	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/containersource"
 	"knative.dev/eventing/test/rekt/resources/delivery"
@@ -166,7 +164,7 @@ func SingleEventWithEncoding(encoding binding.Encoding) *feature.Feature {
 
 	event := cloudevents.NewEvent()
 	event.SetID(feature.MakeRandomK8sName("test"))
-	event.SetType(testlib.DefaultEventType)
+	event.SetType("myevent")
 	event.SetSource("http://sender.svc/")
 	prober.ExpectEvents([]string{event.ID()})
 


### PR DESCRIPTION
Fixes: #6046

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Set missing event type on CloudEvent in a test helper
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

