### PR TITLE
Updates for Go 1.19

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -49,7 +49,8 @@ import (
 )
 
 // TODO make these constants configurable (either as env variables, config map, or part of broker spec).
-//  Issue: https://github.com/knative/eventing/issues/1777
+//
+//	Issue: https://github.com/knative/eventing/issues/1777
 const (
 	// Constants for the underlying HTTP Client transport. These would enable better connection reuse.
 	// Purposely set them to be equal, as the ingress only connects to its channel.

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,11 +20,14 @@ import (
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
+	"errors"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
 
 	"knative.dev/eventing/pkg/reconciler/apiserversource"
 	"knative.dev/eventing/pkg/reconciler/channel"
@@ -40,25 +43,37 @@ import (
 )
 
 func main() {
-	// sets up liveness and readiness probes.
-	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", handler)
-	mux.HandleFunc("/health", handler)
-	mux.HandleFunc("/readiness", handler)
+	ctx := signals.NewContext()
 
 	port := os.Getenv("PROBES_PORT")
 	if port == "" {
 		port = "8080"
 	}
 
+	// sets up liveness and readiness probes.
+	server := http.Server{
+		ReadTimeout: 5 * time.Second,
+		Handler:     http.HandlerFunc(handler),
+		Addr:        ":" + port,
+	}
+
 	go func() {
+
+		go func() {
+			<-ctx.Done()
+			_ = server.Shutdown(ctx)
+		}()
+
 		// start the web server on port and accept requests
 		log.Printf("Readiness and health check server listening on port %s", port)
-		log.Fatal(http.ListenAndServe(":"+port, mux))
+
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
 	}()
 
-	sharedmain.Main("controller",
+	sharedmain.MainWithContext(ctx, "controller",
 		// Messaging
 		channel.NewController,
 		subscription.NewController,

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -2146,7 +2146,7 @@ string values are supported.</p>
 <p>
 <p>TriggerFilterAttributes is a map of context attribute names to values for
 filtering by equality. Only exact matches will pass the filter. You can use
-the value &ldquo; to indicate all strings match.</p>
+the value ” to indicate all strings match.</p>
 </p>
 <h3 id="eventing.knative.dev/v1.TriggerSpec">TriggerSpec
 </h3>

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -121,7 +121,7 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 	}
 
 	srv := &http.Server{
-		Addr:              ":8080",
+		Addr: ":8080",
 		// Configure read header timeout to overcome potential Slowloris Attack because ReadHeaderTimeout is not
 		// configured in the http.Server.
 		ReadHeaderTimeout: 10 * time.Second,

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
+
 	"knative.dev/eventing/pkg/adapter/v2"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 )
@@ -120,7 +121,10 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 	}
 
 	srv := &http.Server{
-		Addr: ":8080",
+		Addr:              ":8080",
+		// Configure read header timeout to overcome potential Slowloris Attack because ReadHeaderTimeout is not
+		// configured in the http.Server.
+		ReadHeaderTimeout: 10 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/adapter/apiserver/delegate_test.go
+++ b/pkg/adapter/apiserver/delegate_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/adapter/apiserver/ref_test.go
+++ b/pkg/adapter/apiserver/ref_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/adapter/v2/test/test_client.go
+++ b/pkg/adapter/v2/test/test_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/duck/v1/register_test.go
+++ b/pkg/apis/duck/v1/register_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2020 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/apis/duck/v1/register_test.go
+++ b/pkg/apis/duck/v1/register_test.go
@@ -3,7 +3,9 @@ Copyright 2020 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1alpha1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/duck/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1beta1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -177,7 +177,7 @@ type SubscriptionsAPIFilter struct {
 
 // TriggerFilterAttributes is a map of context attribute names to values for
 // filtering by equality. Only exact matches will pass the filter. You can use
-// the value '' to indicate all strings match.
+// the value ” to indicate all strings match.
 type TriggerFilterAttributes map[string]string
 
 // TriggerStatus represents the current state of a Trigger.

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1beta1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/flows/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/flows/v1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/messaging/config/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/config/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/messaging/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/sources/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/sources/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1beta2/zz_generated.deepcopy.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -769,7 +769,7 @@ func (h *fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(h.expectedResponse.StatusCode)
 		if h.expectedResponse.Body != nil {
 			defer h.expectedResponse.Body.Close()
-			body, err := ioutil.ReadAll(h.expectedResponse.Body)
+			body, err := io.ReadAll(h.expectedResponse.Body)
 			if err != nil {
 				h.t.Fatal("Unable to read body: ", err)
 			}
@@ -858,7 +858,7 @@ func makeNonEmptyResponse() *http.Response {
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(invalidEvent)),
+		Body:       io.NopCloser(bytes.NewBufferString(invalidEvent)),
 		Header:     make(http.Header),
 	}
 	r.Header.Set("Content-Type", "garbage")
@@ -886,7 +886,7 @@ func makeMalformedStructuredEventResponse() *http.Response {
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte("{}"))),
+		Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
 		Header:     make(http.Header),
 	}
 	r.Header.Set("Content-Type", cloudevents.ApplicationCloudEventsJSON)

--- a/pkg/broker/ttl.go
+++ b/pkg/broker/ttl.go
@@ -55,9 +55,10 @@ func DeleteTTL(ctx cloudevents.EventContext) error {
 
 // TTLDefaulter returns a cloudevents event defaulter that will manage the TTL
 // for events with the following rules:
-//   If TTL is not found, it will set it to the default passed in.
-//   If TTL is <= 0, it will remain 0.
-//   If TTL is > 1, it will be reduced by one.
+//
+//	If TTL is not found, it will set it to the default passed in.
+//	If TTL is <= 0, it will remain 0.
+//	If TTL is > 1, it will be reduced by one.
 func TTLDefaulter(logger *zap.Logger, defaultTTL int32) client.EventDefaulter {
 	return func(ctx context.Context, event cloudevents.Event) cloudevents.Event {
 		// Get the current or default TTL from the event.

--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -169,7 +168,7 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			expectedErr:  true,
 			lastReceiver: "destination",
@@ -234,7 +233,7 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusNotFound,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			expectedErr: true,
 		},
@@ -270,7 +269,7 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			expectedErr:  true,
 			lastReceiver: "reply",
@@ -313,7 +312,7 @@ func TestDispatchMessage(t *testing.T) {
 					"knative-1":          {"new-knative-1-value"},
 					"ce-abc":             {`"new-ce-abc-value"`},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+				Body: io.NopCloser(bytes.NewBufferString("")),
 			},
 			lastReceiver: "reply",
 		},
@@ -360,7 +359,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-type":            {testCeType},
 					"ce-specversion":     {cloudevents.VersionV1},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body: io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			expectedReplyRequest: &requestValidation{
 				Headers: map[string][]string{
@@ -427,7 +426,7 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			fakeDeadLetterResponse: &http.Response{
 				StatusCode: http.StatusAccepted,
@@ -442,7 +441,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-type":            {testCeType},
 					"ce-specversion":     {cloudevents.VersionV1},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("deadlettersink-response")),
+				Body: io.NopCloser(bytes.NewBufferString("deadlettersink-response")),
 			},
 			lastReceiver: "deadLetter",
 		},
@@ -495,11 +494,11 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			fakeDeadLetterResponse: &http.Response{
 				StatusCode: http.StatusAccepted,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("deadlettersink-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("deadlettersink-response")),
 			},
 			lastReceiver: "deadLetter",
 		},
@@ -551,11 +550,11 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeReplyResponse: &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			fakeDeadLetterResponse: &http.Response{
 				StatusCode: http.StatusAccepted,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("deadlettersink-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("deadlettersink-response")),
 			},
 			lastReceiver: "deadLetter",
 		},
@@ -633,11 +632,11 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-type":            {testCeType},
 					"ce-specversion":     {cloudevents.VersionV1},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("destination-response")),
+				Body: io.NopCloser(bytes.NewBufferString("destination-response")),
 			},
 			fakeReplyResponse: &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("reply-response")),
+				Body:       io.NopCloser(bytes.NewBufferString("reply-response")),
 			},
 			fakeDeadLetterResponse: &http.Response{
 				StatusCode: http.StatusAccepted,
@@ -652,7 +651,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-type":            {testCeType},
 					"ce-specversion":     {cloudevents.VersionV1},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("deadlettersink-response")),
+				Body: io.NopCloser(bytes.NewBufferString("deadlettersink-response")),
 			},
 			lastReceiver: "deadLetter",
 		},
@@ -705,7 +704,7 @@ func TestDispatchMessage(t *testing.T) {
 			},
 			fakeResponse: &http.Response{
 				StatusCode: http.StatusBadRequest,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("destination\n multi-line\n response")),
+				Body:       io.NopCloser(bytes.NewBufferString("destination\n multi-line\n response")),
 			},
 			fakeDeadLetterResponse: &http.Response{
 				StatusCode: http.StatusAccepted,
@@ -720,7 +719,7 @@ func TestDispatchMessage(t *testing.T) {
 					"ce-type":            {testCeType},
 					"ce-specversion":     {cloudevents.VersionV1},
 				},
-				Body: ioutil.NopCloser(bytes.NewBufferString("deadlettersink-response")),
+				Body: io.NopCloser(bytes.NewBufferString("deadlettersink-response")),
 			},
 			lastReceiver: "deadLetter",
 		},
@@ -884,7 +883,7 @@ func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	// Make a copy of the request.
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		f.t.Error("Failed to read the request body")
 	}

--- a/pkg/channel/message_dispatcher_various_response_benchmark_test.go
+++ b/pkg/channel/message_dispatcher_various_response_benchmark_test.go
@@ -19,7 +19,7 @@ package channel_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -90,7 +90,7 @@ func newSampleResponseAcceptedAndNotNull() *fakeMessageHandler {
 	}
 	fakeResponse := &http.Response{
 		StatusCode: http.StatusAccepted,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(uuid.NewString())),
+		Body:       io.NopCloser(bytes.NewBufferString(uuid.NewString())),
 	}
 	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
 	return fmh
@@ -110,7 +110,7 @@ func newSampleResponseStatusInternalServerErrorAndNotNull() *fakeMessageHandler 
 	}
 	fakeResponse := &http.Response{
 		StatusCode: http.StatusInternalServerError,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(uuid.NewString())),
+		Body:       io.NopCloser(bytes.NewBufferString(uuid.NewString())),
 	}
 	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
 	return fmh
@@ -130,7 +130,7 @@ func newSampleResponseAcceptedAndNull() *fakeMessageHandler {
 	}
 	fakeResponse := &http.Response{
 		StatusCode: http.StatusAccepted,
-		Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+		Body:       io.NopCloser(bytes.NewBufferString("")),
 	}
 	fmh := NewFakeMessageHandler(true, false, eventExtensions, header, body, fakeResponse, nil)
 	return fmh
@@ -219,7 +219,7 @@ func (f *fakeHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	// Make a copy of the request.
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 
 		f.b.Error("Failed to read the request body")

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/doc.go
+++ b/pkg/client/clientset/versioned/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/fake/doc.go
+++ b/pkg/client/clientset/versioned/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -47,14 +47,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/doc.go
+++ b/pkg/client/clientset/versioned/scheme/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -47,14 +47,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/typed/eventing/v1/broker.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/doc.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/eventing_client.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/eventing_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_broker.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_eventing_client.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_eventing_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_trigger.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/fake/fake_trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1/trigger.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1/trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/doc.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/eventing_client.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/eventing_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/eventtype.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/fake_eventing_client.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/fake_eventing_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/fake_eventtype.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/fake/fake_eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/eventing/v1beta1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/eventing/v1beta1/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/doc.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_flows_client.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_flows_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_parallel.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_sequence.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/fake/fake_sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/flows_client.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/flows_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/parallel.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/flows/v1/sequence.go
+++ b/pkg/client/clientset/versioned/typed/flows/v1/sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/channel.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/doc.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_channel.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_inmemorychannel.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_messaging_client.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_messaging_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_subscription.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/fake/fake_subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/inmemorychannel.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/messaging_client.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/messaging_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/messaging/v1/subscription.go
+++ b/pkg/client/clientset/versioned/typed/messaging/v1/subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/apiserversource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/containersource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/doc.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_apiserversource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_containersource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_pingsource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_sinkbinding.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_sources_client.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/fake/fake_sources_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/pingsource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/sinkbinding.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1/sources_client.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1/sources_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/doc.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/doc.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/fake_pingsource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/fake_pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/fake_sources_client.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/fake/fake_sources_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/generated_expansion.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/pingsource.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/clientset/versioned/typed/sources/v1beta2/sources_client.go
+++ b/pkg/client/clientset/versioned/typed/sources/v1beta2/sources_client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/interface.go
+++ b/pkg/client/informers/externalversions/eventing/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/v1/broker.go
+++ b/pkg/client/informers/externalversions/eventing/v1/broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/v1/interface.go
+++ b/pkg/client/informers/externalversions/eventing/v1/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/v1/trigger.go
+++ b/pkg/client/informers/externalversions/eventing/v1/trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/v1beta1/eventtype.go
+++ b/pkg/client/informers/externalversions/eventing/v1beta1/eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/eventing/v1beta1/interface.go
+++ b/pkg/client/informers/externalversions/eventing/v1beta1/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/flows/interface.go
+++ b/pkg/client/informers/externalversions/flows/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/flows/v1/interface.go
+++ b/pkg/client/informers/externalversions/flows/v1/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/flows/v1/parallel.go
+++ b/pkg/client/informers/externalversions/flows/v1/parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/flows/v1/sequence.go
+++ b/pkg/client/informers/externalversions/flows/v1/sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/messaging/interface.go
+++ b/pkg/client/informers/externalversions/messaging/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/messaging/v1/channel.go
+++ b/pkg/client/informers/externalversions/messaging/v1/channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/messaging/v1/inmemorychannel.go
+++ b/pkg/client/informers/externalversions/messaging/v1/inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/messaging/v1/interface.go
+++ b/pkg/client/informers/externalversions/messaging/v1/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/messaging/v1/subscription.go
+++ b/pkg/client/informers/externalversions/messaging/v1/subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/interface.go
+++ b/pkg/client/informers/externalversions/sources/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1/apiserversource.go
+++ b/pkg/client/informers/externalversions/sources/v1/apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1/containersource.go
+++ b/pkg/client/informers/externalversions/sources/v1/containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1/interface.go
+++ b/pkg/client/informers/externalversions/sources/v1/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1/pingsource.go
+++ b/pkg/client/informers/externalversions/sources/v1/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1/sinkbinding.go
+++ b/pkg/client/informers/externalversions/sources/v1/sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1beta2/interface.go
+++ b/pkg/client/informers/externalversions/sources/v1beta2/interface.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/informers/externalversions/sources/v1beta2/pingsource.go
+++ b/pkg/client/informers/externalversions/sources/v1beta2/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/client/client.go
+++ b/pkg/client/injection/client/client.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/client/fake/fake.go
+++ b/pkg/client/injection/client/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/ducks/duck/v1/channelable/channelable.go
+++ b/pkg/client/injection/ducks/duck/v1/channelable/channelable.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/ducks/duck/v1/channelable/fake/fake.go
+++ b/pkg/client/injection/ducks/duck/v1/channelable/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/ducks/duck/v1beta1/channelable/channelable.go
+++ b/pkg/client/injection/ducks/duck/v1beta1/channelable/channelable.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/ducks/duck/v1beta1/channelable/fake/fake.go
+++ b/pkg/client/injection/ducks/duck/v1beta1/channelable/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/broker/broker.go
+++ b/pkg/client/injection/informers/eventing/v1/broker/broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/broker/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1/broker/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/broker/filtered/broker.go
+++ b/pkg/client/injection/informers/eventing/v1/broker/filtered/broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/broker/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1/broker/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/trigger/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1/trigger/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/trigger/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1/trigger/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/trigger/filtered/trigger.go
+++ b/pkg/client/injection/informers/eventing/v1/trigger/filtered/trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1/trigger/trigger.go
+++ b/pkg/client/injection/informers/eventing/v1/trigger/trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1beta1/eventtype/eventtype.go
+++ b/pkg/client/injection/informers/eventing/v1beta1/eventtype/eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1beta1/eventtype/filtered/eventtype.go
+++ b/pkg/client/injection/informers/eventing/v1beta1/eventtype/filtered/eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/eventing/v1beta1/eventtype/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/eventing/v1beta1/eventtype/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/factory/factory.go
+++ b/pkg/client/injection/informers/factory/factory.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/factory/fake/fake.go
+++ b/pkg/client/injection/informers/factory/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/factory/filtered/fake/fake_filtered_factory.go
+++ b/pkg/client/injection/informers/factory/filtered/fake/fake_filtered_factory.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/factory/filtered/filtered_factory.go
+++ b/pkg/client/injection/informers/factory/filtered/filtered_factory.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/parallel/fake/fake.go
+++ b/pkg/client/injection/informers/flows/v1/parallel/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/parallel/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/flows/v1/parallel/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/parallel/filtered/parallel.go
+++ b/pkg/client/injection/informers/flows/v1/parallel/filtered/parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/parallel/parallel.go
+++ b/pkg/client/injection/informers/flows/v1/parallel/parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/sequence/fake/fake.go
+++ b/pkg/client/injection/informers/flows/v1/sequence/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/sequence/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/flows/v1/sequence/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/sequence/filtered/sequence.go
+++ b/pkg/client/injection/informers/flows/v1/sequence/filtered/sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/flows/v1/sequence/sequence.go
+++ b/pkg/client/injection/informers/flows/v1/sequence/sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/channel/channel.go
+++ b/pkg/client/injection/informers/messaging/v1/channel/channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/channel/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/channel/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/channel/filtered/channel.go
+++ b/pkg/client/injection/informers/messaging/v1/channel/filtered/channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/channel/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/channel/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/inmemorychannel/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/inmemorychannel/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/inmemorychannel/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/inmemorychannel/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/inmemorychannel/filtered/inmemorychannel.go
+++ b/pkg/client/injection/informers/messaging/v1/inmemorychannel/filtered/inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/inmemorychannel/inmemorychannel.go
+++ b/pkg/client/injection/informers/messaging/v1/inmemorychannel/inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/subscription/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/subscription/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/subscription/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/messaging/v1/subscription/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/subscription/filtered/subscription.go
+++ b/pkg/client/injection/informers/messaging/v1/subscription/filtered/subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/messaging/v1/subscription/subscription.go
+++ b/pkg/client/injection/informers/messaging/v1/subscription/subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/apiserversource/apiserversource.go
+++ b/pkg/client/injection/informers/sources/v1/apiserversource/apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/apiserversource/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/apiserversource/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/apiserversource/filtered/apiserversource.go
+++ b/pkg/client/injection/informers/sources/v1/apiserversource/filtered/apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/apiserversource/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/apiserversource/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/containersource/containersource.go
+++ b/pkg/client/injection/informers/sources/v1/containersource/containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/containersource/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/containersource/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/containersource/filtered/containersource.go
+++ b/pkg/client/injection/informers/sources/v1/containersource/filtered/containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/containersource/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/containersource/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/pingsource/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/pingsource/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/pingsource/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/pingsource/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/pingsource/filtered/pingsource.go
+++ b/pkg/client/injection/informers/sources/v1/pingsource/filtered/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/pingsource/pingsource.go
+++ b/pkg/client/injection/informers/sources/v1/pingsource/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/sinkbinding/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/sinkbinding/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/sinkbinding/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1/sinkbinding/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/sinkbinding/filtered/sinkbinding.go
+++ b/pkg/client/injection/informers/sources/v1/sinkbinding/filtered/sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1/sinkbinding/sinkbinding.go
+++ b/pkg/client/injection/informers/sources/v1/sinkbinding/sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1beta2/pingsource/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1beta2/pingsource/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1beta2/pingsource/filtered/fake/fake.go
+++ b/pkg/client/injection/informers/sources/v1beta2/pingsource/filtered/fake/fake.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1beta2/pingsource/filtered/pingsource.go
+++ b/pkg/client/injection/informers/sources/v1beta2/pingsource/filtered/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/informers/sources/v1beta2/pingsource/pingsource.go
+++ b/pkg/client/injection/informers/sources/v1beta2/pingsource/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/broker/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1/broker/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/broker/reconciler.go
+++ b/pkg/client/injection/reconciler/eventing/v1/broker/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/broker/state.go
+++ b/pkg/client/injection/reconciler/eventing/v1/broker/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/trigger/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1/trigger/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/trigger/reconciler.go
+++ b/pkg/client/injection/reconciler/eventing/v1/trigger/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1/trigger/state.go
+++ b/pkg/client/injection/reconciler/eventing/v1/trigger/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/controller.go
+++ b/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/reconciler.go
+++ b/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/state.go
+++ b/pkg/client/injection/reconciler/eventing/v1beta1/eventtype/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/parallel/controller.go
+++ b/pkg/client/injection/reconciler/flows/v1/parallel/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/parallel/reconciler.go
+++ b/pkg/client/injection/reconciler/flows/v1/parallel/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/parallel/state.go
+++ b/pkg/client/injection/reconciler/flows/v1/parallel/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/sequence/controller.go
+++ b/pkg/client/injection/reconciler/flows/v1/sequence/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/sequence/reconciler.go
+++ b/pkg/client/injection/reconciler/flows/v1/sequence/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/flows/v1/sequence/state.go
+++ b/pkg/client/injection/reconciler/flows/v1/sequence/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/channel/controller.go
+++ b/pkg/client/injection/reconciler/messaging/v1/channel/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/channel/reconciler.go
+++ b/pkg/client/injection/reconciler/messaging/v1/channel/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/channel/state.go
+++ b/pkg/client/injection/reconciler/messaging/v1/channel/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/controller.go
+++ b/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/reconciler.go
+++ b/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/state.go
+++ b/pkg/client/injection/reconciler/messaging/v1/inmemorychannel/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/subscription/controller.go
+++ b/pkg/client/injection/reconciler/messaging/v1/subscription/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/subscription/reconciler.go
+++ b/pkg/client/injection/reconciler/messaging/v1/subscription/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/messaging/v1/subscription/state.go
+++ b/pkg/client/injection/reconciler/messaging/v1/subscription/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/apiserversource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1/apiserversource/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/apiserversource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1/apiserversource/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/apiserversource/state.go
+++ b/pkg/client/injection/reconciler/sources/v1/apiserversource/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/containersource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1/containersource/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/containersource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1/containersource/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/containersource/state.go
+++ b/pkg/client/injection/reconciler/sources/v1/containersource/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/pingsource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1/pingsource/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/pingsource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1/pingsource/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1/pingsource/state.go
+++ b/pkg/client/injection/reconciler/sources/v1/pingsource/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1beta2/pingsource/controller.go
+++ b/pkg/client/injection/reconciler/sources/v1beta2/pingsource/controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1beta2/pingsource/reconciler.go
+++ b/pkg/client/injection/reconciler/sources/v1beta2/pingsource/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/injection/reconciler/sources/v1beta2/pingsource/state.go
+++ b/pkg/client/injection/reconciler/sources/v1beta2/pingsource/state.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/eventing/v1/broker.go
+++ b/pkg/client/listers/eventing/v1/broker.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/eventing/v1/expansion_generated.go
+++ b/pkg/client/listers/eventing/v1/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/eventing/v1/trigger.go
+++ b/pkg/client/listers/eventing/v1/trigger.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/eventing/v1beta1/eventtype.go
+++ b/pkg/client/listers/eventing/v1beta1/eventtype.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/eventing/v1beta1/expansion_generated.go
+++ b/pkg/client/listers/eventing/v1beta1/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/flows/v1/expansion_generated.go
+++ b/pkg/client/listers/flows/v1/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/flows/v1/parallel.go
+++ b/pkg/client/listers/flows/v1/parallel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/flows/v1/sequence.go
+++ b/pkg/client/listers/flows/v1/sequence.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/messaging/v1/channel.go
+++ b/pkg/client/listers/messaging/v1/channel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/messaging/v1/expansion_generated.go
+++ b/pkg/client/listers/messaging/v1/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/messaging/v1/inmemorychannel.go
+++ b/pkg/client/listers/messaging/v1/inmemorychannel.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/messaging/v1/subscription.go
+++ b/pkg/client/listers/messaging/v1/subscription.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1/apiserversource.go
+++ b/pkg/client/listers/sources/v1/apiserversource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1/containersource.go
+++ b/pkg/client/listers/sources/v1/containersource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1/expansion_generated.go
+++ b/pkg/client/listers/sources/v1/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1/pingsource.go
+++ b/pkg/client/listers/sources/v1/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1/sinkbinding.go
+++ b/pkg/client/listers/sources/v1/sinkbinding.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1beta2/expansion_generated.go
+++ b/pkg/client/listers/sources/v1beta2/expansion_generated.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/listers/sources/v1beta2/pingsource.go
+++ b/pkg/client/listers/sources/v1beta2/pingsource.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/duck/channel.go
+++ b/pkg/duck/channel.go
@@ -136,11 +136,14 @@ func WithPhysicalChannelSpec(physicalChannelSpec *runtime.RawExtension) Physical
 // apiVersion: messaging.knative.dev/v1
 // kind: InMemoryChannel
 // metadata:
-//   name: "hello"
-//   namespace: "world"
+//
+//	name: "hello"
+//	namespace: "world"
+//
 // spec:
-//   delivery:
-//     retry: 3
+//
+//	delivery:
+//	  retry: 3
 func NewPhysicalChannel(typeMeta metav1.TypeMeta, objMeta metav1.ObjectMeta, opts ...PhysicalChannelOption) (*unstructured.Unstructured, error) {
 	// Set the name of the resource we're creating as well as the namespace, etc.
 	template := channelTemplateSpecInternal{

--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -83,7 +83,7 @@ func WithDrainQuietPeriod(duration time.Duration) HTTPMessageReceiverOption {
 func WithWriteTimeout(duration time.Duration) HTTPMessageReceiverOption {
 	return func(h *HTTPMessageReceiver) {
 		if h.server == nil {
-			h.server = &http.Server{}
+			h.server = newServer()
 		}
 
 		h.server.WriteTimeout = duration
@@ -95,7 +95,7 @@ func WithWriteTimeout(duration time.Duration) HTTPMessageReceiverOption {
 func WithReadTimeout(duration time.Duration) HTTPMessageReceiverOption {
 	return func(h *HTTPMessageReceiver) {
 		if h.server == nil {
-			h.server = &http.Server{}
+			h.server = newServer()
 		}
 
 		h.server.ReadTimeout = duration
@@ -160,5 +160,11 @@ func CreateHandler(handler http.Handler) http.Handler {
 	return &ochttp.Handler{
 		Propagation: tracecontextb3.TraceContextEgress,
 		Handler:     handler,
+	}
+}
+
+func newServer() *http.Server {
+	return &http.Server{
+		ReadTimeout: 10 * time.Second,
 	}
 }

--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -115,7 +115,7 @@ func (recv *HTTPMessageReceiver) StartListen(ctx context.Context, handler http.H
 		QuietPeriod: recv.drainQuietPeriod,
 	}
 	if recv.server == nil {
-		recv.server = &http.Server{}
+		recv.server = newServer()
 	}
 	recv.server.Addr = recv.listener.Addr().String()
 	recv.server.Handler = drainer

--- a/pkg/kncloudevents/retries.go
+++ b/pkg/kncloudevents/retries.go
@@ -139,7 +139,8 @@ func RetryIfGreaterThan300(_ context.Context, response *http.Response, err error
 // SelectiveRetry is an alternative function to determine whether to retry based on response
 //
 // Note - Returning true indicates a retry should occur.  Returning an error will result in that
-//        error being returned instead of any errors from the Request.
+//
+//	error being returned instead of any errors from the Request.
 //
 // A retry is triggered for:
 // * nil responses

--- a/pkg/kncloudevents/utils_test.go
+++ b/pkg/kncloudevents/utils_test.go
@@ -18,7 +18,7 @@ package kncloudevents
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +52,7 @@ func TestWriteHTTPRequestWithAdditionalHeadersWritesIntoRequest(t *testing.T) {
 	assert.Equal(t, []string{ceSource}, request.Header["Ce-Source"])
 	assert.Equal(t, []string{ceType}, request.Header["Ce-Type"])
 	assert.Equal(t, []string{cloudevents.TextPlain}, request.Header["Content-Type"])
-	gotPayload, err := ioutil.ReadAll(request.Body)
+	gotPayload, err := io.ReadAll(request.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(ceData), gotPayload)
 

--- a/pkg/reconciler/source/duck/duck.go
+++ b/pkg/reconciler/source/duck/duck.go
@@ -105,7 +105,8 @@ func (r *Reconciler) reconcile(ctx context.Context, source *duckv1.Source) error
 }
 
 // TODO revisit most of this logic once we get rid of Broker and maybe some other bits.
-//  https://github.com/knative/eventing/issues/2750.
+//
+//	https://github.com/knative/eventing/issues/2750.
 func (r *Reconciler) reconcileEventTypes(ctx context.Context, src *duckv1.Source) error {
 	current, err := r.getEventTypes(ctx, src)
 	if err != nil {

--- a/test/conformance/helpers/broker_data_plane_test_helper.go
+++ b/test/conformance/helpers/broker_data_plane_test_helper.go
@@ -79,12 +79,12 @@ func BrokerDataPlaneNamespaceSetupOption(ctx context.Context, namespace string) 
 	}
 }
 
-//At ingress
-//Supports CE 0.3 or CE 1.0 via HTTP
-//Supports structured or Binary mode
-//Respond with 2xx on good CE
-//Respond with 400 on bad CE
-//Reject non-POST, non-OPTIONS requests to publish URI (beyond spec?!)
+// At ingress
+// Supports CE 0.3 or CE 1.0 via HTTP
+// Supports structured or Binary mode
+// Respond with 2xx on good CE
+// Respond with 400 on bad CE
+// Reject non-POST, non-OPTIONS requests to publish URI (beyond spec?!)
 func BrokerIngressDataPlaneTestHelper(
 	ctx context.Context,
 	t *testing.T,
@@ -250,14 +250,14 @@ func BrokerIngressDataPlaneTestHelper(
 	})
 }
 
-//At consumer
-//No upgrade of version
-//Attributes received should be the same as produced (attributes may be added)
-//Events are filtered
-//Events are delivered to multiple subscribers
-//Deliveries succeed at least once
-//Replies are accepted and delivered
-//Replies that are unsuccessfully forwarded cause initial message to be redelivered (Very difficult to test, can be ignored)
+// At consumer
+// No upgrade of version
+// Attributes received should be the same as produced (attributes may be added)
+// Events are filtered
+// Events are delivered to multiple subscribers
+// Deliveries succeed at least once
+// Replies are accepted and delivered
+// Replies that are unsuccessfully forwarded cause initial message to be redelivered (Very difficult to test, can be ignored)
 func BrokerConsumerDataPlaneTestHelper(
 	ctx context.Context,
 	t *testing.T,

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -50,7 +50,9 @@ func ChannelTracingTestHelperWithChannelTestRunner(
 
 // setupChannelTracing is the general setup for TestChannelTracing. It creates the following:
 // SendEvents (Pod) -> Channel -> Subscription -> K8s Service -> Mutate (Pod)
-//                                                                   v
+//
+//	v
+//
 // LogEvents (Pod) <- K8s Service <- Subscription  <- Channel <- (Reply) Subscription
 // It returns the expected trace tree and a match function that is expected to be sent
 // by the SendEvents Pod and should be present in the RecordEvents list of events.

--- a/test/conformance/helpers/sources/source_crd_rbac_test_helper.go
+++ b/test/conformance/helpers/sources/source_crd_rbac_test_helper.go
@@ -34,11 +34,11 @@ var clusterRoleLabel = map[string]string{
 }
 
 /*
-	The test checks for the following in this order:
-	1. Find cluster roles that match these criteria -
-		a. Has label duck.knative.dev/source: "true",
-		b. Has the eventing source in Resources for a Policy Rule, and
-		c. Has all the expected verbs (get, list, watch)
+The test checks for the following in this order:
+ 1. Find cluster roles that match these criteria -
+    a. Has label duck.knative.dev/source: "true",
+    b. Has the eventing source in Resources for a Policy Rule, and
+    c. Has all the expected verbs (get, list, watch)
 */
 func SourceCRDRBACTestHelperWithComponentsTestRunner(
 	t *testing.T,

--- a/test/conformance/helpers/sources/source_status_test_helper.go
+++ b/test/conformance/helpers/sources/source_status_test_helper.go
@@ -33,7 +33,7 @@ import (
 // SourceStatusTestHelperWithComponentsTestRunner runs the Source status
 // conformance tests for all sources in the ComponentsTestRunner. This test
 // needs an already created instance of each source which should be initialized
-//via ComponentsTestRunner.AddComponentSetupClientOption.
+// via ComponentsTestRunner.AddComponentSetupClientOption.
 //
 // Note: The source object name must be the lower case Kind name (e.g.
 // apiserversource for the Kind: ApiServerSource source)

--- a/test/conformance/helpers/tracing/traces.go
+++ b/test/conformance/helpers/tracing/traces.go
@@ -30,11 +30,15 @@ import (
 
 // hostSuffix is an optional suffix that might appear at the end of hostnames.
 // We supplement matches with this to allow matches for:
-//    foo.bar
+//
+//	foo.bar
+//
 // to match all of:
-//    foo.bar
-//    foo.bar.svc
-//    foo.bar.svc.cluster.local
+//
+//	foo.bar
+//	foo.bar.svc
+//	foo.bar.svc.cluster.local
+//
 // It's hardly perfect, but requires the suffix to start with the delimiter '.'
 // and then match anything prior to the path starting, e.g. '/'
 const HostSuffix = "[.][^/]+"

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -28,22 +28,23 @@ import (
 /*
 TestBrokerChannelFlow tests the following topology:
 
-                   ------------- ----------------------
-                   |           | |                    |
-                   v	       | v                    |
+	------------- ----------------------
+	|           | |                    |
+	v	       | v                    |
+
 EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
-                   |
-                   |
-                   |-------> Trigger2 -------> Service(Logger1)
-                   |
-                   |
-                   |-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger2)
+
+	|
+	|
+	|-------> Trigger2 -------> Service(Logger1)
+	|
+	|
+	|-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger2)
 
 Explanation:
 Trigger1 filters the orignal event and transforms it to a new event,
 Trigger2 logs all events,
 Trigger3 filters the transformed event and sends it to Channel.
-
 */
 func TestBrokerChannelFlowTriggerV1BrokerV1(t *testing.T) {
 	helpers.BrokerChannelFlowWithTransformation(context.Background(), t, brokerClass, "v1", "v1", channelTestRunner)

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -31,14 +31,16 @@ import (
 /*
 TestEventTransformationForTrigger tests the following scenario:
 
-                         5                 4
-                   ------------- ----------------------
-                   |           | |                    |
-             1     v	 2     | v        3           |
+	            5                 4
+	      ------------- ----------------------
+	      |           | |                    |
+	1     v	 2     | v        3           |
+
 EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
-                   |
-                   | 6                   7
-                   |-------> Trigger2 -------> Service(Logger)
+
+	|
+	| 6                   7
+	|-------> Trigger2 -------> Service(Logger)
 
 Note: the number denotes the sequence of the event that flows in this test case.
 */

--- a/test/e2e/helpers/broker_channel_flow_helper.go
+++ b/test/e2e/helpers/broker_channel_flow_helper.go
@@ -33,22 +33,23 @@ import (
 /*
 BrokerChannelFlowWithTransformation tests the following topology:
 
-                   ------------- ----------------------
-                   |           | |                    |
-                   v	       | v                    |
+	------------- ----------------------
+	|           | |                    |
+	v	       | v                    |
+
 EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
-                   |
-                   |
-                   |-------> Trigger2 -------> Service(Logger1)
-                   |
-                   |
-                   |-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger2)
+
+	|
+	|
+	|-------> Trigger2 -------> Service(Logger1)
+	|
+	|
+	|-------> Trigger3 -------> Channel --------> Subscription --------> Service(Logger2)
 
 Explanation:
 Trigger1 filters the orignal event and transforms it to a new event,
 Trigger2 logs all events,
 Trigger3 filters the transformed event and sends it to Channel.
-
 */
 func BrokerChannelFlowWithTransformation(
 	ctx context.Context,

--- a/test/e2e/helpers/broker_event_transformation_test_helper.go
+++ b/test/e2e/helpers/broker_event_transformation_test_helper.go
@@ -31,14 +31,16 @@ import (
 /*
 EventTransformationForTriggerTestHelper tests the following scenario:
 
-                         5                 4
-                   ------------- ----------------------
-                   |           | |                    |
-             1     v	 2     | v        3           |
+	            5                 4
+	      ------------- ----------------------
+	      |           | |                    |
+	1     v	 2     | v        3           |
+
 EventSource ---> Broker ---> Trigger1 -------> Service(Transformation)
-                   |
-                   | 6                   7
-                   |-------> Trigger2 -------> Service(Logger)
+
+	|
+	| 6                   7
+	|-------> Trigger2 -------> Service(Logger)
 
 Note: the number denotes the sequence of the event that flows in this test case.
 */

--- a/test/lib/await.go
+++ b/test/lib/await.go
@@ -17,7 +17,7 @@ package lib
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -72,7 +72,7 @@ func WaitForReadiness(port int, log *zap.SugaredLogger) error {
 		defer func() {
 			_ = resp.Body.Close()
 		}()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, err
 		}

--- a/test/lib/recordevents/sender/sender.go
+++ b/test/lib/recordevents/sender/sender.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	nethttp "net/http"
 	"strconv"
 	"strings"
@@ -161,7 +161,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 		}
 
 		if env.InputBody != "" {
-			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(env.InputBody)))
+			req.Body = io.NopCloser(bytes.NewReader([]byte(env.InputBody)))
 		}
 
 		res, err := httpClient.Do(req)
@@ -218,7 +218,7 @@ func Start(ctx context.Context, logs *recordevents.EventLogs) error {
 				StatusCode:  res.StatusCode,
 			}
 			if responseMessage.ReadEncoding() == binding.EncodingUnknown {
-				body, err := ioutil.ReadAll(res.Body)
+				body, err := io.ReadAll(res.Body)
 
 				if err != nil {
 					responseInfo.Error = err.Error()

--- a/test/lib/resources/constants.go
+++ b/test/lib/resources/constants.go
@@ -80,7 +80,7 @@ const (
 	FlowsParallelKind string = "Parallel"
 )
 
-//Kind for sources resources that exist in Eventing core
+// Kind for sources resources that exist in Eventing core
 const (
 	ApiServerSourceKind string = "ApiServerSource"
 	PingSourceKind      string = "PingSource"

--- a/test/performance/infra/receiver/id_extractor.go
+++ b/test/performance/infra/receiver/id_extractor.go
@@ -22,7 +22,9 @@ import cloudevents "github.com/cloudevents/sdk-go/v2"
 type IdExtractor func(event cloudevents.Event) string
 
 // EventIdExtractor uses
-//  event.ID()
+//
+//	event.ID()
+//
 // to extract the event id
 func EventIdExtractor(event cloudevents.Event) string {
 	return event.ID()

--- a/test/performance/infra/receiver/type_extractor.go
+++ b/test/performance/infra/receiver/type_extractor.go
@@ -22,7 +22,9 @@ import cloudevents "github.com/cloudevents/sdk-go/v2"
 type TypeExtractor func(event cloudevents.Event) string
 
 // EventTypeExtractor uses
-//  event.Type()
+//
+//	event.Type()
+//
 // to extract the event type
 func EventTypeExtractor(event cloudevents.Event) string {
 	return event.Type()

--- a/test/performance/infra/sender/http_load_generator_test.go
+++ b/test/performance/infra/sender/http_load_generator_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Knative Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/performance/infra/sender/http_load_generator_test.go
+++ b/test/performance/infra/sender/http_load_generator_test.go
@@ -3,7 +3,9 @@ Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -155,7 +155,6 @@ func TestSmoke_ChannelImplWithSubscription(t *testing.T) {
 TestChannelChain tests the following scenario:
 
 EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
-
 */
 func TestChannelChain(t *testing.T) {
 	t.Parallel()
@@ -220,13 +219,15 @@ func TestGenericChannelDeadLetterSink(t *testing.T) {
 /*
 TestEventTransformationForSubscription tests the following scenario:
 
-             1            2                 5            6                  7
+	1            2                 5            6                  7
+
 EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> Service(Logger)
-                                   |  ^
-                                 3 |  | 4
-                                   |  |
-                                   |  ---------
-                                   -----------> Service(Transformation)
+
+	  |  ^
+	3 |  | 4
+	  |  |
+	  |  ---------
+	  -----------> Service(Transformation)
 */
 func TestEventTransformationForSubscriptionV1(t *testing.T) {
 	t.Parallel()
@@ -246,7 +247,6 @@ func TestEventTransformationForSubscriptionV1(t *testing.T) {
 TestBinaryEventForChannel tests the following scenario:
 
 EventSource (binary-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
-
 */
 func TestBinaryEventForChannel(t *testing.T) {
 	t.Parallel()
@@ -266,7 +266,6 @@ func TestBinaryEventForChannel(t *testing.T) {
 TestStructuredEventForChannel tests the following scenario:
 
 EventSource (structured-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
-
 */
 func TestStructuredEventForChannel(t *testing.T) {
 	t.Parallel()

--- a/test/rekt/features/broker/source_to_sink.go
+++ b/test/rekt/features/broker/source_to_sink.go
@@ -75,9 +75,9 @@ func SourceToSink(brokerName string) *feature.Feature {
 // to a Ready Broker, forward unsent events to it's Broker's DLQ
 //
 // source ---> broker<Via> --[trigger]--> bad uri
-//                |
-//                +--[DLQ]--> dlq
 //
+//	|
+//	+--[DLQ]--> dlq
 func SourceToSinkWithDLQ() *feature.Feature {
 	f := feature.NewFeature()
 
@@ -125,9 +125,9 @@ func SourceToSinkWithDLQ() *feature.Feature {
 // SourceToSinkWithFlakyDLQ tests to see if a Ready Broker acts as middleware.
 //
 // source ---> broker --[trigger]--> flake 1/3 --> recorder
-//                  |
-//                  +--[DLQ]--> recorder
 //
+//	|
+//	+--[DLQ]--> recorder
 func SourceToSinkWithFlakyDLQ(brokerName string) *feature.Feature {
 	source := feature.MakeRandomK8sName("source")
 	sink := feature.MakeRandomK8sName("sink")

--- a/test/rekt/features/broker/topology.go
+++ b/test/rekt/features/broker/topology.go
@@ -42,20 +42,19 @@ type triggerCfg struct {
 	reply     *conformanceevent.Event
 }
 
-//
 // createBrokerTriggerDeliveryTopology creates a topology that allows us to test the various
 // delivery configurations.
 //
 // source ---> [broker (brokerDS)] --+--[trigger0 (ds, filter)]--> "t0" + (optional reply)
-//                         |         |              |
-//                         |         |              +--> "t0dlq" (optional)
-//                         |        ...
-//                         |         +-[trigger{n} (ds, filter)]--> "t{n}" + (optional reply)
-//                         |                       |
-//                         |                       +--> "t{n}dlq" (optional)
-//                         |
-//                         +--[DLQ]--> "dlq" (optional)
 //
+//	|         |              |
+//	|         |              +--> "t0dlq" (optional)
+//	|        ...
+//	|         +-[trigger{n} (ds, filter)]--> "t{n}" + (optional reply)
+//	|                       |
+//	|                       +--> "t{n}dlq" (optional)
+//	|
+//	+--[DLQ]--> "dlq" (optional)
 func createBrokerTriggerTopology(f *feature.Feature, brokerName string, brokerDS *v1.DeliverySpec, triggers []triggerCfg, brokerOpts ...manifest.CfgFn) *eventshub.EventProber {
 	prober := eventshub.NewProber()
 

--- a/test/rekt/features/channel/topology.go
+++ b/test/rekt/features/channel/topology.go
@@ -58,16 +58,15 @@ func (s *subCfg) dlqName() string {
 // createChannelTopology creates a channel and {n} subscriptions with recorders
 // attached to each endpoint.
 //
-//  source --> [channel (chDS)] --+--[sub1 (sub1DS)]--> sub1sub (optional) --> sub1reply (optional)
-//                        |       |            |
-//                        |       |            +-->sub1dlq (optional)
-//                        |      ...
-//                        |       +-[sub{n} (sub{n}DS)]--> sub{n}sub (optional)--> sub{n}reply (optional)
-//                        |                   |
-//                        |                   +-->sub{n}dlq (optional)
-//                        |
-//                        +--[DLQ]--> chdlq (optional)
-//
+//	source --> [channel (chDS)] --+--[sub1 (sub1DS)]--> sub1sub (optional) --> sub1reply (optional)
+//	                      |       |            |
+//	                      |       |            +-->sub1dlq (optional)
+//	                      |      ...
+//	                      |       +-[sub{n} (sub{n}DS)]--> sub{n}sub (optional)--> sub{n}reply (optional)
+//	                      |                   |
+//	                      |                   +-->sub{n}dlq (optional)
+//	                      |
+//	                      +--[DLQ]--> chdlq (optional)
 func createChannelTopology(f *feature.Feature, chName string, chDS *v1.DeliverySpec, subs []subCfg) *eventshub.EventProber {
 	prober := eventshub.NewProber()
 	// Install the receivers.

--- a/test/rekt/features/trigger/trigger_sink_resolution.go
+++ b/test/rekt/features/trigger/trigger_sink_resolution.go
@@ -33,9 +33,9 @@ import (
 // failing events to it's DLS.
 //
 // source ---> broker --[trigger]--> bad uri
-//                          |
-//                          +--[DLS]--> sink
 //
+//	|
+//	+--[DLS]--> sink
 func SourceToTriggerSinkWithDLS() *feature.Feature {
 	f := feature.NewFeatureNamed("Trigger with DLS")
 
@@ -87,9 +87,9 @@ func SourceToTriggerSinkWithDLS() *feature.Feature {
 // failing events to it's DLS even when it's corresponding Ready Broker also have a DLS defined.
 //
 // source ---> broker --[trigger]--> bad uri
-//               |          |
-//               +--[DLS]   +--[DLS]--> sink
 //
+//	|          |
+//	+--[DLS]   +--[DLS]--> sink
 func SourceToTriggerSinkWithDLSDontUseBrokers() *feature.Feature {
 	f := feature.NewFeatureNamed("When Trigger DLS is defined, Broker DLS is ignored")
 
@@ -147,11 +147,11 @@ func SourceToTriggerSinkWithDLSDontUseBrokers() *feature.Feature {
 }
 
 // source ---> broker +--[trigger<via1>]--> bad uri
-//                |   |
-//                |   +--[trigger<vai2>]--> sink
-//                |
-//                +--[DLQ]--> dlq
 //
+//	|   |
+//	|   +--[trigger<vai2>]--> sink
+//	|
+//	+--[DLQ]--> dlq
 func BadTriggerDoesNotAffectOkTrigger() *feature.Feature {
 	f := feature.NewFeatureNamed("Bad Trigger does not affect good Trigger")
 

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -83,7 +83,7 @@ func WithDataBase64(contentType, dataBase64 string) manifest.CfgFn {
 	}
 }
 
-//WithSchedule add the schedule config to a Pingsource spec.
+// WithSchedule add the schedule config to a Pingsource spec.
 func WithSchedule(schedule string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		if schedule != "" {

--- a/test/test_images/wathola-fetcher/main_test.go
+++ b/test/test_images/wathola-fetcher/main_test.go
@@ -18,13 +18,14 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"knative.dev/eventing/test/upgrade/prober/wathola/config"
 	"knative.dev/eventing/test/upgrade/prober/wathola/fetcher"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
@@ -65,7 +66,7 @@ func TestFetcherMain(t *testing.T) {
 		main()
 
 		_ = w.Close()
-		out, _ := ioutil.ReadAll(r)
+		out, _ := io.ReadAll(r)
 		os.Stdout = rescueStdout
 		return out
 	}()

--- a/test/upgrade/prober/configuration.go
+++ b/test/upgrade/prober/configuration.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 	"text/template"
@@ -27,13 +27,14 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgTest "knative.dev/pkg/test"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
 	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/eventing/test/upgrade/prober/sut"
 	"knative.dev/eventing/test/upgrade/prober/wathola/forwarder"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	pkgTest "knative.dev/pkg/test"
-	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
 
 const (
@@ -173,7 +174,7 @@ func (p *prober) deployConfigToml(endpoint interface{}) {
 func (p *prober) compileTemplate(templateName string, endpoint interface{}, tracingConfig string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	templateFilepath := path.Join(path.Dir(filename), templateName)
-	templateBytes, err := ioutil.ReadFile(templateFilepath)
+	templateBytes, err := os.ReadFile(templateFilepath)
 	p.ensureNoError(err)
 	tmpl, err := template.New(templateName).Parse(string(templateBytes))
 	p.ensureNoError(err)

--- a/test/upgrade/prober/wathola/config/reader_test.go
+++ b/test/upgrade/prober/wathola/config/reader_test.go
@@ -17,8 +17,6 @@ package config
 
 import (
 	"fmt"
-
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -141,7 +139,7 @@ func withConfigContents(t *testing.T, content string, fn func()) {
 	t.Helper()
 	configFile := ensureConfigFileNotPresent(t)
 	data := []byte(content)
-	assert.NoError(t, ioutil.WriteFile(configFile, data, 0644))
+	assert.NoError(t, os.WriteFile(configFile, data, 0644))
 	defer func() { assert.NoError(t, os.RemoveAll(configFile)) }()
 	fn()
 }

--- a/test/upgrade/prober/wathola/event/tracing.go
+++ b/test/upgrade/prober/wathola/event/tracing.go
@@ -19,7 +19,7 @@ package event
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/openzipkin/zipkin-go/model"
@@ -65,7 +65,7 @@ func SendTraceQuery(endpoint string, annotationQuery string) ([][]model.SpanMode
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return empty, err
 	}

--- a/test/upgrade/prober/wathola/fetcher/operations.go
+++ b/test/upgrade/prober/wathola/fetcher/operations.go
@@ -18,7 +18,7 @@ package fetcher
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -26,6 +26,7 @@ import (
 	"github.com/wavesoftware/go-ensure"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
 	"knative.dev/eventing/test/upgrade/prober/wathola/config"
 	"knative.dev/eventing/test/upgrade/prober/wathola/receiver"
 )
@@ -71,7 +72,7 @@ func (f *fetcher) fetchReport() error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
As per title.

Go 1.19 is now required to generate and verify generated code.

- Fix new lint errors
- Run update-codegen.sh