### PR TITLE
Cleanup Zipkin tracing only once in upgrade test suite

### DIFF
--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -60,7 +60,6 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		// Required for proper cleanup.
 		zipkin.ZipkinTracingEnabled = true
 	}
-	defer zipkin.CleanupZipkinTracingSetup(p.log.Infof)
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
 	if err := wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {


### PR DESCRIPTION
Fixes #6330

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Do not cleanup Zipkin port-forwarding in every test but only do it once

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

