### PR TITLE
Add field for subscribers & replys CA certs to `SubscriberSpec` and `SubscriptionStatusPhysicalSubscription`

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -637,6 +637,20 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
+<code>subscriberCACerts</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberCACerts is the Certification Authority (CA) certificates in PEM
+format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
+subscriberUri</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replyUri</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
@@ -647,6 +661,20 @@ knative.dev/pkg/apis.URL
 <td>
 <em>(Optional)</em>
 <p>ReplyURI is the endpoint for the reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyCACerts</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyCACerts is the Certification Authority (CA) certificates in PEM
+format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
+replyUri.</p>
 </td>
 </tr>
 <tr>
@@ -4528,6 +4556,20 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
+<code>subscriberCACerts</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberCACerts is the Certification Authority (CA) certificates in PEM
+format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
+resolved URI for spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replyUri</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
@@ -4538,6 +4580,20 @@ knative.dev/pkg/apis.URL
 <td>
 <em>(Optional)</em>
 <p>ReplyURI is the fully resolved URI for the spec.reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyCACerts</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyCACerts is the Certification Authority (CA) certificates in PEM
+format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
+resolved URI for the spec.reply.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/duck/v1/subscribable_types.go
+++ b/pkg/apis/duck/v1/subscribable_types.go
@@ -42,9 +42,19 @@ type SubscriberSpec struct {
 	// SubscriberURI is the endpoint for the subscriber
 	// +optional
 	SubscriberURI *apis.URL `json:"subscriberUri,omitempty"`
+	// SubscriberCACerts is the Certification Authority (CA) certificates in PEM
+	// format according to https://www.rfc-editor.org/rfc/rfc7468 for the
+	// subscriberUri
+	// +optional
+	SubscriberCACerts *string `json:"subscriberCACerts,omitempty"`
 	// ReplyURI is the endpoint for the reply
 	// +optional
 	ReplyURI *apis.URL `json:"replyUri,omitempty"`
+	// ReplyCACerts is the Certification Authority (CA) certificates in PEM
+	// format according to https://www.rfc-editor.org/rfc/rfc7468 for the
+	// replyUri.
+	// +optional
+	ReplyCACerts *string `json:"replyCACerts,omitempty"`
 	// +optional
 	// DeliverySpec contains options controlling the event delivery
 	// +optional

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -310,10 +310,20 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SubscriberCACerts != nil {
+		in, out := &in.SubscriberCACerts, &out.SubscriberCACerts
+		*out = new(string)
+		**out = **in
+	}
 	if in.ReplyURI != nil {
 		in, out := &in.ReplyURI, &out.ReplyURI
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ReplyCACerts != nil {
+		in, out := &in.ReplyCACerts, &out.ReplyCACerts
+		*out = new(string)
+		**out = **in
 	}
 	if in.Delivery != nil {
 		in, out := &in.Delivery, &out.Delivery

--- a/pkg/apis/messaging/v1/subscription_types.go
+++ b/pkg/apis/messaging/v1/subscription_types.go
@@ -123,9 +123,21 @@ type SubscriptionStatusPhysicalSubscription struct {
 	// +optional
 	SubscriberURI *apis.URL `json:"subscriberUri,omitempty"`
 
+	// SubscriberCACerts is the Certification Authority (CA) certificates in PEM
+	// format according to https://www.rfc-editor.org/rfc/rfc7468 for the
+	// resolved URI for spec.subscriber.
+	// +optional
+	SubscriberCACerts *string `json:"subscriberCACerts,omitempty"`
+
 	// ReplyURI is the fully resolved URI for the spec.reply.
 	// +optional
 	ReplyURI *apis.URL `json:"replyUri,omitempty"`
+
+	// ReplyCACerts is the Certification Authority (CA) certificates in PEM
+	// format according to https://www.rfc-editor.org/rfc/rfc7468 for the
+	// resolved URI for the spec.reply.
+	// +optional
+	ReplyCACerts *string `json:"replyCACerts,omitempty"`
 
 	// DeliveryStatus contains a resolved URL to the dead letter sink address, and any other
 	// resolved delivery options.

--- a/pkg/apis/messaging/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1/zz_generated.deepcopy.go
@@ -377,10 +377,20 @@ func (in *SubscriptionStatusPhysicalSubscription) DeepCopyInto(out *Subscription
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SubscriberCACerts != nil {
+		in, out := &in.SubscriberCACerts, &out.SubscriberCACerts
+		*out = new(string)
+		**out = **in
+	}
 	if in.ReplyURI != nil {
 		in, out := &in.ReplyURI, &out.ReplyURI
 		*out = new(apis.URL)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ReplyCACerts != nil {
+		in, out := &in.ReplyCACerts, &out.ReplyCACerts
+		*out = new(string)
+		**out = **in
 	}
 	in.DeliveryStatus.DeepCopyInto(&out.DeliveryStatus)
 	return

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -226,13 +226,10 @@ func (r *Reconciler) resolveSubscriber(ctx context.Context, subscription *v1.Sub
 			subscription.Status.MarkReferencesNotResolved(subscriberResolveFailed, "Failed to resolve spec.subscriber: %v", err)
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, subscriberResolveFailed, "Failed to resolve spec.subscriber: %w", err)
 		}
-		subscriberURI := subscriberAddr.URL
-		// If there is a change in resolved URI, log it.
-		if subscription.Status.PhysicalSubscription.SubscriberURI == nil || subscription.Status.PhysicalSubscription.SubscriberURI.String() != subscriberURI.String() {
-			logging.FromContext(ctx).Debugw("Resolved Subscriber", zap.String("subscriberURI", subscriberURI.String()), zap.Stringp("subscriberCACerts", subscriberAddr.CACerts))
-			subscription.Status.PhysicalSubscription.SubscriberURI = subscriberURI
-			subscription.Status.PhysicalSubscription.SubscriberCACerts = subscriberAddr.CACerts
-		}
+
+		logging.FromContext(ctx).Debugw("Resolved Subscriber", zap.Any("subscriber", subscriberAddr))
+		subscription.Status.PhysicalSubscription.SubscriberURI = subscriberAddr.URL
+		subscription.Status.PhysicalSubscription.SubscriberCACerts = subscriberAddr.CACerts
 	} else {
 		subscription.Status.PhysicalSubscription.SubscriberURI = nil
 		subscription.Status.PhysicalSubscription.SubscriberCACerts = nil
@@ -258,13 +255,10 @@ func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1.Subscrip
 			subscription.Status.MarkReferencesNotResolved(replyResolveFailed, "Failed to resolve spec.reply: %v", err)
 			return pkgreconciler.NewEvent(corev1.EventTypeWarning, replyResolveFailed, "Failed to resolve spec.reply: %w", err)
 		}
-		replyURI := replyAddr.URL
-		// If there is a change in resolved URI, log it.
-		if subscription.Status.PhysicalSubscription.ReplyURI == nil || subscription.Status.PhysicalSubscription.ReplyURI.String() != replyURI.String() {
-			logging.FromContext(ctx).Debugw("Resolved reply", zap.String("replyURI", replyURI.String()), zap.Stringp("replyCACerts", replyAddr.CACerts))
-			subscription.Status.PhysicalSubscription.ReplyURI = replyURI
-			subscription.Status.PhysicalSubscription.ReplyCACerts = replyAddr.CACerts
-		}
+
+		logging.FromContext(ctx).Debugw("Resolved reply", zap.Any("reply", replyAddr))
+		subscription.Status.PhysicalSubscription.ReplyURI = replyAddr.URL
+		subscription.Status.PhysicalSubscription.ReplyCACerts = replyAddr.CACerts
 	} else {
 		subscription.Status.PhysicalSubscription.ReplyURI = nil
 		subscription.Status.PhysicalSubscription.ReplyCACerts = nil

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -80,20 +80,35 @@ var (
 
 	subscriberDNS = "subscriber.mynamespace.svc." + network.GetClusterDomainName()
 	subscriberURI = apis.HTTP(subscriberDNS)
+	subscriber    = duckv1.Addressable{
+		URL: subscriberURI,
+	}
 
 	replyDNS = "reply.mynamespace.svc." + network.GetClusterDomainName()
 	replyURI = apis.HTTP(replyDNS)
+	reply    = duckv1.Addressable{
+		URL: replyURI,
+	}
 
 	serviceDNS = serviceName + "." + testNS + ".svc." + network.GetClusterDomainName()
 	serviceURI = apis.HTTP(serviceDNS)
+	service    = duckv1.Addressable{
+		URL: serviceURI,
+	}
 
 	dlcDNS = "dlc.mynamespace.svc." + network.GetClusterDomainName()
 	dlcURI = apis.HTTP(dlcDNS)
+	dlc    = duckv1.Addressable{
+		URL: dlcURI,
+	}
 
 	dlc2DNS = "dlc2.mynamespace.svc." + network.GetClusterDomainName()
 
 	dlsDNS = "dls.mynamespace.svc." + network.GetClusterDomainName()
 	dlsURI = apis.HTTP(dlsDNS)
+	dls    = duckv1.Addressable{
+		URL: dlsURI,
+	}
 
 	subscriberGVK = metav1.GroupVersionKind{
 		Group:   "messaging.knative.dev",
@@ -130,8 +145,8 @@ var (
 		Namespace:  testNS,
 		Name:       channelName,
 	}
-	sinkURL         = apis.HTTP("example.com")
-	sinkAddressable = &duckv1.Addressable{
+	sinkURL = apis.HTTP("example.com")
+	sink    = &duckv1.Addressable{
 		Name: &sinkURL.Scheme,
 		URL:  sinkURL,
 	}
@@ -161,8 +176,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -209,8 +224,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -227,8 +242,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS+"-2",
@@ -275,8 +290,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -293,8 +308,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -341,8 +356,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS+"-2"),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -362,8 +377,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -420,8 +435,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -441,8 +456,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -499,8 +514,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -520,8 +535,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -586,8 +601,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -607,8 +622,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionFinalizers(finalizerName),
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 				// Subscriber
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -673,8 +688,8 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 					// - Status Update -
 					MarkSubscriptionReady,
 				),
@@ -831,7 +846,7 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionReply(imcV1GVK, replyName, testNS),
 					// The first reconciliation will initialize the status conditions.
 					WithInitSubscriptionConditions,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 					WithSubscriptionReferencesNotResolved(replyResolveFailed, fmt.Sprintf(`Failed to resolve spec.reply: failed to get object testnamespace/reply: inmemorychannels.messaging.knative.dev %q not found`, replyName)),
 				),
 			}},
@@ -866,7 +881,7 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionUID(subscriptionUID),
 					WithSubscriptionChannel(imcV1GVK, channelName),
 					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 					WithSubscriptionReply(nonAddressableGVK, replyName, testNS),
 					// The first reconciliation will initialize the status conditions.
 					WithInitSubscriptionConditions,
@@ -909,7 +924,7 @@ func TestAllCases(t *testing.T) {
 					MarkReferencesResolved,
 					MarkAddedToChannel,
 
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -951,7 +966,7 @@ func TestAllCases(t *testing.T) {
 					// The first reconciliation will initialize the status conditions.
 					WithInitSubscriptionConditions,
 					WithSubscriptionReferencesNotResolved("DeadLetterSinkResolveFailed", `Failed to resolve spec.delivery.deadLetterSink: failed to get object testnamespace/dls: subscribers.messaging.knative.dev "dls" not found`),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -994,7 +1009,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 					WithSubscriptionDeadLetterSinkURI(dlsURI),
 				),
 			}},
@@ -1019,7 +1034,7 @@ func TestAllCases(t *testing.T) {
 					WithInitChannelConditions,
 					WithBackingChannelObjRef(&imcV1KRef),
 					WithBackingChannelReady,
-					WithChannelAddress(sinkAddressable),
+					WithChannelAddress(sink),
 					WithChannelDLSUnknown(),
 				),
 				NewInMemoryChannel(channelName, testNS,
@@ -1045,7 +1060,7 @@ func TestAllCases(t *testing.T) {
 					MarkReferencesResolved,
 					MarkAddedToChannel,
 
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1133,8 +1148,8 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1181,8 +1196,8 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
-					WithSubscriptionPhysicalSubscriptionReply(replyURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
+					WithSubscriptionPhysicalSubscriptionReply(&reply),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1202,7 +1217,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
 					MarkSubscriptionReady,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 				),
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
 					WithUnstructuredAddressable(subscriberDNS),
@@ -1230,7 +1245,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					WithSubscriptionFinalizers(finalizerName),
 					MarkSubscriptionReady,
-					WithSubscriptionPhysicalSubscriptionSubscriber(subscriberURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&subscriber),
 					WithSubscriptionStatusObservedGeneration(subscriptionGeneration),
 				),
 			}},
@@ -1269,7 +1284,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1293,7 +1308,7 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionSubscriberRef(serviceGVK, serviceName, testNS),
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,
@@ -1318,7 +1333,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1347,7 +1362,7 @@ func TestAllCases(t *testing.T) {
 					WithSubscriptionSubscriberRef(serviceGVK, serviceName, testNS),
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,
@@ -1376,7 +1391,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeadLetterSinkURI(dlsURI),
 				),
 			}},
@@ -1435,7 +1450,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeliverySpec(&eventingduck.DeliverySpec{
 						DeadLetterSink: &duckv1.Destination{
 							Ref: &duckv1.KReference{
@@ -1518,7 +1533,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeadLetterSinkURI(dlcURI),
 				),
 			}},
@@ -1583,7 +1598,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1634,7 +1649,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 			}},
 			WantPatches: []clientgotesting.PatchActionImpl{
@@ -1695,7 +1710,7 @@ func TestAllCases(t *testing.T) {
 					// The first reconciliation will initialize the status conditions.
 					WithInitSubscriptionConditions,
 					WithSubscriptionReferencesNotResolved("DeadLetterSinkResolveFailed", fmt.Sprintf("channel %s didn't set status.deadLetterSinkURI", channelName)),
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 				),
 			}},
 		},
@@ -1762,7 +1777,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeliverySpec(&eventingduck.DeliverySpec{
 						DeadLetterSink: &duckv1.Destination{
 							Ref: &duckv1.KReference{
@@ -1846,7 +1861,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkReferencesResolved,
 					MarkAddedToChannel,
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeliverySpec(&eventingduck.DeliverySpec{
 						Timeout:       pointer.String("PT1S"),
 						RetryAfterMax: pointer.String("PT2S"),
@@ -1877,7 +1892,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeleted,
 				),
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -1911,7 +1926,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeleted,
 				),
 				NewUnstructured(subscriberGVK, subscriberName, testNS,
@@ -1942,7 +1957,7 @@ func TestAllCases(t *testing.T) {
 					MarkNotAddedToChannel("PhysicalChannelSyncFailed", "Failed to sync physical Channel: inducing failure for patch inmemorychannels"),
 					WithSubscriptionSubscriberRef(subscriberGVK, subscriberName, testNS),
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeleted,
 				),
 			}},
@@ -1960,7 +1975,7 @@ func TestAllCases(t *testing.T) {
 					WithInitSubscriptionConditions,
 					MarkSubscriptionReady,
 					WithSubscriptionFinalizers(finalizerName),
-					WithSubscriptionPhysicalSubscriptionSubscriber(serviceURI),
+					WithSubscriptionPhysicalSubscriptionSubscriber(&service),
 					WithSubscriptionDeleted,
 				),
 				NewUnstructured(subscriberGVK, subscriberName, testNS,

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -127,17 +127,11 @@ Vw==
 
 	dlcDNS = "dlc.mynamespace.svc." + network.GetClusterDomainName()
 	dlcURI = apis.HTTP(dlcDNS)
-	dlc    = duckv1.Addressable{
-		URL: dlcURI,
-	}
 
 	dlc2DNS = "dlc2.mynamespace.svc." + network.GetClusterDomainName()
 
 	dlsDNS = "dls.mynamespace.svc." + network.GetClusterDomainName()
 	dlsURI = apis.HTTP(dlsDNS)
-	dls    = duckv1.Addressable{
-		URL: dlsURI,
-	}
 
 	subscriberGVK = metav1.GroupVersionKind{
 		Group:   "messaging.knative.dev",

--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -201,33 +201,23 @@ func WithSubscriptionDeliveryRef(gvk metav1.GroupVersionKind, name, namespace st
 	}
 }
 
-func WithSubscriptionPhysicalSubscriptionSubscriber(uri *apis.URL) SubscriptionOption {
+func WithSubscriptionPhysicalSubscriptionSubscriber(subscriber *duckv1.Addressable) SubscriptionOption {
 	return func(s *v1.Subscription) {
-		if uri == nil {
-			panic(errors.New("nil URI"))
+		if subscriber == nil {
+			panic(errors.New("nil subscriber"))
 		}
-		s.Status.PhysicalSubscription.SubscriberURI = uri
+		s.Status.PhysicalSubscription.SubscriberURI = subscriber.URL
+		s.Status.PhysicalSubscription.SubscriberCACerts = subscriber.CACerts
 	}
 }
 
-func WithSubscriptionPhysicalSubscriptionSubscriberCACerts(caCerts string) SubscriptionOption {
+func WithSubscriptionPhysicalSubscriptionReply(reply *duckv1.Addressable) SubscriptionOption {
 	return func(s *v1.Subscription) {
-		s.Status.PhysicalSubscription.SubscriberCACerts = &caCerts
-	}
-}
-
-func WithSubscriptionPhysicalSubscriptionReply(uri *apis.URL) SubscriptionOption {
-	return func(s *v1.Subscription) {
-		if uri == nil {
-			panic(errors.New("nil URI"))
+		if reply == nil {
+			panic(errors.New("nil reply"))
 		}
-		s.Status.PhysicalSubscription.ReplyURI = uri
-	}
-}
-
-func WithSubscriptionPhysicalSubscriptionReplyCACerts(caCerts string) SubscriptionOption {
-	return func(s *v1.Subscription) {
-		s.Status.PhysicalSubscription.ReplyCACerts = &caCerts
+		s.Status.PhysicalSubscription.ReplyURI = reply.URL
+		s.Status.PhysicalSubscription.ReplyCACerts = reply.CACerts
 	}
 }
 

--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -210,12 +210,24 @@ func WithSubscriptionPhysicalSubscriptionSubscriber(uri *apis.URL) SubscriptionO
 	}
 }
 
+func WithSubscriptionPhysicalSubscriptionSubscriberCACerts(caCerts string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.PhysicalSubscription.SubscriberCACerts = &caCerts
+	}
+}
+
 func WithSubscriptionPhysicalSubscriptionReply(uri *apis.URL) SubscriptionOption {
 	return func(s *v1.Subscription) {
 		if uri == nil {
 			panic(errors.New("nil URI"))
 		}
 		s.Status.PhysicalSubscription.ReplyURI = uri
+	}
+}
+
+func WithSubscriptionPhysicalSubscriptionReplyCACerts(caCerts string) SubscriptionOption {
+	return func(s *v1.Subscription) {
+		s.Status.PhysicalSubscription.ReplyCACerts = &caCerts
 	}
 }
 

--- a/pkg/reconciler/testing/v1/unstructured.go
+++ b/pkg/reconciler/testing/v1/unstructured.go
@@ -59,15 +59,19 @@ func WithUnstructuredAddressable(hostname string) UnstructuredOption {
 	}
 }
 
-func WithUnstructuredAddressableTLS(hostname string, caCerts string) UnstructuredOption {
+func WithUnstructuredAddressableTLS(hostname string, caCerts *string) UnstructuredOption {
 	return func(u *unstructured.Unstructured) {
 		status, ok := u.Object["status"].(map[string]interface{})
 		if ok {
-			status["address"] = map[string]interface{}{
+			address := map[string]interface{}{
 				"hostname": hostname,
 				"url":      fmt.Sprintf("https://%s", hostname),
-				"caCerts":  caCerts,
 			}
+			if caCerts != nil {
+				address["caCerts"] = *caCerts
+			}
+
+			status["address"] = address
 		}
 	}
 }

--- a/pkg/reconciler/testing/v1/unstructured.go
+++ b/pkg/reconciler/testing/v1/unstructured.go
@@ -59,6 +59,19 @@ func WithUnstructuredAddressable(hostname string) UnstructuredOption {
 	}
 }
 
+func WithUnstructuredAddressableTLS(hostname string, caCerts string) UnstructuredOption {
+	return func(u *unstructured.Unstructured) {
+		status, ok := u.Object["status"].(map[string]interface{})
+		if ok {
+			status["address"] = map[string]interface{}{
+				"hostname": hostname,
+				"url":      fmt.Sprintf("https://%s", hostname),
+				"caCerts":  caCerts,
+			}
+		}
+	}
+}
+
 func apiVersion(gvk metav1.GroupVersionKind) string {
 	groupVersion := gvk.Version
 	if gvk.Group != "" {


### PR DESCRIPTION
## Proposed Changes

- :gift: Add `subscriberCACerts` & `replyCACerts` fields to `SubscriberSpec`
- :gift: Add `subscriberCACerts` & `replyCACerts` fields to `SubscriptionStatusPhysicalSubscription`