### PR TITLE
Eventing TLS: Support K_CA_CERTS env variable injection for SinkBinding subjects

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -132,11 +132,6 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 				Name:  "K_CA_CERTS",
 				Value: *addr.CACerts,
 			})
-		} else {
-			spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
-				Name:  "K_CA_CERTS",
-				Value: "",
-			})
 		}
 		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
 			Name:  "K_CE_OVERRIDES",
@@ -152,11 +147,6 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "K_CA_CERTS",
 				Value: *addr.CACerts,
-			})
-		} else {
-			spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-				Name:  "K_CA_CERTS",
-				Value: "",
 			})
 		}
 		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -127,13 +127,20 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			Name:  "K_SINK",
 			Value: addr.URL.String(),
 		})
+		if addr.CACerts != nil {
+			spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
+				Name:  "K_CA_CERTS",
+				Value: *addr.CACerts,
+			})
+		} else {
+			spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
+				Name:  "K_CA_CERTS",
+				Value: "",
+			})
+		}
 		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
 			Name:  "K_CE_OVERRIDES",
 			Value: ceOverrides,
-		})
-		spec.InitContainers[i].Env = append(spec.InitContainers[i].Env, corev1.EnvVar{
-			Name:  "K_CA_CERTS",
-			Value: *addr.CACerts,
 		})
 	}
 	for i := range spec.Containers {
@@ -141,13 +148,20 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			Name:  "K_SINK",
 			Value: addr.URL.String(),
 		})
+		if addr.CACerts != nil {
+			spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+				Name:  "K_CA_CERTS",
+				Value: *addr.CACerts,
+			})
+		} else {
+			spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+				Name:  "K_CA_CERTS",
+				Value: "",
+			})
+		}
 		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
 			Name:  "K_CE_OVERRIDES",
 			Value: ceOverrides,
-		})
-		spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-			Name:  "K_CA_CERTS",
-			Value: *addr.CACerts,
 		})
 	}
 }

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -94,6 +94,15 @@ func (sbs *SinkBindingStatus) MarkSink(uri *apis.URL) {
 	}
 }
 
+func (sbs *SinkBindingStatus) MarkSinkCACerts(certs *string) {
+	sbs.SinkCACerts = certs
+	if certs != nil {
+		sbCondSet.Manage(sbs).MarkTrue(SinkBindingConditionSinkCACertsProvided)
+	} else {
+		sbCondSet.Manage(sbs).MarkFalse(SinkBindingConditionSinkCACertsProvided, "SinkCACertsEmpty", "Sink CA Certs has resolved to empty.%s", "")
+	}
+}
+
 // Do implements psbinding.Bindable
 func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	// First undo so that we can just unconditionally append below.
@@ -111,6 +120,7 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	}
 	uri := addr.URL
 	sb.Status.MarkSink(uri)
+	sb.Status.MarkSinkCACerts(addr.CACerts)
 
 	var ceOverrides string
 	if sb.Spec.CloudEventOverrides != nil {

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -342,6 +342,7 @@ func TestSinkBindingDo(t *testing.T) {
 			Host:   "thing.ns.svc.cluster.local",
 			Path:   "/a/path",
 		},
+		CACerts: &caCert,
 	}
 
 	overrides := duckv1.CloudEventOverrides{Extensions: map[string]string{"foo": "bar"}}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -26,12 +26,38 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
+)
+
+var (
+	caCert = `
+	-----BEGIN CERTIFICATE-----
+	MIIDPzCCAiegAwIBAgIUYuysnNGPwBjbiDRc+/9s9Jl3N8YwDQYJKoZIhvcNAQEL
+	BQAwLzELMAkGA1UEBhMCVVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290
+	LUNBMB4XDTIzMDQwNTEzMTQxMloXDTI2MDEyMzEzMTQxMlowLzELMAkGA1UEBhMC
+	VVMxIDAeBgNVBAMMF0tuYXRpdmUtRXhhbXBsZS1Sb290LUNBMIIBIjANBgkqhkiG
+	9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyEwyvWKc/SJzblAc/pNIE7UJHIpbEUDtwOom
+	YvytwcMhI73zlSVhAcOagwnn3AvBg3McGPyLGghr9EuXBE1Vx584Pw1cmKOwbyiC
+	SQtaRwbztzM555T4Rtrk4tdKm+WHD/HiYAB/s+OnPJ6F6yBedT6nW08HlTP5lJX1
+	U21+OAiOSU4zx+YYlkRbHq8aYggB1YM+hdRSStl9Mc/nw6TWlVsd2LjppXgoxSKl
+	YTB4ZwnaKmrIRa9hFf1DVY/nTlmUP2iGr9131CLs3/5QyoFRWI6ayfnRSkmVwKLS
+	8AW/b4jh+qJVIaeLCw5QF4RuqsE5VaUj6wlEqWM4eI+5Uaj+5QIDAQABo1MwUTAd
+	BgNVHQ4EFgQUklwJ+26zi+P3w3TNBBq62yMS7zYwHwYDVR0jBBgwFoAUklwJ+26z
+	i+P3w3TNBBq62yMS7zYwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+	AQEAWwlatEXUTiB4O3M/fLSZ4JlAA1bq2U+dafiUiq5Ym0F1/UGu7YD74LGm4n03
+	X9QU4jVwAkxL8pFV68NEBFJXOwFRyVQ1THAfhzij5teMAd4aqaffEPF0YfE8+rdg
+	MSQx9n/OOeeyqWlaAqI3D9SEoSFPk5Xbfdzu6zGggizJwIYus77LOYxS7hvGxCci
+	dTnEHvGoP14/13F/2vZLSaH9qrAv3cTenVYRN1QSSVI0V2XAhz+HAOjO2muaaYEG
+	2eKiYvHvG0p5aCRIZYi4z3q6QAr9z+nyRyO1Tw/CnbCOeULQoOZWLy8xE9zBOE1t
+	JQArXobwA4IZrx13xxsMafyt0A==
+	-----END CERTIFICATE-----
+	`
 )
 
 func init() {
@@ -97,8 +123,12 @@ func TestSinkBindingSetObsGen(t *testing.T) {
 }
 
 func TestSinkBindingStatusIsReady(t *testing.T) {
-	sink := apis.HTTP("table.ns.svc.cluster.local/flip")
-	sink.Scheme = "uri"
+	sink := &duckv1.Addressable{
+		Name:    pointer.String("http"),
+		URL:     apis.HTTP("table.ns.svc.cluster.local/flip"),
+		CACerts: &caCert,
+	}
+	sink.URL.Scheme = "uri"
 	tests := []struct {
 		name string
 		s    *SinkBindingStatus
@@ -203,6 +233,9 @@ func TestSinkBindingUndo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: "http://localhost:8080",
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
@@ -220,6 +253,9 @@ func TestSinkBindingUndo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: "http://localhost:8080",
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "BAZ",
 								Value: "INGA",
 							}, {
@@ -232,6 +268,9 @@ func TestSinkBindingUndo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: "http://localhost:8080",
+							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
 							}, {
 								Name:  "BAZ",
 								Value: "INGA",
@@ -324,6 +363,9 @@ func TestSinkBindingDo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
@@ -342,6 +384,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
+							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -364,6 +409,9 @@ func TestSinkBindingDo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: "the wrong value",
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"wrong":"value"}}`,
 							}},
@@ -382,6 +430,9 @@ func TestSinkBindingDo(t *testing.T) {
 							Env: []corev1.EnvVar{{
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
+							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -434,6 +485,9 @@ func TestSinkBindingDo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
@@ -451,6 +505,9 @@ func TestSinkBindingDo(t *testing.T) {
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
 							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
 							}},
@@ -463,6 +520,9 @@ func TestSinkBindingDo(t *testing.T) {
 							}, {
 								Name:  "K_SINK",
 								Value: destination.URI.String(),
+							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"foo":"bar"}}`,
@@ -520,6 +580,9 @@ func TestSinkBindingDoNoURI(t *testing.T) {
 						Image: "busybox",
 						Env: []corev1.EnvVar{{
 							Name:  "K_SINK",
+							Value: "this should be removed",
+						}, {
+							Name:  "K_CA_CERTS",
 							Value: "this should be removed",
 						}, {
 							Name:  "K_CE_OVERRIDES",

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -410,7 +410,7 @@ func TestSinkBindingDo(t *testing.T) {
 								Value: "the wrong value",
 							}, {
 								Name:  "K_CA_CERTS",
-								Value: caCert,
+								Value: "wrong value",
 							}, {
 								Name:  "K_CE_OVERRIDES",
 								Value: `{"extensions":{"wrong":"value"}}`,

--- a/pkg/apis/sources/v1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1/sinkbinding_types.go
@@ -77,6 +77,10 @@ const (
 	// SinkBindingConditionSinkProvided is configured to indicate whether the
 	// sink has been properly extracted from the resolver.
 	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
+
+	// SinkBindingConditionSinkCACertsProvided is configured to indicate whether the
+	// sink cacerts has been properly extracted from the resolver.
+	SinkBindingConditionSinkCACertsProvided apis.ConditionType = "SinkCACertsProvided"
 )
 
 // SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).

--- a/pkg/apis/sources/v1/sinkbinding_types.go
+++ b/pkg/apis/sources/v1/sinkbinding_types.go
@@ -77,10 +77,6 @@ const (
 	// SinkBindingConditionSinkProvided is configured to indicate whether the
 	// sink has been properly extracted from the resolver.
 	SinkBindingConditionSinkProvided apis.ConditionType = "SinkProvided"
-
-	// SinkBindingConditionSinkCACertsProvided is configured to indicate whether the
-	// sink cacerts has been properly extracted from the resolver.
-	SinkBindingConditionSinkCACertsProvided apis.ConditionType = "SinkCACertsProvided"
 )
 
 // SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -163,8 +163,8 @@ func (s *SinkBindingSubResourcesReconciler) Reconcile(ctx context.Context, b psb
 	}
 	addr, err := s.res.AddressableFromDestinationV1(ctx, sb.Spec.Sink, sb)
 	if err != nil {
-		logging.FromContext(ctx).Errorf("Failed to get URI from Destination: %w", err)
-		sb.Status.MarkBindingUnavailable("NoURI", "URI could not be extracted from destination")
+		logging.FromContext(ctx).Errorf("Failed to get Addressable from Destination: %w", err)
+		sb.Status.MarkBindingUnavailable("NoAddressable", "Addressable could not be extracted from destination")
 		return err
 	}
 	uri := addr.URL

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -167,8 +167,7 @@ func (s *SinkBindingSubResourcesReconciler) Reconcile(ctx context.Context, b psb
 		sb.Status.MarkBindingUnavailable("NoAddressable", "Addressable could not be extracted from destination")
 		return err
 	}
-	sb.Status.MarkSink(addr.URL)
-	sb.Status.MarkSinkCACerts(addr.CACerts)
+	sb.Status.MarkSink(addr)
 	return nil
 }
 

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -167,8 +167,8 @@ func (s *SinkBindingSubResourcesReconciler) Reconcile(ctx context.Context, b psb
 		sb.Status.MarkBindingUnavailable("NoAddressable", "Addressable could not be extracted from destination")
 		return err
 	}
-	uri := addr.URL
-	sb.Status.MarkSink(uri)
+	sb.Status.MarkSink(addr.URL)
+	sb.Status.MarkSinkCACerts(addr.CACerts)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>
Fixes #6915

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
Now sets the K_CA_CERTS environment variable in sinkbinding

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Update or clean up current behavior
- Added K_CA_CERTS env variable support

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

