### PR TITLE
Remove sanitize HTTP body for `knativeerrordata` extension

### DIFF
--- a/pkg/channel/message_dispatcher_test.go
+++ b/pkg/channel/message_dispatcher_test.go
@@ -693,7 +693,7 @@ func TestDispatchMessage(t *testing.T) {
 					"traceparent":         {"ignored-value-header"},
 					"ce-abc":              {`"ce-abc-value"`},
 					"ce-knativeerrorcode": {strconv.Itoa(http.StatusBadRequest)},
-					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination multi-line response"))},
+					"ce-knativeerrordata": {base64.StdEncoding.EncodeToString([]byte("destination\n multi-line\n response"))},
 					"ce-id":               {"ignored-value-header"},
 					"ce-time":             {"2002-10-02T15:00:00Z"},
 					"ce-source":           {testCeSource},


### PR DESCRIPTION
Sanitizing the HTTP body was added as a measure to try to handle as many HTTP body as possible, now that we're base64 encoding the error body [1], it is not necessary anymore, it just breaks any consumer trying to use such info.

[1] https://github.com/knative/eventing/pull/6542