### PR TITLE
Propagate log level to env var in sources `ConfigWatcher`

### DIFF
--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 const testComponent = "test_component"
+const testComponentWithCustomLogLevel = "test_component_custom_loglevel"
 
 func TestNewConfigWatcher_defaults(t *testing.T) {
 	testCases := []struct {
@@ -136,6 +137,18 @@ func TestNewConfigWatcher_withOptions(t *testing.T) {
 	}
 }
 
+func TestLoggingConfigWithCustomLoggingLevel(t *testing.T) {
+	ctx := loggingtesting.TestContextWithLogger(t)
+	cw := WatchConfigurations(ctx, testComponentWithCustomLogLevel, configMapWatcherWithSampleData())
+
+	envs := cw.ToEnvVars()
+
+	require.Equal(t, EnvLoggingCfg, envs[0].Name, "first env var is logging config")
+
+	const expectLoggingContains = `"zap-logger-config":"{\"level\":\"debug\",`
+	assert.Contains(t, envs[0].Value, expectLoggingContains)
+}
+
 func TestEmptyVarsGenerator(t *testing.T) {
 	g := &EmptyVarsGenerator{}
 	envs := g.ToEnvVars()
@@ -195,6 +208,8 @@ func newTestConfigMap(name string, data map[string]string) *corev1.ConfigMap {
 func loggingConfigMapData() map[string]string {
 	return map[string]string{
 		"zap-logger-config": `{"level": "fatal"}`,
+
+		"loglevel." + testComponentWithCustomLogLevel: "debug",
 	}
 }
 func metricsConfigMapData() map[string]string {


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Propagate `config-logging`'s per-component logging level to sources' adapters

Until now, the `ConfigWatcher` inside `pkg/reconciler/source` was always returning the _global_ `zap-config-logging` from the observed configmap, without taking into account `loglevel.<component>` keys inside that same configmap.

As a user, I would like e.g. 

```yaml
loglevel.pingsource: debug
```

to propagate to the PingSource adapter(s) when the `ConfigWatcher` is initialized with

```go
// https://github.com/knative/eventing/blob/v0.24.0/pkg/reconciler/pingsource/controller.go#L71
WatchConfigurations(ctx, "pingsource", cmw)
```

### Pre-review Checklist

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Propagate per-component logging levels to source receive adapters.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

