### PR TITLE
Reduce log noise in upgrade tests

### DIFF
--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -97,7 +97,8 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	}
 	for i, t := range report.Thrown.Duplicated {
 		if p.config.OnDuplicate == Warn {
-			p.log.Warn("Duplicate events: ", t)
+			// Print at info level to prevent excessive stacktraces.
+			p.log.Info("WARNING: Duplicate:", t)
 		} else if p.config.OnDuplicate == Error {
 			eventErrs = append(eventErrs, errors.New(t))
 		}
@@ -141,7 +142,7 @@ func (p *prober) getStepNoFromMsg(message string) (string, error) {
 }
 
 func (p *prober) getTraceForStepEvent(eventNo string) []byte {
-	p.log.Infof("Fetching trace for Step event #%s", eventNo)
+	p.log.Debugf("Fetching trace for Step event #%s", eventNo)
 	query := fmt.Sprintf("step=%s and cloudevents.type=%s and target=%s",
 		eventNo, event.StepType, fmt.Sprintf(forwarderTargetFmt, p.client.Namespace))
 	trace, err := event.FindTrace(query)


### PR DESCRIPTION
* Print "Fetching trace ..." at DEBUG level because we already print another message "Exporting trace into /file/path/step-XXXX.json" at INFO level which is sufficient.
* Print "Duplicate events: event #XXXX received X times, but should be received only once" at INFO level to get rid of the stacktrace that is printed at WARN level. This stack trace is really noisy and not useful at all. And with tens to hundreds of duplicate events it makes the logs really long.

This will reduce the log in the following way for each duplicate event:

Before:
```
2023-01-19T09:54:40.013-0500	WARN	prober/verify.go:99	Duplicate events: event #4278 received 2 times, but should be received only once
knative.dev/eventing/test/upgrade/prober.(*prober).Verify
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/eventing/test/upgrade/prober/verify.go:99
knative.dev/eventing/test/upgrade/prober.(*probeRunner).Verify
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/eventing/test/upgrade/prober/prober.go:74
knative.dev/eventing/test/upgrade/prober.NewContinualVerification.func2
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/eventing/test/upgrade/prober/continual.go:56
knative.dev/pkg/test/upgrade.NewBackgroundVerification.func1.1
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/functions.go:65
knative.dev/pkg/test/upgrade.handleStopEvent
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/functions.go:126
knative.dev/pkg/test/upgrade.WaitForStopEvent
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/functions.go:94
knative.dev/pkg/test/upgrade.NewBackgroundVerification.func1
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/functions.go:62
knative.dev/pkg/test/upgrade.(*suiteExecution).startContinualTests.func1.2
	/tmp/gopath-ZSUHshgs6a/src/github.com/openshift-knative/serverless-operator/vendor/knative.dev/pkg/test/upgrade/steps.go:81
2023-01-19T09:54:40.013-0500	INFO	prober/verify.go:135	Fetching trace for Step event #4278
2023-01-19T09:54:42.593-0500	INFO	prober/verify.go:168	Exporting trace into /home/jenkins/workspace/functional_tests/stream1_27/rolling-upgrade-1.27/artifacts/build-18/traces/events/step-4278.json

```

After:
```
2023-01-19T09:54:40.013-0500	INFO	prober/verify.go:99	WARNING: Duplicate: event #4278 received 2 times, but should be received only once
2023-01-19T09:54:42.593-0500	INFO	prober/verify.go:168	Exporting trace into /home/jenkins/workspace/functional_tests/stream1_27/rolling-upgrade-1.27/artifacts/build-18/traces/events/step-4278.json

```

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

