### PR TITLE
Upgrade e2e test to Kubernetes 1.27.1

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.3
+        - v1.27.1
 
         test-suite:
         - ./test/rekt/...
@@ -27,11 +27,11 @@ jobs:
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.17.0
+        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.19.0
         include:
-        - k8s-version: v1.25.3
-          kind-version: v0.17.0
-          kind-image-sha: sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
+        - k8s-version: v1.27.1
+          kind-version: v0.19.0
+          kind-image-sha: sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e


### PR DESCRIPTION
As per title (latest [kind support](https://github.com/kubernetes-sigs/kind/releases/tag/v0.19.0)s 1.27.1).