### PR TITLE
Enable features configmap watching and fix mt broker filter subscriptions API implementation

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -17,13 +17,14 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
-
+	"knative.dev/eventing/pkg/apis/feature"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	configmap "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
@@ -36,12 +37,11 @@ import (
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 
-	broker "knative.dev/eventing/cmd/broker"
+	"knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/broker/filter"
-	"knative.dev/eventing/pkg/reconciler/names"
-
 	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	eventinginformers "knative.dev/eventing/pkg/client/informers/externalversions"
+	"knative.dev/eventing/pkg/reconciler/names"
 )
 
 const (
@@ -103,6 +103,14 @@ func main() {
 	// Watch the observability config map and dynamically update request logs.
 	configMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(sl, atomicLevel, component))
 
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"))
+	featureStore.WatchConfigs(configMapWatcher)
+
+	// Decorate contexts with the current state of the feature config.
+	ctxFunc := func(ctx context.Context) context.Context {
+		return featureStore.ToContext(ctx)
+	}
+
 	bin := fmt.Sprintf("%s.%s", names.BrokerFilterName, system.Namespace())
 	if err = tracing.SetupDynamicPublishing(sl, configMapWatcher, bin, tracingconfig.ConfigName); err != nil {
 		logger.Fatal("Error setting up trace publishing", zap.Error(err))
@@ -112,7 +120,7 @@ func main() {
 
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	handler, err := filter.NewHandler(logger, triggerInformer.Lister(), reporter, env.Port)
+	handler, err := filter.NewHandler(logger, triggerInformer.Lister(), reporter, env.Port, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
-	"knative.dev/eventing/pkg/apis/feature"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	configmap "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
@@ -38,6 +37,7 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"knative.dev/eventing/cmd/broker"
+	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/broker/filter"
 	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	eventinginformers "knative.dev/eventing/pkg/client/informers/externalversions"

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -337,13 +337,16 @@ func (h *Handler) getTrigger(ref path.NamespacedNameUID) (*eventingv1.Trigger, e
 	return t, nil
 }
 
-func filterEvent(ctx context.Context, filterSpec eventingv1.TriggerSpec, event cloudevents.Event) eventfilter.FilterResult {
+func filterEvent(ctx context.Context, triggerSpec eventingv1.TriggerSpec, event cloudevents.Event) eventfilter.FilterResult {
 	switch {
-	case feature.FromContext(ctx).IsEnabled(feature.NewTriggerFilters) && len(filterSpec.Filters) > 0:
-		return applySubscriptionsAPIFilters(ctx, filterSpec.Filters, event)
-	case filterSpec.Filter != nil:
-		return applyAttributesFilter(ctx, filterSpec.Filter, event)
+	case feature.FromContext(ctx).IsEnabled(feature.NewTriggerFilters) && len(triggerSpec.Filters) > 0:
+		logging.FromContext(ctx).Debugw("New trigger filters feature is enabled. Applying new filters.", zap.Any("filters", triggerSpec.Filters))
+		return applySubscriptionsAPIFilters(ctx, triggerSpec.Filters, event)
+	case triggerSpec.Filter != nil:
+		logging.FromContext(ctx).Debugw("Applying attributes filter.", zap.Any("filter", triggerSpec.Filter))
+		return applyAttributesFilter(ctx, triggerSpec.Filter, event)
 	default:
+		logging.FromContext(ctx).Debugw("Found no filters in trigger", zap.Any("triggerSpec", triggerSpec))
 		return eventfilter.NoFilter
 	}
 }
@@ -367,7 +370,7 @@ func materializeSubscriptionsAPIFilter(ctx context.Context, filter eventingv1.Su
 		}
 	case len(filter.Prefix) > 0:
 		// The webhook validates that this map has only a single key:value pair.
-		for attribute, prefix := range filter.Exact {
+		for attribute, prefix := range filter.Prefix {
 			materializedFilter, err = subscriptionsapi.NewPrefixFilter(attribute, prefix)
 			if err != nil {
 				logging.FromContext(ctx).Debugw("Invalid prefix expression", zap.String("attribute", attribute), zap.String("prefix", prefix), zap.Error(err))
@@ -376,7 +379,7 @@ func materializeSubscriptionsAPIFilter(ctx context.Context, filter eventingv1.Su
 		}
 	case len(filter.Suffix) > 0:
 		// The webhook validates that this map has only a single key:value pair.
-		for attribute, suffix := range filter.Exact {
+		for attribute, suffix := range filter.Suffix {
 			materializedFilter, err = subscriptionsapi.NewSuffixFilter(attribute, suffix)
 			if err != nil {
 				logging.FromContext(ctx).Debugw("Invalid suffix expression", zap.String("attribute", attribute), zap.String("suffix", suffix), zap.Error(err))
@@ -386,8 +389,7 @@ func materializeSubscriptionsAPIFilter(ctx context.Context, filter eventingv1.Su
 	case len(filter.All) > 0:
 		materializedFilter = subscriptionsapi.NewAllFilter(materializeFiltersList(ctx, filter.All)...)
 	case len(filter.Any) > 0:
-		materializedFilter = subscriptionsapi.NewAnyFilter(materializeFiltersList(ctx, filter.All)...)
-
+		materializedFilter = subscriptionsapi.NewAnyFilter(materializeFiltersList(ctx, filter.Any)...)
 	case filter.Not != nil:
 		materializedFilter = subscriptionsapi.NewNotFilter(materializeSubscriptionsAPIFilter(ctx, *filter.Not))
 	case filter.SQL != "":
@@ -403,7 +405,12 @@ func materializeSubscriptionsAPIFilter(ctx context.Context, filter eventingv1.Su
 func materializeFiltersList(ctx context.Context, filters []eventingv1.SubscriptionsAPIFilter) []eventfilter.Filter {
 	materializedFilters := make([]eventfilter.Filter, 0, len(filters))
 	for _, f := range filters {
-		materializedFilters = append(materializedFilters, materializeSubscriptionsAPIFilter(ctx, f))
+		f := materializeSubscriptionsAPIFilter(ctx, f)
+		if f == nil {
+			logging.FromContext(ctx).Warnw("Failed to parse filter. Skipping filter.", zap.Any("filter", f))
+			continue
+		}
+		materializedFilters = append(materializedFilters, f)
 	}
 	return materializedFilters
 }

--- a/pkg/eventfilter/subscriptionsapi/all_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/all_filter.go
@@ -18,10 +18,10 @@ package subscriptionsapi
 
 import (
 	"context"
-	"go.uber.org/zap"
-	"knative.dev/pkg/logging"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 
 	"knative.dev/eventing/pkg/eventfilter"
 )

--- a/pkg/eventfilter/subscriptionsapi/all_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/all_filter.go
@@ -18,6 +18,8 @@ package subscriptionsapi
 
 import (
 	"context"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
@@ -33,6 +35,7 @@ func NewAllFilter(filters ...eventfilter.Filter) eventfilter.Filter {
 
 func (filter allFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
 	res := eventfilter.NoFilter
+	logging.FromContext(ctx).Debugw("Performing an ALL match ", zap.Any("filters", filter), zap.Any("event", event))
 	for _, f := range filter {
 		res = res.And(f.Filter(ctx, event))
 		// Short circuit to optimize it

--- a/pkg/eventfilter/subscriptionsapi/any_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/any_filter.go
@@ -18,10 +18,10 @@ package subscriptionsapi
 
 import (
 	"context"
-	"go.uber.org/zap"
-	"knative.dev/pkg/logging"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 
 	"knative.dev/eventing/pkg/eventfilter"
 )

--- a/pkg/eventfilter/subscriptionsapi/any_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/any_filter.go
@@ -18,6 +18,8 @@ package subscriptionsapi
 
 import (
 	"context"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
@@ -34,6 +36,7 @@ func NewAnyFilter(filters ...eventfilter.Filter) eventfilter.Filter {
 
 func (filter anyFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
 	res := eventfilter.NoFilter
+	logging.FromContext(ctx).Debugw("Performing an ANY match ", zap.Any("filters", filter), zap.Any("event", event))
 	for _, f := range filter {
 		res = res.Or(f.Filter(ctx, event))
 		// Short circuit to optimize it


### PR DESCRIPTION
MT broker filter pod wasn't correctly populating the context with enabled features.

## Proposed Changes

- :bug: Enable features ConfigMap watching and handle new trigger filters correctly.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] ~~**Docs PR** for any user-facing impact~~
- [ ] ~~**Spec PR** for any new API feature~~
- [ ] ~~**Conformance test** for any change to the spec~~
