### PR TITLE
Allow PingSource adapter to have additional env variables

### DIFF
--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -178,7 +178,7 @@ func needsUpdating(ctx context.Context, oldDeploymentSpec *appsv1.DeploymentSpec
 		return false, nil
 	}
 
-	return zero(oldDeploymentSpec.Replicas) || !equality.Semantic.DeepEqual(container.Env, newEnvVars), container
+	return zero(oldDeploymentSpec.Replicas) || !equality.Semantic.DeepDerivative(newEnvVars, container.Env), container
 }
 
 func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {

--- a/pkg/reconciler/testing/deployment.go
+++ b/pkg/reconciler/testing/deployment.go
@@ -96,3 +96,12 @@ func WithDeploymentAvailable() DeploymentOption {
 		}
 	}
 }
+
+func WithContainerEnv(name, value string) DeploymentOption {
+	return func(deployment *appsv1.Deployment) {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}


### PR DESCRIPTION
Whenever I set additional PingSource adapter env variables, the controller reverts my changes since it's doing a `DeepEqual` on env variables instead of doing `DeepDerivative(expected, current)`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allow PingSource adapter to have additional env variables

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Allow PingSource adapter to have additional env variables
```


/kind bug
