### PR TITLE
Eventing TLS: Added Support for setting K_CA_CERTS in the ApiServerSource controller for the adapter

### DIFF
--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -39,6 +39,7 @@ const (
 	EnvConfigName                 = "NAME"
 	EnvConfigResourceGroup        = "K_RESOURCE_GROUP"
 	EnvConfigSink                 = "K_SINK"
+	EnvConfigCACert               = "K_CA_CERTS"
 	EnvConfigCEOverrides          = "K_CE_OVERRIDES"
 	EnvConfigMetricsConfig        = "K_METRICS_CONFIG"
 	EnvConfigLoggingConfig        = "K_LOGGING_CONFIG"

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -118,7 +118,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 
 	// An empty selector targets all namespaces.
 	allNamespaces := isEmptySelector(source.Spec.NamespaceSelector)
-	ra, err := r.createReceiveAdapter(ctx, source, sinkURI.String(), namespaces, allNamespaces)
+	ra, err := r.createReceiveAdapter(ctx, source, sinkAddr, namespaces, allNamespaces)
 	if err != nil {
 		logging.FromContext(ctx).Errorw("Unable to create the receive adapter", zap.Error(err))
 		return err
@@ -170,7 +170,7 @@ func isEmptySelector(selector *metav1.LabelSelector) bool {
 	return false
 }
 
-func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServerSource, sinkURI string, namespaces []string, allNamespaces bool) (*appsv1.Deployment, error) {
+func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServerSource, sinkAddr *duckv1.Addressable, namespaces []string, allNamespaces bool) (*appsv1.Deployment, error) {
 	// TODO: missing.
 	// if err := checkResourcesStatus(src); err != nil {
 	// 	return nil, err
@@ -180,7 +180,8 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 		Image:         r.receiveAdapterImage,
 		Source:        src,
 		Labels:        resources.Labels(src.Name),
-		SinkURI:       sinkURI,
+		CACerts:       sinkAddr.CACerts,
+		SinkURI:       sinkAddr.URL.String(),
 		Configs:       r.configs,
 		Namespaces:    namespaces,
 		AllNamespaces: allNamespaces,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -45,6 +45,7 @@ type ReceiveAdapterArgs struct {
 	Source        *v1.ApiServerSource
 	Labels        map[string]string
 	SinkURI       string
+	CACerts       string
 	Configs       reconcilersource.ConfigAccessor
 	Namespaces    []string
 	AllNamespaces bool
@@ -152,6 +153,9 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 	envs := []corev1.EnvVar{{
 		Name:  adapter.EnvConfigSink,
 		Value: args.SinkURI,
+	}, {
+		Name:  adapter.EnvConfigCACert,
+		Value: args.CACerts,
 	}, {
 		Name:  "K_SOURCE_CONFIG",
 		Value: config,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter.go
@@ -45,7 +45,7 @@ type ReceiveAdapterArgs struct {
 	Source        *v1.ApiServerSource
 	Labels        map[string]string
 	SinkURI       string
-	CACerts       string
+	CACerts       *string
 	Configs       reconcilersource.ConfigAccessor
 	Namespaces    []string
 	AllNamespaces bool
@@ -154,9 +154,6 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 		Name:  adapter.EnvConfigSink,
 		Value: args.SinkURI,
 	}, {
-		Name:  adapter.EnvConfigCACert,
-		Value: args.CACerts,
-	}, {
 		Name:  "K_SOURCE_CONFIG",
 		Value: config,
 	}, {
@@ -177,12 +174,19 @@ func makeEnv(args *ReceiveAdapterArgs) ([]corev1.EnvVar, error) {
 		Value: "knative.dev/eventing",
 	}}
 
+	if args.CACerts != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  adapter.EnvConfigCACert,
+			Value: *args.CACerts,
+		})
+	}
+
 	envs = append(envs, args.Configs.ToEnvVars()...)
 
 	if args.Source.Spec.CloudEventOverrides != nil {
 		ceJson, err := json.Marshal(args.Source.Spec.CloudEventOverrides)
 		if err != nil {
-			return nil, fmt.Errorf("Failure to marshal cloud event overrides %v: %v", args.Source.Spec.CloudEventOverrides, err)
+			return nil, fmt.Errorf("failure to marshal cloud event overrides %v: %v", args.Source.Spec.CloudEventOverrides, err)
 		}
 		envs = append(envs, corev1.EnvVar{Name: adapter.EnvConfigCEOverrides, Value: string(ceJson)})
 	}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -37,8 +37,11 @@ import (
 	_ "knative.dev/pkg/system/testing"
 )
 
-const (
-	testCaCerts = `
+func TestMakeReceiveAdapters(t *testing.T) {
+	name := "source-name"
+	one := int32(1)
+	trueValue := true
+	testCert := `
 -----BEGIN CERTIFICATE-----
 MIIDmjCCAoKgAwIBAgIUYzA4bTMXevuk3pl2Mn8hpCYL2C0wDQYJKoZIhvcNAQEL
 BQAwLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290
@@ -62,13 +65,6 @@ s/wImGnMVk5RzpBVrq2VB9SkX/ThTVYEC/Sd9BQM364MCR+TA1l8/ptaLFLuwyw8
 O2dgzikq8iSy1BlRsVw=
 -----END CERTIFICATE-----
 `
-)
-
-func TestMakeReceiveAdapters(t *testing.T) {
-	testCert := testCaCerts
-	name := "source-name"
-	one := int32(1)
-	trueValue := true
 
 	src := &v1.ApiServerSource{
 		ObjectMeta: metav1.ObjectMeta{
@@ -175,7 +171,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 									Value: "knative.dev/eventing",
 								}, {
 									Name:  "K_CA_CERTS",
-									Value: testCaCerts,
+									Value: testCert,
 								}, {
 									Name:  source.EnvLoggingCfg,
 									Value: "",

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -240,9 +240,8 @@ func TestMakeReceiveAdapters(t *testing.T) {
 					"test-key1": "test-value1",
 					"test-key2": "test-value2",
 				},
-				SinkURI: "sink-uri",
-				CACerts: testCaCerts,
-
+				SinkURI:    "sink-uri",
+				CACerts:    testCaCerts,
 				Configs:    &source.EmptyVarsGenerator{},
 				Namespaces: []string{"source-namespace"},
 			})

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -38,6 +38,33 @@ import (
 	_ "knative.dev/pkg/system/testing"
 )
 
+const (
+	testCaCerts = `
+-----BEGIN CERTIFICATE-----
+MIIDmjCCAoKgAwIBAgIUYzA4bTMXevuk3pl2Mn8hpCYL2C0wDQYJKoZIhvcNAQEL
+BQAwLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290
+LUNBMB4XDTIzMDQwNTEzMTUyNFoXDTI2MDEyMzEzMTUyNFowbTELMAkGA1UEBhMC
+VVMxEjAQBgNVBAgMCVlvdXJTdGF0ZTERMA8GA1UEBwwIWW91ckNpdHkxHTAbBgNV
+BAoMFEV4YW1wbGUtQ2VydGlmaWNhdGVzMRgwFgYDVQQDDA9sb2NhbGhvc3QubG9j
+YWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5teo+En6U5nhqn7Sc
+uanqswUmPlgs9j/8l21Rhb4T+ezlYKGQGhbJyFFMuiCE1Rjn8bpCwi7Nnv12Y2nz
+FhEv2Jx0yL3Tqx0Q593myqKDq7326EtbO7wmDT0XD03twH5i9XZ0L0ihPWn1mjUy
+WxhnHhoFpXrsnQECJorZY6aTrFbGVYelIaj5AriwiqyL0fET8pueI2GwLjgWHFSH
+X8XsGAlcLUhkQG0Z+VO9usy4M1Wpt+cL6cnTiQ+sRmZ6uvaj8fKOT1Slk/oUeAi4
+WqFkChGzGzLik0QrhKGTdw3uUvI1F2sdQj0GYzXaWqRz+tP9qnXdzk1GrszKKSlm
+WBTLAgMBAAGjcDBuMB8GA1UdIwQYMBaAFJJcCftus4vj98N0zQQautsjEu82MAkG
+A1UdEwQCMAAwCwYDVR0PBAQDAgTwMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDAdBgNV
+HQ4EFgQUnu/3vqA3VEzm128x/hLyZzR9JlgwDQYJKoZIhvcNAQELBQADggEBAFc+
+1cKt/CNjHXUsirgEhry2Mm96R6Yxuq//mP2+SEjdab+FaXPZkjHx118u3PPX5uTh
+gTT7rMfka6J5xzzQNqJbRMgNpdEFH1bbc11aYuhi0khOAe0cpQDtktyuDJQMMv3/
+3wu6rLr6fmENo0gdcyUY9EiYrglWGtdXhlo4ySRY8UZkUScG2upvyOhHTxVCAjhP
+efbMkNjmDuZOMK+wqanqr5YV6zMPzkQK7DspfRgasMAQmugQu7r2MZpXg8Ilhro1
+s/wImGnMVk5RzpBVrq2VB9SkX/ThTVYEC/Sd9BQM364MCR+TA1l8/ptaLFLuwyw8
+O2dgzikq8iSy1BlRsVw=
+-----END CERTIFICATE-----
+`
+)
+
 func TestMakeReceiveAdapters(t *testing.T) {
 	name := "source-name"
 	one := int32(1)
@@ -127,6 +154,10 @@ func TestMakeReceiveAdapters(t *testing.T) {
 								{
 									Name:  "K_SINK",
 									Value: "sink-uri",
+								},
+								{
+									Name:  "K_CA_CERTS",
+									Value: testCaCerts,
 								}, {
 									Name:  "K_SOURCE_CONFIG",
 									Value: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
@@ -209,7 +240,9 @@ func TestMakeReceiveAdapters(t *testing.T) {
 					"test-key1": "test-value1",
 					"test-key2": "test-value2",
 				},
-				SinkURI:    "sink-uri",
+				SinkURI: "sink-uri",
+				CACerts: testCaCerts,
+
 				Configs:    &source.EmptyVarsGenerator{},
 				Namespaces: []string{"source-namespace"},
 			})

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -231,6 +231,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+
 			got, _ := MakeReceiveAdapter(&ReceiveAdapterArgs{
 				Image:  "test-image",
 				Source: tc.src,

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +65,7 @@ O2dgzikq8iSy1BlRsVw=
 )
 
 func TestMakeReceiveAdapters(t *testing.T) {
+	testCert := testCaCerts
 	name := "source-name"
 	one := int32(1)
 	trueValue := true
@@ -154,10 +154,6 @@ func TestMakeReceiveAdapters(t *testing.T) {
 								{
 									Name:  "K_SINK",
 									Value: "sink-uri",
-								},
-								{
-									Name:  "K_CA_CERTS",
-									Value: testCaCerts,
 								}, {
 									Name:  "K_SOURCE_CONFIG",
 									Value: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
@@ -177,6 +173,9 @@ func TestMakeReceiveAdapters(t *testing.T) {
 								}, {
 									Name:  "METRICS_DOMAIN",
 									Value: "knative.dev/eventing",
+								}, {
+									Name:  "K_CA_CERTS",
+									Value: testCaCerts,
 								}, {
 									Name:  source.EnvLoggingCfg,
 									Value: "",
@@ -232,7 +231,6 @@ func TestMakeReceiveAdapters(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			got, _ := MakeReceiveAdapter(&ReceiveAdapterArgs{
 				Image:  "test-image",
 				Source: tc.src,
@@ -241,7 +239,7 @@ func TestMakeReceiveAdapters(t *testing.T) {
 					"test-key2": "test-value2",
 				},
 				SinkURI:    "sink-uri",
-				CACerts:    testCaCerts,
+				CACerts:    &testCert,
 				Configs:    &source.EmptyVarsGenerator{},
 				Namespaces: []string{"source-namespace"},
 			})


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>
Fixes #6894

<!-- Please include the 'why' behind your changes if no issue exists -->

The ApiServerSource controller now sets the K_CA_CERTS environment variable when creating the adapter and the sink has CACerts defined.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Update or clean up current behavior
- Added K_CA_CERTS env variable support
- Updated tests

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The ApiServerSource controller now sets the K_CA_CERTS environment variable when creating the adapter and the sink has CACerts defined.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

