### PR TITLE
Remove a second trigger of the autoscaler

### DIFF
--- a/pkg/scheduler/statefulset/autoscaler.go
+++ b/pkg/scheduler/statefulset/autoscaler.go
@@ -103,7 +103,6 @@ func (a *autoscaler) Start(ctx context.Context) {
 }
 
 func (a *autoscaler) Autoscale(ctx context.Context, attemptScaleDown bool, pending int32) {
-	a.trigger <- pending
 	a.syncAutoscale(ctx, attemptScaleDown, pending)
 }
 


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Randomly noticing two consecutive calls of syncAutoscale() when there are pending vreplicas. This removes the second trigger.

/cc @lionelvillard 