### PR TITLE
Process empty tracing config in test images

### DIFF
--- a/test/test_images/utils.go
+++ b/test/test_images/utils.go
@@ -56,23 +56,17 @@ const (
 	ConfigLoggingEnv = "K_CONFIG_LOGGING"
 )
 
-// ConfigureTracing can be used in test-images to configure tracing
+// ConfigureTracing can be used in test-images to configure tracing.
 func ConfigureTracing(logger *zap.SugaredLogger, serviceName string) error {
 	tracingEnv := os.Getenv(ConfigTracingEnv)
-
-	if tracingEnv == "" {
-		return tracing.SetupStaticPublishing(logger, serviceName, config.NoopConfig())
-	}
-
 	conf, err := config.JSONToTracingConfig(tracingEnv)
 	if err != nil {
-		return err
+		logger.Warn("Error while trying to read the tracing config, using NoopConfig: ", err)
 	}
-
 	return tracing.SetupStaticPublishing(logger, serviceName, conf)
 }
 
-// ConfigureTracing can be used in test-images to configure tracing
+// ConfigureLogging can be used in test-images to configure logging.
 func ConfigureLogging(ctx context.Context, name string) context.Context {
 	loggingEnv := os.Getenv(ConfigLoggingEnv)
 	conf, err := logging.JSONToConfig(loggingEnv)


### PR DESCRIPTION
Fixes the comment from https://github.com/knative/eventing/pull/6219#discussion_r837432218

The function `config.JSONToTracingConfig(tracingEnv)` can process empty string in which case it returns a NoopConfig.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

