### PR TITLE
Use Go 1.17 for downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -47,10 +47,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-    - name: Set up Go 1.16.x
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
     - name: Install Dependencies
       run: |
         go get github.com/google/go-licenses


### PR DESCRIPTION
Some downstream repositories require Go 1.17.