### PR TITLE
Prober waits until receiver state != active or timeout

### DIFF
--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -40,7 +40,6 @@ const (
 	defaultHomedir           = "/home/nonroot"
 	defaultConfigFilename    = "config.toml"
 	defaultHealthEndpoint    = "/healthz"
-	defaultFinishedSleep     = 5 * time.Second
 
 	// Silence will suppress notification about event duplicates.
 	Silence DuplicateAction = "silence"

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -63,12 +63,11 @@ type DuplicateAction string
 // Config represents a configuration for prober.
 type Config struct {
 	Wathola
-	Interval      time.Duration
-	FinishedSleep time.Duration
-	Serving       ServingConfig
-	FailOnErrors  bool
-	OnDuplicate   DuplicateAction
-	Ctx           context.Context
+	Interval     time.Duration
+	Serving      ServingConfig
+	FailOnErrors bool
+	OnDuplicate  DuplicateAction
+	Ctx          context.Context
 }
 
 // Wathola represents options related strictly to wathola testing tool.
@@ -109,11 +108,10 @@ func NewConfigOrFail(c pkgupgrade.Context) *Config {
 // NewConfig will create a prober.Config or return error.
 func NewConfig() (*Config, error) {
 	config := &Config{
-		Interval:      Interval,
-		FinishedSleep: defaultFinishedSleep,
-		FailOnErrors:  true,
-		OnDuplicate:   Warn,
-		Ctx:           context.Background(),
+		Interval:     Interval,
+		FailOnErrors: true,
+		OnDuplicate:  Warn,
+		Ctx:          context.Background(),
 		Serving: ServingConfig{
 			Use:         false,
 			ScaleToZero: true,

--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -67,7 +67,6 @@ func (p *probeRunner) Verify(ctx pkgupgrade.Context) {
 	p.client.T = ctx.T
 	t := ctx.T
 	p.Finish()
-	waitAfterFinished(p.prober)
 
 	errors, events := p.prober.Verify()
 	if len(errors) == 0 {
@@ -136,9 +135,4 @@ func (p *prober) remove() {
 		p.removeForwarder()
 	}
 	p.ensureNoError(p.client.Tracker.Clean(true))
-}
-
-func waitAfterFinished(p *prober) {
-	p.log.Infof("Waiting %v after sender finished...", p.config.FinishedSleep)
-	time.Sleep(p.config.FinishedSleep)
 }

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -178,7 +178,7 @@ func (p *prober) deployFetcher() *batchv1.Job {
 	created, err := jobs.Create(p.config.Ctx, fetcherJob, metav1.CreateOptions{})
 	p.ensureNoError(err)
 	p.log.Info("Waiting for fetcher job to succeed: ", fetcherName)
-	err = waitForJobToComplete(p.config.Ctx, p.client.Kube, fetcherName, p.client.Namespace)
+	err = waitForJobToComplete(p.config.Ctx, p.client.Kube, created.Name, p.client.Namespace)
 	p.ensureNoError(err)
 
 	return created

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -43,7 +43,7 @@ const (
 // Verify will verify prober state after finished has been sent.
 func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	var report *receiver.Report
-	p.log.Info("Waiting for complete report from receiver")
+	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
 	if fetchErr := wait.PollImmediate(time.Second, 5*jobWaitTimeout, func() (bool, error) {
 		report = p.fetchReport()
@@ -108,7 +108,7 @@ func replayLogs(log *zap.SugaredLogger, exec *fetcher.Execution) {
 func (p *prober) fetchExecution() *fetcher.Execution {
 	ns := p.client.Namespace
 	job := p.deployFetcher()
-	defer p.deleteFetcher()
+	defer p.deleteFetcher(job.Name)
 	pod, err := p.findSucceededPod(job)
 	p.ensureNoError(err)
 	bytes, err := pkgTest.PodLogs(p.config.Ctx, p.client.Kube, pod.Name, fetcherName, ns)
@@ -138,8 +138,8 @@ func (p *prober) deployFetcher() *batchv1.Job {
 	var replicas int32 = 1
 	fetcherJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fetcherName,
-			Namespace: p.client.Namespace,
+			GenerateName: fetcherName + "-",
+			Namespace:    p.client.Namespace,
 		},
 		Spec: batchv1.JobSpec{
 			Completions: &replicas,
@@ -184,11 +184,10 @@ func (p *prober) deployFetcher() *batchv1.Job {
 	return created
 }
 
-func (p *prober) deleteFetcher() {
+func (p *prober) deleteFetcher(name string) {
 	ns := p.client.Namespace
 	jobs := p.client.Kube.BatchV1().Jobs(ns)
-	foreground := metav1.DeletePropagationForeground
-	err := jobs.Delete(p.config.Ctx, fetcherName, metav1.DeleteOptions{PropagationPolicy: &foreground})
+	err := jobs.Delete(p.config.Ctx, name, metav1.DeleteOptions{})
 	p.ensureNoError(err)
 }
 

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -37,7 +37,7 @@ import (
 const (
 	fetcherName     = "wathola-fetcher"
 	jobWaitInterval = time.Second
-	jobWaitTimeout  = 1 * time.Minute
+	jobWaitTimeout  = 10 * time.Minute
 )
 
 // Verify will verify prober state after finished has been sent.
@@ -45,7 +45,7 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	var report *receiver.Report
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
-	if err := wait.PollImmediate(time.Second, 5*jobWaitTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {
 		report = p.fetchReport()
 		return report.State != "active", nil
 	}); err != nil {

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -45,11 +45,11 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	var report *receiver.Report
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
-	if fetchErr := wait.PollImmediate(time.Second, 5*jobWaitTimeout, func() (bool, error) {
+	if err := wait.PollImmediate(time.Second, 5*jobWaitTimeout, func() (bool, error) {
 		report = p.fetchReport()
 		return report.State != "active", nil
-	}); fetchErr != nil {
-		p.client.T.Fatalf("Error fetching complete (inactive) report: %v\nReport: %+v", fetchErr, report)
+	}); err != nil {
+		p.client.T.Fatalf("Error fetching complete/inactive report: %v\nReport: %+v", err, report)
 	}
 	elapsed := time.Since(start)
 	availRate := 0.0

--- a/test/upgrade/prober/wathola/receiver/services.go
+++ b/test/upgrade/prober/wathola/receiver/services.go
@@ -97,11 +97,11 @@ type reportHandler struct {
 
 func (r reportHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.RequestURI == "/report" {
-		s := r.receiver.finished.State()
+		//s := r.receiver.finished.State()
 		events := r.receiver.step.Count()
 		totalReq := r.receiver.finished.TotalRequests()
 		sj := &Report{
-			State:         stateToString(s),
+			State:         "active",
 			EventsSent:    events,
 			TotalRequests: totalReq,
 			Thrown: Thrown{

--- a/test/upgrade/prober/wathola/receiver/services.go
+++ b/test/upgrade/prober/wathola/receiver/services.go
@@ -97,11 +97,11 @@ type reportHandler struct {
 
 func (r reportHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.RequestURI == "/report" {
-		//s := r.receiver.finished.State()
+		s := r.receiver.finished.State()
 		events := r.receiver.step.Count()
 		totalReq := r.receiver.finished.TotalRequests()
 		sj := &Report{
-			State:         "active",
+			State:         stateToString(s),
 			EventsSent:    events,
 			TotalRequests: totalReq,
 			Thrown: Thrown{


### PR DESCRIPTION
Fixes #6045

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- do not use FinishedSleep before fetching the report but rather wait for the report to be complete/inactive or eventually time out
- shorter jobWaitTimeout for a single "fetcher" job - the job takes just a couple of seconds to complete, and use 5*jobWaitTimeout for waiting for the complete report

The successful run can be seen [here](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/6074/pull-knative-eventing-upgrade-tests/1484423708683538432
)
The failed run (with "active" report and timeout) is [here](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/6074/pull-knative-eventing-upgrade-tests/1484177429432897536)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

