### PR TITLE
Increase timeout for rekt tests

### DIFF
--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -35,6 +35,6 @@ initialize $@ --skip-istio-addon
 export SKIP_UPLOAD_TEST_IMAGES="true"
 
 echo "Running E2E Reconciler Tests"
-go_test_e2e -timeout=30m -parallel=20 ./test/rekt || fail_test
+go_test_e2e -timeout=1h -parallel=20 ./test/rekt || fail_test
 
 success


### PR DESCRIPTION
A recent run failed with this error:
```
panic: test timed out after 30m0s
```

Fixes #6064