### PR TITLE
Send namespace header in MT components

### DIFF
--- a/pkg/adapter/mtping/runner.go
+++ b/pkg/adapter/mtping/runner.go
@@ -192,7 +192,7 @@ func (a *cronJobsRunner) newPingSourceClient(source *sourcesv1.PingSource) (adap
 	var env adapter.EnvConfig
 	if a.clientConfig.Env != nil {
 		env = adapter.EnvConfig{
-			Namespace:      a.clientConfig.Env.GetNamespace(),
+			Namespace:      source.GetNamespace(),
 			Name:           a.clientConfig.Env.GetName(),
 			EnvSinkTimeout: fmt.Sprintf("%d", a.clientConfig.Env.GetSinktimeout()),
 		}

--- a/pkg/adapter/v2/cloudevents.go
+++ b/pkg/adapter/v2/cloudevents.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 
 	"knative.dev/eventing/pkg/adapter/v2/util/crstatusevent"
+	"knative.dev/eventing/pkg/apis"
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/metrics/source"
 	obsclient "knative.dev/eventing/pkg/observability/client"
@@ -171,6 +172,8 @@ func NewClient(cfg ClientConfig) (Client, error) {
 				return nil, err
 			}
 		}
+
+		pOpts = append(pOpts, http.WithHeader(apis.KnNamespaceHeader, cfg.Env.GetNamespace()))
 	}
 
 	pOpts = append(pOpts, http.WithRoundTripper(transport))

--- a/pkg/apis/http.go
+++ b/pkg/apis/http.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+const (
+	KnNamespaceHeader = "Kn-Namespace"
+)

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -32,10 +32,12 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding/buffering"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"knative.dev/eventing/pkg/apis"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/kncloudevents"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 const (
@@ -191,6 +193,7 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 			go func(m binding.Message, h nethttp.Header, s *trace.Span, r *channel.StatsReporter, args *channel.ReportArgs) {
 				// Run async dispatch with background context.
 				ctx = trace.NewContext(context.Background(), s)
+				h.Set(apis.KnNamespaceHeader, ref.Namespace)
 				// Any returned error is already logged in f.dispatch().
 				dispatchResultForFanout := f.dispatch(ctx, subs, m, h)
 				_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -38,6 +38,8 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
 
+	eventingapis "knative.dev/eventing/pkg/apis"
+
 	"knative.dev/eventing/pkg/broker"
 	"knative.dev/eventing/pkg/channel/attributes"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -146,6 +148,13 @@ func (d *MessageDispatcherImpl) DispatchMessageWithRetries(ctx context.Context, 
 		// No destination url, try to send to reply if available
 		responseMessage = message
 		responseAdditionalHeaders = additionalHeaders
+	}
+
+	if additionalHeaders.Get(eventingapis.KnNamespaceHeader) != "" {
+		if responseAdditionalHeaders == nil {
+			responseAdditionalHeaders = make(nethttp.Header)
+		}
+		responseAdditionalHeaders.Set(eventingapis.KnNamespaceHeader, additionalHeaders.Get(eventingapis.KnNamespaceHeader))
 	}
 
 	// No response, dispatch completed

--- a/test/rekt/features/channel/features.go
+++ b/test/rekt/features/channel/features.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -35,6 +36,7 @@ import (
 
 	eventasssert "knative.dev/reconciler-test/pkg/eventshub/assert"
 
+	"knative.dev/eventing/test/rekt/features"
 	"knative.dev/eventing/test/rekt/resources/channel"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/containersource"
@@ -107,10 +109,12 @@ func DeadLetterSink(createSubscriberFn func(ref *duckv1.KReference, uri string) 
 	f.Requirement("containersource is ready", containersource.IsReady(cs))
 	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(name, channel_impl.GVR()))
 
-	f.Assert("dls receives events", assert.OnStore(sink).
-		MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
-		AtLeast(1),
-	)
+	f.Assert("dls receives events", func(ctx context.Context, t feature.T) {
+		assert.OnStore(sink).
+			Match(features.HasKnNamespaceHeader(environment.FromContext(ctx).Namespace())).
+			MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
+			AtLeast(1)(ctx, t)
+	})
 
 	return f
 }
@@ -140,10 +144,12 @@ func DeadLetterSinkGenericChannel(createSubscriberFn func(ref *duckv1.KReference
 	f.Requirement("containersource is ready", containersource.IsReady(cs))
 	f.Requirement("Channel has dead letter sink uri", channel_impl.HasDeadLetterSinkURI(name, channel.GVR()))
 
-	f.Assert("dls receives events", assert.OnStore(sink).
-		MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
-		AtLeast(1),
-	)
+	f.Assert("dls receives events", func(ctx context.Context, t feature.T) {
+		assert.OnStore(sink).
+			Match(features.HasKnNamespaceHeader(environment.FromContext(ctx).Namespace())).
+			MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).
+			AtLeast(1)(ctx, t)
+	})
 
 	return f
 }
@@ -306,10 +312,12 @@ func ChannelPreferHeaderCheck(createSubscriberFn func(ref *duckv1.KReference, ur
 	))
 
 	f.Stable("test message without explicit prefer header should have the header").
-		Must("delivers events",
+		Must("delivers events", func(ctx context.Context, t feature.T) {
 			eventasssert.OnStore(sink).Match(
+				features.HasKnNamespaceHeader(environment.FromContext(ctx).Namespace()),
 				eventasssert.HasAdditionalHeader("Prefer", "reply"),
-			).AtLeast(1))
+			).AtLeast(1)(ctx, t)
+		})
 
 	return f
 }

--- a/test/rekt/features/matchers.go
+++ b/test/rekt/features/matchers.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+
+	"knative.dev/reconciler-test/pkg/eventshub"
+
+	"knative.dev/eventing/pkg/apis"
+)
+
+func HasKnNamespaceHeader(ns string) eventshub.EventInfoMatcher {
+	return func(info eventshub.EventInfo) error {
+		values, ok := info.HTTPHeaders[apis.KnNamespaceHeader]
+		if !ok {
+			return fmt.Errorf("%s header not found", apis.KnNamespaceHeader)
+		}
+		for _, v := range values {
+			if v == ns {
+				return nil
+			}
+		}
+		return fmt.Errorf("wanted %s header to have value %s, got %+v", apis.KnNamespaceHeader, ns, values)
+	}
+}


### PR DESCRIPTION
When running MT components [1] in mesh mode with Istio, 
we lose the ability to define fine grained policies since we
don't know the resource namespace that originated such
request, therefore, by having a `Kn-Namespace` header, 
in mesh mode, users case define fine-grained policies and
isolate namespaces.

[1] IMC, MTChannelBasedBroker, and PingSource