### PR TITLE
Clearing out Scheduler state info when there aren't enough Pods for placements

### DIFF
--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -165,7 +165,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			vreplicas: 1,
 			replicas:  int32(0),
 			err:       scheduler.ErrNotEnoughReplicas,
-			expected:  []duckv1alpha1.Placement{},
+			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
 					{Name: "PodFitsResources"},
@@ -208,7 +208,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			vreplicas: 15,
 			replicas:  int32(1),
 			err:       scheduler.ErrNotEnoughReplicas,
-			expected:  []duckv1alpha1.Placement{{PodName: "statefulset-name-0", VReplicas: 10}},
+			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
 					{Name: "PodFitsResources"},
@@ -314,7 +314,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			vreplicas: 1,
 			replicas:  int32(0),
 			err:       scheduler.ErrNotEnoughReplicas,
-			expected:  []duckv1alpha1.Placement{},
+			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
 					{Name: "PodFitsResources"},
@@ -367,7 +367,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			vreplicas: 15,
 			replicas:  int32(1),
 			err:       scheduler.ErrNotEnoughReplicas,
-			expected:  []duckv1alpha1.Placement{},
+			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
 					{Name: "PodFitsResources"},


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- State info like `FreeCap[]`, `PodSpread` etc are dependent on placements stored temporarily in `StatefulSetScheduler.reserved`. Reserved must be cleared when new placements are calculated BUT there aren't enough pod replicas (`scheduler.ErrNotEnoughReplicas`) to schedule on. This is because all vreplicas will be re-placed during the next schedule cycle (not just the `pending`) for the new HA scheduler based on the predicates/priorities. 

