### PR TITLE
Set dead letter sink URI in the `Channel` status

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -234,6 +234,9 @@ spec:
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                     type: string
+              deadLetterSinkUri:
+                description: DeadLetterSinkURI is the resolved URI of the dead letter sink that will be used as a fallback when not specified by Triggers.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -3969,6 +3969,11 @@ in verbatim to the Channel CRD as Spec section.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="messaging.knative.dev/v1.ChannelTemplateSpecOption">ChannelTemplateSpecOption
+</h3>
+<p>
+<p>ChannelTemplateSpecOption is an optional function for ChannelTemplateSpec.</p>
+</p>
 <h3 id="messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec
 </h3>
 <p>

--- a/pkg/apis/messaging/v1/channel_template_types.go
+++ b/pkg/apis/messaging/v1/channel_template_types.go
@@ -30,3 +30,6 @@ type ChannelTemplateSpec struct {
 	// +optional
 	Spec *runtime.RawExtension `json:"spec,omitempty"`
 }
+
+// ChannelTemplateSpecOption is an optional function for ChannelTemplateSpec.
+type ChannelTemplateSpecOption func(*ChannelTemplateSpec) error

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -23,10 +23,6 @@ import (
 	"testing"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"knative.dev/eventing/test/rekt/features/channel"
-	ch "knative.dev/eventing/test/rekt/resources/channel"
-	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
-	"knative.dev/eventing/test/rekt/resources/subscription"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
@@ -34,6 +30,11 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
+
+	"knative.dev/eventing/test/rekt/features/channel"
+	ch "knative.dev/eventing/test/rekt/resources/channel"
+	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/subscription"
 )
 
 // TestChannelConformance
@@ -246,6 +247,25 @@ func TestChannelDeadLetterSink(t *testing.T) {
 		return subscription.WithSubscriber(ref, uri)
 	}
 	env.Test(ctx, t, channel.DeadLetterSink(createSubscriberFn))
+}
+
+// TestGenericChannelDeadLetterSink tests if the events that cannot be delivered end up in
+// the dead letter sink.
+func TestGenericChannelDeadLetterSink(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithSubscriber(ref, uri)
+	}
+	env.Test(ctx, t, channel.DeadLetterSinkGenericChannel(createSubscriberFn))
 }
 
 /*

--- a/test/rekt/resources/channel/channel.go
+++ b/test/rekt/resources/channel/channel.go
@@ -19,6 +19,8 @@ package channel
 import (
 	"context"
 	"embed"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +99,15 @@ func WithTemplate(options ...messagingv1.ChannelTemplateSpecOption) manifest.Cfg
 		}
 		m["channelTemplate"] = channelTemplate
 		if t.Spec != nil {
-			channelTemplate["spec"] = t.Spec
+			s := map[string]string{}
+			bytes, err := t.Spec.MarshalJSON()
+			if err != nil {
+				panic(fmt.Errorf("failed to marshal spec: %w", err))
+			}
+			if err := json.Unmarshal(bytes, &s); err != nil {
+				panic(fmt.Errorf("failed to unmarshal spec '%s': %v", bytes, err))
+			}
+			channelTemplate["spec"] = s
 		}
 	}
 }


### PR DESCRIPTION
We were dropping the dead letter sink URI in the status of the
`Channel`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Set dead letter sink URI in the `Channel` status

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Set dead letter sink URI in the `Channel` status
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->