### PR TITLE
Set TerminationGracePeriodSecond for wathola-sender to 300 seconds

### DIFF
--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -35,6 +35,7 @@ var senderName = "wathola-sender"
 func (p *prober) deploySender() {
 	p.log.Info("Deploy sender deployment: ", senderName)
 	var replicas int32 = 1
+	var gracePeriodSeconds int64 = 300
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      senderName,
@@ -73,6 +74,7 @@ func (p *prober) deploySender() {
 							MountPath: p.config.ConfigMountPoint,
 						}},
 					}},
+					TerminationGracePeriodSeconds: &gracePeriodSeconds,
 				},
 			},
 		},


### PR DESCRIPTION
* There may be blocking calls in the sender which can take longer than
the default period. This prevents the infinite loop from handling the
SIGTERM, resulting in not sending a Stop event.

Fixes #6191

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :bug: Fix bug

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Change the termination grace period from 30 seconds (default) to 5 minutes as there's a vital logic that needs to be executed during shutdown (sending the Stop event)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

