### PR TITLE
Increase max namespace count for e2e test runner

### DIFF
--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -46,7 +46,7 @@ import (
 const (
 	podLogsDir         = "pod-logs"
 	testPullSecretName = "kn-eventing-test-pull-secret"
-	MaxNamespaceSkip   = 100
+	MaxNamespaceSkip   = 200
 	MaxRetries         = 5
 	RetrySleepDuration = 2 * time.Second
 )


### PR DESCRIPTION
We're sometimes getting `unable to find available namespace`
in the Kafka repo.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>