### PR TITLE
Do not parse flags in InitializeEventingFlags

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -36,7 +36,6 @@ jobs:
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e
           extra-test-flags: >
-            -brokerclass=MTChannelBasedBroker
             -channels=messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel
             -sources=sources.knative.dev/v1:ApiServerSource,sources.knative.dev/v1:ContainerSource,sources.knative.dev/v1beta2:PingSource
         - test-suite: ./test/conformance

--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -20,6 +20,7 @@ package conformance
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 	"strings"
@@ -46,6 +47,7 @@ var brokerClass string
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
 		test.InitializeEventingFlags()
+		flag.Parse()
 		testlib.ReuseNamespace = test.EventingFlags.ReuseNamespace
 		channelTestRunner = testlib.ComponentsTestRunner{
 			ComponentFeatureMap: testlib.ChannelFeatureMap,
@@ -61,7 +63,7 @@ func TestMain(m *testing.M) {
 			ComponentName:       test.EventingFlags.BrokerName,
 			ComponentNamespace:  test.EventingFlags.BrokerNamespace,
 		}
-		brokerClass = test.EventingFlags.BrokerClass
+		brokerClass = test.BrokerClass
 
 		addSourcesInitializers()
 		// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -34,7 +34,6 @@ initialize $@ --skip-istio-addon
 
 echo "Running E2E tests for: Multi Tenant Channel Based Broker, Channel (v1), InMemoryChannel (v1) , ApiServerSource (v1), ContainerSource (v1) and PingSource (v1beta2)"
 go_test_e2e -timeout=1h -parallel=20 ./test/e2e \
-  -brokerclass=MTChannelBasedBroker \
   -channels=messaging.knative.dev/v1:Channel,messaging.knative.dev/v1:InMemoryChannel \
   -sources=sources.knative.dev/v1beta2:PingSource,sources.knative.dev/v1:ApiServerSource,sources.knative.dev/v1:ContainerSource \
   || fail_test

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"flag"
 	"os"
 	"testing"
 
@@ -32,12 +33,13 @@ var brokerClass string
 
 func TestMain(m *testing.M) {
 	test.InitializeEventingFlags()
+	flag.Parse()
 	testlib.ReuseNamespace = test.EventingFlags.ReuseNamespace
 	channelTestRunner = testlib.ComponentsTestRunner{
 		ComponentFeatureMap: testlib.ChannelFeatureMap,
 		ComponentsToTest:    test.EventingFlags.Channels,
 	}
-	brokerClass = test.EventingFlags.BrokerClass
+	brokerClass = test.BrokerClass
 
 	exit := m.Run()
 

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -21,7 +21,6 @@ package test
 
 import (
 	"flag"
-	"log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testflags "knative.dev/eventing/test/flags"
@@ -43,17 +42,18 @@ const (
 	BrokerNameUsage = "When testing a pre-existing broker, specify the Broker name so the conformance tests " +
 		"won't create their own."
 	BrokerNamespaceUsage = "When testing a pre-existing broker, this variable specifies the namespace the broker can be found in."
+	BrokerClass          = "MTChannelBasedBroker"
 )
 
 // EventingFlags holds the command line flags specific to knative/eventing.
 var EventingFlags testflags.EventingEnvironmentFlags
 
-// InitializeEventingFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
-// go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
+// InitializeEventingFlags registers flags used by e2e tests.
 func InitializeEventingFlags() {
-
+	// Default value for Channels.
+	EventingFlags.Channels = []metav1.TypeMeta{testlib.DefaultChannel}
 	flag.Var(&EventingFlags.Channels, "channels", ChannelUsage)
-	flag.StringVar(&EventingFlags.BrokerClass, "brokerclass", "MTChannelBasedBroker", BrokerClassUsage)
+
 	flag.Var(&EventingFlags.Sources, "sources", SourceUsage)
 	flag.StringVar(&EventingFlags.PipeFile, "pipefile", "/tmp/prober-signal", "Temporary file to write the prober signal into.")
 	flag.StringVar(&EventingFlags.ReadyFile, "readyfile", "/tmp/prober-ready", "Temporary file to get the prober result.")
@@ -63,18 +63,4 @@ func InitializeEventingFlags() {
 	// Might be useful in restricted environments where namespaces need to be
 	// created by a user with increased privileges (admin).
 	flag.BoolVar(&EventingFlags.ReuseNamespace, "reusenamespace", false, "Whether to re-use namespace for a test if it already exists.")
-	flag.Parse()
-
-	// If no channel is passed through the flag, initialize it as the DefaultChannel.
-	if EventingFlags.Channels == nil || len(EventingFlags.Channels) == 0 {
-		EventingFlags.Channels = []metav1.TypeMeta{testlib.DefaultChannel}
-	}
-
-	if EventingFlags.BrokerClass == "" {
-		log.Fatalf("Brokerclass not specified")
-	}
-
-	if EventingFlags.BrokerClass != "MTChannelBasedBroker" {
-		log.Fatalf("Invalid Brokerclass specified, got %q must be %q", EventingFlags.BrokerClass, "MTChannelBasedBroker")
-	}
 }

--- a/test/flags/eventing_environment.go
+++ b/test/flags/eventing_environment.go
@@ -18,7 +18,6 @@ package flags
 
 // EventingEnvironmentFlags holds the e2e flags needed only by the eventing repo.
 type EventingEnvironmentFlags struct {
-	BrokerClass string
 	Channels
 	Sources
 	Brokers

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -26,11 +26,10 @@ import (
 	"knative.dev/pkg/test/zipkin"
 )
 
-// RunMainTest initializes the flags to run the eventing upgrade tests, and runs the channel tests.
+// RunMainTest expects flags to be already initialized.
 // This function needs to be exposed, so that test cases in other repositories can call the upgrade
 // main tests in eventing.
 func RunMainTest(m *testing.M) {
-	test.InitializeEventingFlags()
 	channelTestRunner = testlib.ComponentsTestRunner{
 		ComponentFeatureMap: testlib.ChannelFeatureMap,
 		ComponentsToTest:    test.EventingFlags.Channels,

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -20,8 +20,10 @@ limitations under the License.
 package upgrade
 
 import (
+	"flag"
 	"testing"
 
+	"knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/upgrade/installation"
 	"knative.dev/pkg/system"
@@ -70,5 +72,7 @@ func TestEventingUpgrades(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	test.InitializeEventingFlags()
+	flag.Parse()
 	RunMainTest(m)
 }


### PR DESCRIPTION
Provides better flexibility for reusing in downstream repositories. It is now possible to initialize flags from this repo and any additional flags from downstream repositories and then call flag.Parse explicitly to fill the flags. Then it's possible to run RunMainTest independently.

This is especially useful when we want to combine REKT tests with upgrade test suite.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove BrokerClass flag and make it a const, there's only one possible value anyway.
- Pull `flag.Parse()` out of InitializeEventingFlags.
- It is now possible to do something like this in downstream repos and combine tests with REKT framework:
```
func TestMain(m *testing.M) {
	// Initialize any Eventing flags here.
        eventingtest.InitializeEventingFlags()

	restConfig, err := pkgTest.Flags.ClientConfig.GetRESTConfig()
	if err != nil {
		log.Fatal("Error building client config: ", err)
	}
        
        // Initialize additional REKT flags.
        // This function calls `flag.Parse()` internally
	global = environment.NewStandardGlobalEnvironment(func(cfg environment.Configuration) environment.Configuration {
		cfg.Config = restConfig
		return cfg
	})

        // Run the test suite.
	eventingupgrade.RunMainTest(m)
}
```

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

