### PR TITLE
Updated DEVELOPMENT.md to provide better instructions on setting up kubernetes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,7 @@ You must install these tools:
 
 1. Set up a kubernetes cluster. You can use one of the resources below, or any other kubernetes cluster:
    - [minikube start](https://minikube.sigs.k8s.io/docs/start/)
-   - [KinD quickstart](https://minikube.sigs.k8s.io/docs/start/)
+   - [KinD quickstart](https://kind.sigs.k8s.io/docs/user/quick-start/)
 1. Set up a Linux Container repository for pushing images. You can use any
    container image registry by adjusting the authentication methods and
    repository paths mentioned in the sections below.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,12 +42,9 @@ You must install these tools:
 
 ### Create a cluster and a repo
 
-1. [Set up a kubernetes cluster](https://www.knative.dev/docs/install/)
-   - Follow an install guide up through "Creating a Kubernetes Cluster"
-   - You do _not_ need to install Istio or Knative using the instructions in the
-     guide. Simply create the cluster and come back here.
-   - If you _did_ install Istio/Knative following those instructions, that's
-     fine too, you'll just redeploy over them, below.
+1. Set up a kubernetes cluster. You can use one of the resources below, or any other kubernetes cluster:
+   - [minikube start](https://minikube.sigs.k8s.io/docs/start/)
+   - [KinD quickstart](https://minikube.sigs.k8s.io/docs/start/)
 1. Set up a Linux Container repository for pushing images. You can use any
    container image registry by adjusting the authentication methods and
    repository paths mentioned in the sections below.


### PR DESCRIPTION
# Fixes

<!-- Please include the 'why' behind your changes if no issue exists -->
When following `DEVELOPMENT.md` to get set up to develop on this project, I noticed that the section on setting up a kubernetes cluster linked to a page which didn't seem to cover how to set up a kubernetes cluster.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Update `DEVELOPMENT.md` to provide more helpful links to setting up a kubernetes cluster locally


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

As this PR only updates the development setup docs, I don't think these requirements apply to it.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

