### PR TITLE
Make ServerManager independent from kncloudevents package

### DIFF
--- a/pkg/eventingtls/servermanager.go
+++ b/pkg/eventingtls/servermanager.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 
 	"knative.dev/eventing/pkg/apis/feature"
-	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 )
@@ -35,14 +34,18 @@ import (
 // permissive: both http and https servers
 // strict: only https server
 type ServerManager struct {
-	httpReceiver  *kncloudevents.HTTPMessageReceiver
-	httpsReceiver *kncloudevents.HTTPMessageReceiver
+	httpReceiver  Receiver
+	httpsReceiver Receiver
 	handler       http.Handler
 	cmw           configmap.Watcher
 	featureStore  *feature.Store
 }
 
-func NewServerManager(ctx context.Context, httpReceiver, httpsReceiver *kncloudevents.HTTPMessageReceiver, handler http.Handler, cmw configmap.Watcher) (*ServerManager, error) {
+type Receiver interface {
+	StartListen(context.Context, http.Handler) error
+}
+
+func NewServerManager(ctx context.Context, httpReceiver, httpsReceiver Receiver, handler http.Handler, cmw configmap.Watcher) (*ServerManager, error) {
 	if httpReceiver == nil || httpsReceiver == nil {
 		return nil, fmt.Errorf("message receiver not provided")
 	}

--- a/pkg/eventingtls/servermanager_test.go
+++ b/pkg/eventingtls/servermanager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package eventingtls
+package eventingtls_test
 
 import (
 	"context"
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/eventing/pkg/apis/feature"
+	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/configmap"
 )
@@ -62,7 +63,7 @@ func TestStartServers(t *testing.T) {
 			errChan := make(chan error)
 
 			cmw := newFeatureCMW(tc.transportEncryption)
-			sm, err := NewServerManager(ctx, httpReceiver, httpsReceiver, &basicHandler{}, cmw)
+			sm, err := eventingtls.NewServerManager(ctx, httpReceiver, httpsReceiver, &basicHandler{}, cmw)
 			assert.NoError(t, err)
 			go func() {
 				errChan <- sm.StartServers(ctx)
@@ -109,11 +110,11 @@ func TestStartServersHttpError(t *testing.T) {
 	cmw := newFeatureCMW(feature.Disabled)
 
 	// httpReceiver set to nil
-	_, err := NewServerManager(ctx, nil, receiver, &basicHandler{}, cmw)
+	_, err := eventingtls.NewServerManager(ctx, nil, receiver, &basicHandler{}, cmw)
 	assert.Error(t, err)
 
 	// httpsReceiver set to nil
-	_, err = NewServerManager(ctx, receiver, nil, &basicHandler{}, cmw)
+	_, err = eventingtls.NewServerManager(ctx, receiver, nil, &basicHandler{}, cmw)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Currently the eventingtls package depends on the kncloudevents package. This leads to circular dependencies, when using eventingtls for testing in kncloudevents.
This PR removes the dependency from eventingtls to kncloudevents.

## Proposed Changes

- :broom: Remove dependency from `eventingtls` to `kncloudevents` package