### PR TITLE
Fix error bodyofMessage in executeRequest not read

### DIFF
--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -17,6 +17,7 @@ limitations under the License.
 package channel
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -233,24 +234,36 @@ func (d *MessageDispatcherImpl) executeRequest(ctx context.Context,
 	}
 	execInfo.Time = dispatchTime
 
-	// Read response body into execInfo
 	body := make([]byte, attributes.KnativeErrorDataExtensionMaxLength)
-	readLen, err := response.Body.Read(body)
-	if err != nil && err != io.EOF {
-		d.logger.Error("failed to read response body into DispatchExecutionInfo", zap.Error(err))
-		execInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", err.Error()))
-	} else {
-		execInfo.ResponseBody = body[:readLen]
-	}
-	_ = response.Body.Close()
 
 	if isFailure(response.StatusCode) {
+		// Read response body into execInfo for failures
+		readLen, err := response.Body.Read(body)
+		if err != nil && err != io.EOF {
+			d.logger.Error("failed to read response body into DispatchExecutionInfo", zap.Error(err))
+			execInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", err.Error()))
+		} else {
+			execInfo.ResponseBody = body[:readLen]
+		}
+		_ = response.Body.Close()
 		// Reject non-successful responses.
 		return ctx, nil, nil, &execInfo, fmt.Errorf("unexpected HTTP response, expected 2xx, got %d", response.StatusCode)
 	}
-	responseMessage := http.NewMessageFromHttpResponse(response)
+
+	var responseMessageBody []byte
+	// Read response body into responseMessage for message accepted
+	readLen, err := response.Body.Read(body)
+	if err != nil && err != io.EOF {
+		d.logger.Error("failed to read response body into cloudevents' Message", zap.Error(err))
+		responseMessageBody = []byte(fmt.Sprintf("Failed to read response body: %s", err.Error()))
+	} else {
+		responseMessageBody = body[:readLen]
+	}
+	responseMessage := http.NewMessage(response.Header, io.NopCloser(bytes.NewReader(responseMessageBody)))
+
 	if responseMessage.ReadEncoding() == binding.EncodingUnknown {
 		_ = response.Body.Close()
+		_ = responseMessage.BodyReader.Close()
 		d.logger.Debug("Response is a non event, discarding it", zap.Int("status_code", response.StatusCode))
 		return ctx, nil, nil, &execInfo, nil
 	}

--- a/pkg/channel/message_dispatcher_various_response_benchmark_test.go
+++ b/pkg/channel/message_dispatcher_various_response_benchmark_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/binding/transformer"
+	"github.com/cloudevents/sdk-go/v2/test"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"knative.dev/eventing/pkg/channel"
+	"knative.dev/eventing/pkg/utils"
+)
+
+type fakeMessageHandler struct {
+	sendToDestination      bool
+	hasDeadLetterSink      bool
+	eventExtensions        map[string]string
+	header                 http.Header
+	body                   string
+	fakeResponse           *http.Response
+	fakeDeadLetterResponse *http.Response
+}
+
+func NewFakeMessageHandler(sendToDestination bool, hasDeadLetterSink bool, eventExtensionsmap map[string]string, header http.Header, body string,
+	fakeResponse *http.Response, fakeDeadLetterResponse *http.Response) *fakeMessageHandler {
+
+	fakeMessageHandler := &fakeMessageHandler{
+		sendToDestination:      sendToDestination,
+		hasDeadLetterSink:      hasDeadLetterSink,
+		eventExtensions:        eventExtensionsmap,
+		header:                 header,
+		body:                   body,
+		fakeResponse:           fakeResponse,
+		fakeDeadLetterResponse: fakeDeadLetterResponse,
+	}
+	return fakeMessageHandler
+}
+
+func BenchmarkDispatcher_dispatch_ok_response_not_null(b *testing.B) {
+	fmh := newSampleResponseAcceptedAndNotNull()
+	benchmarkMessageDispatcher(*fmh, b)
+}
+
+func BenchmarkDispatcher_dispatch_ok_response_null(b *testing.B) {
+	fmh := newSampleResponseAcceptedAndNull()
+	benchmarkMessageDispatcher(*fmh, b)
+}
+
+func BenchmarkDispatcher_dispatch_fail_response_null(b *testing.B) {
+	fmh := newSampleResponseStatusInternalServerErrorAndNotNull()
+	benchmarkMessageDispatcher(*fmh, b)
+}
+
+func newSampleResponseAcceptedAndNotNull() *fakeMessageHandler {
+	header := map[string][]string{
+		// do-not-forward should not get forwarded.
+		"do-not-forward": {"header"},
+		"x-request-id":   {"id123"},
+		"knative-1":      {"knative-1-value"},
+		"knative-2":      {"knative-2-value"},
+	}
+	body := "destintation"
+	eventExtensions := map[string]string{
+		"abc": `"ce-abc-value"`,
+	}
+	fakeResponse := &http.Response{
+		StatusCode: http.StatusAccepted,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(uuid.NewString())),
+	}
+	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
+	return fmh
+}
+
+func newSampleResponseStatusInternalServerErrorAndNotNull() *fakeMessageHandler {
+	header := map[string][]string{
+		// do-not-forward should not get forwarded.
+		"do-not-forward": {"header"},
+		"x-request-id":   {"id123"},
+		"knative-1":      {"knative-1-value"},
+		"knative-2":      {"knative-2-value"},
+	}
+	body := "destintation"
+	eventExtensions := map[string]string{
+		"abc": `"ce-abc-value"`,
+	}
+	fakeResponse := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(uuid.NewString())),
+	}
+	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
+	return fmh
+}
+
+func newSampleResponseAcceptedAndNull() *fakeMessageHandler {
+	header := map[string][]string{
+		// do-not-forward should not get forwarded.
+		"do-not-forward": {"header"},
+		"x-request-id":   {"id123"},
+		"knative-1":      {"knative-1-value"},
+		"knative-2":      {"knative-2-value"},
+	}
+	body := "destintation"
+	eventExtensions := map[string]string{
+		"abc": `"ce-abc-value"`,
+	}
+	fakeResponse := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+	}
+	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
+	return fmh
+}
+
+func benchmarkMessageDispatcher(fmh fakeMessageHandler, b *testing.B) {
+	logger := zap.NewNop()
+	md := channel.NewMessageDispatcher(logger)
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(fmh.fakeResponse.Body)
+	s := buf.String()
+
+	destHandler := &fakeHttpHandler{
+		b:            b,
+		response:     fmh.fakeResponse,
+		requests:     make([]requestValidation, 0),
+		responseBody: s,
+	}
+	destServer := httptest.NewServer(destHandler)
+	destination := getOnlyDomainURL(b, fmh.sendToDestination, destServer.URL)
+
+	var deadLetterSinkHandler *fakeHttpHandler
+	var deadLetterSinkServer *httptest.Server
+	var deadLetterSink *url.URL
+	if fmh.hasDeadLetterSink {
+		deadLetterSinkHandler = &fakeHttpHandler{
+			b:        b,
+			response: fmh.fakeDeadLetterResponse,
+			requests: make([]requestValidation, 0),
+		}
+		deadLetterSinkServer = httptest.NewServer(deadLetterSinkHandler)
+		defer deadLetterSinkServer.Close()
+
+		deadLetterSink = getOnlyDomainURL(b, true, deadLetterSinkServer.URL)
+	}
+
+	event := test.FullEvent()
+	event.SetID(uuid.New().String())
+	event.SetType("testtype")
+	event.SetSource("testsource")
+	for n, v := range fmh.eventExtensions {
+		event.SetExtension(n, v)
+	}
+	event.SetData(cloudevents.ApplicationJSON, fmh.body)
+
+	ctx := context.Background()
+
+	message := binding.ToMessage(&event)
+	var err error
+	ev, err := binding.ToEvent(ctx, message, binding.Transformers{transformer.AddTimeNow})
+	if err != nil {
+		b.Fatal(err)
+	}
+	message = binding.ToMessage(ev)
+	finishInvoked := 0
+	message = binding.WithFinish(message, func(err error) {
+		finishInvoked++
+	})
+
+	var headers http.Header = nil
+	if fmh.header != nil {
+		headers = utils.PassThroughHeaders(fmh.header)
+	}
+	// Start the bench
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = md.DispatchMessage(ctx, message, headers, destination, nil, deadLetterSink)
+	}
+
+}
+
+type requestValidation struct {
+	Host    string
+	Headers http.Header
+	Body    string
+}
+
+type fakeHttpHandler struct {
+	b            *testing.B
+	response     *http.Response
+	requests     []requestValidation
+	responseBody string
+}
+
+func (f *fakeHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	// Make a copy of the request.
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+
+		f.b.Error("Failed to read the request body")
+	}
+	f.requests = append(f.requests, requestValidation{
+		Host:    r.Host,
+		Headers: r.Header,
+		Body:    string(body),
+	})
+
+	if f.response != nil {
+		for h, vs := range f.response.Header {
+			for _, v := range vs {
+				w.Header().Add(h, v)
+			}
+		}
+		w.WriteHeader(f.response.StatusCode)
+		w.Write([]byte(f.responseBody))
+	} else {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(""))
+	}
+}
+
+func getOnlyDomainURL(b *testing.B, shouldSend bool, serverURL string) *url.URL {
+	if shouldSend {
+		server, err := url.Parse(serverURL)
+		if err != nil {
+			b.Errorf("Bad serverURL: %q", serverURL)
+		}
+		return &url.URL{
+			Host: server.Host,
+		}
+	}
+	return nil
+}

--- a/pkg/channel/message_dispatcher_various_response_benchmark_test.go
+++ b/pkg/channel/message_dispatcher_various_response_benchmark_test.go
@@ -71,7 +71,7 @@ func BenchmarkDispatcher_dispatch_ok_response_null(b *testing.B) {
 	benchmarkMessageDispatcher(*fmh, b)
 }
 
-func BenchmarkDispatcher_dispatch_fail_response_null(b *testing.B) {
+func BenchmarkDispatcher_dispatch_fail_response_not_null(b *testing.B) {
 	fmh := newSampleResponseStatusInternalServerErrorAndNotNull()
 	benchmarkMessageDispatcher(*fmh, b)
 }
@@ -129,7 +129,7 @@ func newSampleResponseAcceptedAndNull() *fakeMessageHandler {
 		"abc": `"ce-abc-value"`,
 	}
 	fakeResponse := &http.Response{
-		StatusCode: http.StatusInternalServerError,
+		StatusCode: http.StatusAccepted,
 		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 	}
 	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)


### PR DESCRIPTION
Signed-off-by: Teresaliu [changyan.liu@intel.com](mailto:changyan.liu@intel.com)

Fixes #6215 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add a benchmark test to test the latency of different responses, including 3 conditions:
1)  ResponseAccepted(2xx) and contained a body
2)  ResponseAccepted(2xx) and body length is 0
3)  ResponseStatusInternalServerError(5xx) and contained a body
In these three testcases, we could see when a 2xx response contains a body, the number of responses is smaller than those body-free 2xx responses and 5xx responses with a body at a same period of time .
- This PR modify the code of executeRequest() to read the body when a 2xx response with a body comes.
And after that, the speed of those three conditions is almost same.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The benchmark test construct 3 MessageHander:
1. ResponseAccepted and contained a body (BenchmarkDispatcher_dispatch_ok_response_not_nul)
2. ResponseAccepted and body length is 0 (BenchmarkDispatcher_dispatch_ok_response_null)
3. ResponseStatusInternalServerError and contained a body (BenchmarkDispatcher_dispatch_fail_response_not_null)
```

