### PR TITLE
Use `AddressStatus` instead of `Addressable` directly in broker status

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -1943,17 +1943,20 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>address</code><br/>
+<code>AddressStatus</code><br/>
 <em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Addressable">
-knative.dev/pkg/apis/duck/v1.Addressable
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
+knative.dev/pkg/apis/duck/v1.AddressStatus
 </a>
 </em>
 </td>
 <td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
 <em>(Optional)</em>
-<p>Broker is Addressable. It exposes the endpoint as an URI to get events
-delivered into the Broker mesh.</p>
+<p>AddressStatus is the part where the Broker fulfills the Addressable contract.
+It exposes the endpoint as an URI to get events delivered into the Broker mesh.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"knative.dev/pkg/apis"
+	v1 "knative.dev/pkg/apis/duck/v1"
 )
 
 const (
@@ -72,7 +73,12 @@ func (bs *BrokerStatus) GetTopLevelCondition() *apis.Condition {
 // SetAddress makes this Broker addressable by setting the URI. It also
 // sets the BrokerConditionAddressable to true.
 func (bs *BrokerStatus) SetAddress(url *apis.URL) {
-	bs.Address.URL = url
+	bs.AddressStatus = v1.AddressStatus{
+		Address: &v1.Addressable{
+			URL: url,
+		},
+	}
+
 	if url != nil {
 		bs.GetConditionSet().Manage(bs).MarkTrue(BrokerConditionAddressable)
 	} else {

--- a/pkg/apis/eventing/v1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle_test.go
@@ -276,7 +276,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 		name: "default ready status without defined DLS",
 		bs:   TestHelper.ReadyBrokerStatusWithoutDLS(),
 		want: &BrokerStatus{
-			Address: duckv1.Addressable{URL: url},
+			AddressStatus: duckv1.AddressStatus{
+				Address: &duckv1.Addressable{URL: url},
+			},
 			Status: duckv1.Status{
 				Conditions: []apis.Condition{{
 					Type:   BrokerConditionAddressable,

--- a/pkg/apis/eventing/v1/broker_types.go
+++ b/pkg/apis/eventing/v1/broker_types.go
@@ -88,10 +88,10 @@ type BrokerStatus struct {
 	// * Conditions - the latest available observations of a resource's current state.
 	duckv1.Status `json:",inline"`
 
-	// Broker is Addressable. It exposes the endpoint as an URI to get events
-	// delivered into the Broker mesh.
+	// AddressStatus is the part where the Broker fulfills the Addressable contract.
+	// It exposes the endpoint as an URI to get events delivered into the Broker mesh.
 	// +optional
-	Address duckv1.Addressable `json:"address,omitempty"`
+	duckv1.AddressStatus `json:",inline"`
 
 	// DeliveryStatus contains a resolved URL to the dead letter sink address, and any other
 	// resolved delivery options.

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -119,7 +119,7 @@ func (in *BrokerSpec) DeepCopy() *BrokerSpec {
 func (in *BrokerStatus) DeepCopyInto(out *BrokerStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	in.Address.DeepCopyInto(&out.Address)
+	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	in.DeliveryStatus.DeepCopyInto(&out.DeliveryStatus)
 	return
 }

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -583,7 +583,7 @@ func readyBrokerIsAddressable(ctx context.Context, t feature.T) {
 	broker := getBroker(ctx, t)
 
 	if broker.IsReady() {
-		if broker.Status.Address.URL == nil {
+		if broker.Status.AddressStatus.Address == nil || broker.Status.AddressStatus.Address.URL == nil {
 			t.Errorf("broker is not addressable")
 		}
 		// Success!

--- a/test/rekt/features/broker/data_plane.go
+++ b/test/rekt/features/broker/data_plane.go
@@ -82,7 +82,7 @@ func DataPlaneAddressability(brokerName string) *feature.Feature {
 	f.Stable("Conformance").Should("A Broker SHOULD expose either an HTTP or HTTPS endpoint as ingress. It MAY expose both.",
 		func(ctx context.Context, t feature.T) {
 			b := getBroker(ctx, t)
-			addr := b.Status.Address.URL
+			addr := b.Status.AddressStatus.Address.URL
 			if addr == nil {
 				addr = new(apis.URL)
 			}

--- a/test/upgrade/prober/sut/broker.go
+++ b/test/upgrade/prober/sut/broker.go
@@ -102,7 +102,7 @@ func (b *BrokerAndTriggers) fetchURL(ctx Context) *apis.URL {
 	if err != nil {
 		ctx.T.Fatal(err)
 	}
-	url := broker.Status.Address.URL
+	url := broker.Status.AddressStatus.Address.URL
 	ctx.Log.Debugf("\"%s\" broker URL for ns %s is %v",
 		b.Name, namespace, url)
 	return url


### PR DESCRIPTION
Currently the BrokerStatus field uses the `address` directly:
https://github.com/knative/eventing/blob/41653ce64478d0a74470d4609510f2dc3c611de6/pkg/apis/eventing/v1/broker_types.go#L84-L99

Anyhow there is an `AddressStatus` struct, which encapsulates this and (according to its docs) should be used to embed an addressable:
https://github.com/knative/eventing/blob/41653ce64478d0a74470d4609510f2dc3c611de6/vendor/knative.dev/pkg/apis/duck/v1/addressable_types.go#L64-L66

E.g. Channels use this struct:
https://github.com/knative/eventing/blob/41653ce64478d0a74470d4609510f2dc3c611de6/pkg/apis/duck/v1/channelable_types.go#L56-L75

## Proposed Changes
- :broom: Change the BrockerStatus struct to use the `AddressStatus` struct.

:exclamation: As this struct will be embedded inline, the JSON/YAML structure should not change. Anyhow the Golang API will change, as the `Address` field from the `AddressStatus` can be `nil` (before this change it couldn't). 
I am not sure, if this will break any users of `pkg/apis/eventing` and we shouldn't change this in `v1`, so feedback is highly welcome. 

### Pre-review Checklist
- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**
```release-note
```