### PR TITLE
SubscriptionSpec.Delivery is now mutable

### DIFF
--- a/pkg/apis/messaging/v1/subscription_validation.go
+++ b/pkg/apis/messaging/v1/subscription_validation.go
@@ -99,7 +99,7 @@ func (s *Subscription) CheckImmutableFields(ctx context.Context, original *Subsc
 	}
 
 	// Only Subscriber and Reply are mutable.
-	ignoreArguments := cmpopts.IgnoreFields(SubscriptionSpec{}, "Subscriber", "Reply")
+	ignoreArguments := cmpopts.IgnoreFields(SubscriptionSpec{}, "Subscriber", "Reply", "Delivery")
 	if diff, err := kmp.ShortDiff(original.Spec, s.Spec, ignoreArguments); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff Subscription",

--- a/pkg/apis/messaging/v1/subscription_validation_test.go
+++ b/pkg/apis/messaging/v1/subscription_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -525,6 +526,23 @@ func TestSubscriptionImmutable(t *testing.T) {
 			Spec: SubscriptionSpec{
 				Channel: getValidChannelRef(),
 				Reply:   getValidReply(),
+			},
+		},
+		want: nil,
+	}, {
+		name: "valid, change delivery spec",
+		c: &Subscription{
+			Spec: SubscriptionSpec{
+				Channel:    getValidChannelRef(),
+				Subscriber: getValidDestination(),
+				Delivery:   &eventingduckv1.DeliverySpec{Retry: pointer.Int32(2)},
+			},
+		},
+		og: &Subscription{
+			Spec: SubscriptionSpec{
+				Channel:    getValidChannelRef(),
+				Subscriber: getValidDestination(),
+				Delivery:   &eventingduckv1.DeliverySpec{Retry: pointer.Int32(3)},
 			},
 		},
 		want: nil,


### PR DESCRIPTION
Just by creating a subscription in v0.24 and upgrading the cluster to
0.26, the webhook starts throwing errors like this:
```
admission webhook "validation.webhook.eventing.knative.dev" denied the request: validation failed: Immutable fields changed (-old +new): spec
{v1.SubscriptionSpec}.Delivery.DeadLetterSink.Ref.Namespace:
    -: ""
    +: "kc-broker-v1-dlq"
```

In addition, Subscription.Spec.Delivery wasn't meant to be immutable,
in fact, TriggerSpec.Spec.Delivery is mutable.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #6138


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
SubscriptionSpec.Delivery is now mutable
```