### PR TITLE
Install ko using setup-ko in kind e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -61,14 +61,9 @@ jobs:
       with:
         go-version: 1.20.x
 
-    - name: Install Dependencies
-      working-directory: ./
-      run: |
-        echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        echo '::endgroup::'
+    # Install the latest release of ko
+    - name: Install ko
+      uses: ko-build/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2


### PR DESCRIPTION
## Proposed Changes

- 🎁 Install `ko` using `ko-build/setup-ko@v0.6`
- ⚡ This will ensure you use the latest and greatest version of `ko`
- 🗑️ Currently you're using [`v0.6.0`](https://github.com/ko-build/ko/releases/tag/v0.6.0), which is 2 1/2 years old

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
NONE
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

