### PR TITLE
Bump Go to 1.20 in GH workflows

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
 
     - name: Install Dependencies
       working-directory: ./
@@ -122,7 +122,7 @@ jobs:
       run: |
         export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -parallel=12 -v -timeout=50m -tags=e2e \
+        go test -race -count=1 -parallel=12 -timeout=50m -tags=e2e \
            ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
     - name: Collect system diagnostics

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.20.x
     - name: Install Dependencies
       run: |
         go install github.com/google/go-licenses@latest


### PR DESCRIPTION
As per title, similar to: https://github.com/knative-sandbox/reconciler-test/commit/8e242fe2239f0bfff31bee0ca15b962c8c0987df