### PR TITLE
🧹 Remove dead variables & config for presubmit markdown checking

### DIFF
--- a/test/markdown-lint-config.rc
+++ b/test/markdown-lint-config.rc
@@ -1,8 +1,0 @@
-# For help, see
-# https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md
-
-# Ignoring some of the available rules. For more, see
-# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
-
-rules "~MD013", "~MD024"
-

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -26,7 +26,6 @@
 
 # shellcheck disable=SC1090
 
-export DISABLE_MD_LINTING=1
 export GO111MODULE=on
 
 export KO_FLAGS="--platform=linux/amd64"


### PR DESCRIPTION
Addresses https://github.com/knative/hack/issues/200

Markdown linting is no longer performed in the presubmit tests, remove lingering related variables and config