### PR TITLE
Register schemas in webhooks too

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"knative.dev/eventing/pkg/apis/feature"
 
 	"knative.dev/pkg/configmap"
@@ -53,7 +54,13 @@ import (
 	sourcesv1beta2 "knative.dev/eventing/pkg/apis/sources/v1beta2"
 	sugar "knative.dev/eventing/pkg/apis/sugar"
 	"knative.dev/eventing/pkg/reconciler/sinkbinding"
+
+	versionedscheme "knative.dev/eventing/pkg/client/clientset/versioned/scheme"
 )
+
+func init() {
+	versionedscheme.AddToScheme(scheme.Scheme)
+}
 
 var ourTypes = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	// For group eventing.knative.dev.

--- a/cmd/webhook/main_test.go
+++ b/cmd/webhook/main_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+)
+
+func TestSchemaRegistrations(t *testing.T) {
+	sb := sourcesv1.SinkBinding{}
+	_, _, err := scheme.Scheme.ObjectKinds(&sb)
+	if err != nil {
+		t.Errorf("Schemas should have been registered: %v", err)
+	}
+}

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -98,6 +98,18 @@ rules:
       - "leases"
     verbs: *everything
 
+  # For creating events
+  - apiGroups:
+      - ""
+      - "events.k8s.io"
+    resources:
+      - "events"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "patch"
+
   # Necessary for conversion webhook. These are copied from the serving
   # TODO: Do we really need all these permissions?
   - apiGroups: ["apiextensions.k8s.io"]


### PR DESCRIPTION
Fixes #6399

## Proposed Changes

* :bug: Register schemas in webhooks too (d6f5a7183121643cce3e365cba3182dc751f77d3)
* :bug: Setup event recorder in sinkbinding controller to use watches (97f44368f40fa9042ef5dca60b4bd6e0aba5ada7)

### Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**
```release-note
```

**How to verify:**
* Follow the steps from https://github.com/knative/eventing/issues/6399#issuecomment-1323638543 with the changes from this PR
* Check the webhook logs for not reporting the `Could not construct reference to` error
   ```
   $ k -n knative-eventing logs eventing-webhook-7588fd57c9-jc687 | grep -i "construct"
   $
   ```
* Check the event got created instead:
   ```
   $k -n foobar get event -w | grep -i address                                         
    0s          Warning   InternalError            sinkbinding/sender            address not set for &ObjectReference{Kind:Channel,Namespace:foobar,Name:channel,UID:,APIVersion:messaging.knative.dev/v1,ResourceVersion:,FieldPath:,}
    ...
   
   $ k -n foobar describe sinkbindings.sources.knative.dev sender
   ...
   Events:
     Type     Reason         Age                 From                    Message
     ----     ------         ----                ----                    -------
     Warning  InternalError  15s (x12 over 16s)  sinkbinding-controller  address not set for &ObjectReference{Kind:Channel,Namespace:foobar,Name:channel,UID:,APIVersion:messaging.knative.dev/v1,ResourceVersion:,FieldPath:,}
   ```