### PR TITLE
Promote strict subscriber to beta

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -40,9 +40,9 @@ data:
   # For more details: https://github.com/knative/eventing/issues/5593
   kreference-mapping: "disabled"
 
-  # ALPHA feature: The subscriber-strict flag force subscriptions to define a subscriber
+  # BETA feature: The subscriber-strict flag force subscriptions to define a subscriber
   # For more details: https://github.com/knative/eventing/issues/5756
-  strict-subscriber: "disabled"
+  strict-subscriber: "enabled"
 
   # ALPHA feature: The new-trigger-filters flag allows you to use the new `filters` field
   # in Trigger objects with its rich filtering capabilities.

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -3777,8 +3777,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
+<p>Subscriber is reference to function for processing events.
 Events from the Channel will be delivered here and replies are
 sent to a Destination as specified by the Reply.</p>
 </td>
@@ -4108,8 +4107,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
+<p>Subscriber is reference to function for processing events.
 Events from the Channel will be delivered here and replies are
 sent to a Destination as specified by the Reply.</p>
 </td>

--- a/pkg/apis/messaging/v1/subscription_types.go
+++ b/pkg/apis/messaging/v1/subscription_types.go
@@ -90,10 +90,9 @@ type SubscriptionSpec struct {
 	// etc.)
 	Channel duckv1.KReference `json:"channel"`
 
-	// Subscriber is reference to (optional) function for processing events.
+	// Subscriber is reference to function for processing events.
 	// Events from the Channel will be delivered here and replies are
 	// sent to a Destination as specified by the Reply.
-	// +optional
 	Subscriber *duckv1.Destination `json:"subscriber,omitempty"`
 
 	// Reply specifies (optionally) how to handle events returned from

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -25,5 +25,5 @@ data:
   kreference-group: "enabled"
   delivery-retryafter: "enabled"
   delivery-timeout: "enabled"
-  strict-subscriber: "disabled"
+  strict-subscriber: "enabled"
   new-trigger-filters: "enabled"

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -152,33 +152,6 @@ func TestSmoke_ChannelImplWithSubscription(t *testing.T) {
 }
 
 /*
-TestChannelChainByUsingReplyAsSubscriber tests the following scenario:
-
-EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
-
-It uses Subscription's spec.reply as spec.subscriber.
-
-This test should fail with https://github.com/knative/eventing/issues/5756 done.
-
-*/
-func TestChannelChainByUsingReplyAsSubscriber(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
-		return subscription.WithReply(ref, uri)
-	}
-	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
-}
-
-/*
 TestChannelChain tests the following scenario:
 
 EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
@@ -199,31 +172,6 @@ func TestChannelChain(t *testing.T) {
 		return subscription.WithSubscriber(ref, uri)
 	}
 	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
-}
-
-/*
-TestChannelDeadLetterSinkByUsingReplyAsSubscriber tests if the events that cannot be delivered end up in
-the dead letter sink.
-
-It uses Subscription's spec.reply as spec.subscriber.
-
-This test should fail with https://github.com/knative/eventing/issues/5756 done.
-*/
-func TestChannelDeadLetterSinkByUsingReplyAsSubscriber(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
-		return subscription.WithReply(ref, uri)
-	}
-	env.Test(ctx, t, channel.DeadLetterSink(createSubscriberFn))
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Part of #5756

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Promote strict subscriber to beta
- Enable feature by default

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The strict subscriber feature for Subscription API is now beta and enabled by default.
When the reply field is specified without a subscriber, the reply field won't be used as a subscriber by default.
```
