### PR TITLE
only reconcile triggers that point to the MTChannelBroker class

### DIFF
--- a/pkg/reconciler/broker/trigger/controller.go
+++ b/pkg/reconciler/broker/trigger/controller.go
@@ -22,15 +22,15 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	"knative.dev/eventing/pkg/apis/eventing"
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	apiseventing "knative.dev/eventing/pkg/apis/eventing"
+	eventing "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
 	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
 	subscriptioninformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	triggerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
-	v1 "knative.dev/eventing/pkg/client/listers/eventing/v1"
+	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/source"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
@@ -63,34 +63,27 @@ func NewController(
 		triggerLister:      triggerLister,
 		configmapLister:    configmapInformer.Lister(),
 	}
-	impl := triggerreconciler.NewImpl(ctx, r)
+	impl := triggerreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			PromoteFilterFunc: filterTriggers(r.brokerLister),
+		}
+	})
 	r.impl = impl
 
 	r.sourceTracker = duck.NewListableTrackerFromTracker(ctx, source.Get, impl.Tracker)
 	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
-	triggerInformer.Informer().AddEventHandler(controller.HandleAll(
-		func(obj interface{}) {
-			if trigger, ok := obj.(*eventingv1.Trigger); ok {
-				broker, err := brokerInformer.Lister().Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
-				if err != nil {
-					logger.Errorw("Failed to lookup Broker for Trigger", zap.Error(err))
-					return
-				}
-				label := broker.ObjectMeta.Annotations[brokerreconciler.ClassAnnotationKey]
-				if label == eventing.MTChannelBrokerClassValue {
-					impl.Enqueue(obj)
-				}
-			}
-		},
-	))
+	triggerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: filterTriggers(r.brokerLister),
+		Handler:    controller.HandleAll(impl.Enqueue),
+	})
 
 	// Filter Brokers and enqueue associated Triggers
-	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.MTChannelBrokerClassValue, false /*allowUnset*/)
+	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, apiseventing.MTChannelBrokerClassValue, false /*allowUnset*/)
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: brokerFilter,
 		Handler: controller.HandleAll(func(obj interface{}) {
-			if broker, ok := obj.(*eventingv1.Broker); ok {
+			if broker, ok := obj.(*eventing.Broker); ok {
 				for _, t := range getTriggersForBroker(logger, triggerLister, broker) {
 					impl.Enqueue(t)
 				}
@@ -100,20 +93,39 @@ func NewController(
 
 	// Reconcile Trigger when my Subscription changes
 	subscriptionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterController(&eventingv1.Trigger{}),
+		FilterFunc: controller.FilterController(&eventing.Trigger{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	return impl
 }
 
+// filterTriggers returns a function that returns true if the resource passed
+// is a trigger pointing to a MTChannelBroker.
+func filterTriggers(lister eventinglisters.BrokerLister) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		trigger, ok := obj.(*eventing.Trigger)
+		if !ok {
+			return false
+		}
+
+		b, err := lister.Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
+		if err != nil {
+			return false
+		}
+
+		value, ok := b.GetAnnotations()[apiseventing.BrokerClassKey]
+		return ok && value == apiseventing.MTChannelBrokerClassValue
+	}
+}
+
 // getTriggersForBroker makes sure the object passed in is a Broker, and gets all
 // the Triggers belonging to it. As there is no way to return failures in the
 // Informers EventHandler, errors are logged, and an empty array is returned in case
 // of failures.
-func getTriggersForBroker(logger *zap.SugaredLogger, triggerLister v1.TriggerLister, broker *eventingv1.Broker) []*eventingv1.Trigger {
-	r := make([]*eventingv1.Trigger, 0)
-	selector := labels.SelectorFromSet(map[string]string{eventing.BrokerLabelKey: broker.Name})
+func getTriggersForBroker(logger *zap.SugaredLogger, triggerLister eventinglisters.TriggerLister, broker *eventing.Broker) []*eventing.Trigger {
+	r := make([]*eventing.Trigger, 0)
+	selector := labels.SelectorFromSet(map[string]string{apiseventing.BrokerLabelKey: broker.Name})
 	triggers, err := triggerLister.Triggers(broker.Namespace).List(selector)
 	if err != nil {
 		logger.Warn("Failed to list triggers", zap.Any("broker", broker), zap.Error(err))

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -77,12 +77,6 @@ type Reconciler struct {
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) pkgreconciler.Event {
 	logging.FromContext(ctx).Infow("Reconciling", zap.Any("Trigger", t))
-	t.Status.InitializeConditions()
-
-	if t.DeletionTimestamp != nil {
-		// Everything is cleaned up by the garbage collector.
-		return nil
-	}
 
 	b, err := r.brokerLister.Brokers(t.Namespace).Get(t.Spec.Broker)
 	if err != nil {


### PR DESCRIPTION
## Proposed Changes

- :bug: MTChannelBroker was reconciling all triggers, not just triggers pointing to MTChannelBrokers

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
MTChannelBroker can now co-exist with other broker implementations.
```
