### PR TITLE
[WIP] Provide Channels CACerts in Brokers status annotation

### DIFF
--- a/pkg/apis/eventing/register.go
+++ b/pkg/apis/eventing/register.go
@@ -60,6 +60,12 @@ const (
 	// annotation key used to specify the address of its channel.
 	BrokerChannelAddressStatusAnnotationKey = "knative.dev/channelAddress"
 
+	// BrokerChannelCACertsStatusAnnotationKey is the broker status annotation
+	// key used to specify the channels Certification Authority (CA)
+	// certificates in PEM format according to
+	// https://www.rfc-editor.org/rfc/rfc7468
+	BrokerChannelCACertsStatusAnnotationKey = "knative.dev/channelCACerts"
+
 	// BrokerChannelAPIVersionStatusAnnotationKey is the broker status
 	// annotation key used to specify the APIVersion of the channel for
 	// the triggers to subscribe to.

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -153,6 +153,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 	b.Status.Annotations[eventing.BrokerChannelAPIVersionStatusAnnotationKey] = chanMan.ref.APIVersion
 	b.Status.Annotations[eventing.BrokerChannelNameStatusAnnotationKey] = chanMan.ref.Name
 
+	if caCerts := triggerChan.Status.Address.CACerts; caCerts != nil && *caCerts != "" {
+		b.Status.Annotations[eventing.BrokerChannelCACertsStatusAnnotationKey] = *caCerts
+	}
+
 	channelStatus := &duckv1.ChannelableStatus{
 		AddressStatus: pkgduckv1.AddressStatus{
 			Address: &pkgduckv1.Addressable{URL: triggerChan.Status.Address.URL},

--- a/pkg/reconciler/testing/v1/broker.go
+++ b/pkg/reconciler/testing/v1/broker.go
@@ -173,6 +173,15 @@ func WithChannelAddressAnnotation(address string) BrokerOption {
 	}
 }
 
+func WithChannelCACertsAnnotation(caCerts string) BrokerOption {
+	return func(b *v1.Broker) {
+		if b.Status.Annotations == nil {
+			b.Status.Annotations = make(map[string]string, 1)
+		}
+		b.Status.Annotations[eventing.BrokerChannelCACertsStatusAnnotationKey] = caCerts
+	}
+}
+
 func WithBrokerStatusDLSURI(dlsURI *apis.URL) BrokerOption {
 	return func(b *v1.Broker) {
 		b.Status.MarkDeadLetterSinkResolvedSucceeded(dlsURI)


### PR DESCRIPTION
## Proposed Changes

- :gift: Provide the underlying channels CACerts in the Brokers status as an annotation (`knative.dev/channelCACerts`). Similar as the channelsAddress is provided in the `knative.dev/channelAddress` annoation.