### PR TITLE
[Scheduler] Handle permanent pending pods

### DIFF
--- a/pkg/scheduler/state/state.go
+++ b/pkg/scheduler/state/state.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/listers/core/v1"
@@ -180,7 +181,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 	}
 
 	free := make([]int32, 0)
-	schedulablePods := make([]int32, 0)
+	schedulablePods := sets.NewInt32()
 	last := int32(-1)
 
 	// keep track of (vpod key, podname) pairs with existing placements
@@ -224,6 +225,10 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 		})
 
 		if pod != nil {
+			if isPodUnschedulable(pod) {
+				// Pod is marked for eviction - CANNOT SCHEDULE VREPS on this pod.
+				continue
+			}
 
 			node, err := s.nodeLister.Get(pod.Spec.NodeName)
 			if err != nil {
@@ -234,14 +239,10 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 				// Node is marked as Unschedulable - CANNOT SCHEDULE VREPS on a pod running on this node.
 				continue
 			}
-			if isPodUnschedulable(pod) {
-				// Pod is marked for eviction - CANNOT SCHEDULE VREPS on this pod.
-				continue
-			}
 
 			// Pod has no annotation or not annotated as unschedulable and
 			// not on an unschedulable node, so add to feasible
-			schedulablePods = append(schedulablePods, podId)
+			schedulablePods.Insert(podId)
 		}
 	}
 
@@ -271,7 +272,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 				return err == nil, nil
 			})
 
-			if pod != nil {
+			if pod != nil && schedulablePods.Has(OrdinalFromPodName(pod.GetName())) {
 				nodeName := pod.Spec.NodeName       //node name for this pod
 				zoneName := nodeToZoneMap[nodeName] //zone name for this pod
 				podSpread[vpod.GetKey()][podName] = podSpread[vpod.GetKey()][podName] + vreplicas
@@ -296,7 +297,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 					return err == nil, nil
 				})
 
-				if pod != nil {
+				if pod != nil && schedulablePods.Has(OrdinalFromPodName(pod.GetName())) {
 					nodeName := pod.Spec.NodeName       //node name for this pod
 					zoneName := nodeToZoneMap[nodeName] //zone name for this pod
 					podSpread[key][podName] = podSpread[key][podName] + rvreplicas
@@ -310,7 +311,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 	}
 
 	s.logger.Infow("cluster state info", zap.String("NumPods", fmt.Sprint(scale.Spec.Replicas)), zap.String("NumZones", fmt.Sprint(len(zoneMap))), zap.String("NumNodes", fmt.Sprint(len(nodeToZoneMap))), zap.String("Schedulable", fmt.Sprint(schedulablePods)))
-	return &State{FreeCap: free, SchedulablePods: schedulablePods, LastOrdinal: last, Capacity: s.capacity, Replicas: scale.Spec.Replicas, NumZones: int32(len(zoneMap)), NumNodes: int32(len(nodeToZoneMap)),
+	return &State{FreeCap: free, SchedulablePods: schedulablePods.List(), LastOrdinal: last, Capacity: s.capacity, Replicas: scale.Spec.Replicas, NumZones: int32(len(zoneMap)), NumNodes: int32(len(nodeToZoneMap)),
 		SchedulerPolicy: s.schedulerPolicy, SchedPolicy: s.schedPolicy, DeschedPolicy: s.deschedPolicy, NodeToZoneMap: nodeToZoneMap, StatefulSetName: s.statefulSetName, PodLister: s.podLister,
 		PodSpread: podSpread, NodeSpread: nodeSpread, ZoneSpread: zoneSpread}, nil
 }
@@ -371,8 +372,8 @@ func withReserved(key types.NamespacedName, podName string, committed int32, res
 
 func isPodUnschedulable(pod *v1.Pod) bool {
 	annotVal, ok := pod.ObjectMeta.Annotations[scheduler.PodAnnotationKey]
-	unschedulable, val := strconv.ParseBool(annotVal)
-	return ok && val == nil && unschedulable
+	unschedulable, err := strconv.ParseBool(annotVal)
+	return (ok && err == nil && unschedulable) || pod.Spec.NodeName == ""
 }
 
 func isNodeUnschedulable(node *v1.Node) bool {

--- a/pkg/scheduler/state/state.go
+++ b/pkg/scheduler/state/state.go
@@ -373,7 +373,11 @@ func withReserved(key types.NamespacedName, podName string, committed int32, res
 func isPodUnschedulable(pod *v1.Pod) bool {
 	annotVal, ok := pod.ObjectMeta.Annotations[scheduler.PodAnnotationKey]
 	unschedulable, err := strconv.ParseBool(annotVal)
-	return (ok && err == nil && unschedulable) || pod.Spec.NodeName == ""
+
+	isMarkedUnschedulable := ok && err == nil && unschedulable
+	isPending := pod.Spec.NodeName == ""
+
+	return isMarkedUnschedulable || isPending
 }
 
 func isNodeUnschedulable(node *v1.Node) bool {

--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -38,11 +38,12 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 
+	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
+
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/scheduler"
 	"knative.dev/eventing/pkg/scheduler/factory"
 	st "knative.dev/eventing/pkg/scheduler/state"
-	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 
 	_ "knative.dev/eventing/pkg/scheduler/plugins/core/availabilitynodepriority"
 	_ "knative.dev/eventing/pkg/scheduler/plugins/core/availabilityzonepriority"
@@ -81,15 +82,16 @@ func NewScheduler(ctx context.Context,
 
 // StatefulSetScheduler is a scheduler placing VPod into statefulset-managed set of pods
 type StatefulSetScheduler struct {
-	ctx               context.Context
-	logger            *zap.SugaredLogger
-	statefulSetName   string
-	statefulSetClient clientappsv1.StatefulSetInterface
-	podLister         corev1listers.PodNamespaceLister
-	vpodLister        scheduler.VPodLister
-	lock              sync.Locker
-	stateAccessor     st.StateAccessor
-	autoscaler        Autoscaler
+	ctx                  context.Context
+	logger               *zap.SugaredLogger
+	statefulSetName      string
+	statefulSetNamespace string
+	statefulSetClient    clientappsv1.StatefulSetInterface
+	podLister            corev1listers.PodNamespaceLister
+	vpodLister           scheduler.VPodLister
+	lock                 sync.Locker
+	stateAccessor        st.StateAccessor
+	autoscaler           Autoscaler
 
 	// replicas is the (cached) number of statefulset replicas.
 	replicas int32
@@ -111,17 +113,18 @@ func NewStatefulSetScheduler(ctx context.Context,
 	autoscaler Autoscaler, podlister corev1listers.PodNamespaceLister) scheduler.Scheduler {
 
 	scheduler := &StatefulSetScheduler{
-		ctx:               ctx,
-		logger:            logging.FromContext(ctx),
-		statefulSetName:   name,
-		statefulSetClient: kubeclient.Get(ctx).AppsV1().StatefulSets(namespace),
-		podLister:         podlister,
-		vpodLister:        lister,
-		pending:           make(map[types.NamespacedName]int32),
-		lock:              new(sync.Mutex),
-		stateAccessor:     stateAccessor,
-		reserved:          make(map[types.NamespacedName]map[string]int32),
-		autoscaler:        autoscaler,
+		ctx:                  ctx,
+		logger:               logging.FromContext(ctx),
+		statefulSetNamespace: namespace,
+		statefulSetName:      name,
+		statefulSetClient:    kubeclient.Get(ctx).AppsV1().StatefulSets(namespace),
+		podLister:            podlister,
+		vpodLister:           lister,
+		pending:              make(map[types.NamespacedName]int32),
+		lock:                 new(sync.Mutex),
+		stateAccessor:        stateAccessor,
+		reserved:             make(map[types.NamespacedName]map[string]int32),
+		autoscaler:           autoscaler,
 	}
 
 	// Monitor our statefulset
@@ -244,12 +247,12 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 
 		if state.SchedPolicy != nil {
 			logger.Info("reverting to previous placements")
-			s.reservePlacements(vpod, existingPlacements)                          //rebalancing doesn't care about new placements since all vreps will be re-placed
-			delete(s.pending, vpod.GetKey())                                       //rebalancing doesn't care about pending since all vreps will be re-placed
-			return existingPlacements, controller.NewRequeueAfter(5 * time.Second) //requeue to wait for the autoscaler to do its job
+			s.reservePlacements(vpod, existingPlacements)              // rebalancing doesn't care about new placements since all vreps will be re-placed
+			delete(s.pending, vpod.GetKey())                           // rebalancing doesn't care about pending since all vreps will be re-placed
+			return existingPlacements, s.newNotEnoughPodReplicas(left) // requeue to wait for the autoscaler to do its job
 		}
 
-		return placements, controller.NewRequeueAfter(5 * time.Second) //requeue to wait for the autoscaler to do its job
+		return placements, s.newNotEnoughPodReplicas(left)
 	}
 
 	logger.Infow("scheduling successful", zap.Any("placement", placements))
@@ -706,4 +709,16 @@ func (s *StatefulSetScheduler) makeZeroPlacements(vpod scheduler.VPod, placement
 	// This is necessary to make sure State() zeroes out initial pod/node/zone spread and
 	// free capacity when there are existing placements for a vpod
 	s.reservePlacements(vpod, newPlacements)
+}
+
+// newNotEnoughPodReplicas returns an error explaining what is the problem, what are the actions we're taking
+// to try to fix it (retry), wrapping a controller.requeueKeyError which signals to ReconcileKind to requeue the
+// object after a given delay.
+func (s *StatefulSetScheduler) newNotEnoughPodReplicas(left int32) error {
+	// Wrap controller.requeueKeyError error to wait for the autoscaler to do its job.
+	return fmt.Errorf("insufficient running pods replicas for StatefulSet %s/%s to schedule resource replicas (left: %d): retry %w",
+		s.statefulSetNamespace, s.statefulSetName,
+		left,
+		controller.NewRequeueAfter(5*time.Second),
+	)
 }

--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -247,12 +247,12 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 
 		if state.SchedPolicy != nil {
 			logger.Info("reverting to previous placements")
-			s.reservePlacements(vpod, existingPlacements)              // rebalancing doesn't care about new placements since all vreps will be re-placed
-			delete(s.pending, vpod.GetKey())                           // rebalancing doesn't care about pending since all vreps will be re-placed
-			return existingPlacements, s.newNotEnoughPodReplicas(left) // requeue to wait for the autoscaler to do its job
+			s.reservePlacements(vpod, existingPlacements)           // rebalancing doesn't care about new placements since all vreps will be re-placed
+			delete(s.pending, vpod.GetKey())                        // rebalancing doesn't care about pending since all vreps will be re-placed
+			return existingPlacements, s.notEnoughPodReplicas(left) // requeue to wait for the autoscaler to do its job
 		}
 
-		return placements, s.newNotEnoughPodReplicas(left)
+		return placements, s.notEnoughPodReplicas(left)
 	}
 
 	logger.Infow("scheduling successful", zap.Any("placement", placements))
@@ -714,7 +714,7 @@ func (s *StatefulSetScheduler) makeZeroPlacements(vpod scheduler.VPod, placement
 // newNotEnoughPodReplicas returns an error explaining what is the problem, what are the actions we're taking
 // to try to fix it (retry), wrapping a controller.requeueKeyError which signals to ReconcileKind to requeue the
 // object after a given delay.
-func (s *StatefulSetScheduler) newNotEnoughPodReplicas(left int32) error {
+func (s *StatefulSetScheduler) notEnoughPodReplicas(left int32) error {
 	// Wrap controller.requeueKeyError error to wait for the autoscaler to do its job.
 	return fmt.Errorf("insufficient running pods replicas for StatefulSet %s/%s to schedule resource replicas (left: %d): retry %w",
 		s.statefulSetNamespace, s.statefulSetName,


### PR DESCRIPTION
When the autoscaler tries to scale up the number of the statefulset
pods but some pods are unschedulable due to missing resources
in the cluster, the scheduler ends up bringing every already
scheduled resource (vpod) to Ready=False since pending pods have
no nodes assigned (Pod.Spec.NodeName is empty), so when the
scheduler tries to build the state of the system, it will try
to get the empty name node which doesn't ever exist.

To reproduce this issue, we can use this command on a small
cluster (on KinD is consistently reproducible since it's
very unlikely that KinD locally can schedule hundreds of pods):

```
seq 100 | xargs -I{} sh -c "kubectl create ns {}; kubectl apply -f ../kafka-source-example.yaml -n {}"
```

where `kafka-source-example.yaml` is:

```
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaTopic
metadata:
  name: knative-demo-topic
  namespace: kafka
  labels:
    strimzi.io/cluster: my-cluster
spec:
  partitions: 3
  replicas: 1
  config:
    retention.ms: 7200000
    segment.bytes: 1073741824
---
apiVersion: v1
kind: Service
metadata:
  name: event-display-2
spec:
  selector:
    app: event-display-2
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
---
apiVersion: v1
kind: Pod
metadata:
  name: label-demo-2
  labels:
    app: event-display-2
spec:
  containers:
  - name: event-display-2
    image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
    ports:
    - containerPort: 8080
---
apiVersion: v1
kind: Service
metadata:
  name: event-display
spec:
  selector:
    app: event-display
  ports:
    - protocol: TCP
      port: 80
      targetPort: 8080
---
apiVersion: v1
kind: Pod
metadata:
  name: label-demo
  labels:
    app: event-display
spec:
  containers:
  - name: event-display
    image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
    ports:
    - containerPort: 8080
---
apiVersion: sources.knative.dev/v1beta1
kind: KafkaSource
metadata:
  name: kafka-source
spec:
  consumerGroup: knative-group
  bootstrapServers:
  - my-cluster-kafka-bootstrap.kafka:9092 # note the kafka namespace
  topics:
  - knative-demo-topic
  sink:
    ref:
      apiVersion: v1
      kind: Service
      name: event-display
```

In addition, the error message that was set for unschedulable
resources (all initially) was very generic, something like
"requeue after: 5s" without explaining the symptoms and maybe
how to debug it.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Scheduler handles permanent pending pods

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Fix scheduler handling of permanent pending or unschedulable pods
```

