### PR TITLE
[WIP] Do not merge; enabling GKE telemetry

### DIFF
--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -29,4 +29,4 @@ webhooks:
   sideEffects: None
   failurePolicy: Fail
   name: webhook.eventing.knative.dev
-  timeoutSeconds: 10
+  timeoutSeconds: 30

--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -30,6 +30,9 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
+# enable logs saving
+export ENABLE_GKE_TELEMETRY=true
+
 initialize $@ --skip-istio-addon
 
 export SKIP_UPLOAD_TEST_IMAGES="true"


### PR DESCRIPTION
Enabling GCP logging to better debug Prow failures. 

Currently just running the tests once since it seems to reliably fail.
