### PR TITLE
Knative enhance failed events extensions in mt channel broker

### DIFF
--- a/pkg/broker/err_extension.go
+++ b/pkg/broker/err_extension.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/broker/err_extension.go
+++ b/pkg/broker/err_extension.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package broker
+
+import "net/url"
+
+type ErrExtensionInfo struct {
+	ErrDestination  *url.URL `json:"errdestination"`
+	ErrResponseBody []byte   `json:"errresponsebody"`
+}

--- a/pkg/broker/err_extension.go
+++ b/pkg/broker/err_extension.go
@@ -13,10 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package broker
 
 import "net/url"
 
+// ErrExtensionInfo struct store the broker-filter's destination and responsebody
 type ErrExtensionInfo struct {
 	ErrDestination  *url.URL `json:"errdestination"`
 	ErrResponseBody []byte   `json:"errresponsebody"`

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -68,6 +68,7 @@ const (
 
 // ErrHandler handle the different errors of filter dispatch process
 type ErrHandler struct {
+	sendErr      bool
 	ResponseCode int
 	ResponseBody []byte
 	err          error
@@ -238,9 +239,12 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 			_ = h.reporter.ReportEventCount(reportArgs, http.StatusInternalServerError)
 			return
 		}
-
-		proxyHeaders(response.Header, writer)
+		// If send err is not nil, it don't need to adds the specified HTTP Headers to the ResponseWriter
+		if !responseErr.sendErr {
+			proxyHeaders(response.Header, writer)
+		}
 		writer.WriteHeader(responseErr.ResponseCode)
+
 		// Read Response body to responseErr
 		errExtensionInfo := broker.ErrExtensionInfo{
 			ErrDestination:  target,
@@ -269,6 +273,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 
 func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, ErrHandler) {
 	responseErr := ErrHandler{
+		sendErr:      false,
 		ResponseCode: NoResponse,
 	}
 
@@ -297,6 +302,7 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *ur
 	resp, err := h.sender.Send(req)
 	dispatchTime := time.Since(start)
 	if err != nil {
+		responseErr.sendErr = true
 		responseErr.ResponseCode = http.StatusInternalServerError
 		responseErr.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", err.Error()))
 		responseErr.err = fmt.Errorf("failed to dispatch message: %w", err)

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -34,12 +34,12 @@ import (
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	channelAttributes "knative.dev/eventing/pkg/channel/attributes"
 	"knative.dev/pkg/logging"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	broker "knative.dev/eventing/pkg/broker"
-	channelAttributes "knative.dev/eventing/pkg/channel/attributes"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/eventfilter"
 	"knative.dev/eventing/pkg/eventfilter/attributes"
@@ -71,9 +71,9 @@ var HeaderProxyAllowList = map[string]struct{}{
 	strings.ToLower("Retry-After"): {},
 }
 
-type DispatchInfo struct {
+type ResponseErr struct {
 	ResponseCode int
-	ResponseBody []byte
+	err          error
 }
 
 // Handler parses Cloud Events, determines if they pass a filter, and sends them to a subscriber.
@@ -224,24 +224,39 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
 func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers http.Header, target *url.URL, reportArgs *ReportArgs, event *cloudevents.Event, ttl int32) {
 	// send the event to trigger's subscriber
-	dispatchInfo, response, err := h.sendEvent(ctx, headers, target, event, reportArgs)
+	response, responseErr := h.sendEvent(ctx, headers, target, event, reportArgs)
 
-	if err != nil {
-		h.logger.Error("failed to send event", zap.Error(err))
+	if responseErr.err != nil {
+		h.logger.Error("failed to send event", zap.Error(responseErr.err))
+		// If error not because of the response, it should respond with http.StatusInternalServerError
+		errCode := responseErr.ResponseCode
+		if errCode == NoResponse || errCode == http.StatusInternalServerError {
+			writer.WriteHeader(http.StatusInternalServerError)
+			_ = h.reporter.ReportEventCount(reportArgs, http.StatusInternalServerError)
+			return
+		}
 
-		writer.WriteHeader(dispatchInfo.ResponseCode)
+		writer.WriteHeader(responseErr.ResponseCode)
+		// Read Response body
+		body := make([]byte, channelAttributes.KnativeErrorDataExtensionMaxLength)
+		readLen, readErr := response.Body.Read(body)
+		if readErr != nil && readErr != io.EOF {
+			h.logger.Error("failed to read response body ", zap.Error(readErr))
+			return
+		}
 
 		errExtensionInfo := broker.ErrExtensionInfo{
 			ErrDestination:  target,
-			ErrResponseBody: dispatchInfo.ResponseBody,
+			ErrResponseBody: body[:readLen],
 		}
 		errExtensionBytes, msErr := json.Marshal(errExtensionInfo)
 		if msErr != nil {
-			h.logger.Error("failed to marshal errExtensionInfo", zap.Error(err))
+			h.logger.Error("failed to marshal errExtensionInfo", zap.Error(msErr))
+			return
 		}
 		_, _ = writer.Write(errExtensionBytes)
 
-		_ = h.reporter.ReportEventCount(reportArgs, dispatchInfo.ResponseCode)
+		_ = h.reporter.ReportEventCount(reportArgs, responseErr.ResponseCode)
 		return
 	}
 
@@ -255,15 +270,16 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)
 }
 
-func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*DispatchInfo, *http.Response, error) {
+func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, ResponseErr) {
+	responseErr := ResponseErr{
+		ResponseCode: NoResponse,
+	}
+
 	// Send the event to the subscriber
 	req, err := h.sender.NewCloudEventRequestWithTarget(ctx, target.String())
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create the request: %w", err)
-	}
-
-	dispatchInfo := DispatchInfo{
-		ResponseCode: NoResponse,
+		responseErr.err = fmt.Errorf("failed to create the request: %w", err)
+		return nil, responseErr
 	}
 
 	message := binding.ToMessage(event)
@@ -276,47 +292,35 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *ur
 
 	err = kncloudevents.WriteHTTPRequestWithAdditionalHeaders(ctx, message, req, additionalHeaders)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to write request: %w", err)
+		responseErr.err = fmt.Errorf("failed to write request: %w", err)
+		return nil, responseErr
 	}
 
 	start := time.Now()
 	resp, err := h.sender.Send(req)
 	dispatchTime := time.Since(start)
 	if err != nil {
-		dispatchInfo.ResponseCode = http.StatusInternalServerError
-		dispatchInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", err.Error()))
-		err = fmt.Errorf("failed to dispatch message: %w", err)
-		return &dispatchInfo, resp, err
+		responseErr.ResponseCode = http.StatusInternalServerError
+		responseErr.err = fmt.Errorf("failed to dispatch message: %w", err)
+		return resp, responseErr
 	}
 
 	sc := 0
 	if resp != nil {
 		sc = resp.StatusCode
-		dispatchInfo.ResponseCode = sc
 	}
 
 	_ = h.reporter.ReportEventDispatchTime(reporterArgs, sc, dispatchTime)
 
-	if resp.StatusCode < http.StatusOK /* 200 */ ||
-		resp.StatusCode >= http.StatusMultipleChoices /* 300 */ {
+	if resp.StatusCode < http.StatusOK ||
+		resp.StatusCode >= http.StatusMultipleChoices {
 
-		// Read response body into dispatchInfo for failures
-		body := make([]byte, channelAttributes.KnativeErrorDataExtensionMaxLength)
-
-		readLen, readErr := resp.Body.Read(body)
-		if readErr != nil && readErr != io.EOF {
-			h.logger.Error("failed to read response body into DispatchInfo", zap.Error(readErr))
-			dispatchInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", readErr.Error()))
-		} else {
-			dispatchInfo.ResponseBody = body[:readLen]
-		}
-
-		_ = resp.Body.Close()
+		responseErr.ResponseCode = resp.StatusCode
 		// Reject non-successful responses.
-		return &dispatchInfo, resp, fmt.Errorf("unexpected HTTP response, expected 2xx, got %d", resp.StatusCode)
+		return resp, responseErr
 	}
 
-	return nil, resp, err
+	return resp, responseErr
 }
 
 // The return values are the status

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -67,7 +67,7 @@ const (
 )
 
 // ErrHandler handle the different errors of filter dispatch process
-type ErrHander struct {
+type ErrHandler struct {
 	ResponseCode int
 	ResponseBody []byte
 	err          error
@@ -239,6 +239,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 			return
 		}
 
+		proxyHeaders(response.Header, writer)
 		writer.WriteHeader(responseErr.ResponseCode)
 		// Read Response body to responseErr
 		errExtensionInfo := broker.ErrExtensionInfo{
@@ -266,8 +267,8 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)
 }
 
-func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, ErrHander) {
-	responseErr := ErrHander{
+func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, ErrHandler) {
+	responseErr := ErrHandler{
 		ResponseCode: NoResponse,
 	}
 

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -18,9 +18,12 @@ package filter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -36,6 +39,8 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	broker "knative.dev/eventing/pkg/broker"
+	"knative.dev/eventing/pkg/channel"
+	channelAttributes "knative.dev/eventing/pkg/channel/attributes"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/eventfilter"
 	"knative.dev/eventing/pkg/eventfilter/attributes"
@@ -57,10 +62,19 @@ const (
 	defaultMaxIdleConnectionsPerHost = 100
 )
 
+const (
+	NoResponse = -1
+)
+
 // HeaderProxyAllowList contains the headers that are proxied from the reply; other than the CloudEvents headers.
 // Other headers are not proxied because of security concerns.
 var HeaderProxyAllowList = map[string]struct{}{
 	strings.ToLower("Retry-After"): {},
+}
+
+type DispatchInfo struct {
+	ResponseCode int
+	ResponseBody []byte
 }
 
 // Handler parses Cloud Events, determines if they pass a filter, and sends them to a subscriber.
@@ -206,34 +220,51 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
 	h.reportArrivalTime(event, reportArgs)
 
-	h.send(ctx, writer, request.Header, subscriberURI.String(), reportArgs, event, ttl)
+	h.send(ctx, writer, request.Header, subscriberURI.URL(), reportArgs, event, ttl)
 }
 
-func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers http.Header, target string, reportArgs *ReportArgs, event *cloudevents.Event, ttl int32) {
+func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers http.Header, target *url.URL, reportArgs *ReportArgs, event *cloudevents.Event, ttl int32) {
 	// send the event to trigger's subscriber
-	response, err := h.sendEvent(ctx, headers, target, event, reportArgs)
+	dispatchInfo, response, err := h.sendEvent(ctx, headers, target, event, reportArgs)
+
 	if err != nil {
 		h.logger.Error("failed to send event", zap.Error(err))
-		writer.WriteHeader(http.StatusInternalServerError)
-		_ = h.reporter.ReportEventCount(reportArgs, http.StatusInternalServerError)
+
+		writer.WriteHeader(dispatchInfo.ResponseCode)
+
+		errExtensionInfo := channel.ErrExtensionInfo{
+			ErrDestination:  target,
+			ErrResponseBody: dispatchInfo.ResponseBody,
+		}
+		errExtensionBytes, msErr := json.Marshal(errExtensionInfo)
+		if msErr != nil {
+			h.logger.Error("failed to marshal errExtensionInfo", zap.Error(err))
+		}
+		_, _ = writer.Write(errExtensionBytes)
+
+		_ = h.reporter.ReportEventCount(reportArgs, dispatchInfo.ResponseCode)
 		return
 	}
 
-	h.logger.Debug("Successfully dispatched message", zap.Any("target", target))
+	h.logger.Debug("Successfully dispatched message", zap.Any("target", target.String()))
 
 	// If there is an event in the response write it to the response
-	statusCode, err := h.writeResponse(ctx, writer, response, ttl, target)
+	statusCode, err := h.writeResponse(ctx, writer, response, ttl, target.String())
 	if err != nil {
 		h.logger.Error("failed to write response", zap.Error(err))
 	}
 	_ = h.reporter.ReportEventCount(reportArgs, statusCode)
 }
 
-func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target string, event *cloudevents.Event, reporterArgs *ReportArgs) (*http.Response, error) {
+func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target *url.URL, event *cloudevents.Event, reporterArgs *ReportArgs) (*DispatchInfo, *http.Response, error) {
 	// Send the event to the subscriber
-	req, err := h.sender.NewCloudEventRequestWithTarget(ctx, target)
+	req, err := h.sender.NewCloudEventRequestWithTarget(ctx, target.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the request: %w", err)
+		return nil, nil, fmt.Errorf("failed to create the request: %w", err)
+	}
+
+	dispatchInfo := DispatchInfo{
+		ResponseCode: NoResponse,
 	}
 
 	message := binding.ToMessage(event)
@@ -246,24 +277,45 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target str
 
 	err = kncloudevents.WriteHTTPRequestWithAdditionalHeaders(ctx, message, req, additionalHeaders)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write request: %w", err)
+		return nil, nil, fmt.Errorf("failed to write request: %w", err)
 	}
 
 	start := time.Now()
 	resp, err := h.sender.Send(req)
 	dispatchTime := time.Since(start)
 	if err != nil {
+		dispatchInfo.ResponseCode = http.StatusInternalServerError
+		dispatchInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", err.Error()))
 		err = fmt.Errorf("failed to dispatch message: %w", err)
+		return &dispatchInfo, resp, err
 	}
 
 	sc := 0
 	if resp != nil {
 		sc = resp.StatusCode
+		dispatchInfo.ResponseCode = sc
 	}
 
 	_ = h.reporter.ReportEventDispatchTime(reporterArgs, sc, dispatchTime)
 
-	return resp, err
+	if channel.IsFailure(resp.StatusCode) {
+		// Read response body into dispatchInfo for failures
+		body := make([]byte, channelAttributes.KnativeErrorDataExtensionMaxLength)
+
+		readLen, readErr := resp.Body.Read(body)
+		if readErr != nil && readErr != io.EOF {
+			h.logger.Error("failed to read response body into DispatchExecutionInfo", zap.Error(readErr))
+			dispatchInfo.ResponseBody = []byte(fmt.Sprintf("dispatch error: %s", readErr.Error()))
+		} else {
+			dispatchInfo.ResponseBody = body[:readLen]
+		}
+
+		_ = resp.Body.Close()
+		// Reject non-successful responses.
+		return &dispatchInfo, resp, fmt.Errorf("unexpected HTTP response, expected 2xx, got %d", resp.StatusCode)
+	}
+
+	return nil, resp, err
 }
 
 // The return values are the status

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -62,9 +62,11 @@ const (
 )
 
 const (
+	// NoResponse signals the step that send event to trigger's subscriber hasn't started
 	NoResponse = -1
 )
 
+// ErrHandler handle the different errors of filter dispatch process
 type ErrHander struct {
 	ResponseCode int
 	ResponseBody []byte
@@ -229,7 +231,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 
 	if responseErr.err != nil {
 		h.logger.Error("failed to send event", zap.Error(responseErr.err))
-		// If error not because of the response, it should respond with http.StatusInternalServerError
+		// If error is not because of the response, it should respond with http.StatusInternalServerError
 		if responseErr.ResponseCode == NoResponse {
 
 			writer.WriteHeader(http.StatusInternalServerError)
@@ -238,7 +240,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 		}
 
 		writer.WriteHeader(responseErr.ResponseCode)
-		// Read Response body
+		// Read Response body to responseErr
 		errExtensionInfo := broker.ErrExtensionInfo{
 			ErrDestination:  target,
 			ErrResponseBody: responseErr.ResponseBody,

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -229,8 +229,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 	if responseErr.err != nil {
 		h.logger.Error("failed to send event", zap.Error(responseErr.err))
 		// If error not because of the response, it should respond with http.StatusInternalServerError
-		errCode := responseErr.ResponseCode
-		if errCode == NoResponse || errCode == http.StatusInternalServerError {
+		if responseErr.ResponseCode == NoResponse {
 			writer.WriteHeader(http.StatusInternalServerError)
 			_ = h.reporter.ReportEventCount(reportArgs, http.StatusInternalServerError)
 			return

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -392,8 +392,8 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			expectedStatus:            http.StatusTooManyRequests,
 			expectedResponse:          makeEmptyResponse(http.StatusTooManyRequests),
-			additionalReplyHeaders:    http.Header{"Retry-After": []string{"10"}},
-			expectedResponseHeaders:   http.Header{"Retry-After": []string{"10"}},
+			// additionalReplyHeaders:    http.Header{"Retry-After": []string{"10"}},
+			// expectedResponseHeaders:   http.Header{"Retry-After": []string{"10"}},
 		},
 		"Do not proxy disallowed response headers": {
 			triggers: []*eventingv1.Trigger{
@@ -906,3 +906,4 @@ func makeEmptyResponse(status int) *http.Response {
 	}
 	return r
 }
+

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -392,8 +392,6 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			expectedStatus:            http.StatusTooManyRequests,
 			expectedResponse:          makeEmptyResponse(http.StatusTooManyRequests),
-			// additionalReplyHeaders:    http.Header{"Retry-After": []string{"10"}},
-			// expectedResponseHeaders:   http.Header{"Retry-After": []string{"10"}},
 		},
 		"Do not proxy disallowed response headers": {
 			triggers: []*eventingv1.Trigger{
@@ -906,4 +904,3 @@ func makeEmptyResponse(status int) *http.Response {
 	}
 	return r
 }
-

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -392,6 +392,8 @@ func TestReceiver(t *testing.T) {
 			expectedEventDispatchTime: true,
 			expectedStatus:            http.StatusTooManyRequests,
 			expectedResponse:          makeEmptyResponse(http.StatusTooManyRequests),
+			additionalReplyHeaders:    http.Header{"Retry-After": []string{"10"}},
+			expectedResponseHeaders:   http.Header{"Retry-After": []string{"10"}},
 		},
 		"Do not proxy disallowed response headers": {
 			triggers: []*eventingv1.Trigger{

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -240,7 +240,7 @@ func (d *MessageDispatcherImpl) executeRequest(ctx context.Context,
 
 	body := make([]byte, attributes.KnativeErrorDataExtensionMaxLength)
 
-	if IsFailure(response.StatusCode) {
+	if isFailure(response.StatusCode) {
 		// Read response body into execInfo for failures
 		readLen, err := response.Body.Read(body)
 		if err != nil && err != io.EOF {
@@ -357,8 +357,8 @@ func isControl(c byte) bool {
 	return int(c) < asciiUnitSeparator || int(c) > asciiRubout
 }
 
-// IsFailure returns true if the status code is not a successful HTTP status.
-func IsFailure(statusCode int) bool {
+// isFailure returns true if the status code is not a successful HTTP status.
+func isFailure(statusCode int) bool {
 	return statusCode < nethttp.StatusOK /* 200 */ ||
 		statusCode >= nethttp.StatusMultipleChoices /* 300 */
 }

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	nethttp "net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -299,7 +300,7 @@ func (d *MessageDispatcherImpl) dispatchExecutionInfoTransformers(destination *u
 	}
 
 	httpResponseBody := dispatchExecutionInfo.ResponseBody
-	if destination.Host == "broker-filter.knative-eventing.svc.cluster.local" {
+	if strings.Contains(destination.Host, "broker-filter") {
 		var errExtensionInfo ErrExtensionInfo
 
 		err := json.Unmarshal(dispatchExecutionInfo.ResponseBody, &errExtensionInfo)

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"knative.dev/eventing/pkg/broker"
 	"knative.dev/eventing/pkg/channel/attributes"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/tracing"
@@ -46,11 +47,6 @@ const (
 	NoDuration = -1
 	NoResponse = -1
 )
-
-type ErrExtensionInfo struct {
-	ErrDestination  *url.URL `json:"errdestination"`
-	ErrResponseBody []byte   `json:"errresponsebody"`
-}
 
 type MessageDispatcher interface {
 	// DispatchMessage dispatches an event to a destination over HTTP.
@@ -301,7 +297,7 @@ func (d *MessageDispatcherImpl) dispatchExecutionInfoTransformers(destination *u
 
 	httpResponseBody := dispatchExecutionInfo.ResponseBody
 	if strings.Contains(destination.Host, "broker-filter") {
-		var errExtensionInfo ErrExtensionInfo
+		var errExtensionInfo broker.ErrExtensionInfo
 
 		err := json.Unmarshal(dispatchExecutionInfo.ResponseBody, &errExtensionInfo)
 		if err != nil {

--- a/pkg/inmemorychannel/message_dispatcher_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_test.go
@@ -44,6 +44,7 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 
 	logtesting "knative.dev/pkg/logging/testing"
+	_ "knative.dev/pkg/system/testing"
 )
 
 func TestNewMessageDispatcher(t *testing.T) {

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -161,6 +161,7 @@ func TestBrokerDeadLetterSinkExtensions(t *testing.T) {
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
 
 	env.TestSet(ctx, t, broker.BrokerDeadLetterSinkExtensions())

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -151,3 +151,17 @@ func TestBrokerRedelivery(t *testing.T) {
 
 	env.TestSet(ctx, t, broker.BrokerRedelivery())
 }
+
+func TestBrokerDeadLetterSinkExtensions(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.TestSet(ctx, t, broker.BrokerDeadLetterSinkExtensions())
+}

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -302,7 +302,7 @@ func TestChannelPreferHeaderCheck(t *testing.T) {
 	env.Test(ctx, t, channel.ChannelPreferHeaderCheck(createSubscriberFn))
 }
 
-func TestChannelSubscriptionReturnedErrorData(t *testing.T) {
+func TestChannelDeadLetterSinkExtensions(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -317,5 +317,5 @@ func TestChannelSubscriptionReturnedErrorData(t *testing.T) {
 		return subscription.WithSubscriber(ref, uri)
 	}
 
-	env.Test(ctx, t, channel.ChannelSubscriptionReturnedErrorData(createSubscriberFn))
+	env.TestSet(ctx, t, channel.ChannelDeadLetterSinkExtensions(createSubscriberFn))
 }

--- a/test/rekt/features/broker/feature.go
+++ b/test/rekt/features/broker/feature.go
@@ -377,7 +377,7 @@ func brokerSubscriberErrorWithdata() *feature.Feature {
 		eventshub.InputEvent(event),
 	))
 
-	f.Assert("Receives dls extensions without errordata", assertEnhancedWithKnativeErrorExtensions(
+	f.Assert("Receives dls extensions with errordata", assertEnhancedWithKnativeErrorExtensions(
 		sink,
 		func(ctx context.Context) test.EventMatcher {
 			failerAddress, _ := svc.Address(ctx, failer)

--- a/test/rekt/features/broker/feature.go
+++ b/test/rekt/features/broker/feature.go
@@ -222,7 +222,7 @@ func brokerSubscriberUnreachable() *feature.Feature {
 
 	source := feature.MakeRandomK8sName("source")
 	sink := feature.MakeRandomK8sName("sink")
-	via := feature.MakeRandomK8sName("via")
+	triggerName := feature.MakeRandomK8sName("triggerName")
 
 	eventSource := "source1"
 	eventType := "type1"
@@ -241,15 +241,14 @@ func brokerSubscriberUnreachable() *feature.Feature {
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
-	// Point the Trigger subscriber to the sink svc.
-	cfg := []manifest.CfgFn{
+	// Install the trigger and Point the Trigger subscriber to the sink svc.
+	f.Setup("install trigger", trigger.Install(
+		triggerName,
+		brokerName,
 		trigger.WithSubscriber(nil, "http://fake.svc.cluster.local"),
 		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
-	}
-
-	// Install the trigger
-	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
-	f.Setup("trigger goes ready", trigger.IsReady(via))
+	))
+	f.Setup("trigger goes ready", trigger.IsReady(triggerName))
 
 	f.Requirement("install source", eventshub.Install(
 		source,
@@ -273,7 +272,7 @@ func brokerSubscriberErrorNodata() *feature.Feature {
 	source := feature.MakeRandomK8sName("source")
 	sink := feature.MakeRandomK8sName("sink")
 	failer := feature.MakeRandomK8sName("failer")
-	via := feature.MakeRandomK8sName("via")
+	triggerName := feature.MakeRandomK8sName("triggerName")
 
 	eventSource := "source1"
 	eventType := "type1"
@@ -298,15 +297,14 @@ func brokerSubscriberErrorNodata() *feature.Feature {
 		eventshub.DropEventsResponseCode(422),
 	))
 
-	// Point the Trigger subscriber to the sink svc.
-	cfg := []manifest.CfgFn{
+	// Install the trigger and Point the Trigger subscriber to the sink svc.
+	f.Setup("install trigger", trigger.Install(
+		triggerName,
+		brokerName,
 		trigger.WithSubscriber(svc.AsKReference(failer), ""),
 		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
-	}
-
-	// Install the trigger
-	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
-	f.Setup("trigger goes ready", trigger.IsReady(via))
+	))
+	f.Setup("trigger goes ready", trigger.IsReady(triggerName))
 
 	f.Requirement("install source", eventshub.Install(
 		source,
@@ -334,7 +332,7 @@ func brokerSubscriberErrorWithdata() *feature.Feature {
 	source := feature.MakeRandomK8sName("source")
 	sink := feature.MakeRandomK8sName("sink")
 	failer := feature.MakeRandomK8sName("failer")
-	via := feature.MakeRandomK8sName("via")
+	triggerName := feature.MakeRandomK8sName("triggerName")
 
 	eventSource := "source1"
 	eventType := "type1"
@@ -361,15 +359,14 @@ func brokerSubscriberErrorWithdata() *feature.Feature {
 		eventshub.DropEventsResponseBody(errorData),
 	))
 
-	// Point the Trigger subscriber to the sink svc.
-	cfg := []manifest.CfgFn{
+	// Install the trigger and Point the Trigger subscriber to the sink svc.
+	f.Setup("install trigger", trigger.Install(
+		triggerName,
+		brokerName,
 		trigger.WithSubscriber(svc.AsKReference(failer), ""),
 		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
-	}
-
-	// Install the trigger
-	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
-	f.Setup("trigger goes ready", trigger.IsReady(via))
+	))
+	f.Setup("trigger goes ready", trigger.IsReady(triggerName))
 
 	f.Requirement("install source", eventshub.Install(
 		source,

--- a/test/rekt/features/broker/feature.go
+++ b/test/rekt/features/broker/feature.go
@@ -17,6 +17,9 @@ limitations under the License.
 package broker
 
 import (
+	"context"
+	"encoding/base64"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
@@ -199,4 +202,209 @@ func brokerRedeliveryDropN(retryNum int32, dropNum uint) *feature.Feature {
 			).AtLeast(1))
 
 	return f
+}
+
+func BrokerDeadLetterSinkExtensions() *feature.FeatureSet {
+	fs := &feature.FeatureSet{
+		Name: "Knative Broker - DeadLetterSink - with Extensions",
+
+		Features: []*feature.Feature{
+			brokerSubscriberUnreachable(),
+			brokerSubscriberErrorNodata(),
+			brokerSubscriberErrorWithdata(),
+		},
+	}
+	return fs
+}
+
+func brokerSubscriberUnreachable() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker Subscriber Unreachable")
+
+	source := feature.MakeRandomK8sName("source")
+	sink := feature.MakeRandomK8sName("sink")
+	via := feature.MakeRandomK8sName("via")
+
+	eventSource := "source1"
+	eventType := "type1"
+	eventBody := `{"msg":"test msg"}`
+	event := cloudevents.NewEvent()
+	event.SetID(uuid.New().String())
+	event.SetType(eventType)
+	event.SetSource(eventSource)
+	event.SetData(cloudevents.ApplicationJSON, []byte(eventBody))
+
+	//Install the broker
+	brokerName := feature.MakeRandomK8sName("broker")
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Requirement("broker is ready", broker.IsReady(brokerName))
+	f.Requirement("broker is addressable", broker.IsAddressable(brokerName))
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	// Point the Trigger subscriber to the sink svc.
+	cfg := []manifest.CfgFn{
+		trigger.WithSubscriber(nil, "http://fake.svc.cluster.local"),
+		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
+	}
+
+	// Install the trigger
+	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
+	f.Setup("trigger goes ready", trigger.IsReady(via))
+
+	f.Requirement("install source", eventshub.Install(
+		source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	f.Assert("Receives dls extensions when subscriber is unreachable",
+		eventasssert.OnStore(sink).
+			MatchEvent(
+				test.HasExtension("knativeerrordest", "http://fake.svc.cluster.local"),
+			).
+			AtLeast(1),
+	)
+	return f
+}
+
+func brokerSubscriberErrorNodata() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker Subscriber Error Nodata")
+
+	source := feature.MakeRandomK8sName("source")
+	sink := feature.MakeRandomK8sName("sink")
+	failer := feature.MakeRandomK8sName("failer")
+	via := feature.MakeRandomK8sName("via")
+
+	eventSource := "source1"
+	eventType := "type1"
+	eventBody := `{"msg":"test msg"}`
+	event := cloudevents.NewEvent()
+	event.SetID(uuid.New().String())
+	event.SetType(eventType)
+	event.SetSource(eventSource)
+	event.SetData(cloudevents.ApplicationJSON, []byte(eventBody))
+
+	//Install the broker
+	brokerName := feature.MakeRandomK8sName("broker")
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Requirement("broker is ready", broker.IsReady(brokerName))
+	f.Requirement("broker is addressable", broker.IsAddressable(brokerName))
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	f.Setup("install failing receiver", eventshub.Install(failer,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(1),
+		eventshub.DropEventsResponseCode(422),
+	))
+
+	// Point the Trigger subscriber to the sink svc.
+	cfg := []manifest.CfgFn{
+		trigger.WithSubscriber(svc.AsKReference(failer), ""),
+		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
+	}
+
+	// Install the trigger
+	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
+	f.Setup("trigger goes ready", trigger.IsReady(via))
+
+	f.Requirement("install source", eventshub.Install(
+		source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	f.Assert("Receives dls extensions without errordata", assertEnhancedWithKnativeErrorExtensions(
+		sink,
+		func(ctx context.Context) test.EventMatcher {
+			failerAddress, _ := svc.Address(ctx, failer)
+			return test.HasExtension("knativeerrordest", failerAddress.String())
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrorcode", "422")
+		},
+	))
+
+	return f
+}
+
+func brokerSubscriberErrorWithdata() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker Subscriber Error With data encoded")
+
+	source := feature.MakeRandomK8sName("source")
+	sink := feature.MakeRandomK8sName("sink")
+	failer := feature.MakeRandomK8sName("failer")
+	via := feature.MakeRandomK8sName("via")
+
+	eventSource := "source1"
+	eventType := "type1"
+	eventBody := `{"msg":"test msg"}`
+	event := cloudevents.NewEvent()
+	event.SetID(uuid.New().String())
+	event.SetType(eventType)
+	event.SetSource(eventSource)
+	event.SetData(cloudevents.ApplicationJSON, []byte(eventBody))
+
+	//Install the broker
+	brokerName := feature.MakeRandomK8sName("broker")
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Requirement("broker is ready", broker.IsReady(brokerName))
+	f.Requirement("broker is addressable", broker.IsAddressable(brokerName))
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	errorData := `{ "message": "catastrophic failure" }`
+	f.Setup("install failing receiver", eventshub.Install(failer,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(1),
+		eventshub.DropEventsResponseCode(422),
+		eventshub.DropEventsResponseBody(errorData),
+	))
+
+	// Point the Trigger subscriber to the sink svc.
+	cfg := []manifest.CfgFn{
+		trigger.WithSubscriber(svc.AsKReference(failer), ""),
+		trigger.WithDeadLetterSink(svc.AsKReference(sink), ""),
+	}
+
+	// Install the trigger
+	f.Setup("install trigger", trigger.Install(via, brokerName, cfg...))
+	f.Setup("trigger goes ready", trigger.IsReady(via))
+
+	f.Requirement("install source", eventshub.Install(
+		source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	f.Assert("Receives dls extensions without errordata", assertEnhancedWithKnativeErrorExtensions(
+		sink,
+		func(ctx context.Context) test.EventMatcher {
+			failerAddress, _ := svc.Address(ctx, failer)
+			return test.HasExtension("knativeerrordest", failerAddress.String())
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrorcode", "422")
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrordata", base64.StdEncoding.EncodeToString([]byte(errorData)))
+		},
+	))
+
+	return f
+}
+
+func assertEnhancedWithKnativeErrorExtensions(sinkName string, matcherfns ...func(ctx context.Context) test.EventMatcher) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		matchers := make([]test.EventMatcher, len(matcherfns))
+		for i, fn := range matcherfns {
+			matchers[i] = fn(ctx)
+		}
+		_ = eventshub.StoreFromContext(ctx, sinkName).AssertExact(
+			t,
+			1,
+			eventasssert.MatchKind(eventshub.EventReceived),
+			eventasssert.MatchEvent(matchers...),
+		)
+	}
 }

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -323,7 +323,105 @@ func ChannelPreferHeaderCheck(createSubscriberFn func(ref *duckv1.KReference, ur
 	return f
 }
 
-func ChannelSubscriptionReturnedErrorData(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
+func ChannelDeadLetterSinkExtensions(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.FeatureSet {
+	fs := &feature.FeatureSet{
+		Name: "Knative Channel - DeadLetterSink - with Extensions",
+		Features: []*feature.Feature{
+			channelSubscriberUnreachable(createSubscriberFn),
+			channelSubscriberReturnedErrorNoData(createSubscriberFn),
+			channelSubscriberReturnedErrorWithData(createSubscriberFn),
+		},
+	}
+	return fs
+}
+
+func channelSubscriberUnreachable(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
+	f := feature.NewFeature()
+	sink := feature.MakeRandomK8sName("sink")
+
+	sourceName := feature.MakeRandomK8sName("source")
+	channelName := feature.MakeRandomK8sName("channel")
+
+	ev := test.FullEvent()
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	f.Setup("install channel", channel_impl.Install(channelName, delivery.WithDeadLetterSink(svc.AsKReference(sink), "")))
+
+	f.Setup("install subscription", subscription.Install(feature.MakeRandomK8sName("subscription"),
+		subscription.WithChannel(channel_impl.AsRef(channelName)),
+		createSubscriberFn(nil, "http://fake.svc.cluster.local"),
+	))
+
+	f.Requirement("install source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(channel_impl.GVR(), channelName),
+		eventshub.InputEvent(ev),
+	))
+
+	f.Setup("channel is ready", channel_impl.IsReady(channelName))
+	f.Setup("channel is addressable", channel_impl.IsAddressable(channelName))
+
+	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(channelName, channel_impl.GVR()))
+
+	f.Assert("Receives dls extensions when subscriber is unreachable", eventasssert.OnStore(sink).
+		MatchEvent(test.HasExtension("knativeerrordest", "http://fake.svc.cluster.local")).
+		AtLeast(1),
+	)
+
+	return f
+}
+
+func channelSubscriberReturnedErrorNoData(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
+	f := feature.NewFeature()
+	sink := feature.MakeRandomK8sName("sink")
+
+	sourceName := feature.MakeRandomK8sName("source")
+	failer := feature.MakeRandomK8sName("failerWitdata")
+	channelName := feature.MakeRandomK8sName("channel")
+
+	ev := test.FullEvent()
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	f.Setup("install failing receiver", eventshub.Install(failer,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(1),
+		eventshub.DropEventsResponseCode(422),
+	))
+	f.Setup("install channel", channel_impl.Install(channelName, delivery.WithDeadLetterSink(svc.AsKReference(sink), "")))
+
+	f.Setup("install subscription", subscription.Install(feature.MakeRandomK8sName("subscription"),
+		subscription.WithChannel(channel_impl.AsRef(channelName)),
+		createSubscriberFn(svc.AsKReference(failer), ""),
+	))
+
+	f.Requirement("install source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(channel_impl.GVR(), channelName),
+		eventshub.InputEvent(ev),
+	))
+
+	f.Setup("channel is ready", channel_impl.IsReady(channelName))
+	f.Setup("channel is addressable", channel_impl.IsAddressable(channelName))
+
+	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(channelName, channel_impl.GVR()))
+
+	f.Assert("Receives dls extensions without errordata", assertEnhancedWithKnativeErrorExtensions(
+		sink,
+		func(ctx context.Context) test.EventMatcher {
+			failerAddress, _ := svc.Address(ctx, failer)
+			return test.HasExtension("knativeerrordest", failerAddress.String())
+		},
+		func(ctx context.Context) test.EventMatcher {
+			return test.HasExtension("knativeerrorcode", "422")
+		},
+	))
+
+	return f
+}
+
+func channelSubscriberReturnedErrorWithData(createSubscriberFn func(ref *duckv1.KReference, uri string) manifest.CfgFn) *feature.Feature {
 	f := feature.NewFeature()
 	sink := feature.MakeRandomK8sName("sink")
 

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -365,7 +365,8 @@ func channelSubscriberUnreachable(createSubscriberFn func(ref *duckv1.KReference
 	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(channelName, channel_impl.GVR()))
 
 	f.Assert("Receives dls extensions when subscriber is unreachable", eventasssert.OnStore(sink).
-		MatchEvent(test.HasExtension("knativeerrordest", "http://fake.svc.cluster.local")).
+		MatchEvent(
+			test.HasExtension("knativeerrordest", "http://fake.svc.cluster.local")).
 		AtLeast(1),
 	)
 


### PR DESCRIPTION
Fixes #6541  
Signed-off-by: Teresaliu [changyan.liu@intel.com](https://github.com/knative/eventing/pull/changyan.liu@intel.com)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add Reconciler Test of Channel to test failer extensions metadata
- Add failed events extensions `knativeerrordest, knativeerrordata,knativeerrorcode` to MTChannelBroker and corresponding Reconciler Test to Broker

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Add contextual information on why the message landed in deadletter sink of the MTChannel-based Broker or its Triggers.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

