### PR TITLE
Add readiness and liveness probes in controller

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -100,8 +100,27 @@ spec:
           seccompProfile:
             type: RuntimeDefault
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080


### PR DESCRIPTION
Partial fix for https://github.com/knative/pkg/issues/1048

Having both readiness and liveness probes is good kube practice.

For now the implementation relies on a simple http server we can improve later as needed.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-  :gift: Add readiness and liveness probes in Knative Eventing controller
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x ] **At least 80% unit test coverage**
- [x ] **E2E tests** for any new behavior
- [x ] **Docs PR** for any user-facing impact
- [ x] **Spec PR** for any new API feature
- [x ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
 :gift: Add readiness and liveness probes in Knative Eventing controller
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->


