### PR TITLE
Doing base64 encode in channel's responseBody

### DIFF
--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -19,6 +19,7 @@ package channel
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -415,7 +416,7 @@ func TestDispatchMessage(t *testing.T) {
 					"traceparent":         {"ignored-value-header"},
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {"destination-response"},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination-response"))},
 					"ce-id":               {"ignored-value-header"},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},
@@ -484,7 +485,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-id":               {"ignored-value-header"},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {"destination-response"},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination-response"))},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},
 					"ce-type":             {testCeType},
@@ -540,7 +541,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-id":               {"ignored-value-header"},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {"destination-response"},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination-response"))},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},
 					"ce-type":             {testCeType},
@@ -611,7 +612,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-id":               {"ignored-value-header"},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {"reply-response"},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("reply-response"))},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},
 					"ce-type":             {testCeType},
@@ -693,7 +694,7 @@ func TestDispatchMessage(t *testing.T) {
 					"traceparent":         {"ignored-value-header"},
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {"destination multi-line response"},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination multi-line response"))},
 					"ce-id":               {"ignored-value-header"},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -282,8 +282,8 @@ func TestStructuredEventForChannel(t *testing.T) {
 	env.Test(ctx, t, channel.SingleEventWithEncoding(binding.EncodingStructured))
 }
 
-//TestChannelPreferHeaderCheck test if the test message without explicit prefer header
-//should have it after fanout.
+// TestChannelPreferHeaderCheck test if the test message without explicit prefer header
+// should have it after fanout.
 func TestChannelPreferHeaderCheck(t *testing.T) {
 	t.Parallel()
 
@@ -300,4 +300,22 @@ func TestChannelPreferHeaderCheck(t *testing.T) {
 	}
 
 	env.Test(ctx, t, channel.ChannelPreferHeaderCheck(createSubscriberFn))
+}
+
+func TestChannelSubscriptionReturnedErrorData(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithSubscriber(ref, uri)
+	}
+
+	env.Test(ctx, t, channel.ChannelSubscriptionReturnedErrorData(createSubscriberFn))
 }

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -336,7 +336,7 @@ func ChannelSubscriptionReturnedErrorData(createSubscriberFn func(ref *duckv1.KR
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
 	errorData := "<!doctype html>\n<html>\n<head>\n    <title>Error Page(tm)</title>\n</head>\n<body>\n<p>Quoth the server, 404!\n</body></html>"
-	sanitizeData := sanitizeHTTPBody([]byte(errorData))
+	sanitizeBodyData := sanitizeHTTPBody([]byte(errorData))
 	f.Setup("install failing receiver", eventshub.Install(failer,
 		eventshub.StartReceiver,
 		eventshub.DropFirstN(1),
@@ -371,7 +371,7 @@ func ChannelSubscriptionReturnedErrorData(createSubscriberFn func(ref *duckv1.KR
 			return test.HasExtension("knativeerrorcode", "422")
 		},
 		func(ctx context.Context) test.EventMatcher {
-			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(sanitizeData)))
+			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(sanitizeBodyData)))
 		},
 	))
 
@@ -407,15 +407,6 @@ func sanitizeHTTPBody(body []byte) string {
 	return string(sanitizedResponse)
 }
 
-func hasControlChars(data []byte) bool {
-	for _, v := range data {
-		if isControl(v) {
-			return true
-		}
-	}
-	return false
-}
-
 func isControl(c byte) bool {
 	// US ASCII codes range for printable graphic characters and a space.
 	// http://www.columbia.edu/kermit/ascii.html
@@ -425,3 +416,11 @@ func isControl(c byte) bool {
 	return int(c) < asciiUnitSeparator || int(c) > asciiRubout
 }
 
+func hasControlChars(data []byte) bool {
+	for _, v := range data {
+		if isControl(v) {
+			return true
+		}
+	}
+	return false
+}

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -18,6 +18,7 @@ package channel
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -321,3 +322,106 @@ func ChannelPreferHeaderCheck(createSubscriberFn func(ref *duckv1.KReference, ur
 
 	return f
 }
+
+func ChannelSubscriptionReturnedErrorData(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
+	f := feature.NewFeature()
+	sink := feature.MakeRandomK8sName("sink")
+
+	sourceName := feature.MakeRandomK8sName("source")
+	failer := feature.MakeRandomK8sName("failerWitdata")
+	channelName := feature.MakeRandomK8sName("channel")
+
+	ev := test.FullEvent()
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	errorData := "<!doctype html>\n<html>\n<head>\n    <title>Error Page(tm)</title>\n</head>\n<body>\n<p>Quoth the server, 404!\n</body></html>"
+	sanitizeData := sanitizeHTTPBody([]byte(errorData))
+	f.Setup("install failing receiver", eventshub.Install(failer,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(1),
+		eventshub.DropEventsResponseCode(422),
+		eventshub.DropEventsResponseBody(errorData),
+	))
+	f.Setup("install channel", channel_impl.Install(channelName, delivery.WithDeadLetterSink(svc.AsKReference(sink), "")))
+
+	f.Setup("install subscription", subscription.Install(feature.MakeRandomK8sName("subscription"),
+		subscription.WithChannel(channel_impl.AsRef(channelName)),
+		createSubscriberFn(svc.AsKReference(failer), ""),
+	))
+
+	f.Requirement("install source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(channel_impl.GVR(), channelName),
+		eventshub.InputEvent(ev),
+	))
+
+	f.Setup("channel is ready", channel_impl.IsReady(channelName))
+	f.Setup("channel is addressable", channel_impl.IsAddressable(channelName))
+
+	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(channelName, channel_impl.GVR()))
+
+	f.Assert("Receives dls extensions with errordata Base64encoding", assertEnhancedWithKnativeErrorExtensions(
+		sink,
+		func(ctx context.Context) test.EventMatcher {
+			failerAddress, _ := svc.Address(ctx, failer)
+			return test.HasExtension("knativeerrordest", failerAddress.String())
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrorcode", "422")
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(sanitizeData)))
+		},
+	))
+
+	return f
+}
+
+func assertEnhancedWithKnativeErrorExtensions(sinkName string, matcherfns ...func(ctx context.Context) test.EventMatcher) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		matchers := make([]test.EventMatcher, len(matcherfns))
+		for i, fn := range matcherfns {
+			matchers[i] = fn(ctx)
+		}
+		_ = eventshub.StoreFromContext(ctx, sinkName).AssertExact(
+			t,
+			1,
+			assert.MatchKind(eventshub.EventReceived),
+			assert.MatchEvent(matchers...),
+		)
+	}
+}
+
+func sanitizeHTTPBody(body []byte) string {
+	if !hasControlChars(body) {
+		return string(body)
+	}
+
+	sanitizedResponse := make([]byte, 0, len(body))
+	for _, v := range body {
+		if !isControl(v) {
+			sanitizedResponse = append(sanitizedResponse, v)
+		}
+	}
+	return string(sanitizedResponse)
+}
+
+func hasControlChars(data []byte) bool {
+	for _, v := range data {
+		if isControl(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func isControl(c byte) bool {
+	// US ASCII codes range for printable graphic characters and a space.
+	// http://www.columbia.edu/kermit/ascii.html
+	const asciiUnitSeparator = 31
+	const asciiRubout = 127
+
+	return int(c) < asciiUnitSeparator || int(c) > asciiRubout
+}
+


### PR DESCRIPTION
Fixes #6547 
Signed-off-by: Teresaliu [changyan.liu@intel.com](changyan.liu@intel.com)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Avoiding "invalid" HTTP header values for CE extension to encode channel's response body
- Update unit and e2e tests
- Add corresponding rekt test

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

