### PR TITLE
Upgrade test reports last error for unavailability periods

### DIFF
--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -116,10 +116,11 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 	// check down time
 	for _, unavailablePeriod := range finished.UnavailablePeriods {
 		if unavailablePeriod.Period > config.Instance.Receiver.Errors.UnavailablePeriodToReport {
-			f.errors.throwUnavail("event #%d had unavailable period %v which is over down time limit of %v",
+			f.errors.throwUnavail("event #%d had unavailable period %v which is over down time limit of %v, last error %v",
 				unavailablePeriod.Step.Number,
 				unavailablePeriod.Period,
-				config.Instance.Receiver.Errors.UnavailablePeriodToReport)
+				config.Instance.Receiver.Errors.UnavailablePeriodToReport,
+				unavailablePeriod.LastErr)
 			f.errors.state = Failed
 		}
 		log.Infof("detecting unavailable time %v", unavailablePeriod)

--- a/test/upgrade/prober/wathola/event/types.go
+++ b/test/upgrade/prober/wathola/event/types.go
@@ -36,8 +36,9 @@ type Step struct {
 // UnavailablePeriod tracks for the given step event how
 // long it could not be sent.
 type UnavailablePeriod struct {
-	Step   *Step
-	Period time.Duration
+	Step    *Step
+	Period  time.Duration
+	LastErr string
 }
 
 // Finished is step call after verification finishes


### PR DESCRIPTION
The generic error `event #%d had unavailable period %v which is over down time limit of %v`
doesn't include an actual error that was causing the downtime. 

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
