### PR TITLE
Upgrade test waits for sender deletion

### DIFF
--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -25,7 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
 	pkgTest "knative.dev/pkg/test"
 
 	testlib "knative.dev/eventing/test/lib"
@@ -95,10 +94,7 @@ func (p *prober) removeSender() {
 	p.log.Info("Remove of sender deployment: ", senderName)
 
 	foreground := metav1.DeletePropagationForeground
-	dOpts := metav1.DeleteOptions{
-		GracePeriodSeconds: pointer.Int64(0),
-		PropagationPolicy:  &foreground,
-	}
+	dOpts := metav1.DeleteOptions{PropagationPolicy: &foreground}
 	err := p.client.Kube.AppsV1().
 		Deployments(p.client.Namespace).
 		Delete(p.config.Ctx, senderName, dOpts)

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -114,7 +114,7 @@ func (p *prober) removeSender() {
 			return true, nil
 		}
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		return false, nil
 	})


### PR DESCRIPTION
Deleting a deployment doesn't guarantee that the pods associated
with it will be deleted in a reasonable time.

By setting foreground deletion, grace period seconds to 0,
and waiting for the top-level resource to be deleted we effectively know
that the sender is actually stopped.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>