### PR TITLE
APIServerSource with selector to target namespaces

### DIFF
--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -137,6 +137,32 @@ spec:
                   uri:
                     description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
                     type: string
+              namespaceSelector:
+                description: NamespaceSelector is a label selector to capture the namespaces that should be watched by the source.
+                type: object
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+
           status:
             type: object
             properties:

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -216,6 +216,11 @@ spec:
               sinkUri:
                 description: SinkURI is the current active sink URI that has been configured for the Source.
                 type: string
+              namespaces:
+                description: Namespaces show the namespaces currently watched by the ApiServerSource
+                type: array
+                items:
+                  type: string
     additionalPrinterColumns:
     - name: Sink
       type: string

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -5072,6 +5072,17 @@ state.
 Source.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>namespaces</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Namespaces show the namespaces currently watched by the ApiServerSource</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="sources.knative.dev/v1.ContainerSourceSpec">ContainerSourceSpec

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -4410,6 +4410,21 @@ string
 source. Defaults to default if not set.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>namespaceSelector</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamespaceSelector is a label selector to capture the namespaces that
+should be watched by the source.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -5000,6 +5015,21 @@ string
 <em>(Optional)</em>
 <p>ServiceAccountName is the name of the ServiceAccount to use to run this
 source. Defaults to default if not set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespaceSelector</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NamespaceSelector is a label selector to capture the namespaces that
+should be watched by the source.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -98,7 +98,8 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 
 				var res dynamic.ResourceInterface
 				if apires.Namespaced {
-					res = a.k8s.Resource(configRes.GVR).Namespace(a.config.Namespace)
+					// TODO: update to cycle through namespaces
+					res = a.k8s.Resource(configRes.GVR).Namespace(a.config.Namespaces[0])
 				} else {
 					res = a.k8s.Resource(configRes.GVR)
 				}

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -96,7 +96,7 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		for _, apires := range resources.APIResources {
 			if apires.Name == configRes.GVR.Resource {
 				var resources []dynamic.ResourceInterface
-				if apires.Namespaced && len(a.config.Namespaces) > 0 {
+				if apires.Namespaced && !a.config.AllNamespaces {
 					for _, ns := range a.config.Namespaces {
 						resources = append(resources, a.k8s.Resource(configRes.GVR).Namespace(ns))
 					}

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -96,7 +96,7 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		for _, apires := range resources.APIResources {
 			if apires.Name == configRes.GVR.Resource {
 				var resources []dynamic.ResourceInterface
-				if apires.Namespaced {
+				if apires.Namespaced && len(a.config.Namespaces) > 0 {
 					for _, ns := range a.config.Namespaces {
 						resources = append(resources, a.k8s.Resource(configRes.GVR).Namespace(ns))
 					}

--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -95,22 +95,25 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		exists := false
 		for _, apires := range resources.APIResources {
 			if apires.Name == configRes.GVR.Resource {
-
-				var res dynamic.ResourceInterface
+				var resources []dynamic.ResourceInterface
 				if apires.Namespaced {
-					// TODO: update to cycle through namespaces
-					res = a.k8s.Resource(configRes.GVR).Namespace(a.config.Namespaces[0])
+					for _, ns := range a.config.Namespaces {
+						resources = append(resources, a.k8s.Resource(configRes.GVR).Namespace(ns))
+					}
 				} else {
-					res = a.k8s.Resource(configRes.GVR)
+					resources = append(resources, a.k8s.Resource(configRes.GVR))
 				}
 
-				lw := &cache.ListWatch{
-					ListFunc:  asUnstructuredLister(ctx, res.List, configRes.LabelSelector),
-					WatchFunc: asUnstructuredWatcher(ctx, res.Watch, configRes.LabelSelector),
+				for _, res := range resources {
+					lw := &cache.ListWatch{
+						ListFunc:  asUnstructuredLister(ctx, res.List, configRes.LabelSelector),
+						WatchFunc: asUnstructuredWatcher(ctx, res.Watch, configRes.LabelSelector),
+					}
+
+					reflector := cache.NewReflector(lw, &unstructured.Unstructured{}, delegate, resyncPeriod)
+					go reflector.Run(stop)
 				}
 
-				reflector := cache.NewReflector(lw, &unstructured.Unstructured{}, delegate, resyncPeriod)
-				go reflector.Run(stop)
 				exists = true
 				break
 			}

--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -45,7 +45,7 @@ func TestAdapter_StartRef(t *testing.T) {
 	ce := adaptertest.NewTestClient()
 
 	config := Config{
-		Namespace: "default",
+		Namespaces: []string{"default"},
 		Resources: []ResourceWatch{{
 			GVR: schema.GroupVersionResource{
 				Version:  "v1",
@@ -93,7 +93,7 @@ func TestAdapter_StartResource(t *testing.T) {
 	ce := adaptertest.NewTestClient()
 
 	config := Config{
-		Namespace: "default",
+		Namespaces: []string{"default"},
 		Resources: []ResourceWatch{{
 			GVR: schema.GroupVersionResource{
 				Version:  "v1",
@@ -140,7 +140,7 @@ func TestAdapter_StartNonNamespacedResource(t *testing.T) {
 	ce := adaptertest.NewTestClient()
 
 	config := Config{
-		Namespace: "default",
+		Namespaces: []string{"default"},
 		Resources: []ResourceWatch{{
 			GVR: schema.GroupVersionResource{
 				Version:  "v1",

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -32,9 +32,12 @@ type ResourceWatch struct {
 
 type Config struct {
 	// Namespaces specifies the namespaces where Resources[] exist.
-	// An empty slice means all namespaces
 	// +required
 	Namespaces []string `json:"namespaces"`
+
+	// AllNamespaces indicates whether this source is watching all
+	// existing namespaces
+	AllNamespaces bool `json:"allNamespaces"`
 
 	// Resource is the resource this source will track and send related
 	// lifecycle events from the Kubernetes ApiServer.

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -31,9 +31,9 @@ type ResourceWatch struct {
 }
 
 type Config struct {
-	// Namespace specifies the namespace that Resources[] exist.
+	// Namespaces specifies the namespace that Resources[] exist.
 	// +required
-	Namespace string `json:"namespace"`
+	Namespaces []string `json:"namespaces"`
 
 	// Resource is the resource this source will track and send related
 	// lifecycle events from the Kubernetes ApiServer.

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -32,6 +32,7 @@ type ResourceWatch struct {
 
 type Config struct {
 	// Namespaces specifies the namespaces where Resources[] exist.
+	// An empty slice means all namespaces
 	// +required
 	Namespaces []string `json:"namespaces"`
 

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -31,7 +31,7 @@ type ResourceWatch struct {
 }
 
 type Config struct {
-	// Namespaces specifies the namespace that Resources[] exist.
+	// Namespaces specifies the namespaces where Resources[] exist.
 	// +required
 	Namespaces []string `json:"namespaces"`
 

--- a/pkg/apis/sources/v1/apiserver_types.go
+++ b/pkg/apis/sources/v1/apiserver_types.go
@@ -80,6 +80,11 @@ type ApiServerSourceSpec struct {
 	// source. Defaults to default if not set.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// NamespaceSelector is a label selector to capture the namespaces that
+	// should be watched by the source.
+	// +optional
+	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 }
 
 // ApiServerSourceStatus defines the observed state of ApiServerSource

--- a/pkg/apis/sources/v1/apiserver_types.go
+++ b/pkg/apis/sources/v1/apiserver_types.go
@@ -97,6 +97,9 @@ type ApiServerSourceStatus struct {
 	// * SinkURI - the current active sink URI that has been configured for the
 	//   Source.
 	duckv1.SourceStatus `json:",inline"`
+
+	// Namespaces show the namespaces currently watched by the ApiServerSource
+	Namespaces []string `json:"namespaces"`
 }
 
 // APIVersionKind is an APIVersion and Kind tuple.

--- a/pkg/apis/sources/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1/zz_generated.deepcopy.go
@@ -162,6 +162,11 @@ func (in *ApiServerSourceSpec) DeepCopy() *ApiServerSourceSpec {
 func (in *ApiServerSourceStatus) DeepCopyInto(out *ApiServerSourceStatus) {
 	*out = *in
 	in.SourceStatus.DeepCopyInto(&out.SourceStatus)
+	if in.Namespaces != nil {
+		in, out := &in.Namespaces, &out.Namespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/sources/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1/zz_generated.deepcopy.go
@@ -140,6 +140,11 @@ func (in *ApiServerSourceSpec) DeepCopyInto(out *ApiServerSourceSpec) {
 		*out = new(APIVersionKind)
 		**out = **in
 	}
+	if in.NamespaceSelector != nil {
+		in, out := &in.NamespaceSelector, &out.NamespaceSelector
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -150,6 +151,7 @@ func (r *Reconciler) namespacesFromSelector(src *v1.ApiServerSource) ([]string, 
 	for _, ns := range namespaces {
 		nsString = append(nsString, ns.Name)
 	}
+	sort.Strings(nsString)
 	return nsString, nil
 }
 

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -115,11 +115,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 		return err
 	}
 
-	allNamespaces := false
 	// An empty selector targets all namespaces.
-	if isEmptySelector(source.Spec.NamespaceSelector) {
-		allNamespaces = true
-	}
+	allNamespaces := isEmptySelector(source.Spec.NamespaceSelector)
 	ra, err := r.createReceiveAdapter(ctx, source, sinkURI.String(), namespaces, allNamespaces)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Unable to create the receive adapter", zap.Error(err))

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -104,6 +104,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 		logging.FromContext(ctx).Errorw("cannot retrieve namespaces to watch", zap.Error(err))
 		return err
 	}
+	source.Status.Namespaces = namespaces
 
 	err = r.runAccessCheck(ctx, source, namespaces)
 	if err != nil {

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -101,7 +101,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 	source.Status.MarkSink(sinkURI)
 
 	// resolve namespaces to watch
-	namespaces, err := r.namespacesFromSelector(ctx, source)
+	namespaces, err := r.namespacesFromSelector(source)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("cannot retrieve namespaces to watch", zap.Error(err))
 		return err
@@ -131,7 +131,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 	return nil
 }
 
-func (r *Reconciler) namespacesFromSelector(ctx context.Context, src *v1.ApiServerSource) ([]string, error) {
+func (r *Reconciler) namespacesFromSelector(src *v1.ApiServerSource) ([]string, error) {
 	if src.Spec.NamespaceSelector == nil {
 		return []string{src.Namespace}, nil
 	}

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -137,7 +137,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group ""`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
 		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -740,6 +740,7 @@ func TestReconcile(t *testing.T) {
 			receiveAdapterImage: image,
 			sinkResolver:        resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 			configs:             &reconcilersource.EmptyVarsGenerator{},
+			namespaceLister:     listers.GetNamespaceLister(),
 		}
 		return apiserversource.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetApiServerSourceLister(),

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -127,6 +127,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
 				rttestingv1.WithApiServerSourceSink(sinkURI),
 				rttestingv1.WithApiServerSourceNoSufficientPermissions,
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -179,6 +180,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -232,6 +234,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
 				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b"}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -291,6 +294,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceResourceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -339,6 +343,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -430,6 +435,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSink(sinkURI),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
 				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -493,6 +499,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -544,6 +551,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceDeploymentUnavailable,
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -604,6 +612,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -658,6 +667,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -709,6 +719,7 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceSufficientPermissions,
 				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
 				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
 		WantCreates: []runtime.Object{

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -246,7 +246,7 @@ func TestReconcile(t *testing.T) {
 			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}),
+			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
@@ -312,7 +312,7 @@ func TestReconcile(t *testing.T) {
 			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-c"),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{}),
+			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
@@ -929,7 +929,7 @@ func makeAvailableReceiveAdapterWithEventMode(t *testing.T, eventMode string) *a
 	return ra
 }
 
-func makeAvailableReceiveAdapterWithNamespaces(t *testing.T, namespaces []string) *appsv1.Deployment {
+func makeAvailableReceiveAdapterWithNamespaces(t *testing.T, namespaces []string, allNamespaces bool) *appsv1.Deployment {
 	t.Helper()
 
 	src := rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -948,12 +948,13 @@ func makeAvailableReceiveAdapterWithNamespaces(t *testing.T, namespaces []string
 	)
 
 	args := resources.ReceiveAdapterArgs{
-		Image:      image,
-		Source:     src,
-		Labels:     resources.Labels(sourceName),
-		SinkURI:    sinkURI.String(),
-		Configs:    &reconcilersource.EmptyVarsGenerator{},
-		Namespaces: namespaces,
+		Image:         image,
+		Source:        src,
+		Labels:        resources.Labels(sourceName),
+		SinkURI:       sinkURI.String(),
+		Configs:       &reconcilersource.EmptyVarsGenerator{},
+		Namespaces:    namespaces,
+		AllNamespaces: allNamespaces,
 	}
 
 	ra, err := resources.MakeReceiveAdapter(&args)

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -78,15 +78,15 @@ func NewController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	cb := func(obj interface{}) {
+	cb := func() {
 		logging.FromContext(ctx).Info("Global resync of APIServerSources due to namespaces changing.")
 		impl.GlobalResync(apiServerSourceInformer.Informer())
 	}
 
 	namespaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    cb,
-		UpdateFunc: func(oldObj, newObj interface{}) { cb(oldObj) },
-		DeleteFunc: cb,
+		AddFunc:    func(obj interface{}) { cb() },
+		UpdateFunc: func(oldObj, newObj interface{}) { cb() },
+		DeleteFunc: func(obj interface{}) { cb() },
 	})
 
 	return impl

--- a/pkg/reconciler/apiserversource/controller.go
+++ b/pkg/reconciler/apiserversource/controller.go
@@ -56,9 +56,10 @@ func NewController(
 	namespaceInformer := namespace.Get(ctx)
 
 	r := &Reconciler{
-		kubeClientSet: kubeclient.Get(ctx),
-		ceSource:      GetCfgHost(ctx),
-		configs:       reconcilersource.WatchConfigurations(ctx, component, cmw),
+		kubeClientSet:   kubeclient.Get(ctx),
+		ceSource:        GetCfgHost(ctx),
+		configs:         reconcilersource.WatchConfigurations(ctx, component, cmw),
+		namespaceLister: namespaceInformer.Lister(),
 	}
 
 	env := &envConfig{}

--- a/pkg/reconciler/apiserversource/controller_test.go
+++ b/pkg/reconciler/apiserversource/controller_test.go
@@ -33,6 +33,7 @@ import (
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/sources/v1/apiserversource/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace/fake"
 	. "knative.dev/pkg/reconciler/testing"
 )
 

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -41,12 +41,13 @@ import (
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
 // Every field is required.
 type ReceiveAdapterArgs struct {
-	Image      string
-	Source     *v1.ApiServerSource
-	Labels     map[string]string
-	SinkURI    string
-	Configs    reconcilersource.ConfigAccessor
-	Namespaces []string
+	Image         string
+	Source        *v1.ApiServerSource
+	Labels        map[string]string
+	SinkURI       string
+	Configs       reconcilersource.ConfigAccessor
+	Namespaces    []string
+	AllNamespaces bool
 }
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
@@ -116,6 +117,7 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 		Resources:     make([]apiserver.ResourceWatch, 0, len(args.Source.Spec.Resources)),
 		ResourceOwner: args.Source.Spec.ResourceOwner,
 		EventMode:     args.Source.Spec.EventMode,
+		AllNamespaces: args.AllNamespaces,
 	}
 
 	for _, r := range args.Source.Spec.Resources {

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -41,11 +41,12 @@ import (
 // ReceiveAdapterArgs are the arguments needed to create a ApiServer Receive Adapter.
 // Every field is required.
 type ReceiveAdapterArgs struct {
-	Image   string
-	Source  *v1.ApiServerSource
-	Labels  map[string]string
-	SinkURI string
-	Configs reconcilersource.ConfigAccessor
+	Image      string
+	Source     *v1.ApiServerSource
+	Labels     map[string]string
+	SinkURI    string
+	Configs    reconcilersource.ConfigAccessor
+	Namespaces []string
 }
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
@@ -111,7 +112,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 
 func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 	cfg := &apiserver.Config{
-		Namespace:     args.Source.Namespace,
+		Namespaces:    args.Namespaces,
 		Resources:     make([]apiserver.ResourceWatch, 0, len(args.Source.Spec.Resources)),
 		ResourceOwner: args.Source.Spec.ResourceOwner,
 		EventMode:     args.Source.Spec.EventMode,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -129,7 +129,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 									Value: "sink-uri",
 								}, {
 									Name:  "K_SOURCE_CONFIG",
-									Value: `{"namespace":"source-namespace","resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
+									Value: `{"namespaces":["source-namespace"],"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
 								}, {
 									Name:  "SYSTEM_NAMESPACE",
 									Value: "knative-testing",
@@ -202,8 +202,9 @@ func TestMakeReceiveAdapters(t *testing.T) {
 					"test-key1": "test-value1",
 					"test-key2": "test-value2",
 				},
-				SinkURI: "sink-uri",
-				Configs: &source.EmptyVarsGenerator{},
+				SinkURI:    "sink-uri",
+				Configs:    &source.EmptyVarsGenerator{},
+				Namespaces: []string{"source-namespace"},
 			})
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -129,7 +129,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 									Value: "sink-uri",
 								}, {
 									Name:  "K_SOURCE_CONFIG",
-									Value: `{"namespaces":["source-namespace"],"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
+									Value: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
 								}, {
 									Name:  "SYSTEM_NAMESPACE",
 									Value: "knative-testing",

--- a/pkg/reconciler/testing/v1/apiserversouce.go
+++ b/pkg/reconciler/testing/v1/apiserversouce.go
@@ -136,3 +136,9 @@ func WithApiServerSourceObjectMetaGeneration(generation int64) ApiServerSourceOp
 		c.ObjectMeta.Generation = generation
 	}
 }
+
+func WithApiServerSourceNamespaceSelector(nsSelector metav1.LabelSelector) ApiServerSourceOption {
+	return func(c *v1.ApiServerSource) {
+		c.Spec.NamespaceSelector = &nsSelector
+	}
+}

--- a/pkg/reconciler/testing/v1/apiserversouce.go
+++ b/pkg/reconciler/testing/v1/apiserversouce.go
@@ -111,7 +111,7 @@ func WithApiServerSourceSufficientPermissions(s *v1.ApiServerSource) {
 }
 
 func WithApiServerSourceNoSufficientPermissions(s *v1.ApiServerSource) {
-	s.Status.MarkNoSufficientPermissions("", `User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group ""`)
+	s.Status.MarkNoSufficientPermissions("", `User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`)
 }
 
 func WithApiServerSourceDeleted(c *v1.ApiServerSource) {

--- a/pkg/reconciler/testing/v1/apiserversouce.go
+++ b/pkg/reconciler/testing/v1/apiserversouce.go
@@ -142,3 +142,9 @@ func WithApiServerSourceNamespaceSelector(nsSelector metav1.LabelSelector) ApiSe
 		c.Spec.NamespaceSelector = &nsSelector
 	}
 }
+
+func WithApiServerSourceStatusNamespaces(namespaces []string) ApiServerSourceOption {
+	return func(c *v1.ApiServerSource) {
+		c.Status.Namespaces = namespaces
+	}
+}

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -120,3 +120,17 @@ func TestApiServerSourceDataPlane_EventsRetries(t *testing.T) {
 
 	env.Test(ctx, t, apiserversourcefeatures.SendsEventsWithRetries())
 }
+
+func TestApiServerSourceDataPlane_MultipleNamespaces(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, apiserversourcefeatures.SendsEventsForAllResourcesWithNamespaceSelector())
+}

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -134,3 +134,17 @@ func TestApiServerSourceDataPlane_MultipleNamespaces(t *testing.T) {
 
 	env.Test(ctx, t, apiserversourcefeatures.SendsEventsForAllResourcesWithNamespaceSelector())
 }
+
+func TestApiServerSourceDataPlane_MultipleNamespacesEmptySelector(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, apiserversourcefeatures.SendsEventsForAllResourcesWithEmptyNamespaceSelector())
+}

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -357,16 +357,16 @@ func SendsEventsForAllResourcesWithNamespaceSelector() *feature.Feature {
 	f.Setup("Create Service Account for ApiServerSource with RBAC for v1.Pod resources",
 		setupAccountAndRoleForPods(sacmName))
 
-	testNS1 := feature.MakeRandomK8sName("source-namespace")
-	testNS2 := feature.MakeRandomK8sName("source-namespace")
-	testNS3 := feature.MakeRandomK8sName("source-namespace")
+	testNS1 := feature.MakeRandomK8sName("source-namespace-1")
+	testNS2 := feature.MakeRandomK8sName("source-namespace-2")
+	testNS3 := feature.MakeRandomK8sName("source-namespace-3")
 
 	// create two new namespaces with matching selector
-	f.Setup("create test-a namespace with matching selector", namespace.Install(testNS1, namespace.WithLabels(map[string]string{"env": "development"})))
-	f.Setup("create test-a namespace with matching selector", namespace.Install(testNS2, namespace.WithLabels(map[string]string{"env": "development"})))
+	f.Setup("create a namespace with matching label", namespace.Install(testNS1, namespace.WithLabels(map[string]string{"env": "development"})))
+	f.Setup("create a namespace with matching label", namespace.Install(testNS2, namespace.WithLabels(map[string]string{"env": "development"})))
 
 	// create one new namespace that doesn't match selector
-	f.Setup("create test-a namespace with matching selector", namespace.Install(testNS3, namespace.WithLabels(map[string]string{"env": "production"})))
+	f.Setup("create a namespace without matching label", namespace.Install(testNS3, namespace.WithLabels(map[string]string{"env": "production"})))
 
 	cfg := []manifest.CfgFn{
 		apiserversource.WithServiceAccountName(sacmName),
@@ -384,9 +384,9 @@ func SendsEventsForAllResourcesWithNamespaceSelector() *feature.Feature {
 	f.Setup("install ApiServerSource", apiserversource.Install(source, cfg...))
 	f.Setup("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	pod1 := feature.MakeRandomK8sName("example")
-	pod2 := feature.MakeRandomK8sName("example")
-	pod3 := feature.MakeRandomK8sName("example")
+	pod1 := feature.MakeRandomK8sName("example-pod-1")
+	pod2 := feature.MakeRandomK8sName("example-pod-2")
+	pod3 := feature.MakeRandomK8sName("example-pod-3")
 	f.Requirement("install example pod 1",
 		pod.Install(pod1, pod.WithImage(exampleImage), pod.WithNamespace(testNS1)),
 	)
@@ -437,12 +437,12 @@ func SendsEventsForAllResourcesWithEmptyNamespaceSelector() *feature.Feature {
 	f.Setup("Create Service Account for ApiServerSource with RBAC for v1.Pod resources",
 		setupAccountAndRoleForPods(sacmName))
 
-	testNS1 := feature.MakeRandomK8sName("source-namespace")
-	testNS2 := feature.MakeRandomK8sName("source-namespace")
+	testNS1 := feature.MakeRandomK8sName("source-namespace-1")
+	testNS2 := feature.MakeRandomK8sName("source-namespace-2")
 
 	// create two new namespaces
-	f.Setup("create test-a namespace with matching selector", namespace.Install(testNS1))
-	f.Setup("create test-a namespace with matching selector", namespace.Install(testNS2))
+	f.Setup("create a namespace", namespace.Install(testNS1))
+	f.Setup("create a namespace", namespace.Install(testNS2))
 
 	cfg := []manifest.CfgFn{
 		apiserversource.WithServiceAccountName(sacmName),
@@ -461,8 +461,8 @@ func SendsEventsForAllResourcesWithEmptyNamespaceSelector() *feature.Feature {
 	f.Setup("install ApiServerSource", apiserversource.Install(source, cfg...))
 	f.Setup("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	pod1 := feature.MakeRandomK8sName("example")
-	pod2 := feature.MakeRandomK8sName("example")
+	pod1 := feature.MakeRandomK8sName("example-pod-1")
+	pod2 := feature.MakeRandomK8sName("example-pod-2")
 
 	f.Requirement("install example pod 1",
 		pod.Install(pod1, pod.WithImage(exampleImage), pod.WithNamespace(testNS1)),

--- a/test/rekt/resources/apiserversource/apiserversource.go
+++ b/test/rekt/resources/apiserversource/apiserversource.go
@@ -120,6 +120,13 @@ func WithResources(resources ...v1.APIVersionKindSelector) manifest.CfgFn {
 	}
 }
 
+// WithNamespaceSelector adds a namespace selector to an ApiServerSource spec.
+func WithNamespaceSelector(selector *metav1.LabelSelector) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["namespaceSelector"] = labelSelectorToStringMap(selector)
+	}
+}
+
 func labelSelectorToStringMap(selector *metav1.LabelSelector) map[string]interface{} {
 	if selector == nil {
 		return nil

--- a/test/rekt/resources/apiserversource/apiserversource.yaml
+++ b/test/rekt/resources/apiserversource/apiserversource.yaml
@@ -24,6 +24,26 @@ spec:
   {{ if .mode }}
   mode: {{ .mode }}
   {{ end }}
+  {{ if .namespaceSelector }}
+  namespaceSelector:
+    {{ if .namespaceSelector.matchLabels }}
+    matchLabels:
+      {{ range $key, $value := .namespaceSelector.matchLabels }}
+      {{ $key }}: {{ $value }}
+      {{ end }}
+    {{ end }}
+    {{ if .namespaceSelector.matchExpressions }}
+    matchExpressions:
+      {{ range $_, $expr := .namespaceSelector.matchExpressions }}
+      - key: {{ $expr.key }}
+        operator: {{ $expr.operator }}
+        values:
+          {{ range $_, $exprValue := $expr.values }}
+          - {{ $exprValue }}
+          {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
   {{ if .resources }}
   resources:
     {{ range $_, $resource := .resources }}

--- a/test/rekt/resources/apiserversource/apiserversource.yaml
+++ b/test/rekt/resources/apiserversource/apiserversource.yaml
@@ -26,13 +26,10 @@ spec:
   {{ end }}
   {{ if .namespaceSelector }}
   namespaceSelector:
-    {{ if .namespaceSelector.matchLabels }}
     matchLabels:
       {{ range $key, $value := .namespaceSelector.matchLabels }}
       {{ $key }}: {{ $value }}
       {{ end }}
-    {{ end }}
-    {{ if .namespaceSelector.matchExpressions }}
     matchExpressions:
       {{ range $_, $expr := .namespaceSelector.matchExpressions }}
       - key: {{ $expr.key }}
@@ -42,7 +39,6 @@ spec:
           - {{ $exprValue }}
           {{ end }}
       {{ end }}
-    {{ end }}
   {{ end }}
   {{ if .resources }}
   resources:

--- a/test/rekt/resources/apiserversource/apiserversource_test.go
+++ b/test/rekt/resources/apiserversource/apiserversource_test.go
@@ -263,6 +263,37 @@ func Example_withNamespaceSelector() {
 	//           - b
 }
 
+func Example_withEmptyNamespaceSelector() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+	}
+
+	apiserversource.WithNamespaceSelector(&metav1.LabelSelector{
+		MatchLabels:      map[string]string{},
+		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: sources.knative.dev/v1
+	// kind: ApiServerSource
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   namespaceSelector:
+	//     matchLabels:
+	//     matchExpressions:
+}
+
 func Example_full() {
 	ctx := testlog.NewContext()
 	images := map[string]string{}

--- a/test/rekt/resources/apiserversource/apiserversource_test.go
+++ b/test/rekt/resources/apiserversource/apiserversource_test.go
@@ -222,6 +222,47 @@ func Example_withResources() {
 	//               - b
 }
 
+func Example_withNamespaceSelector() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+	}
+
+	apiserversource.WithNamespaceSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "development"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "daf",
+			Operator: "uk",
+			Values:   []string{"a", "b"},
+		}},
+	})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: sources.knative.dev/v1
+	// kind: ApiServerSource
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   namespaceSelector:
+	//     matchLabels:
+	//       env: development
+	//     matchExpressions:
+	//       - key: daf
+	//         operator: uk
+	//         values:
+	//           - a
+	//           - b
+}
+
 func Example_full() {
 	ctx := testlog.NewContext()
 	images := map[string]string{}

--- a/test/rekt/resources/namespace/namespace.go
+++ b/test/rekt/resources/namespace/namespace.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/rekt/resources/namespace/namespace.go
+++ b/test/rekt/resources/namespace/namespace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Knative Authors
+Copyright 2023 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pod
+package namespace
 
 import (
 	"context"
@@ -27,14 +27,9 @@ import (
 //go:embed *.yaml
 var yaml embed.FS
 
-// Install will create a Pod with defaults that can be overwritten by
-// the With* methods.
 func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	cfg := map[string]interface{}{
-		"name":   name,
-		"labels": map[string]string{"app": name},         // default
-		"image":  "gcr.io/knative-samples/helloworld-go", // default
-		"port":   8080,                                   // default
+		"name": name,
 	}
 
 	for _, fn := range opts {
@@ -42,36 +37,17 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 	}
 
 	return func(ctx context.Context, t feature.T) {
-		manifest.PodSecurityCfgFn(ctx, t)(cfg)
 		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
 	}
 }
 
-// WithLabels sets the given labels on the Pod.
+// WithLabels sets the given labels on the Namespace.
 func WithLabels(labels map[string]string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		if labels != nil {
 			cfg["labels"] = labels
-		}
-	}
-}
-
-// WithImage sets the given image on the Pod spec.
-func WithImage(image string) manifest.CfgFn {
-	return func(cfg map[string]interface{}) {
-		if image != "" {
-			cfg["image"] = image
-		}
-	}
-}
-
-// WithOverriddenNamespace will modify the namespace of the pod from the specs to the provided one
-func WithOverriddenNamespace(ns string) manifest.CfgFn {
-	return func(cfg map[string]interface{}) {
-		if ns != "" {
-			cfg["overriddenNamespace"] = ns
 		}
 	}
 }

--- a/test/rekt/resources/namespace/namespace.yaml
+++ b/test/rekt/resources/namespace/namespace.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .name }}
+  {{ if .labels }}
+  labels:
+    {{ range $key, $value := .labels }}
+    {{ $key }}: {{ $value }}
+    {{ end }}
+  {{ end}}

--- a/test/rekt/resources/namespace/namespace_test.go
+++ b/test/rekt/resources/namespace/namespace_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/rekt/resources/namespace/namespace_test.go
+++ b/test/rekt/resources/namespace/namespace_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace_test
+
+import (
+	"embed"
+	"os"
+
+	"knative.dev/eventing/test/rekt/resources/namespace"
+	testlog "knative.dev/reconciler-test/pkg/logging"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+//go:embed *.yaml
+var yaml embed.FS
+
+func Example_min() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name": "foo",
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: Namespace
+	// metadata:
+	//   name: foo
+}
+
+func Example_withLabels() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":   "foo",
+		"labels": map[string]string{"target": "yes"},
+	}
+
+	namespace.WithLabels(map[string]string{"overwrite": "yes"})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: Namespace
+	// metadata:
+	//   name: foo
+	//   labels:
+	//     overwrite: yes
+}

--- a/test/rekt/resources/pod/pod.go
+++ b/test/rekt/resources/pod/pod.go
@@ -68,10 +68,10 @@ func WithImage(image string) manifest.CfgFn {
 }
 
 // WithOverriddenNamespace will modify the namespace of the pod from the specs to the provided one
-func WithOverriddenNamespace(ns string) manifest.CfgFn {
+func WithNamespace(ns string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		if ns != "" {
-			cfg["overriddenNamespace"] = ns
+			cfg["namespace"] = ns
 		}
 	}
 }

--- a/test/rekt/resources/pod/pod.yaml
+++ b/test/rekt/resources/pod/pod.yaml
@@ -16,7 +16,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ .name }}
+  {{ if .overriddenNamespace }}
+  namespace: {{ .overriddenNamespace }}
+  {{ else }}
   namespace: {{ .namespace }}
+  {{ end }}
   labels:
     {{ range $key, $value := .labels }}
     {{ $key }}: {{ $value }}

--- a/test/rekt/resources/pod/pod.yaml
+++ b/test/rekt/resources/pod/pod.yaml
@@ -16,11 +16,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ .name }}
-  {{ if .overriddenNamespace }}
-  namespace: {{ .overriddenNamespace }}
-  {{ else }}
   namespace: {{ .namespace }}
-  {{ end }}
   labels:
     {{ range $key, $value := .labels }}
     {{ $key }}: {{ $value }}

--- a/test/rekt/resources/pod/pod_test.go
+++ b/test/rekt/resources/pod/pod_test.go
@@ -131,6 +131,41 @@ func Example_withImage() {
 	//         - containerPort: 8080
 }
 
+func Example_withNamespace() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+		"image":     "baz",
+		"port":      "8080",
+		"labels":    map[string]string{"app": "bla"},
+	}
+
+	pod.WithOverriddenNamespace("new-namespace")(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: Pod
+	// metadata:
+	//   name: foo
+	//   namespace: new-namespace
+	//   labels:
+	//     app: bla
+	// spec:
+	//   containers:
+	//     - name: user-container
+	//       image: baz
+	//       ports:
+	//         - containerPort: 8080
+}
+
 func Example_full() {
 	ctx := testlog.NewContext()
 	images := map[string]string{}

--- a/test/rekt/resources/pod/pod_test.go
+++ b/test/rekt/resources/pod/pod_test.go
@@ -142,7 +142,7 @@ func Example_withNamespace() {
 		"labels":    map[string]string{"app": "bla"},
 	}
 
-	pod.WithOverriddenNamespace("new-namespace")(cfg)
+	pod.WithNamespace("new-namespace")(cfg)
 
 	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
 	if err != nil {


### PR DESCRIPTION
Fixes #6644 

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 ApiServerSource can specify a selector to target one or more namespaces. If the selector is missing, it will default to targeting the namespace in which the source resides

API changes (additive):
- `spec.namespaceSelector`: A label selector to identify namespaces to track
-  `status.namespaces`: A list of namespaces currently being tracked by the source


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
📄 ApiServerSource can specify a selector to target one or more namespaces. If the selector is missing, it will default to targeting the namespace in which the source resides
```


**Docs**

Docs to follow once the behaviour is finalized and approved.

