### PR TITLE
fix api docs generation with go1.20

### DIFF
--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is need to work around a gengo/go1.20 issue
+// details https://github.com/ahmetb/gen-crd-api-reference-docs/issues/61
+
+package apis


### PR DESCRIPTION
Context https://github.com/ahmetb/gen-crd-api-reference-docs/issues/61

This fixes the `knative/pkg` downstream tests (which is using go1.20)
