### PR TITLE
Enhance PodSecurityPolicy for restricted namespace

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -96,7 +96,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -96,7 +96,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
 ---
 

--- a/config/brokers/mt-channel-broker/deployments/controller.yaml
+++ b/config/brokers/mt-channel-broker/deployments/controller.yaml
@@ -80,7 +80,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -77,7 +77,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -94,4 +94,6 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -96,7 +96,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -98,6 +98,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
 
       serviceAccountName: pingsource-mt-adapter

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -100,7 +100,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: https-webhook

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -61,5 +61,6 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
-
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/config/tools/appender/appender.yaml
+++ b/config/tools/appender/appender.yaml
@@ -34,4 +34,6 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -31,4 +31,6 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/config/tools/heartbeats/heartbeats.yaml
+++ b/config/tools/heartbeats/heartbeats.yaml
@@ -33,7 +33,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
 
   sink:
     ref:

--- a/config/tools/recordevents/recordevents.yaml
+++ b/config/tools/recordevents/recordevents.yaml
@@ -43,4 +43,6 @@ spec:
         runAsNonRoot: true
         capabilities:
           drop:
-          - all
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -29,7 +29,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-              - all
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
 
   sink:
     ref:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #6532

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom:  replacing `all` with `ALL`, since this is the only acceptable string check [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#30) and [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#L94).
 * :broom: adding seccompProfile to avoid `must set securityContext.seccompProfile.type to "RuntimeDefault"` warnings

-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
 :broom: Fixing PodSecurity Policy warnings for restricted environments 
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

