### PR TITLE
Feature/keep ports for service

### DIFF
--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -664,6 +664,13 @@ func makeChannelService(imc *v1.InMemoryChannel) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: network.GetServiceHostname(dispatcherName, testNS),
+			Ports: []corev1.ServicePort{
+				{
+					Name:     resources.PortName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     resources.PortNumber,
+				},
+			},
 		},
 	}
 }
@@ -684,6 +691,13 @@ func makeChannelServiceNotOwnedByUs(imc *v1.InMemoryChannel) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: network.GetServiceHostname(dispatcherName, testNS),
+			Ports: []corev1.ServicePort{
+				{
+					Name:     resources.PortName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     resources.PortNumber,
+				},
+			},
 		},
 	}
 }

--- a/pkg/reconciler/inmemorychannel/controller/resources/service.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service.go
@@ -84,9 +84,11 @@ func NewK8sService(imc *v1.InMemoryChannel, opts ...K8sServiceOption) (*corev1.S
 }
 
 func GetServicePorts() []corev1.ServicePort {
-	return {
-		Name:     PortName,
-		Protocol: corev1.ProtocolTCP,
-		Port:     PortNumber,
-	},
+	return []corev1.ServicePort{
+		{
+			Name:     PortName,
+			Protocol: corev1.ProtocolTCP,
+			Port:     PortNumber,
+		},
+	}
 }

--- a/pkg/reconciler/inmemorychannel/controller/resources/service.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service.go
@@ -45,6 +45,7 @@ func ExternalService(namespace, service string) K8sServiceOption {
 		svc.Spec = corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: network.GetServiceHostname(service, namespace),
+			Ports:        GetServicePorts(),
 		}
 		return nil
 	}
@@ -71,13 +72,7 @@ func NewK8sService(imc *v1.InMemoryChannel, opts ...K8sServiceOption) (*corev1.S
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:     PortName,
-					Protocol: corev1.ProtocolTCP,
-					Port:     PortNumber,
-				},
-			},
+			Ports: GetServicePorts(),
 		},
 	}
 	for _, opt := range opts {
@@ -86,4 +81,12 @@ func NewK8sService(imc *v1.InMemoryChannel, opts ...K8sServiceOption) (*corev1.S
 		}
 	}
 	return svc, nil
+}
+
+func GetServicePorts() []corev1.ServicePort {
+	return {
+		Name:     PortName,
+		Protocol: corev1.ProtocolTCP,
+		Port:     PortNumber,
+	},
 }

--- a/pkg/reconciler/inmemorychannel/controller/resources/service_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service_test.go
@@ -117,6 +117,13 @@ func TestNewK8sServiceWithExternal(t *testing.T) {
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: "dispatcher-name.dispatcher-namespace.svc.cluster.local",
+			Ports: []corev1.ServicePort{
+				{
+					Name:     PortName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     PortNumber,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes #

I was attempting to set up Istio in a local kind cluster, using STRICT mode across the knative namespaces and the application namespaces. Things were fine up until I tried using KNative eventing to verify an event can be produced/consumed.

Following the breadcrumbs of failing service to service calls I enabled sidecars for each pod. But then there was the dispatcher... it created a k8s `Service` with an `ExternalName`, which is something Istio can't handle w.r.t. its internal service mesh (understandable).

Istio's solution is to add a DestinationRule to let Istio know that when traffic goes to that service, it should be done using Istio's mTLS. No big deal, except after deploying those changes, nothing was changing (failures were still happening trying to call the service). Checking the proxy-config of the sidecar for the dispatcher revealed the service was not included in the routing table, so traffic was never leaving the pod to begin with.

Finally, I found https://github.com/istio/istio/issues/13193, which suggests to add ports to the service. The service that is created here starts with having them, but when the `ExternalName` is added, they get overridden.

I don't know if this was intentional, but I am hoping that by making this change I will be able to continue using Istio's mTLS without having to make a VirtualService wrapper around each broker's service.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Ensure ports for the inmemorychannel service are present

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note
The service created for the inmemorychannel's dispatcher will have ports defined, similar to the rest of the services.
```

