### PR TITLE
Add Ansu as scheduler approver

### DIFF
--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -1,0 +1,7 @@
+# Additional approvers for this component
+approvers:
+- technical-oversight-committee
+- eventing-writers
+- knative-release-leads
+- aavarghese
+


### PR DESCRIPTION
Ansu is the initial contributor of the scheduler and every time
I need to patch this component, I can't think of a better person
to ask for a review.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>