### PR TITLE
Make some broker conformance tests decoratable with broker options

### DIFF
--- a/test/rekt/features/broker/topology.go
+++ b/test/rekt/features/broker/topology.go
@@ -56,11 +56,11 @@ type triggerCfg struct {
 //                         |
 //                         +--[DLQ]--> "dlq" (optional)
 //
-func createBrokerTriggerTopology(f *feature.Feature, brokerName string, brokerDS *v1.DeliverySpec, triggers []triggerCfg) *eventshub.EventProber {
+func createBrokerTriggerTopology(f *feature.Feature, brokerName string, brokerDS *v1.DeliverySpec, triggers []triggerCfg, brokerOpts ...manifest.CfgFn) *eventshub.EventProber {
 	prober := eventshub.NewProber()
 
 	f.Setup("install recorder for broker dlq", prober.ReceiverInstall("brokerdlq"))
-	brokerOpts := brokerresources.WithEnvConfig()
+	brokerOpts = append(brokerOpts, brokerresources.WithEnvConfig()...)
 
 	if brokerDS != nil {
 		if brokerDS.DeadLetterSink != nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Make some broker conformance tests decoratable with broker options
- Added options as variadic so that existing code is not broken
- Motivation: in https://github.com/knative-sandbox/eventing-kafka-broker/pull/2603, I need to create and update the broker with a specific `spec.config`. Here I make some cases accept broker options so that I can pass options that set the `spec.config`.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

