### PR TITLE
Removing deprecated and broken code for WithAnnotation

### DIFF
--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -79,17 +79,6 @@ func WithSubscriber(ref *duckv1.KReference, uri string) manifest.CfgFn {
 	}
 }
 
-// Deprecated
-// WithAnnotation adds an annotation to the trigger
-func WithAnnotation(key string, value string) manifest.CfgFn {
-	return func(cfg map[string]interface{}) {
-		if _, set := cfg["annotations"]; !set {
-			cfg["annotations"] = map[string]interface{}{}
-		}
-		(cfg["annotations"].(map[string]interface{}))[key] = value
-	}
-}
-
 // WithAnnotations adds annotations to the trigger
 func WithAnnotations(annotations map[string]interface{}) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: Removes deprecated `WithAnnotation` from `Trigger` reconciler test lib, generally better option here to use is `WithAnnotations` which does honor `ceOverrides` anyways

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Removes deprecated `WithAnnotation` from `Trigger` reconciler test lib, generally better option here to use is `WithAnnotations` which does honor `ceOverrides` anyways
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

