### PR TITLE
Remove the filter restriction of only containing exactly one attribute

### DIFF
--- a/pkg/apis/eventing/v1/trigger_validation.go
+++ b/pkg/apis/eventing/v1/trigger_validation.go
@@ -168,22 +168,6 @@ func ValidateAttributesNames(attrs map[string]string) (errs *apis.FieldError) {
 	return errs
 }
 
-func ValidateSingleAttributeMap(expr map[string]string) (errs *apis.FieldError) {
-	if len(expr) == 0 {
-		return nil
-	}
-
-	if len(expr) != 1 {
-		return apis.ErrGeneric("Multiple items found, can have only one key-value", apis.CurrentField)
-	}
-	for attr := range expr {
-		if !validAttributeName.MatchString(attr) {
-			errs = errs.Also(apis.ErrInvalidKeyName(attr, apis.CurrentField, "Attribute name must start with a letter and can only contain lowercase alphanumeric").ViaKey(attr))
-		}
-	}
-	return errs
-}
-
 func ValidateSubscriptionAPIFiltersList(ctx context.Context, filters []SubscriptionsAPIFilter) (errs *apis.FieldError) {
 	if filters == nil || !feature.FromContext(ctx).IsEnabled(feature.NewTriggerFilters) {
 		return nil
@@ -221,11 +205,11 @@ func ValidateSubscriptionAPIFilter(ctx context.Context, filter *SubscriptionsAPI
 	errs = errs.Also(
 		ValidateOneOf(filter),
 	).Also(
-		ValidateSingleAttributeMap(filter.Exact).ViaField("exact"),
+		ValidateAttributesNames(filter.Exact).ViaField("exact"),
 	).Also(
-		ValidateSingleAttributeMap(filter.Prefix).ViaField("prefix"),
+		ValidateAttributesNames(filter.Prefix).ViaField("prefix"),
 	).Also(
-		ValidateSingleAttributeMap(filter.Suffix).ViaField("suffix"),
+		ValidateAttributesNames(filter.Suffix).ViaField("suffix"),
 	).Also(
 		ValidateSubscriptionAPIFiltersList(ctx, filter.All).ViaField("all"),
 	).Also(

--- a/pkg/apis/eventing/v1/trigger_validation_test.go
+++ b/pkg/apis/eventing/v1/trigger_validation_test.go
@@ -547,7 +547,7 @@ func TestFilterSpecValidation(t *testing.T) {
 		filter: validTriggerFilter,
 		want:   &apis.FieldError{},
 	}, {
-		name: "exact filter contains more than one attribute",
+		name: "valid exact filter containing more than one attribute",
 		filters: []SubscriptionsAPIFilter{
 			{
 				Exact: map[string]string{
@@ -555,7 +555,7 @@ func TestFilterSpecValidation(t *testing.T) {
 					"anotherext": "xyz",
 				},
 			}},
-		want: apis.ErrGeneric("Multiple items found, can have only one key-value", "exact").ViaFieldIndex("filters", 0),
+		want: &apis.FieldError{},
 	}, {
 		name: "valid exact filter",
 		filters: []SubscriptionsAPIFilter{
@@ -566,7 +566,7 @@ func TestFilterSpecValidation(t *testing.T) {
 			}},
 		want: &apis.FieldError{},
 	}, {
-		name: "suffix filter contains more than one attribute",
+		name: "valid suffix filter containing more than one attribute",
 		filters: []SubscriptionsAPIFilter{
 			{
 				Suffix: map[string]string{
@@ -574,7 +574,7 @@ func TestFilterSpecValidation(t *testing.T) {
 					"anotherext": "xyz",
 				},
 			}},
-		want: apis.ErrGeneric("Multiple items found, can have only one key-value", "suffix").ViaFieldIndex("filters", 0),
+		want: &apis.FieldError{},
 	}, {
 		name: "suffix filter contains invalid attribute name",
 		filters: []SubscriptionsAPIFilter{
@@ -596,7 +596,7 @@ func TestFilterSpecValidation(t *testing.T) {
 			}},
 		want: &apis.FieldError{},
 	}, {
-		name: "prefix filter contains more than one attribute",
+		name: "valid prefix filter containing more than one attribute",
 		filters: []SubscriptionsAPIFilter{
 			{
 				Prefix: map[string]string{
@@ -604,7 +604,7 @@ func TestFilterSpecValidation(t *testing.T) {
 					"anotherext": "xyz",
 				},
 			}},
-		want: apis.ErrGeneric("Multiple items found, can have only one key-value", "prefix").ViaFieldIndex("filters", 0),
+		want: &apis.FieldError{},
 	}, {
 		name: "prefix filter contains invalid attribute name",
 		filters: []SubscriptionsAPIFilter{


### PR DESCRIPTION
Fixes #6201 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :bug: Remove the filter restriction of only containing exactly one attribute to align with latest filter specifiction
