### PR TITLE
Test PingSource with eventshub TLS receiver as sink

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -103,6 +103,9 @@ spec:
                                 Relative URIs will be resolved using the base URI retrieved
                                 from Ref.'
                     type: string
+                  CACerts:
+                    description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                    type: string
               timezone:
                 description: 'Timezone modifies the actual time relative to the specified
                         timezone. Defaults to the system time zone. More general information
@@ -177,6 +180,9 @@ spec:
               sinkUri:
                 description: 'SinkURI is the current active sink URI that has been
                           configured for the Source.'
+                type: string
+              sinkCACerts:
+                description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
                 type: string
     additionalPrinterColumns:
     - name: Sink

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/cloudevents/sdk-go/v2/test"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -503,10 +504,10 @@ func SendsEventsForAllResourcesWithEmptyNamespaceSelector() *feature.Feature {
 	pingSource2 := feature.MakeRandomK8sName("ping-source-2")
 
 	f.Requirement("install PingSource 1",
-		pingsource.Install(pingSource1, pingsource.WithSink(nil, "http://example.com")),
+		pingsource.Install(pingSource1, pingsource.WithSink(&duckv1.Destination{URI: apis.HTTP("example.com")})),
 	)
 	f.Requirement("install PingSource 2",
-		pingsource.Install(pingSource2, pingsource.WithSink(nil, "http://example.com")),
+		pingsource.Install(pingSource2, pingsource.WithSink(&duckv1.Destination{URI: apis.HTTP("example.com")})),
 	)
 
 	f.Stable("ApiServerSource as event source").

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -21,11 +21,14 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/sets"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
-	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
+
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	eventasssert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -41,12 +44,36 @@ func SendsEventsWithSinkRef() *feature.Feature {
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
-	f.Requirement("install pingsource", pingsource.Install(source, pingsource.WithSink(service.AsKReference(sink), "")))
+	f.Requirement("install pingsource", pingsource.Install(source, pingsource.WithSink(service.AsDestinationRef(sink))))
 	f.Requirement("pingsource goes ready", pingsource.IsReady(source))
 
 	f.Stable("pingsource as event source").
 		Must("delivers events",
 			assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.sources.ping")).AtLeast(1))
+
+	return f
+}
+
+func SendsEventsTLS() *feature.Feature {
+	source := feature.MakeRandomK8sName("pingsource")
+	sink := feature.MakeRandomK8sName("sink")
+	f := feature.NewFeature()
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
+
+	f.Requirement("install pingsource", func(ctx context.Context, t feature.T) {
+		d := service.AsDestinationRef(sink)
+		d.CACerts = eventshub.GetCaCerts(ctx)
+
+		pingsource.Install(source, pingsource.WithSink(d))(ctx, t)
+	})
+	f.Requirement("pingsource goes ready", pingsource.IsReady(source))
+
+	f.Stable("pingsource as event source").
+		Must("delivers events", assert.OnStore(sink).
+			Match(eventasssert.MatchKind(eventshub.EventReceived)).
+			MatchEvent(test.HasType("dev.knative.sources.ping")).
+			AtLeast(1))
 
 	return f
 }
@@ -58,7 +85,7 @@ func SendsEventsWithSinkURI() *feature.Feature {
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
-	f.Requirement("install pingsource", pingsource.Install(source, pingsource.WithSink(service.AsKReference(sink), "")))
+	f.Requirement("install pingsource", pingsource.Install(source, pingsource.WithSink(service.AsDestinationRef(sink))))
 	f.Requirement("pingsource goes ready", pingsource.IsReady(source))
 
 	f.Stable("pingsource as event source").
@@ -77,7 +104,7 @@ func SendsEventsWithCloudEventData() *feature.Feature {
 
 	f.Requirement("install pingsource", pingsource.Install(source,
 		pingsource.WithDataBase64("text/plain", "aGVsbG8sIHdvcmxkIQ=="),
-		pingsource.WithSink(service.AsKReference(sink), ""),
+		pingsource.WithSink(service.AsDestinationRef(sink)),
 	))
 	f.Requirement("pingsource goes ready", pingsource.IsReady(source))
 
@@ -112,7 +139,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 			t.Error("failed to get address of broker", err)
 		}
 		cfg := []manifest.CfgFn{
-			pingsource.WithSink(nil, brokeruri.String()),
+			pingsource.WithSink(&duckv1.Destination{URI: brokeruri}),
 			pingsource.WithData("text/plain", "hello, world!"),
 		}
 		pingsource.Install(source, cfg...)(ctx, t)

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/reconciler-test/pkg/resources/service"
 
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
-	eventasssert "knative.dev/reconciler-test/pkg/eventshub/assert"
+	eventassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -71,7 +71,7 @@ func SendsEventsTLS() *feature.Feature {
 
 	f.Stable("pingsource as event source").
 		Must("delivers events", assert.OnStore(sink).
-			Match(eventasssert.MatchKind(eventshub.EventReceived)).
+			Match(eventassert.MatchKind(eventshub.EventReceived)).
 			MatchEvent(test.HasType("dev.knative.sources.ping")).
 			AtLeast(1))
 

--- a/test/rekt/features/pingsource/readyness.go
+++ b/test/rekt/features/pingsource/readyness.go
@@ -17,11 +17,11 @@ limitations under the License.
 package pingsource
 
 import (
-	"knative.dev/eventing/test/rekt/resources/pingsource"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
+
+	"knative.dev/eventing/test/rekt/resources/pingsource"
 )
 
 // PingSourceGoesReady returns a feature testing if a pingsource becomes ready.
@@ -32,11 +32,7 @@ func PingSourceGoesReady(name string, cfg ...manifest.CfgFn) *feature.Feature {
 	f.Setup("install a service", service.Install(sink,
 		service.WithSelectors(map[string]string{"app": "rekt"})))
 
-	cfg = append(cfg, pingsource.WithSink(&duckv1.KReference{
-		Kind:       "Service",
-		Name:       sink,
-		APIVersion: "v1",
-	}, ""))
+	cfg = append(cfg, pingsource.WithSink(service.AsDestinationRef(sink)))
 
 	f.Setup("install a PingSource", pingsource.Install(name, cfg...))
 

--- a/test/rekt/features/sequence/feature.go
+++ b/test/rekt/features/sequence/feature.go
@@ -22,16 +22,18 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/eventing/test/rekt/resources/channel_template"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/sequence"
 
 	"knative.dev/reconciler-test/pkg/eventshub"
-	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
+
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
 )
 
 func SequenceTest(channelTemplate channel_template.ChannelTemplate) *feature.Feature {
@@ -77,7 +79,7 @@ func SequenceTest(channelTemplate channel_template.ChannelTemplate) *feature.Fea
 			t.Error("failed to get address of broker", err)
 		}
 		cfg := []manifest.CfgFn{
-			pingsource.WithSink(nil, sequenceUri.String()),
+			pingsource.WithSink(&duckv1.Destination{URI: sequenceUri}),
 			pingsource.WithData("text/plain", eventBody),
 		}
 		pingsource.Install(source, cfg...)(ctx, t)

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -20,11 +20,13 @@ import (
 	"context"
 
 	"github.com/cloudevents/sdk-go/v2/test"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
-	"knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
+
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
 
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
@@ -69,7 +71,7 @@ func TriggerDependencyAnnotation() *feature.Feature {
 		}
 		cfg := []manifest.CfgFn{
 			pingsource.WithSchedule("*/1 * * * *"),
-			pingsource.WithSink(nil, brokeruri.String()),
+			pingsource.WithSink(&duckv1.Destination{URI: brokeruri}),
 			pingsource.WithData("text/plain", "Test trigger-annotation"),
 		}
 		pingsource.Install(psourcename, cfg...)(ctx, t)

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -23,11 +23,13 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/eventing/test/rekt/features/pingsource"
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing/test/rekt/features/pingsource"
 )
 
 func TestPingSourceWithSinkRef(t *testing.T) {
@@ -43,6 +45,22 @@ func TestPingSourceWithSinkRef(t *testing.T) {
 	t.Cleanup(env.Finish)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithSinkRef())
+}
+
+func TestPingSourceTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+	t.Cleanup(env.Finish)
+
+	env.Test(ctx, t, pingsource.SendsEventsTLS())
 }
 
 func TestPingSourceWithSinkURI(t *testing.T) {

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -19,6 +19,7 @@ package pingsource
 import (
 	"context"
 	"embed"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -66,6 +67,13 @@ func WithSink(dest *duckv1.Destination) manifest.CfgFn {
 
 		uri := dest.URI
 		ref := dest.Ref
+
+
+		if dest.CACerts != nil {
+			// This is a multi-line string and should be indented accordingly.
+			// Replace "new line" with "new line + spaces".
+			sink["CACerts"] = strings.ReplaceAll(*dest.CACerts, "\n", "\n      ")
+		}
 
 		if uri != nil {
 			sink["uri"] = uri.String()

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -68,7 +68,6 @@ func WithSink(dest *duckv1.Destination) manifest.CfgFn {
 		uri := dest.URI
 		ref := dest.Ref
 
-
 		if dest.CACerts != nil {
 			// This is a multi-line string and should be indented accordingly.
 			// Replace "new line" with "new line + spaces".

--- a/test/rekt/resources/pingsource/pingsource.yaml
+++ b/test/rekt/resources/pingsource/pingsource.yaml
@@ -42,4 +42,8 @@ spec:
     {{ if .sink.uri }}
     uri: {{ .sink.uri }}
     {{ end }}
+    {{ if .sink.CACerts }}
+    CACerts: |-
+      {{ .sink.CACerts }}
+    {{ end }}
   {{ end }}

--- a/test/rekt/resources/pingsource/pingsource_test.go
+++ b/test/rekt/resources/pingsource/pingsource_test.go
@@ -115,7 +115,8 @@ func Example_fullbase64() {
 				"name":       "sinkname",
 				"apiVersion": "sinkversion",
 			},
-			"uri": "uri/parts",
+			"uri":     "uri/parts",
+			"CACerts": "xyz",
 		},
 	}
 
@@ -142,4 +143,6 @@ func Example_fullbase64() {
 	//       name: sinkname
 	//       apiVersion: sinkversion
 	//     uri: uri/parts
+	//     CACerts: |-
+	//       xyz
 }


### PR DESCRIPTION
Fixes #6914

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Test PingSource with eventshub TLS receiver as sink

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
PingSource supports sending events to TLS endpoints, minimum TLS version is v1.2
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

