### PR TITLE
Remove strict check in scorer plugins and respect maxskew, requeue when no pods available rather than fail Scheduler

### DIFF
--- a/pkg/scheduler/plugins/core/availabilitynodepriority/availability_node_priority.go
+++ b/pkg/scheduler/plugins/core/availabilitynodepriority/availability_node_priority.go
@@ -39,9 +39,8 @@ var _ state.ScorePlugin = &AvailabilityNodePriority{}
 const Name = state.AvailabilityNodePriority
 
 const (
-	ErrReasonInvalidArg    = "invalid arguments"
-	ErrReasonNoResource    = "node does not exist"
-	ErrReasonNotEnoughPods = "pods not enough to satisfy node availability"
+	ErrReasonInvalidArg = "invalid arguments"
+	ErrReasonNoResource = "node does not exist"
 )
 
 func init() {
@@ -73,11 +72,6 @@ func (pl *AvailabilityNodePriority) Score(ctx context.Context, args interface{},
 
 	if states.Replicas > 0 { //need at least a pod to compute spread
 		var skew int32
-
-		//Need to check if there is at least one pod in every node to satisfy HA
-		if !state.SatisfyNodeAvailability(states.SchedulablePods, states) {
-			return 0, state.NewStatus(state.Unschedulable, ErrReasonNotEnoughPods)
-		}
 
 		_, nodeName, err := states.GetPodInfo(state.PodNameFromOrdinal(states.StatefulSetName, podID))
 		if err != nil {

--- a/pkg/scheduler/plugins/core/availabilityzonepriority/availability_zone_priority.go
+++ b/pkg/scheduler/plugins/core/availabilityzonepriority/availability_zone_priority.go
@@ -39,9 +39,8 @@ var _ state.ScorePlugin = &AvailabilityZonePriority{}
 const Name = state.AvailabilityZonePriority
 
 const (
-	ErrReasonInvalidArg    = "invalid arguments"
-	ErrReasonNoResource    = "zone does not exist"
-	ErrReasonNotEnoughPods = "pods not enough to satisfy zone availability"
+	ErrReasonInvalidArg = "invalid arguments"
+	ErrReasonNoResource = "zone does not exist"
 )
 
 func init() {
@@ -76,11 +75,6 @@ func (pl *AvailabilityZonePriority) Score(ctx context.Context, args interface{},
 		zoneMap := make(map[string]struct{})
 		for _, zoneName := range states.NodeToZoneMap {
 			zoneMap[zoneName] = struct{}{}
-		}
-
-		//Need to check if there is at least one pod in every zone to satisfy HA
-		if !state.SatisfyZoneAvailability(states.SchedulablePods, states) {
-			return 0, state.NewStatus(state.Unschedulable, ErrReasonNotEnoughPods)
 		}
 
 		zoneName, _, err := states.GetPodInfo(state.PodNameFromOrdinal(states.StatefulSetName, podID))

--- a/pkg/scheduler/plugins/core/availabilityzonepriority/availability_zone_priority_test.go
+++ b/pkg/scheduler/plugins/core/availabilityzonepriority/availability_zone_priority_test.go
@@ -100,7 +100,7 @@ func TestScore(t *testing.T) {
 			replicas: 1,
 			podID:    0,
 			expected: state.NewStatus(state.Success),
-			expScore: math.MaxUint64 - 12,
+			expScore: math.MaxUint64 - 18,
 			args:     "{\"MaxSkew\": 2}",
 		},
 		{
@@ -119,7 +119,7 @@ func TestScore(t *testing.T) {
 			replicas: 1,
 			podID:    0,
 			expected: state.NewStatus(state.Success),
-			expScore: math.MaxUint64 - 12,
+			expScore: math.MaxUint64 - 18,
 			args:     "{\"MaxSkew\": 2}",
 		},
 		{
@@ -135,7 +135,7 @@ func TestScore(t *testing.T) {
 			replicas: 2,
 			podID:    1,
 			expected: state.NewStatus(state.Success),
-			expScore: math.MaxUint64 - 4,
+			expScore: math.MaxUint64 - 10,
 			args:     "{\"MaxSkew\": 2}",
 		},
 		{
@@ -151,7 +151,7 @@ func TestScore(t *testing.T) {
 			replicas: 3,
 			podID:    1,
 			expected: state.NewStatus(state.Success),
-			expScore: math.MaxUint64 - 2,
+			expScore: math.MaxUint64 - 7,
 			args:     "{\"MaxSkew\": 2}",
 		},
 		{
@@ -167,7 +167,29 @@ func TestScore(t *testing.T) {
 			replicas: 5,
 			podID:    0,
 			expected: state.NewStatus(state.Success),
-			expScore: math.MaxUint64 - 11,
+			expScore: math.MaxUint64 - 20,
+			args:     "{\"MaxSkew\": 2}",
+		},
+		{
+			name: "one vpod, seven nodes/pods, unknown zone",
+			vpod: types.NamespacedName{Name: vpodName + "-0", Namespace: vpodNamespace + "-0"},
+			state: &state.State{
+				StatefulSetName: sfsName,
+				Replicas:        7,
+				ZoneSpread: map[types.NamespacedName]map[string]int32{
+					{Name: vpodName + "-0", Namespace: vpodNamespace + "-0"}: {
+						"zone0": 8,
+						"zone1": 4,
+						"zone2": 3,
+					},
+				},
+				SchedulablePods: []int32{0, 1, 2, 3, 4, 5}, //Pod 6 in unknown zone not included in schedulable pods
+				NumZones:        4,                         //Includes unknown zone
+			},
+			replicas: 7,
+			podID:    6,
+			expected: state.NewStatus(state.Success), //Not failing the plugin
+			expScore: math.MaxUint64 - 12,
 			args:     "{\"MaxSkew\": 2}",
 		},
 	}
@@ -194,6 +216,12 @@ func TestScore(t *testing.T) {
 					nodelist = append(nodelist, node)
 				}
 			}
+			nodeName := "node" + fmt.Sprint(numNodes) //Node in unknown zone
+			node, err := kubeclient.Get(ctx).CoreV1().Nodes().Create(ctx, tscheduler.MakeNodeNoLabel(nodeName), metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
+			nodelist = append(nodelist, node)
 
 			for i := int32(0); i < tc.replicas; i++ {
 				nodeName := "node" + fmt.Sprint(i)
@@ -209,10 +237,11 @@ func TestScore(t *testing.T) {
 			for i := 0; i < len(nodelist); i++ {
 				node := nodelist[i]
 				zoneName, ok := node.GetLabels()[scheduler.ZoneLabel]
-				if !ok {
-					continue //ignore node that doesn't have zone info (maybe a test setup or control node)
+				if ok && zoneName != "" {
+					nodeToZoneMap[node.Name] = zoneName
+				} else {
+					nodeToZoneMap[node.Name] = scheduler.UnknownZone
 				}
-				nodeToZoneMap[node.Name] = zoneName
 			}
 
 			lsp := listers.NewListers(podlist)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -17,16 +17,10 @@ limitations under the License.
 package scheduler
 
 import (
-	"errors"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
-)
-
-var (
-	ErrNotEnoughReplicas = errors.New("scheduling failed (not enough pod replicas)")
 )
 
 type SchedulerPolicyType string

--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/statefulset/fake"
+	"knative.dev/pkg/controller"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	listers "knative.dev/eventing/pkg/reconciler/testing/v1"
@@ -68,7 +69,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:                "no replicas, 1 vreplicas, fail.",
 			vreplicas:           1,
 			replicas:            int32(0),
-			err:                 scheduler.ErrNotEnoughReplicas,
+			err:                 controller.NewRequeueAfter(5 * time.Second),
 			expected:            []duckv1alpha1.Placement{},
 			schedulerPolicyType: scheduler.MAXFILLUP,
 		},
@@ -90,7 +91,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:                "one replica, 15 vreplicas, unschedulable",
 			vreplicas:           15,
 			replicas:            int32(1),
-			err:                 scheduler.ErrNotEnoughReplicas,
+			err:                 controller.NewRequeueAfter(5 * time.Second),
 			expected:            []duckv1alpha1.Placement{{PodName: "statefulset-name-0", VReplicas: 10}},
 			schedulerPolicyType: scheduler.MAXFILLUP,
 		},
@@ -164,7 +165,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:      "no replicas, 1 vreplicas, fail with Predicates and Priorities",
 			vreplicas: 1,
 			replicas:  int32(0),
-			err:       scheduler.ErrNotEnoughReplicas,
+			err:       controller.NewRequeueAfter(5 * time.Second),
 			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
@@ -207,7 +208,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:      "one replica, 15 vreplicas, unschedulable with Predicates and Priorities",
 			vreplicas: 15,
 			replicas:  int32(1),
-			err:       scheduler.ErrNotEnoughReplicas,
+			err:       controller.NewRequeueAfter(5 * time.Second),
 			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
@@ -313,7 +314,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:      "no replicas, 1 vreplicas, fail with two Predicates and two Priorities",
 			vreplicas: 1,
 			replicas:  int32(0),
-			err:       scheduler.ErrNotEnoughReplicas,
+			err:       controller.NewRequeueAfter(5 * time.Second),
 			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{
@@ -366,7 +367,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			name:      "one replica, 15 vreplicas, with two Predicates and two Priorities (HA)",
 			vreplicas: 15,
 			replicas:  int32(1),
-			err:       scheduler.ErrNotEnoughReplicas,
+			err:       controller.NewRequeueAfter(5 * time.Second),
 			expected:  nil,
 			schedulerPolicy: &scheduler.SchedulerPolicy{
 				Predicates: []scheduler.PredicatePolicy{


### PR DESCRIPTION
Signed-off-by: aavarghese <avarghese@us.ibm.com>

Fixes #6523 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Removed strict check for at least one pod per zone/node in priority plugins: `AvailabilityZonePriority` and `AvailabilityNodePriority`. Reason: Some worker/control nodes may or may not be assigned to any particular zone topology and so will not have pod replicas created in them...
- Return "Requeue" request to controller when there are more vreplicas to place that need autoscaler to scale up, instead of throwing a Scheduler failed error

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Remove strict check in scorer plugins and respect max skew parameter. Requeue request when no pods available rather than fail scheduler.
```