### PR TITLE
[rekt] Improve various isReady checks

### DIFF
--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -619,21 +619,8 @@ func brokerClassIsImmutable(ctx context.Context, t feature.T) {
 }
 
 func triggerHasReadyInConditions(ctx context.Context, t feature.T) {
-	var trigger *eventingv1.Trigger
-
-	interval, timeout := environment.PollTimingsFromContext(ctx)
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		trigger = triggerfeatures.GetTrigger(ctx, t)
-		if trigger.Status.ObservedGeneration != 0 {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		t.Errorf("unable to get a reconciled Trigger (status.observedGeneration != 0)")
-	}
-
-	knconf.HasReadyInConditions(ctx, t, trigger.Status.Status)
+	name := state.GetStringOrFail(ctx, t, triggerfeatures.TriggerNameKey)
+	knconf.KResourceHasReadyInConditions(triggerresources.GVR(), name)(ctx, t)
 }
 
 func readyTriggerCanDeliver(ctx context.Context, t feature.T) {

--- a/test/rekt/features/broker/readyness.go
+++ b/test/rekt/features/broker/readyness.go
@@ -19,13 +19,11 @@ package broker
 import (
 	"fmt"
 
-	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/resources/svc"
 
 	"knative.dev/eventing/test/rekt/resources/broker"
-	"knative.dev/eventing/test/rekt/resources/delivery"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 )
 
@@ -44,10 +42,8 @@ func TriggerGoesReady(name, brokerName string, cfg ...manifest.CfgFn) *feature.F
 	f.Setup(fmt.Sprintf("install trigger %q", name), trigger.Install(name, brokerName, cfg...))
 
 	// Wait for a ready broker.
-	f.Requirement("Broker is ready", broker.IsReady(brokerName))
-	f.Requirement("Trigger is ready", trigger.IsReady(name))
-
-	f.Stable("trigger")
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+	f.Setup("Trigger is ready", trigger.IsReady(name))
 
 	return f
 }
@@ -58,30 +54,8 @@ func GoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 	f := new(feature.Feature)
 
 	f.Setup(fmt.Sprintf("install broker %q", name), broker.Install(name, cfg...))
-
-	f.Requirement("Broker is ready", broker.IsReady(name))
-
-	f.Stable("broker").
-		Must("be addressable", broker.IsAddressable(name))
-
-	return f
-}
-
-// GoesReadyWithProbeReceiver returns a feature that will create a Broker of the given
-// name and class, with an event receiver as its DLS
-// and confirm it becomes ready with an address.
-func GoesReadyWithProbeReceiver(name, sinkName string, prober *eventshub.EventProber, cfg ...manifest.CfgFn) *feature.Feature {
-	f := new(feature.Feature)
-
-	f.Setup("install probe", prober.ReceiverInstall(sinkName))
-
-	brokerConfig := append(cfg, delivery.WithDeadLetterSink(prober.AsKReference(sinkName), ""))
-	f.Setup(fmt.Sprintf("install broker %q", name), broker.Install(name, brokerConfig...))
-
-	f.Requirement("Broker is ready", broker.IsReady(name))
-
-	f.Stable("broker").
-		Must("be addressable", broker.IsAddressable(name))
+	f.Setup("Broker is ready", broker.IsReady(name))
+	f.Setup("Broker is addressable", broker.IsAddressable(name))
 
 	return f
 }

--- a/test/rekt/features/channel/control_plane.go
+++ b/test/rekt/features/channel/control_plane.go
@@ -22,17 +22,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/duck"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/resources/svc"
+
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/messaging"
 	"knative.dev/eventing/test/rekt/features/knconf"
 	"knative.dev/eventing/test/rekt/resources/account_role"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/delivery"
-	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck"
-	"knative.dev/reconciler-test/pkg/environment"
-	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/resources/svc"
 )
 
 func ControlPlaneConformance(channelName string) *feature.FeatureSet {
@@ -169,7 +170,7 @@ func channelAllowsSubscribersAndStatus(ctx context.Context, t feature.T) {
 	interval, timeout := environment.PollTimingsFromContext(ctx)
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		updated = getChannelable(ctx, t)
-		if updated.Status.ObservedGeneration != updated.Generation {
+		if updated.Status.ObservedGeneration < updated.Generation {
 			// keep polling.
 			return false, nil
 		}

--- a/test/rekt/features/knconf/control_plane.go
+++ b/test/rekt/features/knconf/control_plane.go
@@ -74,7 +74,7 @@ func KResourceHasObservedGeneration(gvr schema.GroupVersionResource, name string
 				// Keep polling
 				return false, nil
 			}
-			if kr.Status.ObservedGeneration != 0 {
+			if kr.Status.ObservedGeneration == kr.Generation {
 				return true, nil
 			}
 			return false, nil
@@ -116,7 +116,7 @@ func KResourceHasReadyInConditions(gvr schema.GroupVersionResource, name string)
 				// Keep polling
 				return false, nil
 			}
-			if kr.Status.ObservedGeneration != 0 {
+			if kr.Status.ObservedGeneration == kr.Generation {
 				return true, nil
 			}
 			return false, nil

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -22,17 +22,18 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/eventing/test/rekt/resources/delivery"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/resources/delivery"
 )
 
 //go:embed *.yaml
 var yaml embed.FS
 
-func gvr() schema.GroupVersionResource {
+func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "eventing.knative.dev", Version: "v1", Resource: "triggers"}
 }
 
@@ -117,5 +118,5 @@ func Install(name, brokerName string, opts ...manifest.CfgFn) feature.StepFn {
 
 // IsReady tests to see if a Trigger becomes ready within the time given.
 func IsReady(name string, timing ...time.Duration) feature.StepFn {
-	return k8s.IsReady(gvr(), name, timing...)
+	return k8s.IsReady(GVR(), name, timing...)
 }

--- a/test/rekt/trigger_test.go
+++ b/test/rekt/trigger_test.go
@@ -22,15 +22,17 @@ package rekt
 import (
 	"testing"
 
-	"knative.dev/eventing/test/rekt/features/broker"
-	"knative.dev/eventing/test/rekt/features/trigger"
-	b "knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing/test/rekt/features/broker"
+	"knative.dev/eventing/test/rekt/features/trigger"
+	b "knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/delivery"
 )
 
 func TestTriggerDefaulting(t *testing.T) {
@@ -72,7 +74,9 @@ func TestTriggerWithDLS(t *testing.T) {
 	//
 	brokerName = "dls-broker"
 	brokerSinkName := "broker-sink"
-	env.Prerequisite(ctx, t, broker.GoesReadyWithProbeReceiver(brokerName, brokerSinkName, prober, b.WithEnvConfig()...))
+	env.Prerequisite(ctx, t, broker.GoesReady(brokerName,
+		delivery.WithDeadLetterSink(prober.AsKReference(brokerSinkName), ""),
+	))
 	env.Test(ctx, t, trigger.SourceToTriggerSinkWithDLSDontUseBrokers("test2", brokerName, brokerSinkName, prober))
 }
 


### PR DESCRIPTION
- Check observed generation == generation
- Check Broker and Trigger readiness in the `Setup` phase

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>