### PR TITLE
Update zipkin image to :2 version to fix the CVE

### DIFF
--- a/test/config/monitoring/monitoring.yaml
+++ b/test/config/monitoring/monitoring.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.23.2
+        image: ghcr.io/openzipkin/zipkin:2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411


### PR DESCRIPTION
See https://github.com/openzipkin/zipkin/releases/tag/2.23.16