### PR TITLE
fix 'host lookup failure' in tracing

### DIFF
--- a/pkg/adapter/v2/configurator_configmap.go
+++ b/pkg/adapter/v2/configurator_configmap.go
@@ -18,7 +18,6 @@ package adapter
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -231,10 +230,9 @@ func (c *tracingConfiguratorFromConfigMap) SetupTracing(ctx context.Context, cfg
 	logger := logging.FromContext(ctx)
 
 	cmw := ConfigWatcherFromContext(ctx)
-	service := fmt.Sprintf("%s.%s", cfg.InstanceName, NamespaceFromContext(ctx))
 
 	logger.Infof("Adding Watcher on ConfigMap %s for tracing", c.configMapName)
-	if err := tracing.SetupDynamicPublishing(logger, cmw, service, c.configMapName); err != nil {
+	if err := tracing.SetupDynamicPublishing(logger, cmw, "", c.configMapName); err != nil {
 		logger.Errorw("Error setting up trace publishing. Tracing configuration will be ignored.", zap.Error(err))
 	}
 }

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -63,7 +63,7 @@ func NewController(
 	endpointsInformer := endpointsinformer.Get(ctx)
 	configmapInformer := configmapinformer.Get(ctx)
 
-	if err := tracing.SetupDynamicPublishing(logger, cmw, "mt-broker-controller", tracingconfig.ConfigName); err != nil {
+	if err := tracing.SetupDynamicPublishing(logger, cmw, "", tracingconfig.ConfigName); err != nil {
 		logger.Fatal("Error setting up trace publishing", zap.Error(err))
 	}
 


### PR DESCRIPTION
Fix issue #6456


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->


when I check tracing of pingsource and mt-broker-controller, both of them have this bug:
```
host lookup failure: lookup pingsource.knative-eventing on 10.96.0.10:53: no such host
```


