### PR TITLE
Print traces for missed events in upgrade tests

### DIFF
--- a/test/config/monitoring/monitoring.yaml
+++ b/test/config/monitoring/monitoring.yaml
@@ -53,9 +53,13 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: JAVA_OPTS
+          value: '-Xms128m -Xmx5G -XX:+ExitOnOutOfMemoryError'
+        - name: MEM_MAX_SPANS
+          value: '10000000'
         resources:
           limits:
-            memory: 1000Mi
+            memory: 6Gi
           requests:
             memory: 256Mi
 

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -119,3 +119,24 @@ struct can be influenced, by using `EVENTING_UPGRADE_TESTS_XXXXX` environmental
 variable prefix (using
 [kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig#usage)
 usage).
+
+#### Inspecting Zipkin traces for undelivered events
+
+When tracing is enabled in the `config-tracing` config map in the system namespace
+the prober collects traces for undelivered events. The traces are exported as json files
+under the artifacts dir. Traces for each event are stored in a separate file.
+Step event traces are stored as `$ARTIFACTS/traces/missed-events/step-<step_number>.json`
+The finished event traces are stored as `$ARTIFACTS/traces/missed-events/finished.json`
+
+Traces can be viewed as follows:
+- Start a Zipkin container on localhost:
+   ```
+   $ docker run -d -p 9411:9411 ghcr.io/openzipkin/zipkin:2
+   ```
+- Send traces to the Zipkin endpoint:
+   ```
+   $ curl -v -X POST localhost:9412/api/v2/spans \
+     -H 'Content-Type: application/json' \
+     -d @$ARTIFACTS/traces/missed-events/step-<step_number>.json
+   ```
+- View traces in Zipkin UI at `http://localhost:9411/zipkin`

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -135,7 +135,7 @@ Traces can be viewed as follows:
    ```
 - Send traces to the Zipkin endpoint:
    ```
-   $ curl -v -X POST localhost:9412/api/v2/spans \
+   $ curl -v -X POST localhost:9411/api/v2/spans \
      -H 'Content-Type: application/json' \
      -d @$ARTIFACTS/traces/missed-events/step-<step_number>.json
    ```

--- a/test/upgrade/prober/config.toml
+++ b/test/upgrade/prober/config.toml
@@ -4,4 +4,4 @@ tracingConfig = '{{- .TracingConfig -}}'
 address = '{{- .Endpoint -}}'
 interval = {{ .Config.Interval.Nanoseconds }}
 [forwarder]
-target = 'http://wathola-receiver.{{- .Namespace -}}.svc.cluster.local'
+target = '{{- .ForwarderTarget -}}'

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -51,6 +51,8 @@ const (
 	Error DuplicateAction = "error"
 
 	prefix = "eventing_upgrade_tests"
+
+	forwarderTargetFmt = "http://" + receiver.Name + ".%s.svc.cluster.local"
 )
 
 var (
@@ -178,17 +180,20 @@ func (p *prober) compileTemplate(templateName string, endpoint interface{}, trac
 	var buff bytes.Buffer
 	data := struct {
 		*Config
+		// Deprecated: use ForwarderTarget
 		Namespace string
 		// Deprecated: use Endpoint
-		BrokerURL     string
-		Endpoint      interface{}
-		TracingConfig string
+		BrokerURL       string
+		Endpoint        interface{}
+		TracingConfig   string
+		ForwarderTarget string
 	}{
 		p.config,
 		p.client.Namespace,
 		fmt.Sprintf("%v", endpoint),
 		endpoint,
 		tracingConfig,
+		fmt.Sprintf(forwarderTargetFmt, p.client.Namespace),
 	}
 	p.ensureNoError(tmpl.Execute(&buff, data))
 	return buff.String()

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,27 +31,40 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
+	"knative.dev/eventing/test/upgrade/prober/wathola/event"
 	"knative.dev/eventing/test/upgrade/prober/wathola/fetcher"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/prow"
+	"knative.dev/pkg/test/zipkin"
 )
 
 const (
-	fetcherName     = "wathola-fetcher"
-	jobWaitInterval = time.Second
-	jobWaitTimeout  = 10 * time.Minute
+	fetcherName         = "wathola-fetcher"
+	jobWaitInterval     = time.Second
+	jobWaitTimeout      = 10 * time.Minute
+	stepEventMsgPattern = "event #([0-9]+).*"
 )
 
 // Verify will verify prober state after finished has been sent.
 func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	var report *receiver.Report
+	// Enable port-forwarding for Zipkin endpoint.
+	tracinghelper.Setup(p.client.T, p.client)
+	// Required for proper cleanup.
+	zipkin.ZipkinTracingEnabled = true
+	defer zipkin.CleanupZipkinTracingSetup(p.log.Infof)
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
 	if err := wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {
 		report = p.fetchReport()
 		return report.State != "active", nil
 	}); err != nil {
+		p.log.Info("Fetching trace for Finished event")
+		p.exportTrace(p.getTraceForFinishedEvent(), "finished.json")
 		p.client.T.Fatalf("Error fetching complete/inactive report: %v\nReport: %+v", err, report)
 	}
 	elapsed := time.Since(start)
@@ -62,6 +78,14 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		availRate, report.TotalRequests)
 	for _, t := range report.Thrown.Missing {
 		eventErrs = append(eventErrs, errors.New(t))
+		r, _ := regexp.Compile(stepEventMsgPattern)
+		matches := r.FindStringSubmatch(t)
+		if len(matches) != 2 {
+			p.log.Warnf("message does not match pattern %s: %s", stepEventMsgPattern, t)
+		}
+		stepNo := matches[1]
+		p.log.Infof("Fetching trace for Step event #%s", stepNo)
+		p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo))
 	}
 	for _, t := range report.Thrown.Unexpected {
 		eventErrs = append(eventErrs, errors.New(t))
@@ -82,6 +106,45 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 // Finish terminates sender which sends finished event.
 func (p *prober) Finish() {
 	p.removeSender()
+}
+
+func (p *prober) getTraceForStepEvent(eventNo string) []byte {
+	query := fmt.Sprintf("step=%s and cloudevents.type=%s and target=%s",
+		eventNo, event.StepType, fmt.Sprintf(forwarderTargetFmt, p.client.Namespace))
+	trace, err := event.FindTrace(query)
+	if err != nil {
+		p.log.Warn(err)
+	}
+	return trace
+}
+
+func (p *prober) getTraceForFinishedEvent() []byte {
+	query := fmt.Sprintf("cloudevents.type=%s and target=%s",
+		event.FinishedType, fmt.Sprintf(forwarderTargetFmt, p.client.Namespace))
+	trace, err := event.FindTrace(query)
+	if err != nil {
+		p.log.Warn(err)
+	}
+	return trace
+}
+
+func (p *prober) exportTrace(trace []byte, fileName string) error {
+	tracesDir := filepath.Join(prow.GetLocalArtifactsDir(), "traces", "missed-events")
+	if err := helpers.CreateDir(tracesDir); err != nil {
+		return fmt.Errorf("error creating directory %q: %w", tracesDir, err)
+	}
+	fp := filepath.Join(tracesDir, fileName)
+	p.log.Infof("Exporting trace into %s", fp)
+	f, err := os.Create(fp)
+	if err != nil {
+		return fmt.Errorf("error creating file %q: %w", fp, err)
+	}
+	defer f.Close()
+	_, err = f.Write(trace)
+	if err != nil {
+		return fmt.Errorf("error writing trace into file %q: %w", fp, err)
+	}
+	return nil
 }
 
 func (p *prober) fetchReport() *receiver.Report {

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -135,7 +135,7 @@ func (p *prober) getTraceForFinishedEvent() []byte {
 }
 
 func (p *prober) exportTrace(trace []byte, fileName string) error {
-	tracesDir := filepath.Join(prow.GetLocalArtifactsDir(), "traces", "missed-events")
+	tracesDir := filepath.Join(prow.GetLocalArtifactsDir(), "traces", "events")
 	if err := helpers.CreateDir(tracesDir); err != nil {
 		return fmt.Errorf("error creating directory %q: %w", tracesDir, err)
 	}

--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -159,10 +159,7 @@ func asStrings(errThrown []thrown) []string {
 func (f *finishedStore) reportViolations(finished *Finished) {
 	steps := f.steps.(*stepStore)
 	for eventNo := 1; eventNo <= finished.EventsSent; eventNo++ {
-		times, ok := steps.store[eventNo]
-		if !ok {
-			times = 0
-		}
+		times := steps.store[eventNo]
 		if times != 1 {
 			throwMethod := f.errors.throwMissing
 			if times > 1 {

--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -104,6 +104,7 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 	log.Infof("waiting additional %v to be sure all events came", d)
 	time.Sleep(d)
 	receivedEvents := f.steps.Count()
+	receivedEvents = receivedEvents - 1 // TODO: Remove
 	if receivedEvents != finished.EventsSent {
 		f.errors.throwUnexpected("expecting to have %v unique events received, "+
 			"but received %v unique events", finished.EventsSent, receivedEvents)
@@ -160,6 +161,10 @@ func (f *finishedStore) reportViolations(finished *Finished) {
 	steps := f.steps.(*stepStore)
 	for eventNo := 1; eventNo <= finished.EventsSent; eventNo++ {
 		times := steps.store[eventNo]
+		// TODO: Remove this induced failure. Test changes.
+		if eventNo == 10 {
+			times = 0
+		}
 		if times != 1 {
 			throwMethod := f.errors.throwMissing
 			if times > 1 {

--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -104,7 +104,6 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 	log.Infof("waiting additional %v to be sure all events came", d)
 	time.Sleep(d)
 	receivedEvents := f.steps.Count()
-	receivedEvents = receivedEvents - 1 // TODO: Remove
 	if receivedEvents != finished.EventsSent {
 		f.errors.throwUnexpected("expecting to have %v unique events received, "+
 			"but received %v unique events", finished.EventsSent, receivedEvents)
@@ -161,10 +160,6 @@ func (f *finishedStore) reportViolations(finished *Finished) {
 	steps := f.steps.(*stepStore)
 	for eventNo := 1; eventNo <= finished.EventsSent; eventNo++ {
 		times := steps.store[eventNo]
-		// TODO: Remove this induced failure. Test changes.
-		if eventNo == 10 {
-			times = 0
-		}
 		if times != 1 {
 			throwMethod := f.errors.throwMissing
 			if times > 1 {

--- a/test/upgrade/prober/wathola/event/tracing.go
+++ b/test/upgrade/prober/wathola/event/tracing.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/openzipkin/zipkin-go/model"
+)
+
+const ZipkinTracesEndpoint = "http://localhost:9411/api/v2/traces"
+
+// FindTrace fetches tracing endpoint and retrieves Zipkin traces matching the annotation query.
+func FindTrace(annotationQuery string) ([]byte, error) {
+	trace := []byte("<unavailable>")
+	spanModelsAll, err := SendTraceQuery(ZipkinTracesEndpoint, annotationQuery)
+	if err != nil {
+		return trace, fmt.Errorf("failed to send trace query %q: %w", annotationQuery, err)
+	}
+	if len(spanModelsAll) == 0 {
+		return trace, fmt.Errorf("no traces found for query %q", annotationQuery)
+	}
+	var models []model.SpanModel
+	for _, m := range spanModelsAll {
+		models = append(models, m...)
+	}
+	b, err := json.MarshalIndent(models, "", "  ")
+	if err != nil {
+		return trace, fmt.Errorf("failed to marshall span models: %w", err)
+	}
+	return b, nil
+}
+
+// SendTraceQuery sends the query to the tracing endpoint and returns all spans matching the query.
+func SendTraceQuery(endpoint string, annotationQuery string) ([][]model.SpanModel, error) {
+	var empty [][]model.SpanModel
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return empty, err
+	}
+	q := req.URL.Query()
+	q.Add("annotationQuery", annotationQuery)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return empty, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return empty, err
+	}
+
+	var models [][]model.SpanModel
+	err = json.Unmarshal(body, &models)
+	if err != nil {
+		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %w", body, err)
+	}
+
+	return models, nil
+}

--- a/test/upgrade/prober/wathola/event/tracing_test.go
+++ b/test/upgrade/prober/wathola/event/tracing_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"testing"
+
+	"github.com/openzipkin/zipkin-go/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceParsing(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			// Using a reduced variant of the response at https://zipkin.io/zipkin-api/#/default/get_traces
+			io.WriteString(w,
+				`[
+  [
+    {
+      "id": "352bff9a74ca9ad2",
+      "traceId": "5af7183fb1d4cf5f",
+      "name": "get /api",
+      "timestamp": 1556604172355737,
+      "duration": 1431,
+      "kind": "SERVER",
+      "tags": {
+        "http.method": "GET",
+        "http.path": "/api"
+      }
+    },
+	{
+      "id": "352bff9a74ca9ad3",
+      "traceId": "5af7183fb1d4cf60",
+      "parentId": "352bff9a74ca9ad2",
+      "name": "get /api",
+      "timestamp": 1556604172355737,
+      "duration": 1431,
+      "kind": "SERVER",
+      "tags": {
+        "http.method": "GET",
+        "http.path": "/api"
+      }
+    }
+  ]
+]`)
+		}))
+	defer ts.Close()
+	trace, err := SendTraceQuery(ts.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, trace, 1)
+	assert.Len(t, trace[0], 2)
+	assert.Equal(t, model.Kind("SERVER"), trace[0][0].Kind)
+}

--- a/test/upgrade/prober/wathola/sender/services.go
+++ b/test/upgrade/prober/wathola/sender/services.go
@@ -242,6 +242,7 @@ func PopulateSpanWithEvent(ctx context.Context, ce cloudevents.Event, spanName s
 	span.AddAttributes(
 		trace.StringAttribute("cloudevents.type", ce.Type()),
 		trace.StringAttribute("cloudevents.id", ce.ID()),
+		trace.StringAttribute("target", config.Instance.Forwarder.Target),
 	)
 	return ctxWithSpan, span
 }

--- a/test/upgrade/prober/wathola/sender/services.go
+++ b/test/upgrade/prober/wathola/sender/services.go
@@ -81,6 +81,7 @@ func (s *sender) SendContinually() {
 
 	var start time.Time
 	retry := 0
+	duplicateCounter := 0
 	for {
 		select {
 		case <-shutdownCh:
@@ -92,6 +93,27 @@ func (s *sender) SendContinually() {
 		default:
 		}
 		err := s.sendStep()
+		// Induce duplicate event.
+		if s.eventsSent == 20 {
+			// Only duplicate three times then continue.
+			if duplicateCounter < 3 {
+				s.eventsSent--
+				duplicateCounter++
+			} else {
+				duplicateCounter = 0
+			}
+		}
+		// Induce duplicate event. This one is sent twice but on receiver side
+		// we simulate it was missed and there should be two traces for this missed event.
+		if s.eventsSent == 10 {
+			// Only duplicate three times then continue.
+			if duplicateCounter < 3 {
+				s.eventsSent--
+				duplicateCounter++
+			} else {
+				duplicateCounter = 0
+			}
+		}
 		if err != nil {
 			if retry == 0 {
 				start = time.Now()

--- a/test/upgrade/prober/wathola/sender/services.go
+++ b/test/upgrade/prober/wathola/sender/services.go
@@ -81,7 +81,6 @@ func (s *sender) SendContinually() {
 
 	var start time.Time
 	retry := 0
-	duplicateCounter := 0
 	for {
 		select {
 		case <-shutdownCh:
@@ -93,27 +92,6 @@ func (s *sender) SendContinually() {
 		default:
 		}
 		err := s.sendStep()
-		// Induce duplicate event.
-		if s.eventsSent == 20 {
-			// Only duplicate three times then continue.
-			if duplicateCounter < 3 {
-				s.eventsSent--
-				duplicateCounter++
-			} else {
-				duplicateCounter = 0
-			}
-		}
-		// Induce duplicate event. This one is sent twice but on receiver side
-		// we simulate it was missed and there should be two traces for this missed event.
-		if s.eventsSent == 10 {
-			// Only duplicate three times then continue.
-			if duplicateCounter < 3 {
-				s.eventsSent--
-				duplicateCounter++
-			} else {
-				duplicateCounter = 0
-			}
-		}
 		if err != nil {
 			if retry == 0 {
 				start = time.Now()


### PR DESCRIPTION
This builds on top of https://github.com/knative/eventing/pull/6219
Fixes point 3. from https://github.com/knative/eventing/issues/6145#issuecomment-1039506502

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- Add a new Tag called "target" to the Traces that helps differentiate traces from different tests running in parallel.
- Search Zipkin endpoint for traces for Events that were not delivered. Store each trace in a json file separately.
- Step events are stored in `step-<num>.json`. Finished event is stored in `finished.json` under `traces/missed-events/`
- Readme with instructions on how to vizualize saved traces
- Increase memory limits for Zipkin Pod. Increase -Xmx settings for gathering more traces from upgrade tests

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

