### PR TITLE
Do not fail upgrade tests if tracing is not configured

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -19,7 +19,7 @@
 # Script entry point.
 
 export GO111MODULE=on
-export DEPLOY_KNATIVE_MONITORING=0
+
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -19,7 +19,7 @@
 # Script entry point.
 
 export GO111MODULE=on
-
+export DEPLOY_KNATIVE_MONITORING=0
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 


### PR DESCRIPTION
Prevent failures such as [this one](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_operator/1018/eventing-upgrade-tests_operator_main/1510363836996128768) when monitoring/tracing is not configured in the system. The problem was recently hit in knative/operator repo.


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- log warning when setting up tracing for the upgrade framework and Zipkin is not configured, do not fail the tests
- log warning when downloading traces but Zipkin is disabled

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

