### PR TITLE
Remove calling 'ExecuteLocalYAML', b/c it is deprecated

### DIFF
--- a/test/rekt/resources/account_role/role_test.go
+++ b/test/rekt/resources/account_role/role_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package account_role_test
 
 import (
+	"embed"
 	"os"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"knative.dev/eventing/test/rekt/resources/account_role"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example() {
 	images := map[string]string{}
@@ -33,7 +37,7 @@ func Example() {
 		"matchLabels": "whomp",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +73,7 @@ func Example_matchLabel() {
 		"matchLabel": "whomp",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +119,7 @@ func Example_channelableManipulator() {
 
 	account_role.AsChannelableManipulator(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -161,7 +165,7 @@ func Example_addressableResolver() {
 
 	account_role.AsAddressableResolver(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -220,7 +224,7 @@ func Example_withRoleAndRules() {
 	account_role.WithRole("baz")(cfg)
 	account_role.WithRules(rule1, rule2)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/apiserversource/apiserversource_test.go
+++ b/test/rekt/resources/apiserversource/apiserversource_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserversource_test
 
 import (
+	"embed"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,9 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
+//go:embed *.yaml
+var yaml embed.FS
+
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
 
@@ -39,7 +43,7 @@ func Example_min() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -63,7 +67,7 @@ func Example_withServiceAccountName() {
 
 	apiserversource.WithServiceAccountName("src-sa")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +92,7 @@ func Example_withEventMode() {
 
 	apiserversource.WithEventMode(v1.ReferenceMode)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -119,7 +123,7 @@ func Example_withSink() {
 	}
 	apiserversource.WithSink(sinkRef, "uri/parts")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -178,7 +182,7 @@ func Example_withResources() {
 
 	apiserversource.WithResources(res1, res2, res3)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -259,7 +263,7 @@ func Example_full() {
 	apiserversource.WithSink(sinkRef, "uri/parts")(cfg)
 	apiserversource.WithResources(res1, res2, res3)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/broker/broker_test.go
+++ b/test/rekt/resources/broker/broker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package broker_test
 
 import (
+	"embed"
 	"os"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -25,6 +26,9 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -37,7 +41,7 @@ func Example_min() {
 		"brokerName": "baz",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +82,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -120,7 +124,7 @@ func ExampleWithBrokerClass() {
 	}
 	broker.WithBrokerClass("a-broker-class")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -149,7 +153,7 @@ func ExampleWithDeadLetterSink() {
 		APIVersion: "deadapi",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -180,7 +184,7 @@ func ExampleWithConfig() {
 	}
 	broker.WithConfig("my-funky-config")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -209,7 +213,7 @@ func ExampleWithRetry() {
 	exp := eventingv1.BackoffPolicyExponential
 	broker.WithRetry(42, &exp, ptr.String("2007-03-01T13:00:00Z/P1Y2M10DT2H30M"))(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -236,7 +240,7 @@ func ExampleWithRetry_onlyCount() {
 	}
 	broker.WithRetry(42, nil, nil)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/channel/channel_test.go
+++ b/test/rekt/resources/channel/channel_test.go
@@ -28,6 +28,9 @@ import (
 	"knative.dev/eventing/test/rekt/resources/channel"
 )
 
+//go:embed *.yaml
+var yaml embed.FS
+
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
 
@@ -38,7 +41,7 @@ func Example_min() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +84,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -112,9 +115,6 @@ func Example_full() {
 	//     backoffPolicy: exponential
 	//     backoffDelay: "2007-03-01T13:00:00Z/P1Y2M10DT2H30M"
 }
-
-//go:embed *.yaml
-var yaml embed.FS
 
 func Example_withTemplate() {
 

--- a/test/rekt/resources/channel_impl/channel_impl_test.go
+++ b/test/rekt/resources/channel_impl/channel_impl_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package channel_impl_test
 
 import (
+	"embed"
 	"log"
 	"os"
 
@@ -24,6 +25,9 @@ import (
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -37,7 +41,7 @@ func Example_min() {
 		"kind":       "Sample",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +66,7 @@ func Example_env() {
 		"apiVersion": apiVersion,
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +99,7 @@ func Example_setenv() {
 		"apiVersion": apiVersion,
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -132,7 +136,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/containersource/containersource_test.go
+++ b/test/rekt/resources/containersource/containersource_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package containersource_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example_min() {
 	images := map[string]string{}
@@ -29,7 +33,7 @@ func Example_min() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +82,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/delivery/delivery_test.go
+++ b/test/rekt/resources/delivery/delivery_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package delivery_test
 
 import (
+	"embed"
 	"os"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -29,11 +30,14 @@ import (
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
 
+//go:embed *.yaml
+var yaml embed.FS
+
 func Example_min() {
 	images := map[string]string{}
 	cfg := map[string]interface{}{}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +66,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +98,7 @@ func ExampleWithDeadLetterSink() {
 		APIVersion: "deadapi",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -118,7 +122,7 @@ func ExampleWithRetry() {
 	exp := eventingv1.BackoffPolicyExponential
 	broker.WithRetry(42, &exp, ptr.String("2007-03-01T13:00:00Z/P1Y2M10DT2H30M"))(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -137,7 +141,7 @@ func ExampleWithRetry_onlyCount() {
 	cfg := map[string]interface{}{}
 	broker.WithRetry(42, nil, nil)(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/deployment/deployment_test.go
+++ b/test/rekt/resources/deployment/deployment_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package deployment_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example() {
 	images := map[string]string{}
@@ -32,7 +36,7 @@ func Example() {
 		"port":      8080,
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/eventlibrary/eventlibrary_test.go
+++ b/test/rekt/resources/eventlibrary/eventlibrary_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package eventlibrary_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example() {
 	images := map[string]string{
@@ -31,7 +35,7 @@ func Example() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/flaker/flaker_test.go
+++ b/test/rekt/resources/flaker/flaker_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package flaker_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example() {
 	images := map[string]string{
@@ -32,7 +36,7 @@ func Example() {
 		"sink":      "uri://to/a/sink",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/parallel/parallel_test.go
+++ b/test/rekt/resources/parallel/parallel_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package parallel_test
 
 import (
+	"embed"
 	"os"
 
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -24,6 +25,9 @@ import (
 
 	"knative.dev/eventing/test/rekt/resources/parallel"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -35,7 +39,7 @@ func Example_min() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +137,7 @@ func Example_fullDelivery() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -286,7 +290,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -382,7 +386,7 @@ func Example_withSubscriberAt() {
 
 	parallel.WithSubscriberAt(2, nil, "http://full/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -439,7 +443,7 @@ func Example_withFilterAt() {
 
 	parallel.WithFilterAt(2, nil, "http://full/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -496,7 +500,7 @@ func Example_withReplyAt() {
 
 	parallel.WithReplyAt(2, nil, "http://full/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -558,7 +562,7 @@ func Example_withFullAt() {
 		Namespace:  "bar",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -609,7 +613,7 @@ func Example_withReply() {
 		Name:       "repname",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/pingsource/pingsource_test.go
+++ b/test/rekt/resources/pingsource/pingsource_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package pingsource_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -33,7 +37,7 @@ func Example_min() {
 		"brokerName": "baz",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +71,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +115,7 @@ func Example_fullbase64() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/pod/pod_test.go
+++ b/test/rekt/resources/pod/pod_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package pod_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/eventing/test/rekt/resources/pod"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example_min() {
 	images := map[string]string{}
@@ -33,7 +37,7 @@ func Example_min() {
 		"labels":    map[string]string{"app": "bla"},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +71,7 @@ func Example_withLabels() {
 
 	pod.WithLabels(map[string]string{"overwrite": "yes"})(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +105,7 @@ func Example_withImage() {
 
 	pod.WithImage("myimage")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -136,7 +140,7 @@ func Example_full() {
 	pod.WithLabels(map[string]string{"overwrite": "yes"})(cfg)
 	pod.WithImage("myimage")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/sequence/sequence_test.go
+++ b/test/rekt/resources/sequence/sequence_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sequence_test
 
 import (
+	"embed"
 	"os"
 
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -24,6 +25,9 @@ import (
 
 	"knative.dev/eventing/test/rekt/resources/sequence"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -35,7 +39,7 @@ func Example_min() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +98,7 @@ func Example_fullDelivery() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -179,7 +183,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -245,7 +249,7 @@ func Example_withStep() {
 
 	sequence.WithStep(nil, "http://full/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -289,7 +293,7 @@ func Example_withReply() {
 		Name:       "repname",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/sinkbinding/sinkbinding_test.go
+++ b/test/rekt/resources/sinkbinding/sinkbinding_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package sinkbinding_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -44,7 +48,7 @@ func Example_min() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +104,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/subscription/subscription_test.go
+++ b/test/rekt/resources/subscription/subscription_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package subscription_test
 
 import (
+	"embed"
 	"os"
 
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -24,6 +25,9 @@ import (
 
 	"knative.dev/eventing/test/rekt/resources/subscription"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -43,7 +47,7 @@ func Example_min() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +75,7 @@ func Example_zero() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +126,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -175,7 +179,7 @@ func ExampleWithChannel() {
 		Name:       "chname",
 		APIVersion: "chversion",
 	})(cfg)
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -206,7 +210,7 @@ func ExampleWithSubscriber() {
 		Name:       "subname",
 		APIVersion: "subversion",
 	}, "/extra/path")(cfg)
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -241,7 +245,7 @@ func ExampleWithReply() {
 		APIVersion: "repversion",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/svc/service_test.go
+++ b/test/rekt/resources/svc/service_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package svc_test
 
 import (
+	"embed"
 	"os"
 
 	"knative.dev/reconciler-test/pkg/manifest"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 func Example() {
 	images := map[string]string{}
@@ -31,7 +35,7 @@ func Example() {
 		"selectorValue": "baf",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/test/rekt/resources/trigger/trigger_test.go
+++ b/test/rekt/resources/trigger/trigger_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package trigger_test
 
 import (
+	"embed"
 	"os"
 
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
@@ -27,6 +28,9 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/resources/svc"
 )
+
+//go:embed *.yaml
+var yaml embed.FS
 
 // The following examples validate the processing of the With* helper methods
 // applied to config and go template parser.
@@ -46,7 +50,7 @@ func Example_min() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +79,7 @@ func Example_zero() {
 		"namespace": "bar",
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -112,7 +116,7 @@ func Example_full() {
 		},
 	}
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -153,7 +157,7 @@ func ExampleWithSubscriber() {
 		APIVersion: "subversion",
 	}, "/extra/path")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -189,7 +193,7 @@ func ExampleWithFilter() {
 		"type": "z",
 	})(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -219,7 +223,7 @@ func ExampleWithDeadLetterSink() {
 
 	delivery.WithDeadLetterSink(svc.AsKReference("targetdlq"), "/uri/here")(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -254,7 +258,7 @@ func ExampleWithRetry() {
 	exp := duckv1.BackoffPolicyExponential
 	delivery.WithRetry(3, &exp, ptr.String("T0"))(cfg)
 
-	files, err := manifest.ExecuteLocalYAML(images, cfg)
+	files, err := manifest.ExecuteYAML(yaml, images, cfg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: remove deprecated api calls
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

