### PR TITLE
Add rekt based broker conformance test to ensure `broker.spec.config` is immutable

### DIFF
--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -96,7 +96,7 @@ func ControlPlaneBroker(brokerName string, brokerOpts ...manifest.CfgFn) *featur
 			readyBrokerHasIngressAvailable).
 		Should("While a Broker is Ready, it SHOULD be a valid Addressable and its `status.address.url` field SHOULD indicate the address of its ingress.",
 			readyBrokerIsAddressable).
-		Should("The class of a Broker object SHOULD be immutable.",
+		Must("The class of a Broker object MUST be immutable.",
 			brokerClassIsImmutable).
 		Should("Set the Broker status.deadLetterSinkURI if there is a valid spec.delivery.deadLetterSink defined",
 			BrokerStatusDLSURISet).

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -588,7 +588,7 @@ func copyBroker(ctx context.Context, srcBroker *eventingv1.Broker, toName string
 			Labels:      srcBroker.Labels,
 			Annotations: srcBroker.Annotations,
 		},
-		Spec: srcBroker.Spec,
+		Spec: *srcBroker.Spec.DeepCopy(),
 	}
 
 	return Client(ctx).Brokers.Create(ctx, broker, metav1.CreateOptions{})


### PR DESCRIPTION
In the "old" conformance tests for the broker, we had a check to ensure that the `broker.spec.config` is immutable:

https://github.com/knative/eventing/blob/df2287d3c4198aa7c275e174cc494226763c0ddd/test/conformance/helpers/broker_control_plane_test_helper.go#L74-L76

This is missing in the rekt based conformance tests for the broker. This PR addresses it and adds a test to the rekt base conformance tests.

## Proposed Changes

- :gift: Add rekt based broker conformance test to test `broker.spec.config` of a ready broker is immutable