### PR TITLE
Allow event display to log requests

### DIFF
--- a/cmd/event_display/main_test.go
+++ b/cmd/event_display/main_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -82,5 +83,28 @@ func waitForClient(ctx context.Context) error {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled: %s. The last HTTP error was: %s", ctx.Err(), httpErr)
 		}
+	}
+}
+
+func TestLogRequest(t *testing.T) {
+	bodyContent := "hello"
+	buffer := bytes.NewBuffer(nil)
+	buffer.WriteString(bodyContent)
+	req, err := http.NewRequest("POST", "https://localhost", buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Add("content-type", "application/json")
+
+	logRequest(req)
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != bodyContent {
+		t.Fatal("got", string(body), "want", bodyContent)
 	}
 }


### PR DESCRIPTION
This allows debugging deserialization issues for services.

When `REQUEST_LOGGING_ENABLED` is set to true, we get a log line like:
```
2023/02/21 12:19:08 {
  "method": "POST",
  "URL": {
    "Scheme": "https",
    "Opaque": "",
    "User": null,
    "Host": "localhost",
    "Path": "",
    "RawPath": "",
    "OmitHost": false,
    "ForceQuery": false,
    "RawQuery": "",
    "Fragment": "",
    "RawFragment": ""
  },
  "proto": "HTTP/1.1",
  "protoMajor": 1,
  "protoMinor": 1,
  "headers": {
    "Content-Type": [
      "application/json"
    ]
  },
  "body": "hello",
  "contentLength": 5,
  "host": "localhost",
  "remoteAddr": "",
  "requestURI": ""
}
```

The feature is explicitly discouraged for production usage with a log line due to the possibility of logging sensitive information, even though event display is not that useful for production