### PR TITLE
Removes the deprecated DeadLetterChannel in ChannelableStatus

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -282,22 +282,6 @@ DeliveryStatus
 resolved delivery options.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>deadLetterChannel</code><br/>
-<em>
-<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
-knative.dev/pkg/apis/duck/v1.KReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-Failed messages are delivered here.
-Deprecated in favor of DeliveryStatus, to be removed September 2022.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="duck.knative.dev/v1.DeliverySpec">DeliverySpec

--- a/pkg/apis/duck/v1/channelable_types.go
+++ b/pkg/apis/duck/v1/channelable_types.go
@@ -67,11 +67,6 @@ type ChannelableStatus struct {
 	// resolved delivery options.
 	// +optional
 	DeliveryStatus `json:",inline"`
-	// DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-	// Failed messages are delivered here.
-	// Deprecated in favor of DeliveryStatus, to be removed September 2022.
-	// +optional
-	DeadLetterChannel *duckv1.KReference `json:"deadLetterChannel,omitempty"`
 }
 
 var (

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -117,11 +117,6 @@ func (in *ChannelableStatus) DeepCopyInto(out *ChannelableStatus) {
 	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	in.SubscribableStatus.DeepCopyInto(&out.SubscribableStatus)
 	in.DeliveryStatus.DeepCopyInto(&out.DeliveryStatus)
-	if in.DeadLetterChannel != nil {
-		in, out := &in.DeadLetterChannel, &out.DeadLetterChannel
-		*out = new(duckv1.KReference)
-		**out = **in
-	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

Fixes #6720 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please catagorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behaviour
- :wastebasket: Remove feature or internal logic
-->

-  :wastebasket: Remove feature or internal logic
- removes deprecated `DeadLetterChannel` https://github.com/knative/eventing/blob/main/pkg/apis/duck/v1/channelable_types.go#L70-L74

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
removes deprecated DeadLetterChannel in favor of DeliveryStatus
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

