### PR TITLE
Fixes issue where a CE response is truncated

### DIFF
--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -198,3 +198,18 @@ func TestBrokerDeliverLongMessage(t *testing.T) {
 
 	env.TestSet(ctx, t, broker.BrokerDeliverLongMessage())
 }
+
+func TestBrokerDeliverLongResponseMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
+	)
+
+	env.TestSet(ctx, t, broker.BrokerDeliverLongResponseMessage())
+}


### PR DESCRIPTION
## Proposed Changes

- 🐛 Fixes an issue where a Cloud Event in a response from a sink was truncated to 1024 bytes

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

```release-note
🐛 Fixes an issue where a Cloud Event in a response from a sink was truncated to 1024 bytes
```

Before the changes in #6521, the response was being truncated when an error occurred. That felt wrong as well, so with these changes, response body isn't truncated regardless of status. 

