### PR TITLE
Heartbeats: quit istio proxy when running in a job

### DIFF
--- a/test/rekt/features/sinkbinding/feature.go
+++ b/test/rekt/features/sinkbinding/feature.go
@@ -18,7 +18,6 @@ package sinkbinding
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +88,6 @@ func SinkBindingV1Job(ctx context.Context) *feature.Feature {
 		cronjob.WitEnvs(map[string]string{
 			"POD_NAME":      "heartbeats",
 			"POD_NAMESPACE": environment.FromContext(ctx).Namespace(),
-			"K_SINK":        fmt.Sprintf("%s://%s.%s.svc", "http", sink, environment.FromContext(ctx).Namespace()),
 			"ONE_SHOT":      "true",
 		}),
 	))


### PR DESCRIPTION
When running with an istio sidecar and
within a job, the job never completes until
all containers shutdown successfully.