### PR TITLE
Fix test helpers for subscription that abuse Subscription's `spec.reply`

### DIFF
--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -27,11 +27,13 @@ import (
 	ch "knative.dev/eventing/test/rekt/resources/channel"
 	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/subscription"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
+	"knative.dev/reconciler-test/pkg/manifest"
 )
 
 // TestChannelConformance
@@ -165,7 +167,10 @@ func TestChannelChain(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Test(ctx, t, channel.ChannelChain(10))
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithReply(ref, uri)
+	}
+	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
 }
 
 func TestChannelDeadLetterSink(t *testing.T) {
@@ -179,7 +184,10 @@ func TestChannelDeadLetterSink(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Test(ctx, t, channel.DeadLetterSink())
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithReply(ref, uri)
+	}
+	env.Test(ctx, t, channel.DeadLetterSink(createSubscriberFn))
 }
 
 /*

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -156,7 +156,7 @@ TestChannelChain tests the following scenario:
 EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
 
 */
-func TestChannelChain(t *testing.T) {
+func TestChannelChainByUsingReplyAsSubscriber(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -173,7 +173,7 @@ func TestChannelChain(t *testing.T) {
 	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
 }
 
-func TestChannelDeadLetterSink(t *testing.T) {
+func TestChannelDeadLetterSinkByUsingReplyAsSubscriber(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Test helpers in Rekt features use Subscription's `spec.reply` as `spec.subscriber`. There's a discussion about that here: #5756
- Because these test helpers abuse `spec.reply`, the tests in KafkaChannel repository fail when I run the same tests against KafkaChannel.
- I did these:
  - Made the test helpers accept a function that either uses `spec.reply` or `spec.subscriber`
  - Test functions (which call helpers) decide which field to use
  - Renamed the test functions that abuse `spec.reply` to denote that this is problematic
  - When #5756 is enabled, the abusing tests will fail and then we can actually convert them to regression tests that we make sure they fail

This PR will unblock me since when this is merged I can call the helpers with `spec.subscriber` in KafkaChannel repository. KafkaChannel doesn't allow leaving `spec.subscriber` empty.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

