### PR TITLE
Fix pod annotations in containersource template

### DIFF
--- a/test/rekt/features/containersource/features.go
+++ b/test/rekt/features/containersource/features.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"knative.dev/reconciler-test/pkg/manifest"
 
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
@@ -78,6 +79,9 @@ func SendsEventsWithCloudEventOverrides() *feature.Feature {
 	f.Requirement("install containersource", containersource.Install(source,
 		pingsource.WithSink(service.AsKReference(sink), ""),
 		containersource.WithExtensions(extensions),
+		manifest.WithPodAnnotations(map[string]interface{}{
+			"foo": true,
+		}),
 	))
 	f.Requirement("containersource goes ready", containersource.IsReady(source))
 

--- a/test/rekt/resources/containersource/containersource.yaml
+++ b/test/rekt/resources/containersource/containersource.yaml
@@ -43,7 +43,7 @@ spec:
     metadata:
       annotations:
         {{ range $key, $value := .podannotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     {{ end }}
     spec:


### PR DESCRIPTION
It was sending 
```
apiVersion: sources.knative.dev/v1
kind: ContainerSource
metadata:
  name: containersource-zktkstuz
  namespace: test-rtirtpit
spec:
  
  ceOverrides:
    
    extensions:
      
      wow: so extended
      
    
  
  sink:
    
    ref:
      kind: Service
      namespace: test-rtirtpit
      name: sink-rematrro
      apiVersion: v1
    
    
  template:
    
    metadata:
      annotations:
        
        sidecar.istio.io/inject: true
        
        sidecar.istio.io/rewriteAppHTTPProbers: true
        
    
    spec:
      containers:
      - name: heartbeats
        image: quay.io/pierdipi/heartbeats@sha256:41da51559b82b577372291ca8b63efc5529b14e00d0d988440986d55eb0d8f05
        imagePullPolicy: IfNotPresent
        args:
        - <no value>
        env:
        - name: POD_NAME
          value: heartbeats
        - name: POD_NAMESPACE
          value: test-rtirtpit
```

which produces:
```
mutation failed: cannot decode incoming new object: json: cannot unmarshal bool into Go struct field ObjectMeta.spec.template.metadata.annotations of type string
```