### PR TITLE
Adds receiver options for configuring read and write timeouts message receiver

### DIFF
--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -78,6 +78,30 @@ func WithDrainQuietPeriod(duration time.Duration) HTTPMessageReceiverOption {
 	}
 }
 
+// WithWriteTimeout sets the HTTP server's WriteTimeout. It covers the time between end of reading
+// Request Header to end of writing response.
+func WithWriteTimeout(duration time.Duration) HTTPMessageReceiverOption {
+	return func(h *HTTPMessageReceiver) {
+		if h.server == nil {
+			h.server = &http.Server{}
+		}
+
+		h.server.WriteTimeout = duration
+	}
+}
+
+// WithReadTimeout sets the HTTP server's ReadTimeout. It covers the duration from reading hte entire request
+// (Headers + Body)
+func WithReadTimeout(duration time.Duration) HTTPMessageReceiverOption {
+	return func(h *HTTPMessageReceiver) {
+		if h.server == nil {
+			h.server = &http.Server{}
+		}
+
+		h.server.ReadTimeout = duration
+	}
+}
+
 // Blocking
 func (recv *HTTPMessageReceiver) StartListen(ctx context.Context, handler http.Handler) error {
 	var err error
@@ -90,10 +114,11 @@ func (recv *HTTPMessageReceiver) StartListen(ctx context.Context, handler http.H
 		HealthCheck: recv.checker,
 		QuietPeriod: recv.drainQuietPeriod,
 	}
-	recv.server = &http.Server{
-		Addr:    recv.listener.Addr().String(),
-		Handler: drainer,
+	if recv.server == nil {
+		recv.server = &http.Server{}
 	}
+	recv.server.Addr = recv.listener.Addr().String()
+	recv.server.Handler = drainer
 
 	errChan := make(chan error, 1)
 	go func() {

--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -90,7 +90,7 @@ func WithWriteTimeout(duration time.Duration) HTTPMessageReceiverOption {
 	}
 }
 
-// WithReadTimeout sets the HTTP server's ReadTimeout. It covers the duration from reading hte entire request
+// WithReadTimeout sets the HTTP server's ReadTimeout. It covers the duration from reading the entire request
 // (Headers + Body)
 func WithReadTimeout(duration time.Duration) HTTPMessageReceiverOption {
 	return func(h *HTTPMessageReceiver) {

--- a/pkg/kncloudevents/message_receiver_test.go
+++ b/pkg/kncloudevents/message_receiver_test.go
@@ -194,7 +194,7 @@ func TestWithWriteTimeout(t *testing.T) {
 	req, err := http.NewRequest("GET", addr, nil)
 	assert.NoError(t, err)
 	_, err = client.Do(req)
-	<- receivedRequest
+	<-receivedRequest
 
 	assert.Error(t, err)
 	// go http server implementation will abruptly close the connection and the client will only see an io EOF error
@@ -207,7 +207,7 @@ func TestWithReadTimeout(t *testing.T) {
 	readTimeout := 30 * time.Second
 
 	messageReceiver := NewHTTPMessageReceiver(0, WithReadTimeout(readTimeout))
-	
+
 	assert.Equal(t, readTimeout, messageReceiver.server.ReadTimeout)
 }
 

--- a/pkg/kncloudevents/message_receiver_test.go
+++ b/pkg/kncloudevents/message_receiver_test.go
@@ -18,6 +18,7 @@ package kncloudevents
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -66,6 +67,7 @@ func TestWithShutdownTimeout(t *testing.T) {
 		errChan <- messageReceiver.StartListen(WithShutdownTimeout(ctx, serverShutdownTimeout), &blockingHandler{
 			blockFor:        serverShutdownTimeout * 100,
 			receivedRequest: receivedRequest,
+			writtenResponse: make(chan bool, 1),
 		})
 	}()
 
@@ -170,6 +172,45 @@ func TestStartListenReceiveEvent(t *testing.T) {
 
 }
 
+func TestWithWriteTimeout(t *testing.T) {
+	writeTimeout := time.Millisecond * 10
+	writtenResponse := make(chan bool, 1)
+	receivedRequest := make(chan bool, 1)
+	messageReceiver := NewHTTPMessageReceiver(0, WithWriteTimeout(writeTimeout))
+	ctx := context.TODO()
+
+	go func() {
+		_ = messageReceiver.StartListen(ctx, &blockingHandler{
+			blockFor:        writeTimeout * 10,
+			writtenResponse: writtenResponse,
+			receivedRequest: receivedRequest,
+		})
+	}()
+
+	<-messageReceiver.Ready
+
+	addr := "http://" + messageReceiver.server.Addr
+	client := http.DefaultClient
+	req, err := http.NewRequest("GET", addr, nil)
+	assert.NoError(t, err)
+	_, err = client.Do(req)
+	<- receivedRequest
+
+	assert.Error(t, err)
+	// go http server implementation will abruptly close the connection and the client will only see an io EOF error
+	// due to a buffer.
+	// issue tracking an enhancement: https://github.com/golang/go/issues/21389
+	assert.EqualError(t, err, fmt.Sprintf("Get \"%s\": EOF", addr))
+}
+
+func TestWithReadTimeout(t *testing.T) {
+	readTimeout := 30 * time.Second
+
+	messageReceiver := NewHTTPMessageReceiver(0, WithReadTimeout(readTimeout))
+	
+	assert.Equal(t, readTimeout, messageReceiver.server.ReadTimeout)
+}
+
 type testEventParsingHandler struct {
 	t              *testing.T
 	ReceivedEvents chan *event.Event
@@ -194,10 +235,12 @@ func (th *testEventParsingHandler) ServeHTTP(writer http.ResponseWriter, request
 type blockingHandler struct {
 	blockFor        time.Duration
 	receivedRequest chan bool
+	writtenResponse chan bool
 }
 
 func (bh *blockingHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	bh.receivedRequest <- true
 	time.Sleep(bh.blockFor)
 	writer.WriteHeader(http.StatusOK)
+	bh.writtenResponse <- true
 }


### PR DESCRIPTION
## Proposed Changes
- adds HTTPMessageReceiverOptions for setting read/write timeouts on the HTTPMessageReceiver

### Pre-review Checklist

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

