### PR TITLE
Set scheduler logging to debug

### DIFF
--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -173,7 +173,7 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 	// Quite an expensive operation but safe and simple.
 	state, err := s.stateAccessor.State(s.reserved)
 	if err != nil {
-		logger.Info("error while refreshing scheduler state (will retry)", zap.Error(err))
+		logger.Debug("error while refreshing scheduler state (will retry)", zap.Error(err))
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- set the logging for schedule failung to fetch resource (e.g. statefulset) to debug.

In downstream usage on "kafka broker", I am seeing lots of log info msgs, like these:

```
kafka-controller-6699c67795-scdkn controller {"level":"info","ts":"2023-01-26T07:44:09.549Z","logger":"kafka-broker-controller","caller":"state/state.go:178","msg":"failed to get statefulset","commit":"1199efa-dirty","knative.dev/pod":"kafka-controller-6699c67795-scdkn","error":"statefulsets.apps \"kafka-source-dispatcher\" not found"}
kafka-controller-6699c67795-scdkn controller {"level":"info","ts":"2023-01-26T07:44:09.549Z","logger":"kafka-broker-controller","caller":"statefulset/autoscaler.go:122","msg":"error while refreshing scheduler state (will retry){error 26 0  statefulsets.apps \"kafka-source-dispatcher\" not found}","commit":"1199efa-dirty","knative.dev/pod":"kafka-controller-6699c67795-scdkn"}
kafka-controller-6699c67795-scdkn controller {"level":"info","ts":"2023-01-26T07:44:09.556Z","logger":"kafka-broker-controller","caller":"state/state.go:178","msg":"failed to get statefulset","commit":"1199efa-dirty","knative.dev/pod":"kafka-controller-6699c67795-scdkn","error":"statefulsets.apps \"kafka-source-dispatcher\" not found"}
kafka-controller-6699c67795-scdkn controller {"level":"info","ts":"2023-01-26T07:44:09.556Z","logger":"kafka-broker-controller","caller":"statefulset/autoscaler.go:122","msg":"error while refreshing scheduler state (will retry){error 26 0  statefulsets.apps \"kafka-source-dispatcher\" not found}","commit":"1199efa-dirty","knative.dev/pod":"kafka-controller-6699c67795-scdkn"}
```

While not running the actual source.  But the amount of repetitive log messages seems a bit verbose 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

