### PR TITLE
Adding retry for 408 (Request Timeout) http status code

### DIFF
--- a/pkg/kncloudevents/retries.go
+++ b/pkg/kncloudevents/retries.go
@@ -144,7 +144,7 @@ func RetryIfGreaterThan300(_ context.Context, response *http.Response, err error
 // A retry is triggered for:
 // * nil responses
 // * emitted errors
-// * status codes that are 5XX, 404, 409, 429 as well if the statuscode is -1.
+// * status codes that are 5XX, 404, 408, 409, 429 as well if the statuscode is -1.
 func SelectiveRetry(_ context.Context, response *http.Response, err error) (bool, error) {
 
 	// Retry Any Nil HTTP Response
@@ -167,12 +167,13 @@ func SelectiveRetry(_ context.Context, response *http.Response, err error) (bool
 	// 404  Although we would ideally not want to retry a permanent "Not Found"
 	//      response, a 404 can be returned when a pod is in the process of becoming
 	//      ready, so a retry can be a useful thing in this situation.
+	// 408  Request Timeout is a good practice to issue a retry.
 	// 409  Returned by the E2E tests, so we must retry when "Conflict" is received, or the
 	//      tests will fail (see knative.dev/eventing/test/lib/recordevents/receiver/receiver.go)
 	// 429  Since retry typically involves a delay (usually an exponential backoff),
 	//      retrying after receiving a "Too Many Requests" response is useful.
 
-	if statusCode >= 500 || statusCode == 404 || statusCode == 429 || statusCode == 409 {
+	if statusCode >= 500 || statusCode == 404 || statusCode == 429 || statusCode == 408 || statusCode == 409 {
 		return true, nil
 	} else if statusCode >= 300 && statusCode <= 399 {
 		return false, nil

--- a/pkg/kncloudevents/retries_test.go
+++ b/pkg/kncloudevents/retries_test.go
@@ -263,6 +263,16 @@ func TestRetryIfGreaterThan300(t *testing.T) {
 			result:   true,
 		},
 		{
+			name:     "Http StatusCode 408",
+			response: &http.Response{StatusCode: http.StatusRequestTimeout},
+			result:   true,
+		},
+		{
+			name:     "Http StatusCode 409",
+			response: &http.Response{StatusCode: http.StatusConflict},
+			result:   true,
+		},
+		{
 			name:     "Http StatusCode 429",
 			response: &http.Response{StatusCode: http.StatusTooManyRequests},
 			result:   true,
@@ -370,6 +380,16 @@ func TestSelectiveRetry(t *testing.T) {
 		{
 			name:     "Http StatusCode 404",
 			response: &http.Response{StatusCode: http.StatusNotFound},
+			result:   true,
+		},
+		{
+			name:     "Http StatusCode 408",
+			response: &http.Response{StatusCode: http.StatusRequestTimeout},
+			result:   true,
+		},
+		{
+			name:     "Http StatusCode 409",
+			response: &http.Response{StatusCode: http.StatusConflict},
 			result:   true,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes https://github.com/knative/specs/issues/96

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adding retry for the `408 - Request Timeout` status code

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

