### PR TITLE
Change subscription patch logic to ensure resource version

### DIFF
--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -250,6 +250,12 @@ func MarkNotAddedToChannel(reason, msg string) SubscriptionOption {
 	}
 }
 
+func MarkChannelFailed(reason, msg string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.MarkChannelFailed(reason, msg)
+	}
+}
+
 func MarkReferencesResolved(s *v1.Subscription) {
 	s.Status.MarkReferencesResolved()
 }


### PR DESCRIPTION
Fixes #6636 

<!-- Please include the 'why' behind your changes if no issue exists -->

In `Subscription`'s reconcile loops, physical channel is updated by `PATCH` logic. It occurs broken sync between the channel and subscriptions.

For ensuring a resource version which can check whether conflict occurred or not, change to `Update` with RetryOnConflict.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Change Patch to Update
- Use RetryOnConflict
- Change condition when sync failed

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

# Open Questions
If there are some users who are already affected by the bug related to this issue, this PR cannot fix them. What should we do?