### PR TITLE
Promote delivery timeout to beta

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -32,9 +32,9 @@ data:
   # For more details: https://github.com/knative/eventing/issues/5811
   delivery-retryafter: "disabled"
 
-  # ALPHA feature: The delivery-timeout allows you to use the Timeout field in DeliverySpec.
+  # BETA feature: The delivery-timeout allows you to use the Timeout field in DeliverySpec.
   # For more details: https://github.com/knative/eventing/issues/5148
-  delivery-timeout: "disabled"
+  delivery-timeout: "enabled"
 
   # ALPHA feature: The kreference-mapping allows you to map kreference onto templated URI
   # For more details: https://github.com/knative/eventing/issues/5593

--- a/test/rekt/delivery_timeout_test.go
+++ b/test/rekt/delivery_timeout_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package experimental
+package rekt
 
 import (
 	"testing"


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #5148

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Promote delivery timeout to beta
- Enable feature by default

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The delivery timeout feature is now beta and enabled by default.
```

