### PR TITLE
Eventing TLS: Test ApiServerSource with eventshub TLS receiver as sink

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -161,6 +161,17 @@ ko apply -f config/brokers/mt-channel-broker/
 Depending on your needs you might want to install other
 [Broker implementations](https://github.com/knative/eventing/tree/main/docs/broker).
 
+## Install Cert-Manager
+
+Install the Cert-manager operator to run e2e tests for TLS
+
+```shell
+kubectl apply -f third_party/cert-manager
+```
+
+Depending on your needs you might want to install other
+[Broker implementations](https://github.com/knative/eventing/tree/main/docs/broker).
+
 ## Enable Sugar controller
 
 If you are running e2e tests that leverage the Sugar Controller, you will need

--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -136,6 +136,9 @@ spec:
                   uri:
                     description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
                     type: string
+                  CACerts:
+                    description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                    type: string
               namespaceSelector:
                 description: NamespaceSelector is a label selector to capture the namespaces that should be watched by the source.
                 type: object

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -24,13 +24,15 @@ import (
 	"time"
 
 	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
-	apiserversourcefeatures "knative.dev/eventing/test/rekt/features/apiserversource"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
+
+	apiserversourcefeatures "knative.dev/eventing/test/rekt/features/apiserversource"
 )
 
 // TestApiServerSourceValidationWebhookConfigurationOnCreate tests if the webhook
@@ -77,6 +79,21 @@ func TestApiServerSourceDataPlane_SinkTypes(t *testing.T) {
 	)
 
 	env.TestSet(ctx, t, apiserversourcefeatures.DataPlane_SinkTypes())
+}
+
+func TestApiServerSourceDataPlaneTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		//environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	env.Test(ctx, t, apiserversourcefeatures.SendsEventsWithTLS())
 }
 
 func TestApiServerSourceDataPlane_EventModes(t *testing.T) {

--- a/test/rekt/features/apiserversource/readiness.go
+++ b/test/rekt/features/apiserversource/readiness.go
@@ -18,13 +18,13 @@ package apiserversource
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/test/rekt/resources/account_role"
-	"knative.dev/eventing/test/rekt/resources/apiserversource"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
+
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/resources/account_role"
+	"knative.dev/eventing/test/rekt/resources/apiserversource"
 )
 
 // GoesReady returns a feature testing if an ApiServerSource becomes ready.
@@ -60,11 +60,7 @@ func Install(name string, cfg ...manifest.CfgFn) *feature.Feature {
 	cfg = append(cfg,
 		apiserversource.WithServiceAccountName(sacmName),
 		apiserversource.WithEventMode(v1.ResourceMode),
-		apiserversource.WithSink(&duckv1.KReference{
-			Kind:       "Service",
-			Name:       sink,
-			APIVersion: "v1",
-		}, ""),
+		apiserversource.WithSink(service.AsDestinationRef(sink)),
 		apiserversource.WithResources(v1.APIVersionKindSelector{
 			APIVersion: "v1",
 			Kind:       "Event",

--- a/test/rekt/features/apiserversource/webhook_validation_smoke.go
+++ b/test/rekt/features/apiserversource/webhook_validation_smoke.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/assert"
+	"knative.dev/reconciler-test/pkg/resources/service"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/reconciler-test/pkg/feature"
+
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/apiserversource"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	"knative.dev/reconciler-test/pkg/feature"
 )
 
 func CreateWithInvalidSpec() *feature.Feature {
@@ -53,11 +54,7 @@ func UpdateWithInvalidSpec(name string) *feature.Feature {
 func createApiServerSourceWithInvalidSpec(name string) func(ctx context.Context, t feature.T) {
 	return func(ctx context.Context, t feature.T) {
 		_, err := apiserversource.InstallLocalYaml(ctx, name,
-			apiserversource.WithSink(&duckv1.KReference{
-				Kind:       "Service",
-				Name:       "foo-svc",
-				APIVersion: "v1",
-			}, ""),
+			apiserversource.WithSink(service.AsDestinationRef("foo-svc")),
 			apiserversource.WithResources(v1.APIVersionKindSelector{
 				APIVersion: "v1",
 				Kind:       "Event",

--- a/test/rekt/resources/apiserversource/apiserversource.yaml
+++ b/test/rekt/resources/apiserversource/apiserversource.yaml
@@ -76,6 +76,10 @@ spec:
       name: {{ .sink.ref.name }}
       apiVersion: {{ .sink.ref.apiVersion }}
     {{ end }}
+    {{ if .sink.CACerts }}
+    CACerts: |-
+      {{ .sink.CACerts }}
+    {{ end }}
     {{ if .sink.uri }}
     uri: {{ .sink.uri }}
     {{ end }}

--- a/test/rekt/resources/apiserversource/apiserversource_test.go
+++ b/test/rekt/resources/apiserversource/apiserversource_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	testlog "knative.dev/reconciler-test/pkg/logging"
 
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
@@ -120,13 +121,16 @@ func Example_withSink() {
 		"namespace": "bar",
 	}
 
-	sinkRef := &duckv1.KReference{
-		Kind:       "sinkkind",
-		Namespace:  "sinknamespace",
-		Name:       "sinkname",
-		APIVersion: "sinkversion",
+	sinkRef := &duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Kind:       "sinkkind",
+			Namespace:  "sinknamespace",
+			Name:       "sinkname",
+			APIVersion: "sinkversion",
+		},
+		URI: &apis.URL{Path: "uri/parts"},
 	}
-	apiserversource.WithSink(sinkRef, "uri/parts")(cfg)
+	apiserversource.WithSink(sinkRef)(cfg)
 
 	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
 	if err != nil {
@@ -302,11 +306,14 @@ func Example_full() {
 		"namespace": "bar",
 	}
 
-	sinkRef := &duckv1.KReference{
-		Kind:       "sinkkind",
-		Namespace:  "sinknamespace",
-		Name:       "sinkname",
-		APIVersion: "sinkversion",
+	sinkRef := &duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Kind:       "sinkkind",
+			Namespace:  "sinknamespace",
+			Name:       "sinkname",
+			APIVersion: "sinkversion",
+		},
+		URI: &apis.URL{Path: "uri/parts"},
 	}
 
 	res1 := v1.APIVersionKindSelector{
@@ -339,7 +346,7 @@ func Example_full() {
 
 	apiserversource.WithServiceAccountName("src-sa")(cfg)
 	apiserversource.WithEventMode(v1.ReferenceMode)(cfg)
-	apiserversource.WithSink(sinkRef, "uri/parts")(cfg)
+	apiserversource.WithSink(sinkRef)(cfg)
 	apiserversource.WithResources(res1, res2, res3)(cfg)
 
 	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)


### PR DESCRIPTION
Fixes #6913

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Test ApiServerSource with eventshub TLS receiver as sink

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
ApiServerSource supports sending events to TLS endpoints, minimum TLS version is v1.2
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

