### PR TITLE
Return error directly if one receiver of servermanager fails

### DIFF
--- a/pkg/eventingtls/servermanager.go
+++ b/pkg/eventingtls/servermanager.go
@@ -62,7 +62,7 @@ func NewServerManager(ctx context.Context, httpReceiver, httpsReceiver *kncloude
 // Blocking call. Starts the 2 servers
 func (s *ServerManager) StartServers(ctx context.Context) error {
 	// start servers
-	errCh := make(chan error)
+	errCh := make(chan error, 2)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/pkg/eventingtls/servermanager.go
+++ b/pkg/eventingtls/servermanager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -61,23 +60,30 @@ func NewServerManager(ctx context.Context, httpReceiver, httpsReceiver *kncloude
 }
 
 // Blocking call. Starts the 2 servers
-func (s *ServerManager) StartServers(ctx context.Context) (httpError, httpsError error) {
+func (s *ServerManager) StartServers(ctx context.Context) error {
 	// start servers
-	wg := sync.WaitGroup{}
-	wg.Add(2)
+	errCh := make(chan error)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	go func() {
-		defer wg.Done()
-		httpError = s.httpReceiver.StartListen(ctx, s.httpHandler())
+		if err := s.httpReceiver.StartListen(ctx, s.httpHandler()); err != nil {
+			errCh <- err
+		}
 	}()
 
 	go func() {
-		defer wg.Done()
-		httpsError = s.httpsReceiver.StartListen(ctx, s.httpsHandler())
+		if err := s.httpsReceiver.StartListen(ctx, s.httpsHandler()); err != nil {
+			errCh <- err
+		}
 	}()
 
-	wg.Wait()
-	return
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return nil
+	}
 }
 
 func (s *ServerManager) httpHandler() http.Handler {

--- a/pkg/eventingtls/servermanager_test.go
+++ b/pkg/eventingtls/servermanager_test.go
@@ -65,9 +65,7 @@ func TestStartServers(t *testing.T) {
 			sm, err := NewServerManager(ctx, httpReceiver, httpsReceiver, &basicHandler{}, cmw)
 			assert.NoError(t, err)
 			go func() {
-				err1, err2 := sm.StartServers(ctx)
-				errChan <- err1
-				errChan <- err2
+				errChan <- sm.StartServers(ctx)
 			}()
 
 			<-httpReceiver.Ready
@@ -100,7 +98,6 @@ func TestStartServers(t *testing.T) {
 
 			// stop servers and ensure no errors for http/https
 			cancelFunc()
-			assert.NoError(t, <-errChan)
 			assert.NoError(t, <-errChan)
 		})
 	}


### PR DESCRIPTION
In https://github.com/knative/eventing/pull/6908#pullrequestreview-1414364902 we discussed an improvement of the servermanager to return the error directly instead of waiting for the 2nd receiver to finish too, before being able to handle the error.

## Proposed Changes

- Return error directly when one receiver from servermanager fails and send a context cancel to the remaining receiver

@gab-satchi @pierDipi @matzew: fyi