### PR TITLE
Extract scheduler config in a dedicate struct instead of many parameters

### DIFF
--- a/pkg/scheduler/statefulset/autoscaler_test.go
+++ b/pkg/scheduler/statefulset/autoscaler_test.go
@@ -30,9 +30,10 @@ import (
 	v1 "k8s.io/client-go/listers/core/v1"
 	gtesting "k8s.io/client-go/testing"
 
-	listers "knative.dev/eventing/pkg/reconciler/testing/v1"
 	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/statefulset/fake"
+
+	listers "knative.dev/eventing/pkg/reconciler/testing/v1"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
 	"knative.dev/eventing/pkg/scheduler"
@@ -377,7 +378,15 @@ func TestAutoscaler(t *testing.T) {
 				return nil
 			}
 
-			autoscaler := NewAutoscaler(ctx, testNs, sfsName, vpodClient.List, stateAccessor, noopEvictor, 10*time.Second, int32(10)).(*autoscaler)
+			cfg := &Config{
+				StatefulSetNamespace: testNs,
+				StatefulSetName:      sfsName,
+				VPodLister:           vpodClient.List,
+				Evictor:              noopEvictor,
+				RefreshPeriod:        10 * time.Second,
+				PodCapacity:          10,
+			}
+			autoscaler := newAutoscaler(ctx, cfg, stateAccessor).(*autoscaler)
 
 			for _, vpod := range tc.vpods {
 				vpodClient.Append(vpod)
@@ -425,7 +434,15 @@ func TestAutoscalerScaleDownToZero(t *testing.T) {
 		return nil
 	}
 
-	autoscaler := NewAutoscaler(ctx, testNs, sfsName, vpodClient.List, stateAccessor, noopEvictor, 2*time.Second, int32(10)).(*autoscaler)
+	cfg := &Config{
+		StatefulSetNamespace: testNs,
+		StatefulSetName:      sfsName,
+		VPodLister:           vpodClient.List,
+		Evictor:              noopEvictor,
+		RefreshPeriod:        2 * time.Second,
+		PodCapacity:          10,
+	}
+	autoscaler := newAutoscaler(ctx, cfg, stateAccessor).(*autoscaler)
 
 	done := make(chan bool)
 	go func() {
@@ -846,7 +863,15 @@ func TestCompactor(t *testing.T) {
 				return nil
 			}
 
-			autoscaler := NewAutoscaler(ctx, testNs, sfsName, vpodClient.List, stateAccessor, recordEviction, 10*time.Second, int32(10)).(*autoscaler)
+			cfg := &Config{
+				StatefulSetNamespace: testNs,
+				StatefulSetName:      sfsName,
+				VPodLister:           vpodClient.List,
+				Evictor:              recordEviction,
+				RefreshPeriod:        10 * time.Second,
+				PodCapacity:          10,
+			}
+			autoscaler := newAutoscaler(ctx, cfg, stateAccessor).(*autoscaler)
 
 			for _, vpod := range tc.vpods {
 				vpodClient.Append(vpod)

--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -774,7 +774,12 @@ func TestStatefulsetScheduler(t *testing.T) {
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
 			sa := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister())
-			s := NewStatefulSetScheduler(ctx, testNs, sfsName, vpodClient.List, sa, nil, lsp.GetPodLister().Pods(testNs)).(*StatefulSetScheduler)
+			cfg := &Config{
+				StatefulSetNamespace: testNs,
+				StatefulSetName:      sfsName,
+				VPodLister:           vpodClient.List,
+			}
+			s := newStatefulSetScheduler(ctx, cfg, sa, nil, lsp.GetPodLister().Pods(testNs)).(*StatefulSetScheduler)
 			if tc.pending != nil {
 				s.pending = tc.pending
 			}
@@ -867,7 +872,12 @@ func TestReservePlacements(t *testing.T) {
 			vpodClient := tscheduler.NewVPodClient()
 			vpodClient.Append(tc.vpod)
 
-			s := NewStatefulSetScheduler(ctx, testNs, sfsName, vpodClient.List, nil, nil, nil).(*StatefulSetScheduler)
+			cfg := &Config{
+				StatefulSetNamespace: testNs,
+				StatefulSetName:      sfsName,
+				VPodLister:           vpodClient.List,
+			}
+			s := newStatefulSetScheduler(ctx, cfg, nil, nil, nil).(*StatefulSetScheduler)
 			s.reservePlacements(tc.vpod, tc.vpod.GetPlacements()) //initial reserve
 
 			s.reservePlacements(tc.vpod, tc.placements) //new reserve


### PR DESCRIPTION
In order to make https://github.com/knative/eventing/issues/6732 we need a way of injecting more configuration down to the scheduler and autoscaler, so in this PR I'm extracting a new function to create a scheduler with `statefulset.New` but with a single `Config` parameter, this will allow us adding configurations without making breaking API changes.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>