### PR TITLE
Properly export trace for duplicated "finished" event

### DIFF
--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -101,7 +102,11 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 		} else if p.config.OnDuplicate == Error {
 			eventErrs = append(eventErrs, errors.New(t))
 		}
-		p.exportStepEventTrace(i, t)
+		if strings.HasPrefix(t, "finish event") {
+			p.exportFinishedEventTrace()
+		} else {
+			p.exportStepEventTrace(i, t)
+		}
 	}
 	return eventErrs, report.EventsSent
 }
@@ -117,19 +122,23 @@ func (p *prober) exportStepEventTrace(i int, msg string) {
 	if i > exportTraceLimit {
 		return
 	}
-	stepNo := p.getStepNoFromMsg(msg)
+	stepNo, err := p.getStepNoFromMsg(msg)
+	if err != nil {
+		p.log.Warnf("Unable to get step number: %v", err)
+		return
+	}
 	if err := p.exportTrace(p.getTraceForStepEvent(stepNo), fmt.Sprintf("step-%s.json", stepNo)); err != nil {
 		p.log.Warnf("Failed to export trace for Step event #%s: %v", stepNo, err)
 	}
 }
 
-func (p *prober) getStepNoFromMsg(message string) string {
+func (p *prober) getStepNoFromMsg(message string) (string, error) {
 	r, _ := regexp.Compile(stepEventMsgPattern)
 	matches := r.FindStringSubmatch(message)
 	if len(matches) != 2 {
-		p.log.Warnf("message does not match pattern %s: %s", stepEventMsgPattern, message)
+		return "", fmt.Errorf("message does not match pattern %s: %s", stepEventMsgPattern, message)
 	}
-	return matches[1]
+	return matches[1], nil
 }
 
 func (p *prober) getTraceForStepEvent(eventNo string) []byte {

--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -95,6 +95,8 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 		f.errors.throwDuplicated(
 			"finish event should be received only once, received %d",
 			f.received+1)
+		// We don't want to record all failures again.
+		return
 	}
 	f.received++
 	f.eventsSent = finished.EventsSent


### PR DESCRIPTION
Fixes an issue with duplicated finished event in which case the following error was thrown:
knative.dev/eventing/test/upgrade/prober.(*prober).getStepNoFromMsg ...
panic: runtime error: index out of range [1] with length 0

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug:
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

