### PR TITLE
Eventing TLS: support exposing https address in Broker controller

### DIFF
--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -81,6 +81,7 @@ func (bs *BrokerStatus) SetAddress(url *apis.URL) {
 
 	if url != nil {
 		bs.GetConditionSet().Manage(bs).MarkTrue(BrokerConditionAddressable)
+		bs.AddressStatus.Address.Name = &url.Scheme
 	} else {
 		bs.GetConditionSet().Manage(bs).MarkFalse(BrokerConditionAddressable, "nil URL", "URL is nil")
 	}

--- a/pkg/apis/eventing/v1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
@@ -277,7 +278,7 @@ func TestBrokerInitializeConditions(t *testing.T) {
 		bs:   TestHelper.ReadyBrokerStatusWithoutDLS(),
 		want: &BrokerStatus{
 			AddressStatus: duckv1.AddressStatus{
-				Address: &duckv1.Addressable{URL: url},
+				Address: &duckv1.Addressable{Name: pointer.String("http"), URL: url},
 			},
 			Status: duckv1.Status{
 				Conditions: []apis.Condition{{

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -43,6 +43,8 @@ const (
 	TLSCrt = "tls.crt"
 	// DefaultMinTLSVersion is the default minimum TLS version for servers and clients.
 	DefaultMinTLSVersion = tls.VersionTLS12
+	// SecretCACrt is the name of the CA Cert in the secret
+	SecretCACert = "ca.crt"
 )
 
 type ClientConfig struct {

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -417,8 +417,9 @@ func (r *Reconciler) httpAddress(b *eventingv1.Broker) pkgduckv1.Addressable {
 	// http address uses host-based routing
 	httpAddress := pkgduckv1.Addressable{
 		Name: pointer.String("http"),
-		URL:  apis.HTTP(network.GetServiceHostname(b.Name, b.Namespace)),
+		URL:  apis.HTTP(network.GetServiceHostname(names.BrokerIngressName, system.Namespace())),
 	}
+	httpAddress.URL.Path = fmt.Sprintf("/%s/%s", b.Namespace, b.Name)
 	return httpAddress
 }
 

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -57,7 +57,7 @@ import (
 )
 
 const (
-	brokerIngressTLSSecretName = "mt-broker-ingress-server-tls"
+	brokerIngressTLSSecretName = "mt-broker-ingress-server-tls" //nolint:gosec // This is not a hardcoded credential
 	caCertsSecretKey           = eventingtls.SecretCACert
 )
 

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/kmeta"
 
 	"knative.dev/pkg/apis"
@@ -44,6 +45,7 @@ import (
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
@@ -51,6 +53,11 @@ import (
 	ducklib "knative.dev/eventing/pkg/duck"
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
 	"knative.dev/eventing/pkg/reconciler/names"
+)
+
+const (
+	brokerIngressTLSSecretName = "mt-broker-ingress-server-tls"
+	caCertsSecretKey           = "ca.crt"
 )
 
 type Reconciler struct {
@@ -61,6 +68,7 @@ type Reconciler struct {
 	endpointsLister    corev1listers.EndpointsLister
 	subscriptionLister messaginglisters.SubscriptionLister
 	configmapLister    corev1listers.ConfigMapLister
+	secretLister       corev1listers.SecretLister
 
 	channelableTracker ducklib.ListableTracker
 
@@ -183,11 +191,41 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 
 	// Route everything to shared ingress, just tack on the namespace/name as path
 	// so we can route there appropriately.
-	b.Status.SetAddress(&apis.URL{
-		Scheme: "http",
-		Host:   network.GetServiceHostname(names.BrokerIngressName, system.Namespace()),
-		Path:   fmt.Sprintf("/%s/%s", b.Namespace, b.Name),
-	})
+	transportEncryptionFlags := feature.FromContext(ctx)
+	if transportEncryptionFlags.IsPermissiveTransportEncryption() {
+		caCerts, err := r.getCaCerts()
+		if err != nil {
+			return err
+		}
+
+		httpAddress := r.httpAddress(b)
+		httpsAddress := r.httpsAddress(caCerts, b)
+		// Permissive mode:
+		// - status.address http address with host-based routing
+		// - status.addresses:
+		//   - https address with path-based routing
+		//   - http address with host-based routing
+		b.Status.Addresses = []pkgduckv1.Addressable{httpsAddress, httpAddress}
+		b.Status.Address = &httpAddress
+	} else if transportEncryptionFlags.IsStrictTransportEncryption() {
+		// Strict mode: (only https addresses)
+		// - status.address https address with path-based routing
+		// - status.addresses:
+		//   - https address with path-based routing
+		caCerts, err := r.getCaCerts()
+		if err != nil {
+			return err
+		}
+
+		httpsAddress := r.httpsAddress(caCerts, b)
+		b.Status.Addresses = []pkgduckv1.Addressable{httpsAddress}
+		b.Status.Address = &httpsAddress
+	} else {
+		httpAddress := r.httpAddress(b)
+		b.Status.Address = &httpAddress
+	}
+
+	b.GetConditionSet().Manage(b.GetStatus()).MarkTrue(eventingv1.BrokerConditionAddressable)
 
 	// So, at this point the Broker is ready and everything should be solid
 	// for the triggers to act upon.
@@ -360,4 +398,37 @@ func TriggerChannelLabels(brokerName string) map[string]string {
 		eventing.BrokerLabelKey:                 brokerName,
 		"eventing.knative.dev/brokerEverything": "true",
 	}
+}
+
+func (r *Reconciler) getCaCerts() (string, error) {
+	// Getting the secret called "mt-broker-ingress-server-tls" from system namespace
+	secret, err := r.secretLister.Secrets(system.Namespace()).Get(brokerIngressTLSSecretName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", system.Namespace(), brokerIngressTLSSecretName, err)
+	}
+	caCerts, ok := secret.Data[caCertsSecretKey]
+	if !ok {
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", system.Namespace(), brokerIngressTLSSecretName, caCertsSecretKey)
+	}
+	return string(caCerts), nil
+}
+
+func (r *Reconciler) httpAddress(b *eventingv1.Broker) pkgduckv1.Addressable {
+	// http address uses host-based routing
+	httpAddress := pkgduckv1.Addressable{
+		Name: pointer.String("http"),
+		URL:  apis.HTTP(network.GetServiceHostname(b.Name, b.Namespace)),
+	}
+	return httpAddress
+}
+
+func (r *Reconciler) httpsAddress(caCerts string, b *eventingv1.Broker) pkgduckv1.Addressable {
+	// https address uses path-based routing
+	httpsAddress := pkgduckv1.Addressable{
+		Name:    pointer.String("https"),
+		URL:     apis.HTTPS(fmt.Sprintf("%s.%s.svc.%s", names.BrokerIngressName, system.Namespace(), network.GetClusterDomainName())),
+		CACerts: pointer.String(caCerts),
+	}
+	httpsAddress.URL.Path = fmt.Sprintf("/%s/%s", b.Namespace, b.Name)
+	return httpsAddress
 }

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -86,7 +86,7 @@ var (
 
 	brokerAddress = &apis.URL{
 		Scheme: "http",
-		Host:   network.GetServiceHostname(ingressServiceName, testNS),
+		Host:   network.GetServiceHostname(ingressServiceName, systemNS),
 		Path:   fmt.Sprintf("/%s/%s", testNS, brokerName),
 	}
 
@@ -589,9 +589,6 @@ func TestReconcile(t *testing.T) {
 				makeTLSSecret(),
 			},
 			WantErr: false,
-			WantCreates: []runtime.Object{
-				createChannel(),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
 					WithBrokerClass(eventing.MTChannelBrokerClassValue),
@@ -642,9 +639,6 @@ func TestReconcile(t *testing.T) {
 				makeTLSSecret(),
 			},
 			WantErr: false,
-			WantCreates: []runtime.Object{
-				createChannel(),
-			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: NewBroker(brokerName, testNS,
 					WithBrokerClass(eventing.MTChannelBrokerClassValue),
@@ -713,11 +707,11 @@ func TestReconcile(t *testing.T) {
 }
 
 func httpsURL(name string, ns string) *apis.URL {
-	u, err := apis.ParseURL(fmt.Sprintf("https://broker-ingress.%s.svc.cluster.local/%s/%s", testNS, ns, name))
-	if err != nil {
-		panic(err)
+	return &apis.URL{
+		Scheme: "https",
+		Host:   network.GetServiceHostname(ingressServiceName, systemNS),
+		Path:   fmt.Sprintf("/%s/%s", ns, name),
 	}
-	return u
 }
 
 func config() *duckv1.KReference {

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -24,12 +24,15 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/eventing/pkg/apis/eventing"
+	"knative.dev/eventing/pkg/apis/feature"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
@@ -83,7 +86,7 @@ var (
 
 	brokerAddress = &apis.URL{
 		Scheme: "http",
-		Host:   network.GetServiceHostname(ingressServiceName, systemNS),
+		Host:   network.GetServiceHostname(ingressServiceName, testNS),
 		Path:   fmt.Sprintf("/%s/%s", testNS, brokerName),
 	}
 
@@ -565,6 +568,112 @@ func TestReconcile(t *testing.T) {
 			WantPatches: []clientgotesting.PatchActionImpl{
 				makeChannelDeliveryRetryPatch(deliveryRetries),
 			},
+		}, {
+			Name: "TLS permissive",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				makeDLSServiceAsUnstructured(),
+				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.MTChannelBrokerClassValue),
+					WithBrokerConfig(config()),
+					WithDeadLeaderSink(sinkSVCDest.Ref, ""),
+					WithInitBrokerConditions),
+				createChannel(withChannelReady, withChannelDeadLetterSink(sinkSVCDest)),
+				imcConfigMap(),
+				NewEndpoints(filterServiceName, systemNS,
+					WithEndpointsLabels(FilterLabels()),
+					WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
+				NewEndpoints(ingressServiceName, systemNS,
+					WithEndpointsLabels(IngressLabels()),
+					WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
+				makeTLSSecret(),
+			},
+			WantErr: false,
+			WantCreates: []runtime.Object{
+				createChannel(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.MTChannelBrokerClassValue),
+					WithBrokerConfig(config()),
+					WithBrokerReadyWithDLS,
+					WithDeadLeaderSink(sinkSVCDest.Ref, ""),
+					WithBrokerAddressURI(brokerAddress),
+					WithBrokerStatusDLSURI(dlsURI),
+					WithChannelAddressAnnotation(triggerChannelURL),
+					WithChannelAPIVersionAnnotation(triggerChannelAPIVersion),
+					WithChannelKindAnnotation(triggerChannelKind),
+					WithChannelNameAnnotation(triggerChannelName),
+					WithBrokersAddresses([]duckv1.Addressable{
+						{
+							Name:    pointer.String("https"),
+							URL:     httpsURL(brokerName, testNS),
+							CACerts: pointer.String(testCaCerts),
+						},
+						{
+							Name: pointer.String("http"),
+							URL:  brokerAddress,
+						},
+					}),
+				),
+			}},
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.TransportEncryption: feature.Permissive,
+			}),
+		},
+		{
+			Name: "TLS strict",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				makeDLSServiceAsUnstructured(),
+				NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.MTChannelBrokerClassValue),
+					WithBrokerConfig(config()),
+					WithDeadLeaderSink(sinkSVCDest.Ref, ""),
+					WithInitBrokerConditions),
+				createChannel(withChannelReady, withChannelDeadLetterSink(sinkSVCDest)),
+				imcConfigMap(),
+				NewEndpoints(filterServiceName, systemNS,
+					WithEndpointsLabels(FilterLabels()),
+					WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
+				NewEndpoints(ingressServiceName, systemNS,
+					WithEndpointsLabels(IngressLabels()),
+					WithEndpointsAddresses(corev1.EndpointAddress{IP: "127.0.0.1"})),
+				makeTLSSecret(),
+			},
+			WantErr: false,
+			WantCreates: []runtime.Object{
+				createChannel(),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewBroker(brokerName, testNS,
+					WithBrokerClass(eventing.MTChannelBrokerClassValue),
+					WithBrokerConfig(config()),
+					WithBrokerReadyWithDLS,
+					WithDeadLeaderSink(sinkSVCDest.Ref, ""),
+					WithBrokerAddressURI(brokerAddress),
+					WithBrokerStatusDLSURI(dlsURI),
+					WithChannelAddressAnnotation(triggerChannelURL),
+					WithChannelAPIVersionAnnotation(triggerChannelAPIVersion),
+					WithChannelKindAnnotation(triggerChannelKind),
+					WithChannelNameAnnotation(triggerChannelName),
+					WithBrokersAddresses([]duckv1.Addressable{
+						{
+							Name:    pointer.String("https"),
+							URL:     httpsURL(brokerName, testNS),
+							CACerts: pointer.String(testCaCerts),
+						},
+					}),
+					WithBrokerAddressHTTPS(duckv1.Addressable{
+						Name:    pointer.String("https"),
+						URL:     httpsURL(brokerName, testNS),
+						CACerts: pointer.String(testCaCerts),
+					}),
+				),
+			}},
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.TransportEncryption: feature.Strict,
+			}),
 		},
 	}
 
@@ -574,12 +683,22 @@ func TestReconcile(t *testing.T) {
 		ctx = v1a1addr.WithDuck(ctx)
 		ctx = v1b1addr.WithDuck(ctx)
 
+		cm, err := listers.GetConfigMapLister().ConfigMaps(testNS).Get("config-features")
+		if err == nil {
+			flags, err := feature.NewFlagsConfigFromConfigMap(cm)
+			if err != nil {
+				panic(err)
+			}
+			ctx = feature.ToContext(ctx, flags)
+		}
+
 		r := &Reconciler{
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			endpointsLister:    listers.GetEndpointsLister(),
 			configmapLister:    listers.GetConfigMapLister(),
+			secretLister:       listers.GetSecretLister(),
 			channelableTracker: duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
 		}
 		return broker.NewReconciler(ctx, logger,
@@ -591,6 +710,14 @@ func TestReconcile(t *testing.T) {
 		false,
 		logger,
 	))
+}
+
+func httpsURL(name string, ns string) *apis.URL {
+	u, err := apis.ParseURL(fmt.Sprintf("https://broker-ingress.%s.svc.cluster.local/%s/%s", testNS, ns, name))
+	if err != nil {
+		panic(err)
+	}
+	return u
 }
 
 func config() *duckv1.KReference {
@@ -778,5 +905,45 @@ func makeChannelDeliveryRetryPatch(retries int) clientgotesting.PatchActionImpl 
 		},
 		Name:  fmt.Sprintf("%s-kne-trigger", brokerName),
 		Patch: []byte(`[{"op":"add","path":"/spec/delivery","value":{"retry":` + strconv.Itoa(retries) + `}}]`),
+	}
+}
+
+const (
+	testCaCerts = `
+-----BEGIN CERTIFICATE-----
+MIIDmjCCAoKgAwIBAgIUYzA4bTMXevuk3pl2Mn8hpCYL2C0wDQYJKoZIhvcNAQEL
+BQAwLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290
+LUNBMB4XDTIzMDQwNTEzMTUyNFoXDTI2MDEyMzEzMTUyNFowbTELMAkGA1UEBhMC
+VVMxEjAQBgNVBAgMCVlvdXJTdGF0ZTERMA8GA1UEBwwIWW91ckNpdHkxHTAbBgNV
+BAoMFEV4YW1wbGUtQ2VydGlmaWNhdGVzMRgwFgYDVQQDDA9sb2NhbGhvc3QubG9j
+YWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5teo+En6U5nhqn7Sc
+uanqswUmPlgs9j/8l21Rhb4T+ezlYKGQGhbJyFFMuiCE1Rjn8bpCwi7Nnv12Y2nz
+FhEv2Jx0yL3Tqx0Q593myqKDq7326EtbO7wmDT0XD03twH5i9XZ0L0ihPWn1mjUy
+WxhnHhoFpXrsnQECJorZY6aTrFbGVYelIaj5AriwiqyL0fET8pueI2GwLjgWHFSH
+X8XsGAlcLUhkQG0Z+VO9usy4M1Wpt+cL6cnTiQ+sRmZ6uvaj8fKOT1Slk/oUeAi4
+WqFkChGzGzLik0QrhKGTdw3uUvI1F2sdQj0GYzXaWqRz+tP9qnXdzk1GrszKKSlm
+WBTLAgMBAAGjcDBuMB8GA1UdIwQYMBaAFJJcCftus4vj98N0zQQautsjEu82MAkG
+A1UdEwQCMAAwCwYDVR0PBAQDAgTwMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDAdBgNV
+HQ4EFgQUnu/3vqA3VEzm128x/hLyZzR9JlgwDQYJKoZIhvcNAQELBQADggEBAFc+
+1cKt/CNjHXUsirgEhry2Mm96R6Yxuq//mP2+SEjdab+FaXPZkjHx118u3PPX5uTh
+gTT7rMfka6J5xzzQNqJbRMgNpdEFH1bbc11aYuhi0khOAe0cpQDtktyuDJQMMv3/
+3wu6rLr6fmENo0gdcyUY9EiYrglWGtdXhlo4ySRY8UZkUScG2upvyOhHTxVCAjhP
+efbMkNjmDuZOMK+wqanqr5YV6zMPzkQK7DspfRgasMAQmugQu7r2MZpXg8Ilhro1
+s/wImGnMVk5RzpBVrq2VB9SkX/ThTVYEC/Sd9BQM364MCR+TA1l8/ptaLFLuwyw8
+O2dgzikq8iSy1BlRsVw=
+-----END CERTIFICATE-----
+`
+)
+
+func makeTLSSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: systemNS,
+			Name:      brokerIngressTLSSecretName,
+		},
+		Data: map[string][]byte{
+			"ca.crt": []byte(testCaCerts),
+		},
+		Type: corev1.SecretTypeTLS,
 	}
 }

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -19,8 +19,12 @@ package broker
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/system"
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
@@ -31,14 +35,58 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
 )
 
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
+
+	secret := types.NamespacedName{
+		Namespace: system.Namespace(),
+		Name:      brokerIngressTLSSecretName,
+	}
+
+	_ = secretinformer.Get(ctx).Informer().GetStore().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		},
+		Data: map[string][]byte{
+			"ca.crt": loadCert(),
+		},
+		Type: corev1.SecretTypeTLS,
+	})
 
 	c := NewController(ctx, &configmap.ManualWatcher{})
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")
 	}
+}
+
+func loadCert() []byte {
+	return []byte(`
+-----BEGIN CERTIFICATE-----
+MIIDmjCCAoKgAwIBAgIUYzA4bTMXevuk3pl2Mn8hpCYL2C0wDQYJKoZIhvcNAQEL
+BQAwLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290
+LUNBMB4XDTIzMDQwNTEzMTUyNFoXDTI2MDEyMzEzMTUyNFowbTELMAkGA1UEBhMC
+VVMxEjAQBgNVBAgMCVlvdXJTdGF0ZTERMA8GA1UEBwwIWW91ckNpdHkxHTAbBgNV
+BAoMFEV4YW1wbGUtQ2VydGlmaWNhdGVzMRgwFgYDVQQDDA9sb2NhbGhvc3QubG9j
+YWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5teo+En6U5nhqn7Sc
+uanqswUmPlgs9j/8l21Rhb4T+ezlYKGQGhbJyFFMuiCE1Rjn8bpCwi7Nnv12Y2nz
+FhEv2Jx0yL3Tqx0Q593myqKDq7326EtbO7wmDT0XD03twH5i9XZ0L0ihPWn1mjUy
+WxhnHhoFpXrsnQECJorZY6aTrFbGVYelIaj5AriwiqyL0fET8pueI2GwLjgWHFSH
+X8XsGAlcLUhkQG0Z+VO9usy4M1Wpt+cL6cnTiQ+sRmZ6uvaj8fKOT1Slk/oUeAi4
+WqFkChGzGzLik0QrhKGTdw3uUvI1F2sdQj0GYzXaWqRz+tP9qnXdzk1GrszKKSlm
+WBTLAgMBAAGjcDBuMB8GA1UdIwQYMBaAFJJcCftus4vj98N0zQQautsjEu82MAkG
+A1UdEwQCMAAwCwYDVR0PBAQDAgTwMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDAdBgNV
+HQ4EFgQUnu/3vqA3VEzm128x/hLyZzR9JlgwDQYJKoZIhvcNAQELBQADggEBAFc+
+1cKt/CNjHXUsirgEhry2Mm96R6Yxuq//mP2+SEjdab+FaXPZkjHx118u3PPX5uTh
+gTT7rMfka6J5xzzQNqJbRMgNpdEFH1bbc11aYuhi0khOAe0cpQDtktyuDJQMMv3/
+3wu6rLr6fmENo0gdcyUY9EiYrglWGtdXhlo4ySRY8UZkUScG2upvyOhHTxVCAjhP
+efbMkNjmDuZOMK+wqanqr5YV6zMPzkQK7DspfRgasMAQmugQu7r2MZpXg8Ilhro1
+s/wImGnMVk5RzpBVrq2VB9SkX/ThTVYEC/Sd9BQM364MCR+TA1l8/ptaLFLuwyw8
+O2dgzikq8iSy1BlRsVw=
+-----END CERTIFICATE-----
+`)
 }

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -46,6 +46,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
+	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/config"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/resources"
 )
@@ -57,7 +58,7 @@ const (
 	dispatcherDeploymentCreated     = "DispatcherDeploymentCreated"
 	dispatcherServiceCreated        = "DispatcherServiceCreated"
 	dispatcherTLSSecretName         = "imc-dispatcher-tls"
-	caCertsSecretKey                = "ca.crt"
+	caCertsSecretKey                = eventingtls.SecretCACert
 )
 
 func newDeploymentWarn(err error) pkgreconciler.Event {

--- a/pkg/reconciler/testing/v1/broker.go
+++ b/pkg/reconciler/testing/v1/broker.go
@@ -253,3 +253,17 @@ func WithDLSNotConfigured() BrokerOption {
 		b.Status.MarkDeadLetterSinkNotConfigured()
 	}
 }
+
+func WithBrokerAddressHTTPS(address duckv1.Addressable) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.Address = &address
+		b.GetConditionSet().Manage(b.GetStatus()).MarkTrue(v1.BrokerConditionAddressable)
+	}
+}
+
+func WithBrokersAddresses(addresses []duckv1.Addressable) BrokerOption {
+	return func(b *v1.Broker) {
+		b.Status.Addresses = addresses
+		b.GetConditionSet().Manage(b.GetStatus()).MarkTrue(v1.BrokerConditionAddressable)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

Fixes #6918 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Exposes endpoints based on the Feature Flag 
-	when the feature flag (see https://github.com/knative/eventing/issues/6836) is set to permissive
	expose 
	- both http and https endpoints in the new status.addresses (see https://github.com/knative/pkg/issues/2711) field
	- the existing status.address will continue to have the existing http endpoint
- when the feature flag (see https://github.com/knative/eventing/issues/6836) is set to strict
	- expose only the https endpoints in both the new status.addresses and the existing status.address

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

