### PR TITLE
Rename more to Resource, instead of broker

### DIFF
--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -89,7 +89,7 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeSource(eventTypeSource),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 				WithInitEventTypeConditions,
-				WithEventTypeBrokerDoesNotExist,
+				WithEventTypeResourceDoesNotExist,
 			),
 		}},
 		WantErr: true,

--- a/pkg/reconciler/testing/v1/eventtype.go
+++ b/pkg/reconciler/testing/v1/eventtype.go
@@ -93,8 +93,8 @@ func WithEventTypeDeletionTimestamp(et *v1beta2.EventType) {
 	et.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
-// WithEventTypeBrokerNotFound calls .Status.MarkFilterFailed on the EventType.
-func WithEventTypeBrokerDoesNotExist(et *v1beta2.EventType) {
+// WithEventTypeResourceDoesNotExist calls .Status.MarkFilterFailed on the EventType.
+func WithEventTypeResourceDoesNotExist(et *v1beta2.EventType) {
 	et.Status.MarkReferenceDoesNotExist()
 }
 

--- a/pkg/reconciler/testing/v1beta2/eventtype.go
+++ b/pkg/reconciler/testing/v1beta2/eventtype.go
@@ -93,7 +93,7 @@ func WithEventTypeDeletionTimestamp(et *v1beta2.EventType) {
 	et.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
-// WithEventTypeBrokerNotFound calls .Status.MarkFilterFailed on the EventType.
+// WithEventTypeResourceDoesNotExist calls .Status.MarkFilterFailed on the EventType.
 func WithEventTypeResourceDoesNotExist(et *v1beta2.EventType) {
 	et.Status.MarkReferenceDoesNotExist()
 }


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- nit: rename test func, to better reflect that we work with a Resource, and not just a broker

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

