### PR TITLE
Adds ServerManager. Supports http/https message receivers

### DIFF
--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -71,6 +71,11 @@ func (e Flags) IsStrictTransportEncryption() bool {
 	return e != nil && e[TransportEncryption] == Strict
 }
 
+// IsDisbledTransportEncryption returns true if the TransportEncryption feature is in Disabled mode.
+func (e Flags) IsDisbledTransportEncryption() bool {
+	return e != nil && e[TransportEncryption] == Disabled
+}
+
 // NewFlagsConfigFromMap creates a Flags from the supplied Map
 func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 	flags := Flags{}

--- a/pkg/eventingtls/servermanager.go
+++ b/pkg/eventingtls/servermanager.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventingtls
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+)
+
+// TODO: write tests
+
+// ServerManager is intended to be used to manage HTTP and HTTPS servers for a component.
+// It relies on the `transport-encryption` feature flag to determine which server(s) should be accepting requests.
+// If a server shouldn't be accepting requests, ServerManager will update that server's handler to respond with a 404
+//
+// disabled: only http server
+// permissive: both http and https servers
+// strict: only https server
+type ServerManager struct {
+	httpReceiver  *kncloudevents.HTTPMessageReceiver
+	httpsReceiver *kncloudevents.HTTPMessageReceiver
+	handler       http.Handler
+	cmw           configmap.Watcher
+}
+
+func NewServerManager(httpReceiver, httpsReceiver *kncloudevents.HTTPMessageReceiver, handler http.Handler, cmw configmap.Watcher) (*ServerManager, error) {
+	if httpReceiver == nil || httpsReceiver == nil {
+		return nil, fmt.Errorf("message receiver not provided")
+	}
+
+	return &ServerManager{
+		httpReceiver:  httpReceiver,
+		httpsReceiver: httpsReceiver,
+		handler:       handler,
+		cmw:           cmw,
+	}, nil
+}
+
+// Blocking call. Starts the 2 servers
+func (s *ServerManager) StartServers(ctx context.Context) (httpError, httpsError error) {
+	// start servers
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		httpError = s.httpReceiver.StartListen(ctx, s.handler)
+	}()
+
+	go func() {
+		defer wg.Done()
+		httpsError = s.httpsReceiver.StartListen(ctx, s.handler)
+	}()
+
+	<-s.httpReceiver.Ready
+	<-s.httpsReceiver.Ready
+
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
+		s.updateHandlers(ctx, value.(feature.Flags))
+	})
+	featureStore.WatchConfigs(s.cmw)
+
+	wg.Wait()
+	return
+}
+
+func (s *ServerManager) updateHandlers(ctx context.Context, flags feature.Flags) {
+	if flags.IsStrictTransportEncryption() {
+		logging.FromContext(ctx).Info("transport-encryption: strict. Disabling http handler")
+		s.httpReceiver.UpdateHandler(statusNotFoundHandler(ctx))
+		s.httpsReceiver.UpdateHandler(s.handler)
+	} else if flags.IsPermissiveTransportEncryption() {
+		logging.FromContext(ctx).Info("transport-encryption: permissive. Enabling both http and https handlers")
+		s.httpReceiver.UpdateHandler(s.handler)
+		s.httpsReceiver.UpdateHandler(s.handler)
+	} else {
+		// disabled mode
+		logging.FromContext(ctx).Info("transport encryption: disabled. Disabling https handler")
+		s.httpReceiver.UpdateHandler(s.handler)
+		s.httpsReceiver.UpdateHandler(statusNotFoundHandler(ctx))
+	}
+}
+
+func statusNotFoundHandler(ctx context.Context) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+}

--- a/pkg/eventingtls/servermanager.go
+++ b/pkg/eventingtls/servermanager.go
@@ -28,8 +28,6 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// TODO: write tests
-
 // ServerManager is intended to be used to manage HTTP and HTTPS servers for a component.
 // It relies on the `transport-encryption` feature flag to determine which server(s) should be accepting requests.
 // If a server shouldn't be accepting requests, ServerManager will update that server's handler to respond with a 404

--- a/pkg/eventingtls/servermanager_test.go
+++ b/pkg/eventingtls/servermanager_test.go
@@ -1,6 +1,3 @@
-//go:build !race
-// +build !race
-
 /*
 Copyright 2023 The Knative Authors
 
@@ -65,7 +62,7 @@ func TestStartServers(t *testing.T) {
 			errChan := make(chan error)
 
 			cmw := newFeatureCMW(tc.transportEncryption)
-			sm, err := NewServerManager(httpReceiver, httpsReceiver, &basicHandler{}, cmw)
+			sm, err := NewServerManager(ctx, httpReceiver, httpsReceiver, &basicHandler{}, cmw)
 			assert.NoError(t, err)
 			go func() {
 				err1, err2 := sm.StartServers(ctx)
@@ -110,15 +107,16 @@ func TestStartServers(t *testing.T) {
 }
 
 func TestStartServersHttpError(t *testing.T) {
+	ctx := context.TODO()
 	receiver := kncloudevents.NewHTTPMessageReceiver(0, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	cmw := newFeatureCMW(feature.Disabled)
 
 	// httpReceiver set to nil
-	_, err := NewServerManager(nil, receiver, &basicHandler{}, cmw)
+	_, err := NewServerManager(ctx, nil, receiver, &basicHandler{}, cmw)
 	assert.Error(t, err)
 
 	// httpsReceiver set to nil
-	_, err = NewServerManager(receiver, nil, &basicHandler{}, cmw)
+	_, err = NewServerManager(ctx, receiver, nil, &basicHandler{}, cmw)
 	assert.Error(t, err)
 }
 

--- a/pkg/eventingtls/servermanager_test.go
+++ b/pkg/eventingtls/servermanager_test.go
@@ -1,0 +1,142 @@
+//go:build !race
+// +build !race
+
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventingtls
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/pkg/configmap"
+)
+
+func TestStartServers(t *testing.T) {
+	testCases := map[string]struct {
+		transportEncryption feature.Flag
+		handleHttp          bool
+		handleHttps         bool
+	}{
+		"disabled: should only support http": {
+			transportEncryption: feature.Disabled,
+			handleHttp:          true,
+			handleHttps:         false,
+		},
+		"permissive: should support both http and https": {
+			transportEncryption: feature.Permissive,
+			handleHttp:          true,
+			handleHttps:         true,
+		},
+		"strict: should only support https": {
+			transportEncryption: feature.Strict,
+			handleHttp:          false,
+			handleHttps:         true,
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			ctx, cancelFunc := context.WithCancel(context.TODO())
+			httpReceiver := kncloudevents.NewHTTPMessageReceiver(0, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+			httpsReceiver := kncloudevents.NewHTTPMessageReceiver(0, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+			errChan := make(chan error)
+
+			cmw := newFeatureCMW(tc.transportEncryption)
+			sm, err := NewServerManager(httpReceiver, httpsReceiver, &basicHandler{}, cmw)
+			assert.NoError(t, err)
+			go func() {
+				err1, err2 := sm.StartServers(ctx)
+				errChan <- err1
+				errChan <- err2
+			}()
+
+			<-httpReceiver.Ready
+			<-httpsReceiver.Ready
+
+			client := &http.Client{}
+			httpAddr := "http://" + httpReceiver.GetAddr()
+			httpsAddr := "http://" + httpsReceiver.GetAddr()
+
+			httpReq, err := http.NewRequest("GET", httpAddr, nil)
+			assert.NoError(t, err)
+			httpsReq, err := http.NewRequest("GET", httpsAddr, nil)
+			assert.NoError(t, err)
+
+			httpResp, err := client.Do(httpReq)
+			assert.NoError(t, err)
+			if tc.handleHttp {
+				assert.Equal(t, http.StatusOK, httpResp.StatusCode)
+			} else {
+				assert.Equal(t, http.StatusNotFound, httpResp.StatusCode)
+			}
+
+			httpsResp, err := client.Do(httpsReq)
+			assert.NoError(t, err)
+			if tc.handleHttps {
+				assert.Equal(t, http.StatusOK, httpsResp.StatusCode)
+			} else {
+				assert.Equal(t, http.StatusNotFound, httpsResp.StatusCode)
+			}
+
+			// stop servers and ensure no errors for http/https
+			cancelFunc()
+			assert.NoError(t, <-errChan)
+			assert.NoError(t, <-errChan)
+		})
+	}
+}
+
+func TestStartServersHttpError(t *testing.T) {
+	receiver := kncloudevents.NewHTTPMessageReceiver(0, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	cmw := newFeatureCMW(feature.Disabled)
+
+	// httpReceiver set to nil
+	_, err := NewServerManager(nil, receiver, &basicHandler{}, cmw)
+	assert.Error(t, err)
+
+	// httpsReceiver set to nil
+	_, err = NewServerManager(receiver, nil, &basicHandler{}, cmw)
+	assert.Error(t, err)
+}
+
+type basicHandler struct{}
+
+func (bh *basicHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	writer.WriteHeader(http.StatusOK)
+}
+
+func newFeatureCMW(value feature.Flag) configmap.Watcher {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: feature.FlagsConfigName,
+		},
+		Data: map[string]string{
+			feature.TransportEncryption: string(value),
+		},
+	}
+
+	return configmap.NewStaticWatcher(cm)
+}

--- a/pkg/kncloudevents/message_receiver.go
+++ b/pkg/kncloudevents/message_receiver.go
@@ -123,6 +123,12 @@ func WithReadTimeout(duration time.Duration) HTTPMessageReceiverOption {
 func (recv *HTTPMessageReceiver) UpdateHandler(handler http.Handler) {
 	recv.handlerMutex.Lock()
 	defer recv.handlerMutex.Unlock()
+
+	// wait for any in-flight requests to finish
+	if recv.drainer != nil {
+		recv.drainer.Drain()
+	}
+
 	drainer := &handlers.Drainer{
 		Inner:       CreateHandler(handler),
 		HealthCheck: recv.checker,

--- a/pkg/kncloudevents/message_receiver_test.go
+++ b/pkg/kncloudevents/message_receiver_test.go
@@ -169,6 +169,7 @@ func TestStartListenReceiveEvent(t *testing.T) {
 	assert.Equal(t, nil, <-errChan)
 
 }
+
 func TestGetAddr(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.TODO())
 	errChan := make(chan error)


### PR DESCRIPTION
Fixes #6899 

ServerManager takes a http receiver, https receiver, handler and a config map watcher. 

The handle will be invoked when the respective server should be available. Otherwise, the handler is swapped to one that returns a 404 (retryable error in case the request is made during a configuration switch)