### PR TITLE
Fix value of "component" label for the Eventing Controller

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -32,7 +32,7 @@ spec:
       labels:
         app: eventing-controller
         eventing.knative.dev/release: devel
-        app.kubernetes.io/component: eventing-autoscaler
+        app.kubernetes.io/component: eventing-controller
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
     spec:


### PR DESCRIPTION
A typo was introduced in #5628.
This PR simply fixes it.