### PR TITLE
feat: Ignore sent messages response body is not empty

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -52,9 +52,10 @@ const (
 type envConfig struct {
 	Namespace string `envconfig:"NAMESPACE" required:"true"`
 	// TODO: change this environment variable to something like "PodGroupName".
-	PodName       string `envconfig:"POD_NAME" required:"true"`
-	ContainerName string `envconfig:"CONTAINER_NAME" required:"true"`
-	Port          int    `envconfig:"FILTER_PORT" default:"8080"`
+	PodName            string `envconfig:"POD_NAME" required:"true"`
+	ContainerName      string `envconfig:"CONTAINER_NAME" required:"true"`
+	Port               int    `envconfig:"FILTER_PORT" default:"8080"`
+	IgnoreResponseBody bool   `envconfig:"IGNORE_RESPONSE_BODY" default:"false"`
 }
 
 func main() {
@@ -120,7 +121,7 @@ func main() {
 
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	handler, err := filter.NewHandler(logger, triggerInformer.Lister(), reporter, env.Port, ctxFunc)
+	handler, err := filter.NewHandler(logger, triggerInformer.Lister(), reporter, env.Port, ctxFunc, env.IgnoreResponseBody)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -440,7 +440,7 @@ func TestReceiver(t *testing.T) {
 				func(ctx context.Context) context.Context {
 					return ctx
 				},
-			)
+				false)
 			if tc.expectNewToFail {
 				if err == nil {
 					t.Fatal("Expected New to fail, it didn't")
@@ -617,7 +617,8 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 					return feature.ToContext(context.TODO(), feature.Flags{
 						feature.NewTriggerFilters: feature.Enabled,
 					})
-				})
+				},
+				false)
 			if err != nil {
 				t.Fatal("Unable to create receiver:", err)
 			}


### PR DESCRIPTION
## Proposed Changes

- :gift: Optional ignoring message response body is not empty

Some of the services in our system do not return a valid cloud event or an empty body response which leads to lost events due to 502 Bad Gateway error.

Log message: Received a non-empty response not recognized as CloudEvent. The response MUST be either empty or a valid CloudEvent.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Ignoring message response body is not a cloud event and not empty can be configured by the environment variable `IGNORE_RESPONSE_BODY=true`.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->