### PR TITLE
Run TLS e2e tests only when Istio is not enabled

### DIFF
--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -23,5 +23,4 @@ const (
 	KReferenceMapping   = "kreference-mapping"
 	NewTriggerFilters   = "new-trigger-filters"
 	TransportEncryption = "transport-encryption"
-	Istio               = "istio"
 )

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -23,4 +23,5 @@ const (
 	KReferenceMapping   = "kreference-mapping"
 	NewTriggerFilters   = "new-trigger-filters"
 	TransportEncryption = "transport-encryption"
+	Istio               = "istio"
 )

--- a/pkg/resolver/kresource_resolver.go
+++ b/pkg/resolver/kresource_resolver.go
@@ -4,13 +4,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0 
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. 
+limitations under the License.
 */
 
 package resolver

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -39,6 +39,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/sources"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/features/source"
 	"knative.dev/eventing/test/rekt/resources/account_role"
 	"knative.dev/eventing/test/rekt/resources/apiserversource"
@@ -175,6 +176,8 @@ func SendsEventsWithTLS() *feature.Feature {
 	sink := feature.MakeRandomK8sName("sink")
 
 	f := feature.NewFeatureNamed("Send events to TLS sink")
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
 

--- a/test/rekt/features/containersource/features.go
+++ b/test/rekt/features/containersource/features.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/containersource"
 )
 
@@ -123,6 +124,8 @@ func SendEventsWithTLSRecieverAsSink() *feature.Feature {
 	source := feature.MakeRandomK8sName("containersource")
 	sink := feature.MakeRandomK8sName("sink")
 	f := feature.NewFeature()
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
 

--- a/test/rekt/features/featureflags/featureflags.go
+++ b/test/rekt/features/featureflags/featureflags.go
@@ -42,6 +42,20 @@ func TransportEncryptionPermissiveOrStrict() feature.ShouldRun {
 	}
 }
 
+func IstioDisabled() feature.ShouldRun {
+	return func(ctx context.Context, t feature.T) (feature.PrerequisiteResult, error) {
+		flags, err := getFeatureFlags(ctx, "config-features")
+		if err != nil {
+			return feature.PrerequisiteResult{}, err
+		}
+
+		return feature.PrerequisiteResult{
+			ShouldRun: !flags.IsEnabled(apifeature.Istio),
+			Reason:    flags.String(),
+		}, nil
+	}
+}
+
 func getFeatureFlags(ctx context.Context, cmName string) (apifeature.Flags, error) {
 	ns := system.Namespace()
 	cm, err := kubeclient.Get(ctx).

--- a/test/rekt/features/featureflags/featureflags.go
+++ b/test/rekt/features/featureflags/featureflags.go
@@ -28,6 +28,10 @@ import (
 	apifeature "knative.dev/eventing/pkg/apis/feature"
 )
 
+const (
+	istioFeatureFlagName = "istio"
+)
+
 func TransportEncryptionPermissiveOrStrict() feature.ShouldRun {
 	return func(ctx context.Context, t feature.T) (feature.PrerequisiteResult, error) {
 		flags, err := getFeatureFlags(ctx, "config-features")
@@ -50,7 +54,7 @@ func IstioDisabled() feature.ShouldRun {
 		}
 
 		return feature.PrerequisiteResult{
-			ShouldRun: !flags.IsEnabled(apifeature.Istio),
+			ShouldRun: !flags.IsEnabled(istioFeatureFlagName),
 			Reason:    flags.String(),
 		}, nil
 	}

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -31,6 +31,7 @@ import (
 	eventassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/features/source"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/eventtype"
@@ -59,6 +60,8 @@ func SendsEventsTLS() *feature.Feature {
 	src := feature.MakeRandomK8sName("pingsource")
 	sink := feature.MakeRandomK8sName("sink")
 	f := feature.NewFeature()
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
 

--- a/test/rekt/features/sinkbinding/feature.go
+++ b/test/rekt/features/sinkbinding/feature.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/reconciler-test/pkg/resources/deployment"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/sinkbinding"
 )
 
@@ -127,6 +128,8 @@ func SinkBindingV1DeploymentTLS(ctx context.Context) *feature.Feature {
 	extensionSecret := string(uuid.NewUUID())
 
 	f := feature.NewFeatureNamed("SinkBinding V1 Deployment test")
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
 
 	env := environment.FromContext(ctx)
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -28,6 +28,7 @@ import (
 
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 
+	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/trigger"
@@ -89,6 +90,8 @@ func TriggerDependencyAnnotation() *feature.Feature {
 
 func TriggerWithTLSSubscriber() *feature.Feature {
 	f := feature.NewFeatureNamed("Trigger with TLS subscriber")
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
 
 	brokerName := feature.MakeRandomK8sName("broker")
 	sourceName := feature.MakeRandomK8sName("source")


### PR DESCRIPTION
Currently the TLS e2e tests run, even when Istio is enabled. This PR addresses it, and adds a prerequisite to the TLS tests to run only, if the istio feature flag is not enabled.