### PR TITLE
Adding missing k8s labels to the post install manifests

### DIFF
--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -17,6 +17,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-post-install-job-role
   labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
     eventing.knative.dev/release: devel
 rules:
   # Storage version upgrader needs to be able to patch CRDs.

--- a/config/post-install/serviceaccount.yaml
+++ b/config/post-install/serviceaccount.yaml
@@ -19,7 +19,8 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: devel
-
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -28,6 +29,8 @@ metadata:
   name: knative-eventing-post-install-job-role-binding
   labels:
     eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: knative-eventing-post-install-job

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "storage-version-migration-eventing"
+    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/component: storage-version-migration-job
+    app.kubernetes.io/version: devel
     eventing.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
@@ -27,6 +30,9 @@ spec:
     metadata:
       labels:
         app: "storage-version-migration-eventing"
+        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/component: storage-version-migration-job
+        app.kubernetes.io/version: devel
         eventing.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- as per title, looks like they were initially forgotten 
- now this matches behavior w/ the serving post install

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Applying k8s labels to post install 
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

