### PR TITLE
[WIP] Parallel to use `subscription.subscriber` instead of `reply` if there's no filter

### DIFF
--- a/pkg/reconciler/parallel/resources/subscription.go
+++ b/pkg/reconciler/parallel/resources/subscription.go
@@ -57,19 +57,28 @@ func NewFilterSubscription(branchNumber int, p *v1.Parallel) *messagingv1.Subscr
 			},
 		},
 	}
-	if p.Spec.Branches[branchNumber].Filter != nil {
+	if p.Spec.Branches[branchNumber].Filter == nil {
+		r.Spec.Subscriber = &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: p.Spec.ChannelTemplate.APIVersion,
+				Kind:       p.Spec.ChannelTemplate.Kind,
+				Name:       ParallelBranchChannelName(p.Name, branchNumber),
+				Namespace:  p.Namespace,
+			},
+		}
+	} else {
 		r.Spec.Subscriber = &duckv1.Destination{
 			Ref: p.Spec.Branches[branchNumber].Filter.Ref,
 			URI: p.Spec.Branches[branchNumber].Filter.URI,
 		}
-	}
-	r.Spec.Reply = &duckv1.Destination{
-		Ref: &duckv1.KReference{
-			APIVersion: p.Spec.ChannelTemplate.APIVersion,
-			Kind:       p.Spec.ChannelTemplate.Kind,
-			Name:       ParallelBranchChannelName(p.Name, branchNumber),
-			Namespace:  p.Namespace,
-		},
+		r.Spec.Reply = &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				APIVersion: p.Spec.ChannelTemplate.APIVersion,
+				Kind:       p.Spec.ChannelTemplate.Kind,
+				Name:       ParallelBranchChannelName(p.Name, branchNumber),
+				Namespace:  p.Namespace,
+			},
+		}
 	}
 	return r
 }


### PR DESCRIPTION
Parallel to use `subscription.subscriber` instead of `reply` if there's no filter

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

