### PR TITLE
Using v1b2 in the reconciler

### DIFF
--- a/pkg/reconciler/eventtype/controller.go
+++ b/pkg/reconciler/eventtype/controller.go
@@ -24,8 +24,8 @@ import (
 
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
-	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype"
-	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/eventtype"
+	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
+	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
 )
 
 // NewController initializes the controller and is called by the generated code

--- a/pkg/reconciler/eventtype/controller_test.go
+++ b/pkg/reconciler/eventtype/controller_test.go
@@ -25,7 +25,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -27,15 +27,15 @@ import (
 	"knative.dev/pkg/tracker"
 
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
-	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/eventtype"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
 	listersv1 "knative.dev/eventing/pkg/client/listers/eventing/v1"
-	listersv1beta1 "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	listersv1beta2 "knative.dev/eventing/pkg/client/listers/eventing/v1beta2"
 )
 
 type Reconciler struct {
 	// listers index properties about resources
-	eventTypeLister listersv1beta1.EventTypeLister
+	eventTypeLister listersv1beta2.EventTypeLister
 	brokerLister    listersv1.BrokerLister
 	tracker         tracker.Interface
 }
@@ -49,7 +49,7 @@ var _ eventtypereconciler.Interface = (*Reconciler)(nil)
 // 1. Verify the Broker exists.
 // 2. Verify the Broker is ready.
 // TODO remove https://github.com/knative/eventing/issues/2750
-func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta1.EventType) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta2.EventType) pkgreconciler.Event {
 	b, err := r.getBroker(et)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
@@ -82,6 +82,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta1.EventType) p
 }
 
 // getBroker returns the Broker for EventType 'et' if it exists, otherwise it returns an error.
-func (r *Reconciler) getBroker(et *v1beta1.EventType) (*v1.Broker, error) {
+func (r *Reconciler) getBroker(et *v1beta2.EventType) (*v1.Broker, error) {
 	return r.brokerLister.Brokers(et.Namespace).Get(et.Spec.Broker)
 }

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta1/eventtype"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"

--- a/pkg/reconciler/testing/v1/eventtype.go
+++ b/pkg/reconciler/testing/v1/eventtype.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2023 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,16 +21,16 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
 	"knative.dev/pkg/apis"
 )
 
 // EventTypeOption enables further configuration of an EventType.
-type EventTypeOption func(*v1beta1.EventType)
+type EventTypeOption func(*v1beta2.EventType)
 
 // NewEventType creates a EventType with EventTypeOptions.
-func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta1.EventType {
-	et := &v1beta1.EventType{
+func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta2.EventType {
+	et := &v1beta2.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -44,76 +44,76 @@ func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta1.EventTy
 }
 
 // WithInitEventTypeConditions initializes the EventType's conditions.
-func WithInitEventTypeConditions(et *v1beta1.EventType) {
+func WithInitEventTypeConditions(et *v1beta2.EventType) {
 	et.Status.InitializeConditions()
 }
 
 func WithEventTypeSource(source *apis.URL) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Spec.Source = source
 	}
 }
 
 func WithEventTypeType(t string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Spec.Type = t
 	}
 }
 
 func WithEventTypeBroker(broker string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Spec.Broker = broker
 	}
 }
 
 func WithEventTypeDescription(description string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Spec.Description = description
 	}
 }
 
 func WithEventTypeLabels(labels map[string]string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.ObjectMeta.Labels = labels
 	}
 }
 
 func WithEventTypeOwnerReference(ownerRef metav1.OwnerReference) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 			ownerRef,
 		}
 	}
 }
 
-func WithEventTypeDeletionTimestamp(et *v1beta1.EventType) {
+func WithEventTypeDeletionTimestamp(et *v1beta2.EventType) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	et.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
 // WithEventTypeBrokerNotFound calls .Status.MarkFilterFailed on the EventType.
-func WithEventTypeBrokerDoesNotExist(et *v1beta1.EventType) {
+func WithEventTypeBrokerDoesNotExist(et *v1beta2.EventType) {
 	et.Status.MarkBrokerDoesNotExist()
 }
 
 // WithEventTypeBrokerExists calls .Status.MarkBrokerExists on the EventType.
-func WithEventTypeBrokerExists(et *v1beta1.EventType) {
+func WithEventTypeBrokerExists(et *v1beta2.EventType) {
 	et.Status.MarkBrokerExists()
 }
 
 func WithEventTypeBrokerFailed(reason, message string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Status.MarkBrokerFailed(reason, message)
 	}
 }
 
 func WithEventTypeBrokerUnknown(reason, message string) EventTypeOption {
-	return func(et *v1beta1.EventType) {
+	return func(et *v1beta2.EventType) {
 		et.Status.MarkBrokerUnknown(reason, message)
 	}
 }
 
 // WithEventTypeBrokerReady calls .Status.MarkBrokerReady on the EventType.
-func WithEventTypeBrokerReady(et *v1beta1.EventType) {
+func WithEventTypeBrokerReady(et *v1beta2.EventType) {
 	et.Status.MarkBrokerReady()
 }

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -31,13 +31,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	eventingv1beta1 "knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
-	eventingv1beta1listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta1"
+	eventingv1beta2listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta2"
 	flowslisters "knative.dev/eventing/pkg/client/listers/flows/v1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	sourcelisters "knative.dev/eventing/pkg/client/listers/sources/v1"
@@ -108,8 +108,8 @@ func (l *Listers) GetAllObjects() []runtime.Object {
 	return all
 }
 
-func (l *Listers) GetEventTypeLister() eventingv1beta1listers.EventTypeLister {
-	return eventingv1beta1listers.NewEventTypeLister(l.indexerFor(&eventingv1beta1.EventType{}))
+func (l *Listers) GetEventTypeLister() eventingv1beta2listers.EventTypeLister {
+	return eventingv1beta2listers.NewEventTypeLister(l.indexerFor(&eventingv1beta2.EventType{}))
 }
 
 func (l *Listers) GetPingSourceLister() sourcelisters.PingSourceLister {


### PR DESCRIPTION
Fixes #6948

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- EventType reconciler/controller is using v1b2 APIs

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
EventType v1beta2 usage on the reconciler
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

