### PR TITLE
Remove eventing-natss from downstream tests

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -38,8 +38,6 @@ jobs:
             org: knative-sandbox
           - repo: eventing-kafka-broker
             org: knative-sandbox
-          - repo: eventing-natss
-            org: knative-sandbox
           - repo: eventing-rabbitmq
             org: knative-sandbox
 


### PR DESCRIPTION
eventing-natss tests are always failing.