### PR TITLE
Improve check reliability in TestChannelNamespaceDefaulting

### DIFF
--- a/test/e2e/channel_defaults_webhook_test.go
+++ b/test/e2e/channel_defaults_webhook_test.go
@@ -183,5 +183,11 @@ func webhookObservedUpdate(ch *messagingv1.Channel) bool {
 }
 
 func webhookObservedUpdateFromDeliverySpec(d *eventingduck.DeliverySpec) bool {
-	return d != nil && d.BackoffDelay != nil && d.Retry != nil && d.BackoffPolicy != nil
+	return d != nil &&
+		d.BackoffDelay != nil &&
+		*d.BackoffDelay == "PT0.5S" &&
+		d.Retry != nil &&
+		*d.Retry == int32(5) &&
+		d.BackoffPolicy != nil &&
+		*d.BackoffPolicy == eventingduck.BackoffPolicyExponential
 }


### PR DESCRIPTION
When we changed the default retry parameters, the check to see if the
webhook has observed the update isn't reliable as it was, this PR
checks for the expected delivery parameters to ensure that the update
was seen by the webhook.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #6078