### PR TITLE
Fixing the golang path for the migrator

### DIFF
--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -35,7 +35,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: ko://knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          image: ko://knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           args:
             - "apiserversources.sources.knative.dev"
             - "brokers.eventing.knative.dev"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Related to this: https://github.com/knative-sandbox/eventing-kafka/pull/967

also this aligns to what other repositories, like serving do too!
(e.g.: https://github.com/knative/serving/pull/11229 )


