### PR TITLE
Remove CA certs empty and non nil check, use URL scheme only

### DIFF
--- a/pkg/adapter/v2/cloudevents.go
+++ b/pkg/adapter/v2/cloudevents.go
@@ -145,11 +145,11 @@ func NewClient(cfg ClientConfig) (Client, error) {
 		if sinkWait := cfg.Env.GetSinktimeout(); sinkWait > 0 {
 			pOpts = append(pOpts, setTimeOut(time.Duration(sinkWait)*time.Second))
 		}
-		if caCerts := cfg.Env.GetCACerts(); (caCerts != nil && *caCerts != "") && eventingtls.IsHttpsSink(cfg.Env.GetSink()) {
+		if eventingtls.IsHttpsSink(cfg.Env.GetSink()) {
 			var err error
 
 			clientConfig := eventingtls.NewDefaultClientConfig()
-			clientConfig.CACerts = caCerts
+			clientConfig.CACerts = cfg.Env.GetCACerts()
 
 			httpTransport := nethttp.DefaultTransport.(*nethttp.Transport).Clone()
 			httpTransport.TLSClientConfig, err = eventingtls.GetTLSClientConfig(clientConfig)

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -170,7 +170,7 @@ func GetTLSServerConfig(config ServerConfig) (*tls.Config, error) {
 // IsHttpsSink returns true if the sink has scheme equal to https.
 func IsHttpsSink(sink string) bool {
 	s, err := apis.ParseURL(sink)
-	if err != nil {
+	if err != nil || s == nil {
 		return false
 	}
 	return strings.EqualFold(s.Scheme, "https")


### PR DESCRIPTION
Not having CA certs with an HTTPS sink is valid and expected when the sink URL is using a public CA.

In addition, the eventingtls package correctly handles `nil` or `""` CA certs correctly: https://github.com/knative/eventing/blob/5c6fe572143c8b15a3bbcfe65dc1bed38ef27f79/pkg/eventingtls/eventingtls.go#L188-L190 and it will also enforce the minimum TLS version for the connection.