### PR TITLE
Drop usage of `eventing.knative.dev/release`

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -18,7 +18,6 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -30,7 +29,6 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: filter
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: broker-filter
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -105,7 +103,6 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -18,7 +18,6 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -30,7 +29,6 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: ingress
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: broker-ingress
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -105,7 +103,6 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -18,7 +18,6 @@ metadata:
   name: mt-broker-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: mt-broker-controller
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -30,7 +29,6 @@ spec:
     metadata:
       labels:
         app: mt-broker-controller
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: broker-controller
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/deployments/hpa.yaml
+++ b/config/brokers/mt-channel-broker/deployments/hpa.yaml
@@ -18,7 +18,6 @@ metadata:
   name: broker-ingress-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-ingress
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -43,7 +42,6 @@ metadata:
   name: broker-filter-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: broker-filter
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/roles/controller-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/controller-clusterrole.yaml
@@ -16,7 +16,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/brokers/mt-channel-broker/roles/controller-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/controller-clusterrolebinding.yaml
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
@@ -16,7 +16,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/brokers/mt-channel-broker/roles/filter-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrolebinding.yaml
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/brokers/mt-channel-broker/roles/filter-serviceaccount.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-serviceaccount.yaml
@@ -17,6 +17,5 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
@@ -16,7 +16,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/brokers/mt-channel-broker/roles/ingress-clusterrolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-clusterrolebinding.yaml
@@ -17,7 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/brokers/mt-channel-broker/roles/ingress-serviceaccount.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-serviceaccount.yaml
@@ -17,6 +17,5 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-controller-serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 ---
@@ -27,7 +26,6 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -45,7 +43,6 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -62,7 +59,6 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
+++ b/config/channels/in-memory-channel/200-imc-dispatcher-serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 ---
@@ -27,7 +26,6 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/channels/in-memory-channel/configmaps/event-dispatcher.yaml
+++ b/config/channels/in-memory-channel/configmaps/event-dispatcher.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -18,7 +18,6 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
@@ -112,7 +111,6 @@ metadata:
     app.kubernetes.io/component: imc-controller
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: devel
   name: inmemorychannel-webhook
   namespace: knative-eventing
 spec:

--- a/config/channels/in-memory-channel/deployments/dispatcher-service.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher-service.yaml
@@ -17,7 +17,6 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -18,7 +18,6 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
     app.kubernetes.io/version: devel

--- a/config/channels/in-memory-channel/resources/in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/resources/in-memory-channel.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
  name: inmemorychannels.messaging.knative.dev
  labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"

--- a/config/channels/in-memory-channel/roles/addressable-resolver-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/addressable-resolver-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: imc-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/channelable-manipulator-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: imc-channelable-manipulator
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
@@ -16,7 +16,6 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/channels/in-memory-channel/roles/webhook-role.yaml
+++ b/config/channels/in-memory-channel/roles/webhook-role.yaml
@@ -18,7 +18,6 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/channels/in-memory-channel/webhooks/defaulting.yaml
+++ b/config/channels/in-memory-channel/webhooks/defaulting.yaml
@@ -17,7 +17,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/channels/in-memory-channel/webhooks/resource-validation.yaml
+++ b/config/channels/in-memory-channel/webhooks/resource-validation.yaml
@@ -17,7 +17,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/channels/in-memory-channel/webhooks/secret.yaml
+++ b/config/channels/in-memory-channel/webhooks/secret.yaml
@@ -18,7 +18,6 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.

--- a/config/core/100-namespace.yaml
+++ b/config/core/100-namespace.yaml
@@ -16,6 +16,5 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/200-eventing-serviceaccount.yaml
+++ b/config/core/200-eventing-serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 
@@ -29,7 +28,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -48,7 +46,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -67,7 +64,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -86,7 +82,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -105,7 +100,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/core/200-pingsource-mt-adapter-serviceaccount.yaml
+++ b/config/core/200-pingsource-mt-adapter-serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 
@@ -28,7 +27,6 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/core/200-webhook-serviceaccount.yaml
+++ b/config/core/200-webhook-serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 ---
@@ -28,7 +27,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -48,7 +46,6 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -67,7 +64,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:
@@ -86,7 +82,6 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/core/configmaps/default-broker-channel.yaml
+++ b/config/core/configmaps/default-broker-channel.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 data:

--- a/config/core/configmaps/default-broker.yaml
+++ b/config/core/configmaps/default-broker.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 data:

--- a/config/core/configmaps/default-channel.yaml
+++ b/config/core/configmaps/default-channel.yaml
@@ -18,7 +18,6 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 data:

--- a/config/core/configmaps/default-pingsource.yaml
+++ b/config/core/configmaps/default-pingsource.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/version: devel
   annotations:
     knative.dev/example-checksum: "9185c153"
     app.kubernetes.io/version: devel

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel

--- a/config/core/configmaps/kreference-mapping.yaml
+++ b/config/core/configmaps/kreference-mapping.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-kreference-mapping
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-observability
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel

--- a/config/core/configmaps/sugar.yaml
+++ b/config/core/configmaps/sugar.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
     app.kubernetes.io/version: devel

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
     app.kubernetes.io/version: devel
@@ -31,7 +30,6 @@ spec:
     metadata:
       labels:
         app: eventing-controller
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: eventing-controller
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -18,7 +18,6 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: pingsource-mt-adapter
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -33,7 +32,6 @@ spec:
     metadata:
       labels:
         <<: *labels
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: pingsource-mt-adapter
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -44,7 +43,6 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -31,7 +30,6 @@ spec:
     metadata:
       labels:
         <<: *labels
-        eventing.knative.dev/release: devel
         app.kubernetes.io/component: eventing-webhook
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -131,7 +129,6 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    eventing.knative.dev/release: devel
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
     app.kubernetes.io/version: devel

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"

--- a/config/core/resources/containersource.yaml
+++ b/config/core/resources/containersource.yaml
@@ -16,7 +16,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -16,7 +16,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"

--- a/config/core/resources/sequence.yaml
+++ b/config/core/resources/sequence.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel

--- a/config/core/resources/sinkbindings.yaml
+++ b/config/core/resources/sinkbindings.yaml
@@ -16,7 +16,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -16,7 +16,6 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -18,7 +18,6 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
@@ -34,7 +33,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -56,7 +54,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: serving-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -81,7 +78,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: channel-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -110,7 +106,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: broker-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -133,7 +128,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flows-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/roles/broker-clusterrole.yaml
+++ b/config/core/roles/broker-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:
@@ -46,7 +45,6 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:
@@ -66,7 +64,6 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/channelable-manipulator-clusterrole.yaml
+++ b/config/core/roles/channelable-manipulator-clusterrole.yaml
@@ -18,7 +18,6 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
@@ -34,7 +33,6 @@ kind: ClusterRole
 metadata:
   name: meta-channelable-manipulator
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-namespaced-admin
   labels:
-    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -31,7 +30,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-messaging-namespaced-admin
   labels:
-    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -45,7 +43,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-flows-namespaced-admin
   labels:
-    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -59,7 +56,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-sources-namespaced-admin
   labels:
-    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -73,7 +69,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-bindings-namespaced-admin
   labels:
-    eventing.knative.dev/release: devel
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
@@ -88,7 +83,6 @@ metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:
@@ -102,7 +96,6 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
+++ b/config/core/roles/pingsource-mt-adapter-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/podspecable-binding-clusterrole.yaml
+++ b/config/core/roles/podspecable-binding-clusterrole.yaml
@@ -18,7 +18,6 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
@@ -34,7 +33,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: builtin-podspecable-binding
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/podspecable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/roles/source-observer-clusterrole.yaml
+++ b/config/core/roles/source-observer-clusterrole.yaml
@@ -18,7 +18,6 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
@@ -34,7 +33,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-sources-source-observer
   labels:
-    eventing.knative.dev/release: devel
     duck.knative.dev/source: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing

--- a/config/core/roles/sources-controller-clusterroles.yaml
+++ b/config/core/roles/sources-controller-clusterroles.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -17,7 +17,6 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/webhook-role.yaml
+++ b/config/core/roles/webhook-role.yaml
@@ -18,7 +18,6 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -17,7 +17,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/core/webhooks/config-validation.yaml
+++ b/config/core/webhooks/config-validation.yaml
@@ -29,7 +29,6 @@ webhooks:
   failurePolicy: Ignore
   name: config.webhook.eventing.knative.dev
   namespaceSelector:
-    matchExpressions:
-    - key: eventing.knative.dev/release
-      operator: Exists
+    matchLabels:
+      app.kubernetes.io/name: knative-eventing
   timeoutSeconds: 10

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -17,7 +17,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -17,7 +17,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/core/webhooks/secret.yaml
+++ b/config/core/webhooks/secret.yaml
@@ -18,7 +18,6 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 # The data is populated at install time.

--- a/config/core/webhooks/sinkbindings.yaml
+++ b/config/core/webhooks/sinkbindings.yaml
@@ -17,7 +17,6 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 webhooks:

--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -19,7 +19,6 @@ metadata:
   labels:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: devel
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:

--- a/config/post-install/serviceaccount.yaml
+++ b/config/post-install/serviceaccount.yaml
@@ -18,7 +18,6 @@ metadata:
   name: knative-eventing-post-install-job
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 ---
@@ -28,7 +27,6 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-post-install-job-role-binding
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 subjects:

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/name: knative-eventing
     app.kubernetes.io/component: storage-version-migration-job
     app.kubernetes.io/version: devel
-    eventing.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/component: storage-version-migration-job
         app.kubernetes.io/version: devel
-        eventing.knative.dev/release: devel
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/config/tools/appender/appender.yaml
+++ b/config/tools/appender/appender.yaml
@@ -18,7 +18,8 @@ kind: Service
 metadata:
   name: appender
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 spec:
   template:
     spec:

--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -18,7 +18,8 @@ kind: Service
 metadata:
   name: event-display
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 spec:
   template:
     spec:

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -71,7 +71,7 @@ fi
 readonly KO_YAML_FLAGS="${KO_YAML_FLAGS} ${KO_FLAGS}"
 
 if [[ -n "${TAG:-}" ]]; then
-  LABEL_YAML_CMD=(sed -e "s|eventing.knative.dev/release: devel|eventing.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
+  LABEL_YAML_CMD=(sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
 else
   LABEL_YAML_CMD=(cat)
 fi

--- a/pkg/apis/config/testdata/config-br-defaults.yaml
+++ b/pkg/apis/config/testdata/config-br-defaults.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 
 data:
   _example: |

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
 data:

--- a/pkg/apis/messaging/config/testdata/default-ch-webhook.yaml
+++ b/pkg/apis/messaging/config/testdata/default-ch-webhook.yaml
@@ -18,7 +18,8 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 
 data:
   _example: |

--- a/pkg/apis/sources/config/testdata/config-ping-defaults-legacy.yaml
+++ b/pkg/apis/sources/config/testdata/config-ping-defaults-legacy.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   _example: |
     ################################

--- a/pkg/apis/sources/config/testdata/config-ping-defaults.yaml
+++ b/pkg/apis/sources/config/testdata/config-ping-defaults.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   _example: |
     ################################

--- a/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-1.yaml
+++ b/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-1.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   # The ConfigMapFromTestFile helper method expects a key named "_example" and it's sample here.
   _example: |

--- a/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-2.yaml
+++ b/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-2.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   # The ConfigMapFromTestFile helper method expects a key named "_example" and it's sample here.
   _example: |

--- a/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-3.yaml
+++ b/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-3.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   # The ConfigMapFromTestFile helper method expects a key named "_example" and it's sample here.
   _example: |

--- a/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-4.yaml
+++ b/pkg/reconciler/inmemorychannel/controller/config/testdata/config-event-dispatcher-4.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 data:
   # The ConfigMapFromTestFile helper method expects a key named "_example" and it's sample here.
   _example: |

--- a/test/config/chaosduck/chaosduck.yaml
+++ b/test/config/chaosduck/chaosduck.yaml
@@ -18,7 +18,8 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 
 ---
 kind: Role
@@ -27,7 +28,8 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -43,7 +45,8 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,7 +63,8 @@ metadata:
   name: chaosduck
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 spec:
   selector:
     matchLabels:

--- a/test/config/configmaps/config-sugar.yaml
+++ b/test/config/configmaps/config-sugar.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 data:

--- a/test/config/configmaps/logging.yaml
+++ b/test/config/configmaps/logging.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
 
 data:
   zap-logger-config: |

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
 data:


### PR DESCRIPTION
Fixes #6383 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Removing deprecated eventing.knative.dev/release label 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
'eventing.knative.dev/release' labels, deprecated in v1.3, have been removed. Switch it to using `app.kubernetes.io/name: knative-eventing` and `app.kuberentes.io/version: devel`.
```
