### PR TITLE
Improve cert-manager resources for Eventing TLS certs provisioning

### DIFF
--- a/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
+++ b/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -27,6 +41,6 @@ spec:
     - broker-filter.knative-eventing.svc.cluster.local
 
   issuerRef:
-    name: selfsigned-issuer
+    name: selfsigned-ca-issuer
     kind: Issuer
     group: cert-manager.io

--- a/config/channels/in-memory-channel-tls/imc-dispatcher-tls-certificate.yaml
+++ b/config/channels/in-memory-channel-tls/imc-dispatcher-tls-certificate.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -27,6 +41,6 @@ spec:
     - imc-dispatcher.knative-eventing.svc.cluster.local
 
   issuerRef:
-    name: selfsigned-issuer
+    name: selfsigned-ca-issuer
     kind: Issuer
     group: cert-manager.io

--- a/config/tls/issuers/eventing-selfsigned-issuer.yaml
+++ b/config/tls/issuers/eventing-selfsigned-issuer.yaml
@@ -1,7 +1,0 @@
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: selfsigned-issuer
-  namespace: knative-eventing
-spec:
-  selfSigned: {}

--- a/config/tls/issuers/selfsigned-ca-issuer.yaml
+++ b/config/tls/issuers/selfsigned-ca-issuer.yaml
@@ -12,35 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This is the issuer that every Eventing component should use to issue their server's certs.
 apiVersion: cert-manager.io/v1
-kind: Certificate
+kind: Issuer
 metadata:
-  name: mt-broker-ingress-server-tls
+  name: selfsigned-ca-issuer
   namespace: knative-eventing
 spec:
-  # Secret names are always required.
-  secretName: mt-broker-ingress-server-tls
-
-  secretTemplate:
-    labels:
-      app.kubernetes.io/component: broker-ingress
-      app.kubernetes.io/name: knative-eventing
-
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
-  subject:
-    organizations:
-      - local
-  isCA: false
-  privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
-
-  dnsNames:
-    - broker-ingress.knative-eventing.svc.cluster.local
-
-  issuerRef:
-    name: selfsigned-ca-issuer
-    kind: Issuer
-    group: cert-manager.io
+  ca:
+    secretName: eventing-ca

--- a/config/tls/issuers/selfsigned-issuer.yaml
+++ b/config/tls/issuers/selfsigned-issuer.yaml
@@ -12,35 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This is the root issuer to bootstrap the eventing CA.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: knative-eventing
+spec:
+  selfSigned: {}
+---
+# This is the Eventing CA certificate.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: mt-broker-ingress-server-tls
+  name: selfsigned-ca
   namespace: knative-eventing
 spec:
-  # Secret names are always required.
-  secretName: mt-broker-ingress-server-tls
+  secretName: eventing-ca
 
-  secretTemplate:
-    labels:
-      app.kubernetes.io/component: broker-ingress
-      app.kubernetes.io/name: knative-eventing
-
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
-  subject:
-    organizations:
-      - local
-  isCA: false
+  isCA: true
+  commonName: selfsigned-ca
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
-
-  dnsNames:
-    - broker-ingress.knative-eventing.svc.cluster.local
+    algorithm: ECDSA
+    size: 256
 
   issuerRef:
-    name: selfsigned-ca-issuer
+    name: selfsigned-issuer
     kind: Issuer
     group: cert-manager.io


### PR DESCRIPTION
This PR is refactoring how we provision certificates with cert-manager
in a way that is much easier for organizations to plug their own
root CA or even use a different issuer.
