### PR TITLE
Patch CVE-2022-41717

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module knative.dev/eventing
 
+// Needs at least go 1.18.9 for CVE-2022-41717
 go 1.18
 
 require (


### PR DESCRIPTION
Update go.mod to force a rebuild for CVE-2022-41717