### PR TITLE
[scheduler] Use node taints for keeping track of available nodes and zones

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -42,6 +42,8 @@ const (
 
 const (
 	ZoneLabel = "topology.kubernetes.io/zone"
+
+	UnknownZone = "unknown"
 )
 
 const (

--- a/pkg/scheduler/state/state.go
+++ b/pkg/scheduler/state/state.go
@@ -371,8 +371,8 @@ func withReserved(key types.NamespacedName, podName string, committed int32, res
 
 func isPodUnschedulable(pod *v1.Pod) bool {
 	annotVal, ok := pod.ObjectMeta.Annotations[scheduler.PodAnnotationKey]
-	unschedulable, _ := strconv.ParseBool(annotVal)
-	return ok && unschedulable
+	unschedulable, val := strconv.ParseBool(annotVal)
+	return ok && val == nil && unschedulable
 }
 
 func isNodeUnschedulable(node *v1.Node) bool {
@@ -388,8 +388,7 @@ func isNodeUnschedulable(node *v1.Node) bool {
 
 	return node.Spec.Unschedulable ||
 		contains(node.Spec.Taints, noExec) ||
-		contains(node.Spec.Taints, noSched) ||
-		isControlPlaneNode(node)
+		contains(node.Spec.Taints, noSched)
 }
 
 func contains(taints []v1.Taint, taint *v1.Taint) bool {
@@ -399,11 +398,4 @@ func contains(taints []v1.Taint, taint *v1.Taint) bool {
 		}
 	}
 	return false
-}
-
-func isControlPlaneNode(node *v1.Node) bool {
-	// "master" is deprecated but there are providers using it.
-	_, m := node.GetLabels()["node-role.kubernetes.io/master"]
-	_, cp := node.GetLabels()["node-role.kubernetes.io/control-plane"]
-	return m || cp
 }

--- a/pkg/scheduler/state/state.go
+++ b/pkg/scheduler/state/state.go
@@ -32,9 +32,10 @@ import (
 	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/listers/core/v1"
 
-	scheduler "knative.dev/eventing/pkg/scheduler"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
+
+	"knative.dev/eventing/pkg/scheduler"
 )
 
 type StateAccessor interface {
@@ -189,16 +190,6 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 	nodeSpread := make(map[types.NamespacedName]map[string]int32)
 	zoneSpread := make(map[types.NamespacedName]map[string]int32)
 
-	noexec := &v1.Taint{
-		Key:    "node.kubernetes.io/unreachable",
-		Effect: v1.TaintEffectNoExecute,
-	}
-
-	nosched := &v1.Taint{
-		Key:    "node.kubernetes.io/unreachable",
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
 	//Build the node to zone map
 	nodes, err := s.nodeLister.List(labels.Everything())
 	if err != nil {
@@ -209,22 +200,20 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 	zoneMap := make(map[string]struct{})
 	for i := 0; i < len(nodes); i++ {
 		node := nodes[i]
-		if node.Spec.Unschedulable {
-			continue //ignore node that is currently unschedulable
-		}
 
-		taints := node.Spec.Taints
-		if contains(taints, noexec) || contains(taints, nosched) {
-			continue //ignore node that is currently unschedulable
+		if isNodeUnschedulable(node) {
+			// Ignore node that is currently unschedulable.
+			continue
 		}
 
 		zoneName, ok := node.GetLabels()[scheduler.ZoneLabel]
-		if !ok {
-			continue //ignore node that doesn't have zone info (maybe a test setup or control node)
+		if ok && zoneName != "" {
+			nodeToZoneMap[node.Name] = zoneName
+			zoneMap[zoneName] = struct{}{}
+		} else {
+			nodeToZoneMap[node.Name] = scheduler.UnknownZone
+			zoneMap[scheduler.UnknownZone] = struct{}{}
 		}
-
-		nodeToZoneMap[node.Name] = zoneName
-		zoneMap[zoneName] = struct{}{}
 	}
 
 	for podId := int32(0); podId < scale.Spec.Replicas && s.podLister != nil; podId++ {
@@ -235,25 +224,24 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 		})
 
 		if pod != nil {
-			var unschedulable bool
-			annotVal, ok := pod.ObjectMeta.Annotations[scheduler.PodAnnotationKey] //Pod is marked for eviction - CANNOT SCHEDULE VREPS on this pod
-			if ok {
-				unschedulable, _ = strconv.ParseBool(annotVal)
-			}
 
-			nodeName := pod.Spec.NodeName
-			node, err := s.nodeLister.Get(nodeName) //Node could be marked as Unschedulable - CANNOT SCHEDULE VREPS on a pod running on this node
+			node, err := s.nodeLister.Get(pod.Spec.NodeName)
 			if err != nil {
 				return nil, err
 			}
 
-			_, okZone := node.GetLabels()[scheduler.ZoneLabel] //Node has no zone info (maybe zone is down or a control node) - CANNOT SCHEDULE VREPS on a pod running on this node
-
-			taints := node.Spec.Taints
-
-			if (!ok || !unschedulable) && !node.Spec.Unschedulable && okZone && !contains(taints, noexec) && !contains(taints, nosched) { //Pod has no annotation or not annotated as unschedulable and not on an unschedulable node, so add to feasible
-				schedulablePods = append(schedulablePods, podId)
+			if isNodeUnschedulable(node) {
+				// Node is marked as Unschedulable - CANNOT SCHEDULE VREPS on a pod running on this node.
+				continue
 			}
+			if isPodUnschedulable(pod) {
+				// Pod is marked for eviction - CANNOT SCHEDULE VREPS on this pod.
+				continue
+			}
+
+			// Pod has no annotation or not annotated as unschedulable and
+			// not on an unschedulable node, so add to feasible
+			schedulablePods = append(schedulablePods, podId)
 		}
 	}
 
@@ -381,12 +369,41 @@ func withReserved(key types.NamespacedName, podName string, committed int32, res
 	return committed
 }
 
+func isPodUnschedulable(pod *v1.Pod) bool {
+	annotVal, ok := pod.ObjectMeta.Annotations[scheduler.PodAnnotationKey]
+	unschedulable, _ := strconv.ParseBool(annotVal)
+	return ok && unschedulable
+}
+
+func isNodeUnschedulable(node *v1.Node) bool {
+	noExec := &v1.Taint{
+		Key:    "node.kubernetes.io/unreachable",
+		Effect: v1.TaintEffectNoExecute,
+	}
+
+	noSched := &v1.Taint{
+		Key:    "node.kubernetes.io/unreachable",
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	return node.Spec.Unschedulable ||
+		contains(node.Spec.Taints, noExec) ||
+		contains(node.Spec.Taints, noSched) ||
+		isControlPlaneNode(node)
+}
+
 func contains(taints []v1.Taint, taint *v1.Taint) bool {
 	for _, v := range taints {
 		if v.MatchTaint(taint) {
 			return true
 		}
 	}
-
 	return false
+}
+
+func isControlPlaneNode(node *v1.Node) bool {
+	// "master" is deprecated but there are providers using it.
+	_, m := node.GetLabels()["node-role.kubernetes.io/master"]
+	_, cp := node.GetLabels()["node-role.kubernetes.io/control-plane"]
+	return m || cp
 }

--- a/pkg/scheduler/state/state_test.go
+++ b/pkg/scheduler/state/state_test.go
@@ -21,15 +21,19 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/listers/core/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	listers "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/eventing/pkg/scheduler"
 	tscheduler "knative.dev/eventing/pkg/scheduler/testing"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
 const (
@@ -388,11 +392,11 @@ func TestStateBuilder(t *testing.T) {
 			nodes:               []*v1.Node{tscheduler.MakeNode("node-0", "zone-0"), tscheduler.MakeNode("node-1", "zone-1"), tscheduler.MakeNode("node-2", "zone-2"), tscheduler.MakeNode("node-3", "zone-0"), tscheduler.MakeNode("node-4", "zone-1")},
 		},
 		{
-			name:     "three vpods but one tainted and one wit no zoen label",
+			name:     "three vpods but one tainted and one with no zone label",
 			replicas: int32(1),
 			vpods:    [][]duckv1alpha1.Placement{{{PodName: "statefulset-name-0", VReplicas: 1}}},
-			expected: State{Capacity: 10, FreeCap: []int32{int32(9)}, SchedulablePods: []int32{int32(0)}, LastOrdinal: 0, Replicas: 1, NumNodes: 1, NumZones: 1, SchedulerPolicy: scheduler.MAXFILLUP, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
-				NodeToZoneMap: map[string]string{"node-0": "zone-0"},
+			expected: State{Capacity: 10, FreeCap: []int32{int32(9)}, SchedulablePods: []int32{int32(0)}, LastOrdinal: 0, Replicas: 1, NumNodes: 2, NumZones: 2, SchedulerPolicy: scheduler.MAXFILLUP, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
+				NodeToZoneMap: map[string]string{"node-0": "zone-0", "node-1": scheduler.UnknownZone},
 				PodSpread: map[types.NamespacedName]map[string]int32{
 					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
 						"statefulset-name-0": 1,
@@ -412,6 +416,32 @@ func TestStateBuilder(t *testing.T) {
 			freec:               int32(9),
 			schedulerPolicyType: scheduler.MAXFILLUP,
 			nodes:               []*v1.Node{tscheduler.MakeNode("node-0", "zone-0"), tscheduler.MakeNodeNoLabel("node-1"), tscheduler.MakeNodeTainted("node-2", "zone-2")},
+		},
+		{
+			name:     "one vpods, three vreplicas but one tainted and one control plane node",
+			replicas: int32(1),
+			vpods:    [][]duckv1alpha1.Placement{{{PodName: "statefulset-name-0", VReplicas: 3}}},
+			expected: State{Capacity: 10, FreeCap: []int32{int32(7)}, SchedulablePods: []int32{int32(0)}, LastOrdinal: 0, Replicas: 1, NumNodes: 1, NumZones: 1, SchedulerPolicy: scheduler.MAXFILLUP, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
+				NodeToZoneMap: map[string]string{"node-0": "zone-0"},
+				PodSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"statefulset-name-0": 3,
+					},
+				},
+				NodeSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"node-0": 3,
+					},
+				},
+				ZoneSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"zone-0": 3,
+					},
+				},
+			},
+			freec:               int32(7),
+			schedulerPolicyType: scheduler.MAXFILLUP,
+			nodes:               []*v1.Node{tscheduler.MakeNode("node-0", "zone-0"), tscheduler.MakeControlPlaneNode("node-1"), tscheduler.MakeNodeTainted("node-2", "zone-2")},
 		},
 		{
 			name:     "one vpod (HA)",
@@ -447,6 +477,51 @@ func TestStateBuilder(t *testing.T) {
 				},
 			},
 			nodes: []*v1.Node{tscheduler.MakeNode("node-0", "zone-0")},
+		},
+		{
+			name:     "two vpod (HA), one control plane node",
+			replicas: int32(2),
+			vpods: [][]duckv1alpha1.Placement{{
+				{PodName: "statefulset-name-0", VReplicas: 1},
+				{PodName: "statefulset-name-1", VReplicas: 1},
+			}},
+			expected: State{Capacity: 10, FreeCap: []int32{int32(9), int32(9)}, SchedulablePods: []int32{int32(0), int32(1)}, LastOrdinal: 1, Replicas: 2, NumNodes: 2, NumZones: 2, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
+				NodeToZoneMap: map[string]string{"node-0": "zone-0", "node-1": "zone-1"},
+				PodSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"statefulset-name-0": 1,
+						"statefulset-name-1": 1,
+					},
+				},
+				NodeSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"node-0": 1,
+						"node-1": 1,
+					},
+				},
+				ZoneSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
+						"zone-0": 1,
+						"zone-1": 1,
+					},
+				},
+			},
+			freec: int32(18),
+			schedulerPolicy: &scheduler.SchedulerPolicy{
+				Predicates: []scheduler.PredicatePolicy{
+					{Name: "PodFitsResources"},
+					{Name: "EvenPodSpread", Args: "{\"MaxSkew\": 1}"},
+				},
+				Priorities: []scheduler.PriorityPolicy{
+					{Name: "AvailabilityNodePriority", Weight: 10, Args: "{\"MaxSkew\": 1}"},
+					{Name: "LowestOrdinalPriority", Weight: 5},
+				},
+			},
+			nodes: []*v1.Node{
+				tscheduler.MakeNode("node-0", "zone-0"),
+				tscheduler.MakeNode("node-1", "zone-1"),
+				tscheduler.MakeControlPlaneNode("node-2"),
+			},
 		},
 	}
 
@@ -522,7 +597,8 @@ func TestStateBuilder(t *testing.T) {
 				tc.expected.NodeToZoneMap = make(map[string]string)
 			}
 			if !reflect.DeepEqual(*state, tc.expected) {
-				t.Errorf("unexpected state, got %v, want %v", *state, tc.expected)
+				diff := cmp.Diff(tc.expected, *state, cmpopts.IgnoreInterfaces(struct{ corev1.PodNamespaceLister }{}))
+				t.Errorf("unexpected state, got %v, want %v\n(-want, +got)\n%s", *state, tc.expected, diff)
 			}
 
 			if state.FreeCapacity() != tc.freec {

--- a/pkg/scheduler/state/state_test.go
+++ b/pkg/scheduler/state/state_test.go
@@ -418,32 +418,6 @@ func TestStateBuilder(t *testing.T) {
 			nodes:               []*v1.Node{tscheduler.MakeNode("node-0", "zone-0"), tscheduler.MakeNodeNoLabel("node-1"), tscheduler.MakeNodeTainted("node-2", "zone-2")},
 		},
 		{
-			name:     "one vpods, three vreplicas but one tainted and one control plane node",
-			replicas: int32(1),
-			vpods:    [][]duckv1alpha1.Placement{{{PodName: "statefulset-name-0", VReplicas: 3}}},
-			expected: State{Capacity: 10, FreeCap: []int32{int32(7)}, SchedulablePods: []int32{int32(0)}, LastOrdinal: 0, Replicas: 1, NumNodes: 1, NumZones: 1, SchedulerPolicy: scheduler.MAXFILLUP, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
-				NodeToZoneMap: map[string]string{"node-0": "zone-0"},
-				PodSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"statefulset-name-0": 3,
-					},
-				},
-				NodeSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"node-0": 3,
-					},
-				},
-				ZoneSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"zone-0": 3,
-					},
-				},
-			},
-			freec:               int32(7),
-			schedulerPolicyType: scheduler.MAXFILLUP,
-			nodes:               []*v1.Node{tscheduler.MakeNode("node-0", "zone-0"), tscheduler.MakeControlPlaneNode("node-1"), tscheduler.MakeNodeTainted("node-2", "zone-2")},
-		},
-		{
 			name:     "one vpod (HA)",
 			replicas: int32(1),
 			vpods:    [][]duckv1alpha1.Placement{{{PodName: "statefulset-name-0", VReplicas: 1}}},
@@ -477,51 +451,6 @@ func TestStateBuilder(t *testing.T) {
 				},
 			},
 			nodes: []*v1.Node{tscheduler.MakeNode("node-0", "zone-0")},
-		},
-		{
-			name:     "two vpod (HA), one control plane node",
-			replicas: int32(2),
-			vpods: [][]duckv1alpha1.Placement{{
-				{PodName: "statefulset-name-0", VReplicas: 1},
-				{PodName: "statefulset-name-1", VReplicas: 1},
-			}},
-			expected: State{Capacity: 10, FreeCap: []int32{int32(9), int32(9)}, SchedulablePods: []int32{int32(0), int32(1)}, LastOrdinal: 1, Replicas: 2, NumNodes: 2, NumZones: 2, SchedPolicy: &scheduler.SchedulerPolicy{}, DeschedPolicy: &scheduler.SchedulerPolicy{}, StatefulSetName: sfsName,
-				NodeToZoneMap: map[string]string{"node-0": "zone-0", "node-1": "zone-1"},
-				PodSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"statefulset-name-0": 1,
-						"statefulset-name-1": 1,
-					},
-				},
-				NodeSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"node-0": 1,
-						"node-1": 1,
-					},
-				},
-				ZoneSpread: map[types.NamespacedName]map[string]int32{
-					{Name: vpodName + "-0", Namespace: vpodNs + "-0"}: {
-						"zone-0": 1,
-						"zone-1": 1,
-					},
-				},
-			},
-			freec: int32(18),
-			schedulerPolicy: &scheduler.SchedulerPolicy{
-				Predicates: []scheduler.PredicatePolicy{
-					{Name: "PodFitsResources"},
-					{Name: "EvenPodSpread", Args: "{\"MaxSkew\": 1}"},
-				},
-				Priorities: []scheduler.PriorityPolicy{
-					{Name: "AvailabilityNodePriority", Weight: 10, Args: "{\"MaxSkew\": 1}"},
-					{Name: "LowestOrdinalPriority", Weight: 5},
-				},
-			},
-			nodes: []*v1.Node{
-				tscheduler.MakeNode("node-0", "zone-0"),
-				tscheduler.MakeNode("node-1", "zone-1"),
-				tscheduler.MakeControlPlaneNode("node-2"),
-			},
 		},
 	}
 

--- a/pkg/scheduler/testing/vpod.go
+++ b/pkg/scheduler/testing/vpod.go
@@ -23,9 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
+
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/scheduler"
-	"knative.dev/pkg/controller"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -79,6 +80,18 @@ func MakeNode(name, zonename string) *v1.Node {
 			Name: name,
 			Labels: map[string]string{
 				scheduler.ZoneLabel: zonename,
+			},
+		},
+	}
+	return obj
+}
+
+func MakeControlPlaneNode(name string) *v1.Node {
+	obj := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"node-role.kubernetes.io/control-plane": "",
 			},
 		},
 	}

--- a/pkg/scheduler/testing/vpod.go
+++ b/pkg/scheduler/testing/vpod.go
@@ -86,18 +86,6 @@ func MakeNode(name, zonename string) *v1.Node {
 	return obj
 }
 
-func MakeControlPlaneNode(name string) *v1.Node {
-	obj := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"node-role.kubernetes.io/control-plane": "",
-			},
-		},
-	}
-	return obj
-}
-
 func MakeNodeNoLabel(name string) *v1.Node {
 	obj := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The state accessor is keeping track of nodes and zones based on
the `topology.kubernetes.io/zone` label.
This label isn't always set and there might be clusters that don't
set it, which leads to a non-functional scheduler because it ends
up with `0` nodes and zones.

Instead of using the zone label, we can use node tains to
discard control unschedulable nodes and when there is no zone information
for a _worker_ node, we can assign a default `unknown` zone, which
means that a cluster without zone labels on nodes is considered as
a single-zone cluster (which makes sense since the administrator
doesn't care about availabily zones or failure domains).

PS: while I was doing this, I made a few clean ups
to extract common functions for checking whether a node or a pod
is `"unschedulable"`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>