### PR TITLE
Add TLS support for mt-broker-filter

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	handler, err := filter.NewHandler(logger, triggerinformer.Get(ctx).Lister(), reporter, ctxFunc)
+	handler, err := filter.NewHandler(logger, triggerinformer.Get(ctx), reporter, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -39,8 +39,7 @@ import (
 	"knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/broker/filter"
-	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
-	eventinginformers "knative.dev/eventing/pkg/client/informers/externalversions"
+	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/reconciler/names"
 )
 
@@ -54,7 +53,8 @@ type envConfig struct {
 	// TODO: change this environment variable to something like "PodGroupName".
 	PodName       string `envconfig:"POD_NAME" required:"true"`
 	ContainerName string `envconfig:"CONTAINER_NAME" required:"true"`
-	Port          int    `envconfig:"FILTER_PORT" default:"8080"`
+	HTTPPort      int    `envconfig:"FILTER_PORT" default:"8080"`
+	HTTPSPort     int    `envconfig:"FILTER_PORT_HTTPS" default:"8443"`
 }
 
 func main() {
@@ -70,7 +70,11 @@ func main() {
 		log.Fatal("Failed to process env var", zap.Error(err))
 	}
 
-	ctx, _ = injection.Default.SetupInformers(ctx, cfg)
+	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
+	log.Printf("Registering %d informer factories", len(injection.Default.GetInformerFactories()))
+	log.Printf("Registering %d informers", len(injection.Default.GetInformers()))
+
+	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 	kubeClient := kubeclient.Get(ctx)
 
 	loggingConfig, err := broker.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
@@ -82,11 +86,6 @@ func main() {
 	defer flush(sl)
 
 	logger.Info("Starting the Broker Filter")
-
-	eventingClient := eventingclientset.NewForConfigOrDie(cfg)
-	eventingFactory := eventinginformers.NewSharedInformerFactory(eventingClient,
-		controller.GetResyncPeriod(ctx))
-	triggerInformer := eventingFactory.Eventing().V1().Triggers()
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher := configmap.NewInformedWatcher(kubeClient, system.Namespace())
@@ -121,9 +120,13 @@ func main() {
 
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	handler, err := filter.NewHandler(logger, triggerInformer.Lister(), reporter, env.Port, ctxFunc)
+	handler, err := filter.NewHandler(logger, triggerinformer.Get(ctx).Lister(), reporter, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
+	}
+	serverManager, err := filter.NewServerManager(ctx, logger, configMapWatcher, env.HTTPPort, env.HTTPSPort, handler)
+	if err != nil {
+		logger.Fatal("Error creating server manager", zap.Error(err))
 	}
 
 	// configMapWatcher does not block, so start it first.
@@ -132,17 +135,16 @@ func main() {
 	}
 
 	// Start all of the informers and wait for them to sync.
-	logger.Info("Starting informer.")
+	logger.Info("Starting informers.")
+	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
+		logger.Fatal("Failed to start informers", zap.Error(err))
+	}
 
-	go eventingFactory.Start(ctx.Done())
-	eventingFactory.WaitForCacheSync(ctx.Done())
-
-	// Start blocks forever.
+	// Start the servers
 	logger.Info("Filter starting...")
-
-	err = handler.Start(ctx)
+	err = serverManager.StartServers(ctx)
 	if err != nil {
-		logger.Fatal("handler.Start() returned an error", zap.Error(err))
+		logger.Fatal("serverManager.StartServers() returned an error", zap.Error(err))
 	}
 	tracer.Shutdown(context.Background())
 	logger.Info("Exiting...")

--- a/config/brokers/mt-channel-broker/200-filter-role.yaml
+++ b/config/brokers/mt-channel-broker/200-filter-role.yaml
@@ -1,0 +1,1 @@
+roles/filter-role.yaml

--- a/config/brokers/mt-channel-broker/201-filter-rolebinding.yaml
+++ b/config/brokers/mt-channel-broker/201-filter-rolebinding.yaml
@@ -1,0 +1,1 @@
+roles/filter-rolebinding.yaml

--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -59,6 +59,9 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
         - containerPort: 9092
           name: metrics
           protocol: TCP
@@ -88,6 +91,8 @@ spec:
             value: knative.dev/internal/eventing
           - name: FILTER_PORT
             value: "8080"
+          - name: FILTER_PORT_HTTPS
+            value: "8443"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -116,6 +121,10 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8080
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
     - name: http-metrics
       port: 9092
       protocol: TCP

--- a/config/brokers/mt-channel-broker/roles/filter-role.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-role.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mt-broker-filter
+  namespace: knative-eventing
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/brokers/mt-channel-broker/roles/filter-rolebinding.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-rolebinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mt-broker-filter
+  namespace: knative-eventing
+subjects:
+  - kind: ServiceAccount
+    name: mt-broker-filter
+    namespace: knative-eventing
+roleRef:
+  kind: Role
+  name: mt-broker-filter
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -409,7 +409,6 @@ func TestReceiver(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			fh := fakeHandler{
 				failRequest:            tc.requestFails,
 				failStatus:             tc.failureStatus,
@@ -441,7 +440,6 @@ func TestReceiver(t *testing.T) {
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				listers.GetTriggerLister(),
 				reporter,
-				8080,
 				func(ctx context.Context) context.Context {
 					return ctx
 				},
@@ -587,7 +585,6 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
-
 			fh := fakeHandler{
 				t: t,
 			}
@@ -613,7 +610,7 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				listers.GetTriggerLister(),
 				reporter,
-				8080, func(ctx context.Context) context.Context {
+				func(ctx context.Context) context.Context {
 					return feature.ToContext(context.TODO(), feature.Flags{
 						feature.NewTriggerFilters: feature.Enabled,
 					})

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -36,14 +36,15 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/broker"
-	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+	reconcilertesting "knative.dev/pkg/reconciler/testing"
+
+	triggerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 )
 
 const (
@@ -409,6 +410,8 @@ func TestReceiver(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			ctx, _ := reconcilertesting.SetupFakeContext(t)
+
 			fh := fakeHandler{
 				failRequest:            tc.requestFails,
 				failStatus:             tc.failureStatus,
@@ -422,7 +425,6 @@ func TestReceiver(t *testing.T) {
 			defer s.Close()
 
 			// Replace the SubscriberURI to point at our fake server.
-			correctURI := make([]runtime.Object, 0, len(tc.triggers))
 			for _, trig := range tc.triggers {
 				if trig.Status.SubscriberURI != nil && trig.Status.SubscriberURI.String() == toBeReplaced {
 
@@ -432,13 +434,12 @@ func TestReceiver(t *testing.T) {
 					}
 					trig.Status.SubscriberURI = url
 				}
-				correctURI = append(correctURI, trig)
+				triggerinformerfake.Get(ctx).Informer().GetStore().Add(trig)
 			}
-			listers := reconcilertesting.NewListers(correctURI)
 			reporter := &mockReporter{}
 			r, err := NewHandler(
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
-				listers.GetTriggerLister(),
+				triggerinformerfake.Get(ctx),
 				reporter,
 				func(ctx context.Context) context.Context {
 					return ctx
@@ -585,6 +586,8 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 	}
 	for n, tc := range testCases {
 		t.Run(n, func(t *testing.T) {
+			ctx, _ := reconcilertesting.SetupFakeContext(t)
+
 			fh := fakeHandler{
 				t: t,
 			}
@@ -592,7 +595,6 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 			defer s.Close()
 
 			// Replace the SubscriberURI to point at our fake server.
-			correctURI := make([]runtime.Object, 0, len(tc.triggers))
 			for _, trig := range tc.triggers {
 				if trig.Status.SubscriberURI != nil && trig.Status.SubscriberURI.String() == toBeReplaced {
 
@@ -602,13 +604,12 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 					}
 					trig.Status.SubscriberURI = url
 				}
-				correctURI = append(correctURI, trig)
+				triggerinformerfake.Get(ctx).Informer().GetStore().Add(trig)
 			}
-			listers := reconcilertesting.NewListers(correctURI)
 			reporter := &mockReporter{}
 			r, err := NewHandler(
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
-				listers.GetTriggerLister(),
+				triggerinformerfake.Get(ctx),
 				reporter,
 				func(ctx context.Context) context.Context {
 					return feature.ToContext(context.TODO(), feature.Flags{

--- a/pkg/broker/filter/server_manager.go
+++ b/pkg/broker/filter/server_manager.go
@@ -45,7 +45,7 @@ func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Wat
 func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 	secret := types.NamespacedName{
 		Namespace: "knative-eventing",
-		Name:      "mt-broker-filter-server-tls", // wasn't it: "mt-channel-based-broker-filter-tls"???
+		Name:      "mt-broker-filter-server-tls",
 	}
 
 	serverTLSConfig := eventingtls.NewDefaultServerConfig()

--- a/pkg/broker/filter/server_manager.go
+++ b/pkg/broker/filter/server_manager.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"crypto/tls"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/eventing/pkg/eventingtls"
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/pkg/configmap"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+)
+
+func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Watcher, httpPort, httpsPort int, handler *Handler) (*eventingtls.ServerManager, error) {
+	tlsConfig, err := getServerTLSConfig(ctx)
+	if err != nil {
+		logger.Info("failed to get TLS server config", zap.Error(err))
+	}
+
+	httpReceiver := kncloudevents.NewHTTPMessageReceiver(httpPort)
+	httpsReceiver := kncloudevents.NewHTTPMessageReceiver(httpsPort, kncloudevents.WithTLSConfig(tlsConfig))
+
+	return eventingtls.NewServerManager(ctx, httpReceiver, httpsReceiver, handler, cmw)
+}
+
+func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
+	secret := types.NamespacedName{
+		Namespace: "knative-eventing",
+		Name:      "mt-broker-filter-server-tls", // wasn't it: "mt-channel-based-broker-filter-tls"???
+	}
+
+	serverTLSConfig := eventingtls.NewDefaultServerConfig()
+	serverTLSConfig.GetCertificate = eventingtls.GetCertificateFromSecret(ctx, secretinformer.Get(ctx), kubeclient.Get(ctx), secret)
+	return eventingtls.GetTLSServerConfig(serverTLSConfig)
+}

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -124,8 +124,10 @@ func GetCertificateFromSecret(ctx context.Context, informer coreinformersv1.Secr
 	firstValue, err := informer.Lister().Secrets(secret.Namespace).Get(secret.Name)
 	if err != nil {
 		// Try to get the secret from the API Server when the lister failed.
-		// Ignore any errors as the Secret may not be available yet.
-		firstValue, _ = kube.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+		firstValue, err = kube.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
+		if err != nil {
+			logger.Warn(err.Error())
+		}
 	}
 	if firstValue != nil {
 		store(firstValue)

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -86,3 +86,46 @@ func TriggerDependencyAnnotation() *feature.Feature {
 
 	return f
 }
+
+func TriggerWithTLSSubscriber() *feature.Feature {
+	f := feature.NewFeatureNamed("Trigger with TLS subscriber")
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	sourceName := feature.MakeRandomK8sName("source")
+	sinkName := feature.MakeRandomK8sName("sink")
+	triggerName := feature.MakeRandomK8sName("trigger")
+
+	eventToSend := test.FullEvent()
+
+	// Install Broker
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+	f.Setup("Broker is addressable", broker.IsAddressable(brokerName))
+
+	// Install Sink
+	f.Setup("Install Sink", eventshub.Install(sinkName, eventshub.StartReceiverTLS))
+
+	// Install Trigger
+	f.Setup("Install trigger", func(ctx context.Context, t feature.T) {
+		subscriber := service.AsDestinationRef(sinkName)
+		subscriber.CACerts = eventshub.GetCaCerts(ctx)
+
+		trigger.Install(triggerName, brokerName,
+			trigger.WithSubscriberFromDestination(subscriber))(ctx, t)
+	})
+	f.Setup("Wait for Trigger to become ready", trigger.IsReady(triggerName))
+
+	// Install Source
+	f.Requirement("Install Source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(eventToSend),
+	))
+
+	f.Assert("Trigger delivers events to TLS subscriber", assert.OnStore(sinkName).
+		MatchEvent(test.HasId(eventToSend.ID())).
+		Match(assert.MatchKind(eventshub.EventReceived)).
+		AtLeast(1))
+
+	return f
+}

--- a/test/rekt/resources/trigger/trigger.yaml
+++ b/test/rekt/resources/trigger/trigger.yaml
@@ -50,6 +50,10 @@ spec:
     {{ if .subscriber.uri }}
     uri: {{ .subscriber.uri }}
     {{ end }}
+    {{ if .subscriber.CACerts }}
+    CACerts: |-
+      {{ .subscriber.CACerts }}
+    {{ end }}
   {{ end }}
   {{ if .delivery }}
   delivery:

--- a/test/rekt/trigger_test.go
+++ b/test/rekt/trigger_test.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
@@ -78,4 +79,17 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 
 	// Test that a bad Trigger doesn't affect sending messages to a valid one
 	env.Test(ctx, t, trigger.TriggerDependencyAnnotation())
+}
+
+func TestTriggerTLSSubscriber(t *testing.T) {
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	env.Test(ctx, t, trigger.TriggerWithTLSSubscriber())
 }


### PR DESCRIPTION
Fixes #6877

Currently includes 98a98cd815a964a20b19edb329c61130322e2a43 as a cherry-pick from #6983.

## Proposed Changes

- :gift: Add TLS support for mt-broker-filter

### Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**
```release-note
Add TLS support for mt-broker-filter
```

