### PR TITLE
Bump kind to 0.15, and the two existing k8s to their own latest version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.4
-        - v1.23.3
+        - v1.22.13
+        - v1.23.10
 
         test-suite:
         - ./test/rekt/...
@@ -28,14 +28,14 @@ jobs:
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
+        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.15.0
         include:
-        - k8s-version: v1.22.4
-          kind-version: v0.11.1
-          kind-image-sha: sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978
-        - k8s-version: v1.23.3
-          kind-version: v0.11.1
-          kind-image-sha: sha256:0df8215895129c0d3221cda19847d1296c4f29ec93487339149333bd9d899e5a
+        - k8s-version: v1.22.13
+          kind-version: v0.15.0
+          kind-image-sha: sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959
+        - k8s-version: v1.23.10
+          kind-version: v0.15.0
+          kind-image-sha: sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- updating kind to latest version

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

