### PR TITLE
Fixing new trigger filters FeatureSet assertions

### DIFF
--- a/test/experimental/features/new_trigger_filters/filters.go
+++ b/test/experimental/features/new_trigger_filters/filters.go
@@ -96,7 +96,7 @@ func FiltersFeatureSet(brokerName string) *feature.FeatureSet {
 		})
 
 		f.Alpha("Triggers with new filters").
-			Must("must deliver matched events", OnStore(subscriber).MatchEvent(HasId(matchedEvent.ID())).Exact(1)).
+			Must("must deliver matched events", OnStore(subscriber).MatchEvent(HasId(matchedEvent.ID())).AtLeast(1)).
 			MustNot("must not deliver unmatched events", OnStore(subscriber).MatchEvent(HasId(unmatchedEvent.ID())).Not())
 		features = append(features, *f)
 	}


### PR DESCRIPTION
The feature set asserts events are delivered exactly once, which is unpredictable for some brokers that give "at least once" delivery guarantees like Kafka broker.Switching to at least one verification matches the expectations.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Change new trigger filters FeatureSet to verify at least once delivery instead of exactly once.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [X] **At least 80% unit test coverage**
- [X] ~**E2E tests** for any new behavior~
- [X] ~**Docs PR** for any user-facing impact~
- [X] ~**Spec PR** for any new API feature~
- [X] ~**Conformance test** for any change to the spec~
