### PR TITLE
Do not overwrite existing imagePullSecrets in CopySecret

### DIFF
--- a/pkg/utils/secret.go
+++ b/pkg/utils/secret.go
@@ -66,8 +66,19 @@ func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecre
 		return nil, fmt.Errorf("error copying the Secret: %s", err)
 	}
 
-	_, err = tgtNamespaceSvcAcct.Patch(context.Background(), svcAccount, types.StrategicMergePatchType,
-		[]byte(`{"imagePullSecrets":[{"name":"`+srcSecretName+`"}]}`), metav1.PatchOptions{})
+	tgtSvcAccount, err := tgtNamespaceSvcAcct.Get(context.Background(), svcAccount, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting service account %s", svcAccount)
+	}
+
+	// Prevent overwriting existing imagePullSecrets
+	if len(tgtSvcAccount.ImagePullSecrets) == 0 {
+		_, err = tgtNamespaceSvcAcct.Patch(context.Background(), svcAccount, types.StrategicMergePatchType,
+			[]byte(`{"imagePullSecrets":[{"name":"`+srcSecretName+`"}]}`), metav1.PatchOptions{})
+	} else {
+		_, err = tgtNamespaceSvcAcct.Patch(context.Background(), svcAccount, types.JSONPatchType,
+			[]byte(`[{"op":"add","path":"/imagePullSecrets/-","value":{"name": "`+srcSecretName+`"}}]`), metav1.PatchOptions{})
+	}
 	if err != nil {
 		return nil, fmt.Errorf("patch failed on NS/SA (%s/%s): %s",
 			tgtNS, srcSecretName, err)


### PR DESCRIPTION
When the target ServiceAccount already has some imagePullSecrets they would be overwritten and lost as can be seen in the example below:
```
 kubectl get sa default -oyaml;
apiVersion: v1
imagePullSecrets:
- name: my-secret
- name: default-dockercfg-x2xwj
kind: ServiceAccount
metadata:
  creationTimestamp: 2023-01-26T08:53:53Z
  name: default
  namespace: test2
  resourceVersion: "76300"
  uid: c4d7b2f4-7d85-4c9a-b274-ff4ad441dd3b
secrets:
- name: default-token-mn5m8
- name: default-dockercfg-x2xwj

❯ kubectl patch sa default -p='{"imagePullSecrets":[{"name":"my-new-secret"}]}'
serviceaccount/default patched

❯ kubectl get sa default -oyaml;
apiVersion: v1
imagePullSecrets:
- name: my-new-secret
- name: default-dockercfg-x2xwj
kind: ServiceAccount
metadata:
  creationTimestamp: 2023-01-26T08:53:53Z
  name: default
  namespace: test2
  resourceVersion: "76535"
  uid: c4d7b2f4-7d85-4c9a-b274-ff4ad441dd3b
secrets:
- name: default-token-mn5m8
- name: default-dockercfg-x2xwj
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add the secret to existing imagePullSecrets if there are any, do not overwrite the whole array.
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

