### PR TITLE
Merge delivery spec instead of using non nil specs

### DIFF
--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -155,3 +155,52 @@ type DeliveryStatus struct {
 	// +optional
 	DeadLetterSinkURI *apis.URL `json:"deadLetterSinkUri,omitempty"`
 }
+
+func (d *DeliverySpec) Merge(other *DeliverySpec) *DeliverySpec {
+	if d == nil {
+		return other
+	}
+	if other == nil {
+		return d
+	}
+
+	r := &DeliverySpec{}
+
+	if d.Retry != nil {
+		r.Retry = d.Retry
+	} else {
+		r.Retry = other.Retry
+	}
+
+	if d.BackoffDelay != nil {
+		r.BackoffDelay = d.BackoffDelay
+	} else {
+		r.BackoffDelay = other.BackoffDelay
+	}
+
+	if d.BackoffPolicy != nil {
+		r.BackoffPolicy = d.BackoffPolicy
+	} else {
+		r.BackoffPolicy = other.BackoffPolicy
+	}
+
+	if d.DeadLetterSink != nil {
+		r.DeadLetterSink = d.DeadLetterSink
+	} else {
+		r.DeadLetterSink = other.DeadLetterSink
+	}
+
+	if d.RetryAfterMax != nil {
+		r.RetryAfterMax = d.RetryAfterMax
+	} else {
+		r.RetryAfterMax = other.RetryAfterMax
+	}
+
+	if d.Timeout != nil {
+		r.Timeout = d.Timeout
+	} else {
+		r.Timeout = other.Timeout
+	}
+
+	return r
+}

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -29,6 +29,15 @@ import (
 	"k8s.io/client-go/dynamic"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/network"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
+	"knative.dev/pkg/system"
+
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
@@ -38,14 +47,6 @@ import (
 	"knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
 	"knative.dev/eventing/pkg/reconciler/sugar/trigger/path"
-	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
-	"knative.dev/pkg/network"
-	pkgreconciler "knative.dev/pkg/reconciler"
-	"knative.dev/pkg/resolver"
-	"knative.dev/pkg/system"
 )
 
 var brokerGVK = eventingv1.SchemeGroupVersion.WithKind("Broker")
@@ -194,10 +195,7 @@ func (r *Reconciler) subscribeToBrokerChannel(ctx context.Context, b *eventingv1
 		Namespace:  b.Namespace,
 	}
 
-	delivery := t.Spec.Delivery
-	if delivery == nil {
-		delivery = b.Spec.Delivery
-	}
+	delivery := t.Spec.Delivery.Merge(b.Spec.Delivery)
 
 	expected := resources.NewSubscription(t, brokerTrigger, brokerObjRef, uri, delivery)
 


### PR DESCRIPTION
In some cases, we're using non-nil values of the delivery spec to
understand if the user is setting this value or not.
For example, when there isn't a delivery spec for a `Trigger`
we're using the _entire_ delivery spec of the `Broker`.

However, if there is a DLS on a `Broker` and an associated
`Trigger` overrides some parameters like `backoffDelay`
the DLS of the `Broker` isn't used and no dead letter sink
will be used.

I think, merging the delivery specs of 2 (or more) objects
is reasonable and provides much stroger guarantees out of
box.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The delivery configs of the Broker are now merged with the one of the Trigger.
Trigger's delivery configs, if defined, have precedence over the individual Broker's delivery configs.
```

