### PR TITLE
No reason for API ServerSource adapter to not inject istio sidecar

### DIFF
--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -77,7 +77,7 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) (*appsv1.Deployment, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "false", // needs to talk to the api server.
+						"sidecar.istio.io/inject": "true",
 					},
 					Labels: args.Labels,
 				},

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -102,7 +102,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"sidecar.istio.io/inject": "false",
+						"sidecar.istio.io/inject": "true",
 					},
 					Labels: map[string]string{
 						"test-key1": "test-value1",


### PR DESCRIPTION
The reasoning as per the comment was that you cannot have istio
sidecar when it needs to talk with the API Server but that is not
true, pods can talk to the API Server even with istio sidecar
injected.

For example, I'm injecting a sidecar in eventing-istio for
PingSource adapter or Kafka controller and they both work
fine.

Part of #6596 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Set sidecar.istio.io/inject to true for API Server Source adapters

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Set sidecar.istio.io/inject to true for API Server Source adapter pods.
```

