### PR TITLE
Added Broker class in `kubectl get -o wide`

### DIFF
--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -157,7 +156,7 @@ spec:
     - name: Class
       type: string
       priority: 1
-      jsonPath: ".metadata.annotations['eventing.knative.dev/broker.class']"
+      jsonPath: '.metadata.annotations.eventing\.knative\.dev/broker\.class'
   names:
     kind: Broker
     plural: brokers

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -154,6 +154,10 @@ spec:
     - name: Reason
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Class
+      type: string
+      priority: 1
+      jsonPath: ".metadata.annotations['eventing.knative.dev/broker.class']"
   names:
     kind: Broker
     plural: brokers


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

Fixes #6721 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add new feature
- `kubectl get -o wide` now also shows `CLASS` for broker

```
» kubectl -n knative-eventing apply -f test-broker.yaml
broker.eventing.knative.dev/my-default-broker created
» kubectl -n knative-eventing get brokers.eventing.knative.dev -o wide 
NAME                URL   AGE   READY   REASON                  CLASS
my-default-broker         13s   False   ChannelTemplateFailed   MTChannelBasedBroker
```

test-broker.yaml
```yaml
apiVersion: eventing.knative.dev/v1
kind: Broker
metadata:
  name: my-default-broker
spec: {}
```

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

