### PR TITLE
Adding source duck type to v1b2

### DIFF
--- a/pkg/reconciler/source/crd/crd_test.go
+++ b/pkg/reconciler/source/crd/crd_test.go
@@ -41,7 +41,7 @@ import (
 
 	// Fake injection informers
 
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
 	fakeclient "knative.dev/pkg/client/injection/apiextensions/client/fake"
 	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/source/fake"

--- a/pkg/reconciler/source/duck/controller.go
+++ b/pkg/reconciler/source/duck/controller.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
-	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype"
+	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
 	crdinfomer "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition"
 	sourceinformer "knative.dev/pkg/client/injection/ducks/duck/v1/source"
 )

--- a/pkg/reconciler/source/duck/controller_test.go
+++ b/pkg/reconciler/source/duck/controller_test.go
@@ -26,7 +26,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 
 	// Fake injection informers
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta1/eventtype/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
 	_ "knative.dev/pkg/client/injection/apiextensions/informers/apiextensions/v1/customresourcedefinition/fake"
 
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"

--- a/pkg/reconciler/source/duck/duck_test.go
+++ b/pkg/reconciler/source/duck/duck_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
+
 	apix1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +33,6 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	v1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/reconciler/source/duck/resources"
 	"knative.dev/pkg/apis"
@@ -42,7 +43,7 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 
-	. "knative.dev/eventing/pkg/reconciler/testing/v1beta1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1beta2"
 	. "knative.dev/pkg/reconciler/testing"
 )
 
@@ -323,9 +324,9 @@ func makeSourceCRD(eventTypes []eventTypeEntry) *apix1.CustomResourceDefinition 
 	}
 }
 
-func makeEventType(ceType, ceSource string) *v1beta1.EventType {
+func makeEventType(ceType, ceSource string) *v1beta2.EventType {
 	ceSourceURL, _ := apis.ParseURL(ceSource)
-	return &v1beta1.EventType{
+	return &v1beta2.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%x", md5.Sum([]byte(ceType+ceSource+sourceUID))),
 			Labels:    resources.Labels(sourceName),
@@ -339,7 +340,7 @@ func makeEventType(ceType, ceSource string) *v1beta1.EventType {
 				Controller:         ptr.Bool(true),
 			}},
 		},
-		Spec: v1beta1.EventTypeSpec{
+		Spec: v1beta2.EventTypeSpec{
 			Type:   ceType,
 			Source: ceSourceURL,
 			Broker: sinkName,
@@ -347,7 +348,7 @@ func makeEventType(ceType, ceSource string) *v1beta1.EventType {
 	}
 }
 
-func makeEventTypeWithName(ceType, ceSource, name string) *v1beta1.EventType {
+func makeEventTypeWithName(ceType, ceSource, name string) *v1beta2.EventType {
 	et := makeEventType(ceType, ceSource)
 	et.Name = name
 	return et

--- a/pkg/reconciler/source/duck/resources/eventtype.go
+++ b/pkg/reconciler/source/duck/resources/eventtype.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
@@ -36,7 +36,7 @@ type EventTypeArgs struct {
 	Description string
 }
 
-func MakeEventType(args *EventTypeArgs) *v1beta1.EventType {
+func MakeEventType(args *EventTypeArgs) *v1beta2.EventType {
 	// Name it with the hash of the concatenation of the three fields.
 	// Cannot generate a fixed name based on type+UUID, because long type names might be cut, and we end up trying to create
 	// event types with the same name.
@@ -44,7 +44,7 @@ func MakeEventType(args *EventTypeArgs) *v1beta1.EventType {
 	//  it will contain. For example, if we remove Broker and Source, then the latter makes more sense.
 	//  See https://github.com/knative/eventing/issues/2750
 	fixedName := fmt.Sprintf("%x", md5.Sum([]byte(args.CeType+args.CeSource.String()+args.CeSchema.String()+string(args.Source.GetUID())))) //nolint:gosec // No strong cryptography needed.
-	return &v1beta1.EventType{
+	return &v1beta2.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fixedName,
 			Labels:    Labels(args.Source.Name),
@@ -58,7 +58,7 @@ func MakeEventType(args *EventTypeArgs) *v1beta1.EventType {
 				Controller:         ptr.Bool(true),
 			}},
 		},
-		Spec: v1beta1.EventTypeSpec{
+		Spec: v1beta2.EventTypeSpec{
 			Type:   args.CeType,
 			Source: args.CeSource,
 			// TODO remove broker https://github.com/knative/eventing/issues/2750

--- a/pkg/reconciler/source/duck/resources/eventtype_test.go
+++ b/pkg/reconciler/source/duck/resources/eventtype_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta1"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
@@ -38,7 +38,7 @@ func TestMakeEventType(t *testing.T) {
 				UID:       "source-uid",
 			},
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "testing.sources.knative.dev/v1beta1",
+				APIVersion: "testing.sources.knative.dev/v1beta2",
 				Kind:       "TestSource",
 			},
 			Spec: duckv1.SourceSpec{
@@ -57,13 +57,13 @@ func TestMakeEventType(t *testing.T) {
 
 	got := MakeEventType(args)
 
-	want := &v1beta1.EventType{
+	want := &v1beta2.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%x", md5.Sum([]byte("my-type"+"http://my-source"+"http://my-schema"+"source-uid"))),
 			Labels:    Labels("source-name"),
 			Namespace: "source-namespace",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "testing.sources.knative.dev/v1beta1",
+				APIVersion:         "testing.sources.knative.dev/v1beta2",
 				Kind:               "TestSource",
 				Name:               "source-name",
 				UID:                "source-uid",
@@ -71,7 +71,7 @@ func TestMakeEventType(t *testing.T) {
 				Controller:         ptr.Bool(true),
 			}},
 		},
-		Spec: v1beta1.EventTypeSpec{
+		Spec: v1beta2.EventTypeSpec{
 			Type:        "my-type",
 			Source:      apis.HTTP("my-source"),
 			Schema:      apis.HTTP("my-schema"),

--- a/pkg/reconciler/testing/v1beta2/factory.go
+++ b/pkg/reconciler/testing/v1beta2/factory.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/tools/record"
+
+	"go.uber.org/zap"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/controller"
+
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	fakeapiextensionsclient "knative.dev/pkg/client/injection/apiextensions/client/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+
+	"knative.dev/pkg/reconciler"
+	. "knative.dev/pkg/reconciler/testing"
+)
+
+const (
+	// maxEventBufferSize is the estimated max number of event notifications that
+	// can be buffered during reconciliation.
+	maxEventBufferSize = 10
+)
+
+// Ctor functions create a k8s controller with given params.
+type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
+
+// MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
+func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factory {
+	return func(t *testing.T, r *TableRow) (controller.Reconciler, ActionRecorderList, EventList) {
+		ls := NewListers(r.Objects)
+
+		ctx := context.Background()
+		ctx = logging.WithLogger(ctx, logger)
+
+		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
+		ctx, client := fakeeventingclient.With(ctx, ls.GetEventingObjects()...)
+		ctx, extClient := fakeapiextensionsclient.With(ctx, ls.GetAPIExtensionObjects()...)
+		ctx, dynamicClient := fakedynamicclient.With(ctx,
+			NewScheme(), ToUnstructured(t, r.Objects)...)
+
+		// The dynamic client's support for patching is BS.  Implement it
+		// here via PrependReactor (this can be overridden below by the
+		// provided reactors).
+		dynamicClient.PrependReactor("patch", "*",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
+		ctx = controller.WithEventRecorder(ctx, eventRecorder)
+
+		// Set up our Controller from the fakes.
+		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
+
+		// If the reconcilers is leader aware, then promote it.
+		if la, ok := c.(reconciler.LeaderAware); ok {
+			la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
+		}
+
+		for _, reactor := range r.WithReactors {
+			kubeClient.PrependReactor("*", "*", reactor)
+			client.PrependReactor("*", "*", reactor)
+			dynamicClient.PrependReactor("*", "*", reactor)
+			extClient.PrependReactor("*", "*", reactor)
+		}
+
+		// Validate all Create operations through the eventing client.
+		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateCreates(ctx, action)
+		})
+		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			return ValidateUpdates(ctx, action)
+		})
+
+		actionRecorderList := ActionRecorderList{dynamicClient, client, kubeClient}
+		eventList := EventList{Recorder: eventRecorder}
+
+		return c, actionRecorderList, eventList
+	}
+}
+
+// ToUnstructured takes a list of k8s resources and converts them to
+// Unstructured objects.
+// We must pass objects as Unstructured to the dynamic client fake, or it
+// won't handle them properly.
+func ToUnstructured(t *testing.T, objs []runtime.Object) (us []runtime.Object) {
+	sch := NewScheme()
+	for _, obj := range objs {
+		obj = obj.DeepCopyObject() // Don't mess with the primary copy
+
+		ta, err := meta.TypeAccessor(obj)
+		if err != nil {
+			t.Fatal("Unable to create type accessor:", err)
+		}
+
+		if ta.GetAPIVersion() == "" || ta.GetKind() == "" {
+			// Determine and set the TypeMeta for this object based on our test scheme.
+			gvks, _, err := sch.ObjectKinds(obj)
+			if err != nil {
+				t.Fatal("Unable to determine kind for type:", err)
+			}
+			apiv, k := gvks[0].ToAPIVersionAndKind()
+			ta.SetAPIVersion(apiv)
+			ta.SetKind(k)
+		}
+
+		b, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatal("Unable to marshal:", err)
+		}
+		u := &unstructured.Unstructured{}
+		if err := json.Unmarshal(b, u); err != nil {
+			t.Fatal("Unable to unmarshal:", err)
+		}
+		us = append(us, u)
+	}
+	return
+}

--- a/pkg/reconciler/testing/v1beta2/listers.go
+++ b/pkg/reconciler/testing/v1beta2/listers.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
+	eventingv1beta2listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta2"
+	testscheme "knative.dev/eventing/pkg/reconciler/testing/scheme"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/reconciler/testing"
+)
+
+var clientSetSchemes = []func(*runtime.Scheme) error{
+	fakekubeclientset.AddToScheme,
+	fakeeventingclientset.AddToScheme,
+	fakeapiextensionsclientset.AddToScheme,
+	duckv1.AddToScheme,
+	testscheme.Eventing.AddToScheme,
+	testscheme.Serving.AddToScheme,
+}
+
+type Listers struct {
+	sorter testing.ObjectSorter
+}
+
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+	return scheme
+}
+
+func NewListers(objs []runtime.Object) Listers {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+
+	ls := Listers{
+		sorter: testing.NewObjectSorter(scheme),
+	}
+
+	ls.sorter.AddObjects(objs...)
+
+	return ls
+}
+
+func (l *Listers) indexerFor(obj runtime.Object) cache.Indexer {
+	return l.sorter.IndexerForObjectType(obj)
+}
+
+func (l *Listers) GetKubeObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
+}
+
+func (l *Listers) GetAPIExtensionObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeapiextensionsclientset.AddToScheme)
+}
+
+func (l *Listers) GetEventingObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeeventingclientset.AddToScheme)
+}
+
+func (l *Listers) GetSubscriberObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(testscheme.SubscriberToScheme)
+}
+
+func (l *Listers) GetAllObjects() []runtime.Object {
+	all := l.GetSubscriberObjects()
+	all = append(all, l.GetEventingObjects()...)
+	all = append(all, l.GetKubeObjects()...)
+	all = append(all, l.GetAPIExtensionObjects()...)
+
+	return all
+}
+
+func (l *Listers) GetEventTypeLister() eventingv1beta2listers.EventTypeLister {
+	return eventingv1beta2listers.NewEventTypeLister(l.indexerFor(&eventingv1beta2.EventType{}))
+}
+
+func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
+	return appsv1listers.NewDeploymentLister(l.indexerFor(&appsv1.Deployment{}))
+}
+
+func (l *Listers) GetK8sServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
+	return corev1listers.NewNamespaceLister(l.indexerFor(&corev1.Namespace{}))
+}
+
+func (l *Listers) GetServiceAccountLister() corev1listers.ServiceAccountLister {
+	return corev1listers.NewServiceAccountLister(l.indexerFor(&corev1.ServiceAccount{}))
+}
+
+func (l *Listers) GetServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.indexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetRoleBindingLister() rbacv1listers.RoleBindingLister {
+	return rbacv1listers.NewRoleBindingLister(l.indexerFor(&rbacv1.RoleBinding{}))
+}
+
+func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
+	return corev1listers.NewEndpointsLister(l.indexerFor(&corev1.Endpoints{}))
+}
+
+func (l *Listers) GetConfigMapLister() corev1listers.ConfigMapLister {
+	return corev1listers.NewConfigMapLister(l.indexerFor(&corev1.ConfigMap{}))
+}
+
+func (l *Listers) GetCustomResourceDefinitionLister() apiextensionsv1listers.CustomResourceDefinitionLister {
+	return apiextensionsv1listers.NewCustomResourceDefinitionLister(l.indexerFor(&apiextensionsv1.CustomResourceDefinition{}))
+}


### PR DESCRIPTION
Fixes #6963

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- use EventType v1b2 on sources `duck` controller/reconciler
- updating reconciler testing for v1b2, adding listers/factory

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
EventType v1b2 on sources `duck` controller/reconciler used
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

