### PR TITLE
Allowing an override of the namespace for the brokers config type

### DIFF
--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -103,6 +103,13 @@ func WithConfig(name string) manifest.CfgFn {
 	}
 }
 
+// WithConfigNamespace adds the specified config map to the Broker spec.
+func WithConfigNamespace(namespace string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["configNamespace"] = namespace
+	}
+}
+
 // WithDeadLetterSink adds the dead letter sink related config to a Broker spec.
 var WithDeadLetterSink = delivery.WithDeadLetterSink
 

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -103,7 +103,7 @@ func WithConfig(name string) manifest.CfgFn {
 	}
 }
 
-// WithConfigNamespace adds the specified config map to the Broker spec.
+// WithConfigNamespace adds the specified config map namespace to the Broker spec.
 func WithConfigNamespace(namespace string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["configNamespace"] = namespace

--- a/test/rekt/resources/broker/broker.yaml
+++ b/test/rekt/resources/broker/broker.yaml
@@ -32,7 +32,11 @@ spec:
   {{ if .config }}
   config:
     kind: {{ .config.kind }}
+    {{ if .configNamespace }}
+    namespace: {{ .configNamespace }}
+    {{ else }}
     namespace: {{ .namespace }}
+    {{ end }}
     name: {{ .config.name }}
     apiVersion: {{ .config.apiVersion }}
   {{ end }}

--- a/test/rekt/resources/broker/broker_test.go
+++ b/test/rekt/resources/broker/broker_test.go
@@ -237,6 +237,37 @@ func ExampleWithConfig() {
 	//     apiVersion: v1
 }
 
+func ExampleWithConfigNamespace() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+	}
+
+	broker.WithConfigNamespace("knative-eventing")(cfg)
+	broker.WithConfig("my-funky-config")(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: eventing.knative.dev/v1
+	// kind: Broker
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   config:
+	//     kind: ConfigMap
+	//     namespace: knative-eventing
+	//     name: my-funky-config
+	//     apiVersion: v1
+}
+
 func ExampleWithRetry() {
 	ctx := testlog.NewContext()
 	images := map[string]string{}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Enhancing broker test framework for allowing different namespace for the config

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

