### PR TITLE
Sugar controller doesn't enforce Broker class

### DIFF
--- a/pkg/reconciler/sugar/namespace/namespace_test.go
+++ b/pkg/reconciler/sugar/namespace/namespace_test.go
@@ -29,7 +29,6 @@ import (
 	sugarconfig "knative.dev/eventing/pkg/apis/sugar"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
-	"knative.dev/pkg/apis"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	namespacereconciler "knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace"
 	"knative.dev/pkg/configmap"
@@ -84,22 +83,6 @@ func TestEnabled(t *testing.T) {
 	// Objects
 	broker := resources.MakeBroker(testNS, resources.DefaultBrokerName)
 
-	// Reactors
-	defaultFunc := func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		if verb := action.GetVerb(); verb != "create" {
-			return false, nil, nil
-		}
-
-		got := action.(clientgotesting.CreateAction).GetObject()
-		obj, ok := got.(apis.Defaultable)
-		if !ok {
-			return false, nil, nil
-		}
-
-		obj.SetDefaults(ctx)
-		return false, got, nil
-	}
-
 	table := TableTest{{
 		Name: "bad workqueue key",
 		// Make sure Reconcile handles bad keys.
@@ -123,7 +106,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
@@ -145,7 +128,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
@@ -172,7 +155,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{

--- a/pkg/reconciler/sugar/namespace/namespace_test.go
+++ b/pkg/reconciler/sugar/namespace/namespace_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing/pkg/apis/config"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sugarconfig "knative.dev/eventing/pkg/apis/sugar"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
@@ -64,6 +65,17 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 }
 
 func TestEnabled(t *testing.T) {
+	// Context with DefaultConfig
+	c := config.Config{
+		Defaults: &config.Defaults{
+			ClusterDefault: &config.ClassAndBrokerConfig{
+				BrokerClass: "AValidBrokerClass",
+			},
+		},
+	}
+
+	ctx := config.ToContext(context.Background(), &c)
+
 	// Events
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker created.")
 
@@ -92,7 +104,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Labelled namespace with expected `key` and `value`",
@@ -111,7 +123,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      SomeLabelKey,
@@ -135,7 +147,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      LegacyInjectionLabelKey,
@@ -150,7 +162,7 @@ func TestEnabled(t *testing.T) {
 			),
 		},
 		Key: testNS,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Namespace enabled, broker exists",
@@ -161,7 +173,7 @@ func TestEnabled(t *testing.T) {
 		Key:                     testNS,
 		SkipNamespaceValidation: true,
 		WantErr:                 false,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Namespace enabled, broker exists with no label",
@@ -177,7 +189,7 @@ func TestEnabled(t *testing.T) {
 		Key:                     testNS,
 		SkipNamespaceValidation: true,
 		WantErr:                 false,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	},
 	}

--- a/pkg/reconciler/sugar/resources/broker.go
+++ b/pkg/reconciler/sugar/resources/broker.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
@@ -29,10 +28,9 @@ const (
 func MakeBroker(namespace, name string) *v1.Broker {
 	return &v1.Broker{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Labels:      Labels(),
-			Annotations: map[string]string{eventing.BrokerClassKey: eventing.MTChannelBrokerClassValue},
+			Namespace: namespace,
+			Name:      name,
+			Labels:    Labels(),
 		},
 	}
 }

--- a/pkg/reconciler/sugar/resources/broker_test.go
+++ b/pkg/reconciler/sugar/resources/broker_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
@@ -43,10 +42,9 @@ func TestMakeBroker(t *testing.T) {
 			},
 			want: &v1.Broker{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   "default",
-					Name:        "df-broker",
-					Labels:      Labels(),
-					Annotations: map[string]string{eventing.BrokerClassKey: eventing.MTChannelBrokerClassValue},
+					Namespace: "default",
+					Name:      "df-broker",
+					Labels:    Labels(),
 				},
 			},
 		},

--- a/pkg/reconciler/sugar/trigger/trigger_test.go
+++ b/pkg/reconciler/sugar/trigger/trigger_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/eventing/pkg/apis/config"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sugarconfig "knative.dev/eventing/pkg/apis/sugar"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
@@ -65,6 +66,17 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 }
 
 func TestEnabled(t *testing.T) {
+	// Context with DefaultConfig
+	c := config.Config{
+		Defaults: &config.Defaults{
+			ClusterDefault: &config.ClassAndBrokerConfig{
+				BrokerClass: "AValidBrokerClass",
+			},
+		},
+	}
+
+	ctx := config.ToContext(context.Background(), &c)
+
 	// Events
 	brokerEvent := Eventf(corev1.EventTypeNormal, "BrokerCreated", "Default eventing.knative.dev Broker %q created.", "default")
 
@@ -93,7 +105,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Labelled namespace with expected `key` and `value`",
@@ -109,7 +121,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      SomeLabelKey,
@@ -130,7 +142,7 @@ func TestEnabled(t *testing.T) {
 		WantCreates: []runtime.Object{
 			broker,
 		},
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      LegacyInjectionLabelKey,
@@ -144,7 +156,7 @@ func TestEnabled(t *testing.T) {
 				WithTriggerDeleted),
 		},
 		Key: testNS + "/" + triggerName,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Trigger enabled, broker exists",
@@ -155,7 +167,7 @@ func TestEnabled(t *testing.T) {
 		Key:                     testNS + "/" + triggerName,
 		SkipNamespaceValidation: true,
 		WantErr:                 false,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	}, {
 		Name: "Trigger enabled, broker exists with no label",
@@ -171,7 +183,7 @@ func TestEnabled(t *testing.T) {
 		Key:                     testNS + "/" + triggerName,
 		SkipNamespaceValidation: true,
 		WantErr:                 false,
-		Ctx: context.WithValue(context.Background(), sugarConfigContextKey,
+		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
 	},
 	}

--- a/pkg/reconciler/sugar/trigger/trigger_test.go
+++ b/pkg/reconciler/sugar/trigger/trigger_test.go
@@ -30,7 +30,6 @@ import (
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/reconciler/sugar/resources"
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -85,22 +84,6 @@ func TestEnabled(t *testing.T) {
 	// Objects
 	broker := resources.MakeBroker(testNS, resources.DefaultBrokerName)
 
-	// Reactors
-	defaultFunc := func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		if verb := action.GetVerb(); verb != "create" {
-			return false, nil, nil
-		}
-
-		got := action.(clientgotesting.CreateAction).GetObject()
-		obj, ok := got.(apis.Defaultable)
-		if !ok {
-			return false, nil, nil
-		}
-
-		obj.SetDefaults(ctx)
-		return false, got, nil
-	}
-
 	table := TableTest{{
 		Name: "bad workqueue key",
 		// Make sure Reconcile handles bad keys.
@@ -124,7 +107,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{}),
@@ -143,7 +126,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{
@@ -167,7 +150,7 @@ func TestEnabled(t *testing.T) {
 			broker,
 		},
 		WithReactors: []clientgotesting.ReactionFunc{
-			defaultFunc,
+			DefaultingReactor(ctx),
 		},
 		Ctx: context.WithValue(ctx, sugarConfigContextKey,
 			&metav1.LabelSelector{

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -99,12 +99,6 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 			la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 		}
 
-		for _, reactor := range r.WithReactors {
-			kubeClient.PrependReactor("*", "*", reactor)
-			client.PrependReactor("*", "*", reactor)
-			dynamicClient.PrependReactor("*", "*", reactor)
-		}
-
 		// Validate all Create operations through the eventing client.
 		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return ValidateCreates(ctx, action)
@@ -112,6 +106,12 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			return ValidateUpdates(ctx, action)
 		})
+
+		for _, reactor := range r.WithReactors {
+			kubeClient.PrependReactor("*", "*", reactor)
+			client.PrependReactor("*", "*", reactor)
+			dynamicClient.PrependReactor("*", "*", reactor)
+		}
 
 		actionRecorderList := ActionRecorderList{dynamicClient, client, kubeClient}
 		eventList := EventList{Recorder: eventRecorder}

--- a/pkg/reconciler/testing/v1/reactor.go
+++ b/pkg/reconciler/testing/v1/reactor.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/apis"
+)
+
+// DefaultingReactor will return a Reactor function that will call SetDefault on newly created Objects
+func DefaultingReactor(ctx context.Context) clientgotesting.ReactionFunc {
+	return func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		if verb := action.GetVerb(); verb != "create" {
+			return false, nil, nil
+		}
+
+		got := action.(clientgotesting.CreateAction).GetObject()
+		obj, ok := got.(apis.Defaultable)
+		if !ok {
+			return false, nil, nil
+		}
+
+		obj.SetDefaults(ctx)
+		return false, got, nil
+	}
+}


### PR DESCRIPTION
- 🐛 Fixes issue where sugar controller was forcing Broker class.

### Pre-review Checklist

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

To reproduce:
- Update the defaults ConfigMap `config-br-defaults` to use `RabbitMQBroker` along with an appropriate broker config.
- Enable sugar controller
- Create a new namespace or trigger with the appropriate label

Expected:
- default broker is created with configuration and class matching the defaults config map

Actual:
- default broker is created with the RabbitMQ broker config but with the class still set to `MTChannelBasedBroker`


```release-note
Fixes issue with sugar controller always setting the broker class to MTChannelBasedBroker instead of using the defaults ConfigMap
```

Relies on [this](https://github.com/knative/pkg/pull/2585) pkg PR to be merged and integrated for tests to pass

/hold until pkg merge