### PR TITLE
Default a subscriptions subscriber and reply in webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
 	knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
 	knative.dev/hack/schema v0.0.0-20230113013652-c7cfcb062de9
-	knative.dev/pkg v0.0.0-20230117181655-247510c00e9d
-	knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644
+	knative.dev/pkg v0.0.0-20230125083639-408ad0773f47
+	knative.dev/reconciler-test v0.0.0-20230123175938-e02964cf4648
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1004,10 +1004,10 @@ knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9 h1:CDa7s9KspEZqPhk7cN68ZypRL
 knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/hack/schema v0.0.0-20230113013652-c7cfcb062de9 h1:89vI4RV1PGCWlaC60uBnEyHEuXMCVnvhXXv+AnIezow=
 knative.dev/hack/schema v0.0.0-20230113013652-c7cfcb062de9/go.mod h1:GeIb+PLd5mllawcpHEGF5J5fYTQrvgEO5liao8lUKUs=
-knative.dev/pkg v0.0.0-20230117181655-247510c00e9d h1:pjKDcvHoMib8nRp56eISRmMj/pFMzJljnzvMvGCIReI=
-knative.dev/pkg v0.0.0-20230117181655-247510c00e9d/go.mod h1:VO/fcEsq43seuONRQxZyftWHjpMabYzRHDtpSEQ/eoQ=
-knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644 h1:DvQeHJR8nPh6SC2lM13t83Sv+5xHn/QQmVjdXi5ORsY=
-knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644/go.mod h1:ZPUBldkrSIOe0c57sDcnuM4bzQy16iTtvMV59nMPpfs=
+knative.dev/pkg v0.0.0-20230125083639-408ad0773f47 h1:zlRO7wXOHVYgKvsC3nIaYGqeQGlLJL8EIUY30Rh37Is=
+knative.dev/pkg v0.0.0-20230125083639-408ad0773f47/go.mod h1:VO/fcEsq43seuONRQxZyftWHjpMabYzRHDtpSEQ/eoQ=
+knative.dev/reconciler-test v0.0.0-20230123175938-e02964cf4648 h1:mONuM5XkQ4+Ez/p3QsdR8UtYKV/MgeYJJt8jbM3YR9s=
+knative.dev/reconciler-test v0.0.0-20230123175938-e02964cf4648/go.mod h1:ZPUBldkrSIOe0c57sDcnuM4bzQy16iTtvMV59nMPpfs=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/apis/messaging/v1/subscription_defaults.go
+++ b/pkg/apis/messaging/v1/subscription_defaults.go
@@ -34,5 +34,14 @@ func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {
 	if ss == nil {
 		return
 	}
+
+	if ss.Subscriber != nil {
+		ss.Subscriber.SetDefaults(ctx)
+	}
+
+	if ss.Reply != nil {
+		ss.Reply.SetDefaults(ctx)
+	}
+
 	ss.Delivery.SetDefaults(ctx)
 }

--- a/pkg/apis/messaging/v1/subscription_defaults.go
+++ b/pkg/apis/messaging/v1/subscription_defaults.go
@@ -35,13 +35,7 @@ func (ss *SubscriptionSpec) SetDefaults(ctx context.Context) {
 		return
 	}
 
-	if ss.Subscriber != nil {
-		ss.Subscriber.SetDefaults(ctx)
-	}
-
-	if ss.Reply != nil {
-		ss.Reply.SetDefaults(ctx)
-	}
-
+	ss.Subscriber.SetDefaults(ctx)
+	ss.Reply.SetDefaults(ctx)
 	ss.Delivery.SetDefaults(ctx)
 }

--- a/pkg/apis/messaging/v1/subscription_defaults_test.go
+++ b/pkg/apis/messaging/v1/subscription_defaults_test.go
@@ -54,6 +54,32 @@ func TestSubscriptionDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "subscription.spec.subscriber empty",
+			given: &Subscription{
+				Spec: SubscriptionSpec{
+					Subscriber: &duckv1.Destination{},
+				},
+			},
+			want: &Subscription{
+				Spec: SubscriptionSpec{
+					Subscriber: &duckv1.Destination{},
+				},
+			},
+		},
+		{
+			name: "subscription.spec.reply empty",
+			given: &Subscription{
+				Spec: SubscriptionSpec{
+					Reply: &duckv1.Destination{},
+				},
+			},
+			want: &Subscription{
+				Spec: SubscriptionSpec{
+					Reply: &duckv1.Destination{},
+				},
+			},
+		},
+		{
 			name: "subscription.spec.delivery empty",
 			given: &Subscription{
 				Spec: SubscriptionSpec{
@@ -63,6 +89,74 @@ func TestSubscriptionDefaults(t *testing.T) {
 			want: &Subscription{
 				Spec: SubscriptionSpec{
 					Delivery: &eventingduckv1.DeliverySpec{},
+				},
+			},
+		},
+		{
+			name: "subscription.spec.subscriber.ref.namespace empty",
+			given: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Subscriber: &duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Kind:       "Service",
+							Name:       "svc",
+							APIVersion: "v1",
+						},
+					},
+				},
+			},
+			want: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Subscriber: &duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Kind:       "Service",
+							Name:       "svc",
+							APIVersion: "v1",
+							Namespace:  "custom",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "subscription.spec.reply.ref.namespace empty",
+			given: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Reply: &duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Kind:       "Service",
+							Name:       "svc",
+							APIVersion: "v1",
+						},
+					},
+				},
+			},
+			want: &Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "custom",
+					Name:      "s",
+				},
+				Spec: SubscriptionSpec{
+					Reply: &duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Kind:       "Service",
+							Name:       "svc",
+							APIVersion: "v1",
+							Namespace:  "custom",
+						},
+					},
 				},
 			},
 		},

--- a/vendor/knative.dev/pkg/apis/duck/v1/destination.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1/destination.go
@@ -73,6 +73,10 @@ func (d *Destination) GetRef() *KReference {
 }
 
 func (d *Destination) SetDefaults(ctx context.Context) {
+	if d == nil {
+		return
+	}
+
 	if d.Ref != nil && d.Ref.Namespace == "" {
 		d.Ref.Namespace = apis.ParentMeta(ctx).Namespace
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1242,7 +1242,7 @@ knative.dev/hack/schema/commands
 knative.dev/hack/schema/docs
 knative.dev/hack/schema/registry
 knative.dev/hack/schema/schema
-# knative.dev/pkg v0.0.0-20230117181655-247510c00e9d
+# knative.dev/pkg v0.0.0-20230125083639-408ad0773f47
 ## explicit; go 1.18
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1377,7 +1377,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20230123181139-476a442e3644
+# knative.dev/reconciler-test v0.0.0-20230123175938-e02964cf4648
 ## explicit; go 1.18
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Default the subscriptions subscriber and reply in webhook. This will set (with the current implementation of `destination.SetDefaults()`) the namespace of the subscriber/reply to the namespace of the subscription.

WIP, as we can switch to nil safe `destination.SetDefaults()` method in [pkg/apis/messaging/v1/subscription_defaults.go](https://github.com/creydr/knative-eventing/blob/439006fcb60ba9d5ba11364f31f87b15201453b3/pkg/apis/messaging/v1/subscription_defaults.go#L38-L44), after knative/pkg#2670 merged