### PR TITLE
Only check if the reference does exist

### DIFF
--- a/pkg/apis/eventing/v1beta2/eventtype_lifecycle_test.go
+++ b/pkg/apis/eventing/v1beta2/eventtype_lifecycle_test.go
@@ -43,11 +43,6 @@ var (
 		Status: corev1.ConditionTrue,
 	}
 
-	eventTypeConditionBrokerReady = apis.Condition{
-		Type:   EventTypeConditionBrokerReady,
-		Status: corev1.ConditionTrue,
-	}
-
 	ignoreAllButTypeAndStatus = cmpopts.IgnoreFields(
 		apis.Condition{},
 		"LastTransitionTime", "Message", "Reason", "Severity")
@@ -89,30 +84,6 @@ func TestEventTypeGetCondition(t *testing.T) {
 		},
 		condQuery: EventTypeConditionBrokerExists,
 		want:      &eventTypeConditionBrokerExists,
-	}, {
-		name: "multiple conditions, condition true",
-		ets: &EventTypeStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{
-					eventTypeConditionBrokerExists,
-					eventTypeConditionBrokerReady,
-				},
-			},
-		},
-		condQuery: EventTypeConditionBrokerReady,
-		want:      &eventTypeConditionBrokerReady,
-	}, {
-		name: "unknown condition",
-		ets: &EventTypeStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{
-					eventTypeConditionBrokerReady,
-					eventTypeConditionReady,
-				},
-			},
-		},
-		condQuery: apis.ConditionType("foo"),
-		want:      nil,
 	}}
 
 	for _, test := range tests {
@@ -139,9 +110,6 @@ func TestEventTypeInitializeConditions(t *testing.T) {
 					Type:   EventTypeConditionBrokerExists,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   EventTypeConditionBrokerReady,
-					Status: corev1.ConditionUnknown,
-				}, {
 					Type:   EventTypeConditionReady,
 					Status: corev1.ConditionUnknown,
 				},
@@ -164,38 +132,12 @@ func TestEventTypeInitializeConditions(t *testing.T) {
 					Type:   EventTypeConditionBrokerExists,
 					Status: corev1.ConditionFalse,
 				}, {
-					Type:   EventTypeConditionBrokerReady,
-					Status: corev1.ConditionUnknown,
-				}, {
 					Type:   EventTypeConditionReady,
 					Status: corev1.ConditionUnknown,
 				}},
 			},
 		},
-	}, {
-		name: "one true",
-		ets: &EventTypeStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   EventTypeConditionBrokerReady,
-					Status: corev1.ConditionTrue,
-				}},
-			},
-		},
-		want: &EventTypeStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   EventTypeConditionBrokerExists,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   EventTypeConditionBrokerReady,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   EventTypeConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		}},
+	},
 	}
 
 	for _, test := range tests {
@@ -230,16 +172,6 @@ func TestEventTypeConditionStatus(t *testing.T) {
 		brokerStatus:        nil,
 		wantConditionStatus: corev1.ConditionFalse,
 	}, {
-		name:                "broker ready sad",
-		markBrokerExists:    &trueValue,
-		brokerStatus:        eventingv1.TestHelper.FalseBrokerStatus(),
-		wantConditionStatus: corev1.ConditionFalse,
-	}, {
-		name:                "broker ready unknown",
-		markBrokerExists:    &trueValue,
-		brokerStatus:        eventingv1.TestHelper.UnknownBrokerStatus(),
-		wantConditionStatus: corev1.ConditionUnknown,
-	}, {
 		name:                "all sad",
 		markBrokerExists:    &falseValue,
 		brokerStatus:        nil,
@@ -254,9 +186,6 @@ func TestEventTypeConditionStatus(t *testing.T) {
 				} else {
 					ets.MarkBrokerDoesNotExist()
 				}
-			}
-			if test.brokerStatus != nil {
-				ets.PropagateBrokerStatus(test.brokerStatus)
 			}
 
 			got := ets.GetTopLevelCondition().Status

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -75,8 +75,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta2.EventType) p
 		return err
 	}
 
-	et.Status.PropagateBrokerStatus(&b.Status)
-
 	return nil
 }
 

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -116,7 +116,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeSource(eventTypeSource),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 				WithEventTypeBrokerExists,
-				WithEventTypeBrokerFailed("DeploymentFailure", "inducing failure for create deployments"),
 			),
 		}},
 	}, {
@@ -138,7 +137,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeSource(eventTypeSource),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 				WithEventTypeBrokerExists,
-				WithEventTypeBrokerUnknown("", ""),
 			),
 		}},
 	}, {
@@ -160,7 +158,6 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeSource(eventTypeSource),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 				WithEventTypeBrokerExists,
-				WithEventTypeBrokerReady,
 			),
 		}},
 	}}

--- a/pkg/reconciler/testing/v1/eventtype.go
+++ b/pkg/reconciler/testing/v1/eventtype.go
@@ -102,20 +102,3 @@ func WithEventTypeBrokerDoesNotExist(et *v1beta2.EventType) {
 func WithEventTypeBrokerExists(et *v1beta2.EventType) {
 	et.Status.MarkBrokerExists()
 }
-
-func WithEventTypeBrokerFailed(reason, message string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Status.MarkBrokerFailed(reason, message)
-	}
-}
-
-func WithEventTypeBrokerUnknown(reason, message string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Status.MarkBrokerUnknown(reason, message)
-	}
-}
-
-// WithEventTypeBrokerReady calls .Status.MarkBrokerReady on the EventType.
-func WithEventTypeBrokerReady(et *v1beta2.EventType) {
-	et.Status.MarkBrokerReady()
-}

--- a/pkg/reconciler/testing/v1beta2/eventtype.go
+++ b/pkg/reconciler/testing/v1beta2/eventtype.go
@@ -102,20 +102,3 @@ func WithEventTypeBrokerDoesNotExist(et *v1beta2.EventType) {
 func WithEventTypeBrokerExists(et *v1beta2.EventType) {
 	et.Status.MarkBrokerExists()
 }
-
-func WithEventTypeBrokerFailed(reason, message string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Status.MarkBrokerFailed(reason, message)
-	}
-}
-
-func WithEventTypeBrokerUnknown(reason, message string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Status.MarkBrokerUnknown(reason, message)
-	}
-}
-
-// WithEventTypeBrokerReady calls .Status.MarkBrokerReady on the EventType.
-func WithEventTypeBrokerReady(et *v1beta2.EventType) {
-	et.Status.MarkBrokerReady()
-}


### PR DESCRIPTION
Fixes #

- Do not check if the reference is `ready`, just if it exists. This is good enough from make use of the `EventType` for building up on (e.g. generating triggers)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

