### PR TITLE
Upgrade test exports logs before shutting down sender

### DIFF
--- a/test/upgrade/prober/prober.go
+++ b/test/upgrade/prober/prober.go
@@ -16,12 +16,15 @@
 package prober
 
 import (
+	"path/filepath"
 	"time"
 
 	"go.uber.org/zap"
+	"knative.dev/pkg/test/prow"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
-	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
 
 var (
@@ -135,4 +138,11 @@ func (p *prober) remove() {
 		p.removeForwarder()
 	}
 	p.ensureNoError(p.client.Tracker.Clean(true))
+}
+
+func (p *prober) exportLogs() {
+	dir := filepath.Join(prow.GetLocalArtifactsDir(), "upgrade-test-namespace-logs")
+	if err := p.client.ExportLogs(dir); err != nil {
+		p.client.T.Logf("Failed to export logs in namespace %s: %v", p.client.Namespace, err)
+	}
 }

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -25,8 +25,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/eventing/test/upgrade/prober/wathola/sender"
 	pkgTest "knative.dev/pkg/test"
+
+	"knative.dev/eventing/test/upgrade/prober/wathola/sender"
 
 	testlib "knative.dev/eventing/test/lib"
 )

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -31,15 +31,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"knative.dev/eventing/test/upgrade/prober/wathola/event"
-	"knative.dev/eventing/test/upgrade/prober/wathola/fetcher"
-	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/helpers"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/prow"
 	"knative.dev/pkg/test/zipkin"
+
+	"knative.dev/eventing/test/upgrade/prober/wathola/event"
+	"knative.dev/eventing/test/upgrade/prober/wathola/fetcher"
+	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 )
 
 const (
@@ -107,6 +108,8 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 
 // Finish terminates sender which sends finished event.
 func (p *prober) Finish() {
+	// Save logs before deleting the sender deployment
+	p.exportLogs()
 	p.removeSender()
 }
 


### PR DESCRIPTION
Removing the sender deployment ends up removing its useful logs
for debugging. In this PR, we save them in the artifacts directory
for later consumption.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>