### PR TITLE
We should not limit the EventType creation from the Sources Duck to just brokers

### DIFF
--- a/pkg/reconciler/source/duck/duck.go
+++ b/pkg/reconciler/source/duck/duck.go
@@ -153,7 +153,7 @@ func (r *Reconciler) makeEventTypes(ctx context.Context, src *duckv1.Source) []v
 	// Only create EventTypes for Broker sinks, for now
 	// We add this check here in case the Source was changed from Broker to non-Broker sink.
 	// If so, we need to delete the existing ones, thus we return empty expected.
-	if ref := src.Spec.Sink.GetRef(); ref == nil || ref.Kind != "Broker" {
+	if ref := src.Spec.Sink.GetRef(); ref == nil {
 		return make([]v1beta2.EventType, 0)
 	}
 

--- a/pkg/reconciler/source/duck/duck.go
+++ b/pkg/reconciler/source/duck/duck.go
@@ -150,7 +150,6 @@ func (r *Reconciler) getEventTypes(ctx context.Context, src *duckv1.Source) ([]v
 }
 
 func (r *Reconciler) makeEventTypes(ctx context.Context, src *duckv1.Source) []v1beta2.EventType {
-	// Only create EventTypes for Broker sinks, for now
 	// We add this check here in case the Source was changed from Broker to non-Broker sink.
 	// If so, we need to delete the existing ones, thus we return empty expected.
 	if ref := src.Spec.Sink.GetRef(); ref == nil {


### PR DESCRIPTION
We should not limit the EventType creation from the Sources Duck to just brokers
If we do create those for all, we have much better visibility into our system on what events are being emitted

Fixes #7033

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Do not restrict Source duck to just broker for event type creation

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Source duck compliant source now create EventTypes for KResources, not just brokers
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

