### PR TITLE
Refactor kncloudevent package to be able to use a test client

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -40,6 +40,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/broker/filter"
 	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
+	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/reconciler/names"
 )
 
@@ -118,9 +119,11 @@ func main() {
 
 	reporter := filter.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 
+	client := kncloudevents.NewClient()
+
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	handler, err := filter.NewHandler(logger, triggerinformer.Get(ctx), reporter, ctxFunc)
+	handler, err := filter.NewHandler(client, logger, triggerinformer.Get(ctx), reporter, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -297,7 +297,7 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target duc
 	}
 
 	// Send the event to the subscriber
-	req, err := h.client.NewRequest(ctx, target)
+	req, err := kncloudevents.NewRequest(ctx, target)
 	if err != nil {
 		responseErr.err = fmt.Errorf("failed to create the request: %w", err)
 		return nil, responseErr
@@ -319,7 +319,7 @@ func (h *Handler) sendEvent(ctx context.Context, headers http.Header, target duc
 	}
 
 	start := time.Now()
-	resp, err := req.Send()
+	resp, err := h.client.Send(req)
 	dispatchTime := time.Since(start)
 	if err != nil {
 		responseErr.ResponseCode = http.StatusInternalServerError

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -42,6 +42,7 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/broker"
+	"knative.dev/eventing/pkg/kncloudevents"
 	reconcilertesting "knative.dev/pkg/reconciler/testing"
 
 	triggerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
@@ -438,6 +439,7 @@ func TestReceiver(t *testing.T) {
 			}
 			reporter := &mockReporter{}
 			r, err := NewHandler(
+				kncloudevents.NewClient(),
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				triggerinformerfake.Get(ctx),
 				reporter,
@@ -608,6 +610,7 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 			}
 			reporter := &mockReporter{}
 			r, err := NewHandler(
+				kncloudevents.NewClient(),
 				zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())),
 				triggerinformerfake.Get(ctx),
 				reporter,

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -212,7 +212,7 @@ func (d *MessageDispatcherImpl) executeRequest(ctx context.Context,
 	ctx, span := trace.StartSpan(ctx, "knative.dev", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
-	req, err := d.client.NewRequest(ctx, *target)
+	req, err := kncloudevents.NewRequest(ctx, *target)
 	if err != nil {
 		return ctx, nil, nil, &execInfo, err
 	}
@@ -227,7 +227,7 @@ func (d *MessageDispatcherImpl) executeRequest(ctx context.Context,
 	}
 
 	start := time.Now()
-	response, err := req.SendWithRetries(configs)
+	response, err := d.client.SendWithRetries(req, configs)
 	dispatchTime := time.Since(start)
 	if err != nil {
 		execInfo.Time = dispatchTime

--- a/pkg/channel/message_dispatcher.go
+++ b/pkg/channel/message_dispatcher.go
@@ -72,6 +72,7 @@ var _ MessageDispatcher = &MessageDispatcherImpl{}
 type MessageDispatcherImpl struct {
 	supportedSchemes sets.String
 
+	client kncloudevents.Client
 	logger *zap.Logger
 }
 
@@ -85,6 +86,7 @@ type DispatchExecutionInfo struct {
 func NewMessageDispatcher(logger *zap.Logger) *MessageDispatcherImpl {
 	return &MessageDispatcherImpl{
 		supportedSchemes: sets.NewString("http", "https"),
+		client:           kncloudevents.NewClient(),
 		logger:           logger,
 	}
 }
@@ -210,7 +212,7 @@ func (d *MessageDispatcherImpl) executeRequest(ctx context.Context,
 	ctx, span := trace.StartSpan(ctx, "knative.dev", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
-	req, err := kncloudevents.NewCloudEventRequest(ctx, *target)
+	req, err := d.client.NewRequest(ctx, *target)
 	if err != nil {
 		return ctx, nil, nil, &execInfo, err
 	}

--- a/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
@@ -102,12 +102,12 @@ func BenchmarkDispatcher_dispatch_ok_through_2_channels(b *testing.B) {
 	// Start the bench
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		req, _ := client.NewRequest(context.Background(), *channelA)
+		req, _ := kncloudevents.NewRequest(context.Background(), *channelA)
 
 		event := test.FullEvent()
 		_ = protocolhttp.WriteRequest(context.Background(), binding.ToMessage(&event), req.HTTPRequest())
 
-		_, _ = req.Send()
+		_, _ = client.Send(req)
 	}
 }
 

--- a/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
+++ b/pkg/inmemorychannel/message_dispatcher_benchmark_test.go
@@ -97,14 +97,15 @@ func BenchmarkDispatcher_dispatch_ok_through_2_channels(b *testing.B) {
 	dispatcher := NewMessageDispatcher(dispatcherArgs)
 	requestHandler := kncloudevents.CreateHandler(dispatcher.handler)
 	httpSender.Client = mockedHTTPClient(clientMock(channelA.URL.Host, transformations.URL.Host, channelB.URL.Host, receiver.URL.Host, requestHandler))
+	client := kncloudevents.NewClient()
 
 	// Start the bench
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		req, _ := kncloudevents.NewCloudEventRequest(context.Background(), *channelA)
+		req, _ := client.NewRequest(context.Background(), *channelA)
 
 		event := test.FullEvent()
-		_ = protocolhttp.WriteRequest(context.Background(), binding.ToMessage(&event), req.Request)
+		_ = protocolhttp.WriteRequest(context.Background(), binding.ToMessage(&event), req.HTTPRequest())
 
 		_, _ = req.Send()
 	}

--- a/pkg/kncloudevents/client.go
+++ b/pkg/kncloudevents/client.go
@@ -17,14 +17,19 @@ limitations under the License.
 package kncloudevents
 
 import (
-	"context"
+	"fmt"
 	nethttp "net/http"
+	"strconv"
+	"time"
 
-	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
+const RetryAfterHeader = "Retry-After"
+
 type Client interface {
-	NewRequest(ctx context.Context, target duckv1.Addressable) (Request, error)
+	Send(*Request) (*nethttp.Response, error)
+	SendWithRetries(*Request, *RetryConfig) (*nethttp.Response, error)
 }
 
 var _ Client = (*clientImpl)(nil)
@@ -40,14 +45,138 @@ func newClientImpl() clientImpl {
 	return clientImpl{}
 }
 
-func (c *clientImpl) NewRequest(ctx context.Context, target duckv1.Addressable) (Request, error) {
-	nethttpReqest, err := nethttp.NewRequestWithContext(ctx, "POST", target.URL.String(), nil)
+func (c *clientImpl) Send(req *Request) (*nethttp.Response, error) {
+	client, err := getClientForAddressable(req.target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client for addressable: %w", err)
+	}
+
+	return client.Do(req.HTTPRequest())
+}
+
+func (c *clientImpl) SendWithRetries(req *Request, config *RetryConfig) (*nethttp.Response, error) {
+	if config == nil {
+		return c.Send(req)
+	}
+
+	client, err := getClientForAddressable(req.target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client for addressable: %w", err)
+	}
+
+	if config.RequestTimeout != 0 {
+		client = &nethttp.Client{
+			Transport:     client.Transport,
+			CheckRedirect: client.CheckRedirect,
+			Jar:           client.Jar,
+			Timeout:       config.RequestTimeout,
+		}
+	}
+
+	retryableClient := retryablehttp.Client{
+		HTTPClient:   client,
+		RetryWaitMin: defaultRetryWaitMin,
+		RetryWaitMax: defaultRetryWaitMax,
+		RetryMax:     config.RetryMax,
+		CheckRetry:   retryablehttp.CheckRetry(config.CheckRetry),
+		Backoff:      generateBackoffFn(config),
+		ErrorHandler: func(resp *nethttp.Response, err error, numTries int) (*nethttp.Response, error) {
+			return resp, err
+		},
+	}
+
+	retryableReq, err := retryablehttp.FromRequest(req.HTTPRequest())
 	if err != nil {
 		return nil, err
 	}
 
-	return &requestImpl{
-		Target:  target,
-		Request: nethttpReqest,
-	}, nil
+	return retryableClient.Do(retryableReq)
+}
+
+// generateBackoffFunction returns a valid retryablehttp.Backoff implementation which
+// wraps the provided RetryConfig.Backoff implementation with optional "Retry-After"
+// header support.
+func generateBackoffFn(config *RetryConfig) retryablehttp.Backoff {
+	return func(_, _ time.Duration, attemptNum int, resp *nethttp.Response) time.Duration {
+
+		//
+		// NOTE - The following logic will need to be altered slightly once the "delivery-retryafter"
+		//        experimental-feature graduates from Alpha/Beta to Stable/GA.  This is according to
+		//        plan as described in https://github.com/knative/eventing/issues/5811.
+		//
+		//        During the Alpha/Beta stages the ability to respect Retry-After headers is "opt-in"
+		//        requiring the DeliverySpec.RetryAfterMax to be populated.  The Stable/GA behavior
+		//        will be "opt-out" where Retry-After headers are always respected (in the context of
+		//        calculating backoff durations for 429 / 503 responses) unless the
+		//        DeliverySpec.RetryAfterMax is set to "PT0S".
+		//
+		//        While this might seem unnecessarily complex, it achieves the following design goals...
+		//          - Does not require an explicit "enabled" flag in the DeliverySpec.
+		//          - Does not require implementations calling the message_sender to be aware of experimental-features.
+		//          - Does not modify existing Knative CRs with arbitrary default "max" values.
+		//
+		//        The intended behavior of RetryConfig.RetryAfterMaxDuration is as follows...
+		//
+		//          RetryAfterMaxDuration    Alpha/Beta                              Stable/GA
+		//          ---------------------    ----------                              ---------
+		//               nil                 Do NOT respect Retry-After headers      Respect Retry-After headers without Max
+		//                0                  Do NOT respect Retry-After headers      Do NOT respect Retry-After headers
+		//               >0                  Respect Retry-After headers with Max    Respect Retry-After headers with Max
+		//
+
+		// If Response is 429 / 503, Then Parse Any Retry-After Header Durations & Enforce Optional MaxDuration
+		var retryAfterDuration time.Duration
+		// TODO - Remove this check when experimental-feature moves to Stable/GA to convert behavior from opt-in to opt-out
+		if config.RetryAfterMaxDuration != nil {
+			// TODO - Keep this logic as is (no change required) when experimental-feature is Stable/GA
+			if resp != nil && (resp.StatusCode == nethttp.StatusTooManyRequests || resp.StatusCode == nethttp.StatusServiceUnavailable) {
+				retryAfterDuration = parseRetryAfterDuration(resp)
+				if config.RetryAfterMaxDuration != nil && *config.RetryAfterMaxDuration < retryAfterDuration {
+					retryAfterDuration = *config.RetryAfterMaxDuration
+				}
+			}
+		}
+
+		// Calculate The RetryConfig Backoff Duration
+		backoffDuration := config.Backoff(attemptNum, resp)
+
+		// Return The Larger Of The Two Backoff Durations
+		if retryAfterDuration > backoffDuration {
+			return retryAfterDuration
+		}
+		return backoffDuration
+	}
+}
+
+// parseRetryAfterDuration returns a Duration expressing the amount of time
+// requested to wait by a Retry-After header, or 0 if not present or invalid.
+// According to the spec (https://tools.ietf.org/html/rfc7231#section-7.1.3)
+// the Retry-After Header's value can be one of an HTTP-date or delay-seconds,
+// both of which are supported here.
+func parseRetryAfterDuration(resp *nethttp.Response) (retryAfterDuration time.Duration) {
+
+	// Return 0 Duration If No Response / Headers
+	if resp == nil || resp.Header == nil {
+		return
+	}
+
+	// Return 0 Duration If No Retry-After Header
+	retryAfterString := resp.Header.Get(RetryAfterHeader)
+	if len(retryAfterString) <= 0 {
+		return
+	}
+
+	// Attempt To Parse Retry-After Header As Seconds - Return If Successful
+	retryAfterInt, parseIntErr := strconv.ParseInt(retryAfterString, 10, 64)
+	if parseIntErr == nil {
+		return time.Duration(retryAfterInt) * time.Second
+	}
+
+	// Attempt To Parse Retry-After Header As Timestamp (RFC850 & ANSIC) - Return If Successful
+	retryAfterTime, parseTimeErr := nethttp.ParseTime(retryAfterString)
+	if parseTimeErr != nil {
+		fmt.Printf("failed to parse Retry-After header: ParseInt Error = %v, ParseTime Error = %v\n", parseIntErr, parseTimeErr)
+		return
+	}
+	return time.Until(retryAfterTime)
 }

--- a/pkg/kncloudevents/client.go
+++ b/pkg/kncloudevents/client.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kncloudevents
+
+import (
+	"context"
+	nethttp "net/http"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+type Client interface {
+	NewRequest(ctx context.Context, target duckv1.Addressable) (Request, error)
+}
+
+var _ Client = (*clientImpl)(nil)
+
+func NewClient() Client {
+	c := newClientImpl()
+	return &c
+}
+
+type clientImpl struct{}
+
+func newClientImpl() clientImpl {
+	return clientImpl{}
+}
+
+func (c *clientImpl) NewRequest(ctx context.Context, target duckv1.Addressable) (Request, error) {
+	nethttpReqest, err := nethttp.NewRequestWithContext(ctx, "POST", target.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &requestImpl{
+		Target:  target,
+		Request: nethttpReqest,
+	}, nil
+}

--- a/pkg/kncloudevents/client_test.go
+++ b/pkg/kncloudevents/client_test.go
@@ -48,7 +48,7 @@ const (
 	Invalid
 )
 
-func TestCloudEventRequest_SendWithRetries(t *testing.T) {
+func Test_clientImpl_SendWithRetries(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -98,9 +98,9 @@ func TestCloudEventRequest_SendWithRetries(t *testing.T) {
 
 			client := newClientImpl()
 			target := urlstrToAddressable(t, server.URL)
-			request, err := client.NewRequest(ctx, target)
+			request, err := NewRequest(ctx, target)
 			assert.Nil(t, err)
-			got, err := request.SendWithRetries(tt.config)
+			got, err := client.SendWithRetries(request, tt.config)
 			if err != nil {
 				t.Fatalf("SendWithRetries() error = %v, wantErr nil", err)
 			}
@@ -114,7 +114,7 @@ func TestCloudEventRequest_SendWithRetries(t *testing.T) {
 	}
 }
 
-func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
+func Test_clientImpl_SendWithRetriesWithBufferedMessage(t *testing.T) {
 	t.Parallel()
 
 	const wantToSkip = 9
@@ -140,7 +140,7 @@ func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
 
 	client := newClientImpl()
 	target := urlstrToAddressable(t, server.URL)
-	request, err := client.NewRequest(context.TODO(), target)
+	request, err := NewRequest(context.TODO(), target)
 	assert.Nil(t, err)
 
 	// Create a message similar to the one we send with channels
@@ -151,7 +151,7 @@ func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
 	err = cehttp.WriteRequest(context.TODO(), bufferedMessage, request.HTTPRequest())
 	assert.Nil(t, err)
 
-	got, err := request.SendWithRetries(config)
+	got, err := client.SendWithRetries(request, config)
 	if err != nil {
 		t.Fatalf("SendWithRetries() error = %v, wantErr nil", err)
 	}
@@ -163,7 +163,7 @@ func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
 	}
 }
 
-func TestCloudEventRequest_SendWithRetriesWithSingleRequestTimeout(t *testing.T) {
+func Test_clientImpl_SendWithRetriesWithSingleRequestTimeout(t *testing.T) {
 	t.Parallel()
 
 	timeout := time.Second * 3
@@ -192,17 +192,17 @@ func TestCloudEventRequest_SendWithRetriesWithSingleRequestTimeout(t *testing.T)
 
 	target := urlstrToAddressable(t, server.URL)
 	client := newClientImpl()
-	request, err := client.NewRequest(context.TODO(), target)
+	request, err := NewRequest(context.TODO(), target)
 	require.NoError(t, err)
 
-	got, err := request.SendWithRetries(config)
+	got, err := client.SendWithRetries(request, config)
 
 	require.Equal(t, 5, int(atomic.LoadInt32(&n)))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, got.StatusCode)
 }
 
-func TestCloudEventRequest_SendWithRetriesOnNetworkErrors(t *testing.T) {
+func Test_clientImpl_SendWithRetriesOnNetworkErrors(t *testing.T) {
 
 	n := int32(10)
 	linear := v1.BackoffPolicyLinear
@@ -268,10 +268,10 @@ func TestCloudEventRequest_SendWithRetriesOnNetworkErrors(t *testing.T) {
 
 	client := newClientImpl()
 	targetAddressable := urlstrToAddressable(t, "http://"+target)
-	request, err := client.NewRequest(context.TODO(), targetAddressable)
+	request, err := NewRequest(context.TODO(), targetAddressable)
 	assert.Nil(t, err)
 
-	_, err = request.SendWithRetries(&r)
+	_, err = client.SendWithRetries(request, &r)
 	assert.Nil(t, err)
 
 	// nCalls keeps track of how many times a call to check retry occurs.

--- a/pkg/kncloudevents/request.go
+++ b/pkg/kncloudevents/request.go
@@ -18,177 +18,38 @@ package kncloudevents
 
 import (
 	"context"
-	"fmt"
 	nethttp "net/http"
-	"strconv"
-	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
-	"github.com/hashicorp/go-retryablehttp"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-const RetryAfterHeader = "Retry-After"
-
-type Request interface {
-	BindEvent(context.Context, event.Event) error
-	Send() (*nethttp.Response, error)
-	SendWithRetries(config *RetryConfig) (*nethttp.Response, error)
-	HTTPRequest() *nethttp.Request
-}
-
-var _ Request = (*requestImpl)(nil)
-
-type requestImpl struct {
+type Request struct {
 	*nethttp.Request
-	Target duckv1.Addressable
+	target duckv1.Addressable
 }
 
-func (req *requestImpl) HTTPRequest() *nethttp.Request {
-	return req.Request
-}
-
-func (req *requestImpl) BindEvent(ctx context.Context, event event.Event) error {
-	message := binding.ToMessage(&event)
-	defer message.Finish(nil)
-
-	err := http.WriteRequest(ctx, message, req.HTTPRequest())
-	return err
-}
-
-func (req *requestImpl) Send() (*nethttp.Response, error) {
-	client, err := getClientForAddressable(req.Target)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client for addressable: %w", err)
-	}
-	return client.Do(req.Request)
-}
-
-func (req *requestImpl) SendWithRetries(config *RetryConfig) (*nethttp.Response, error) {
-	if config == nil {
-		return req.Send()
-	}
-
-	client, err := getClientForAddressable(req.Target)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get client for addressable: %w", err)
-	}
-
-	if config.RequestTimeout != 0 {
-		client = &nethttp.Client{
-			Transport:     client.Transport,
-			CheckRedirect: client.CheckRedirect,
-			Jar:           client.Jar,
-			Timeout:       config.RequestTimeout,
-		}
-	}
-
-	retryableClient := retryablehttp.Client{
-		HTTPClient:   client,
-		RetryWaitMin: defaultRetryWaitMin,
-		RetryWaitMax: defaultRetryWaitMax,
-		RetryMax:     config.RetryMax,
-		CheckRetry:   retryablehttp.CheckRetry(config.CheckRetry),
-		Backoff:      generateBackoffFn(config),
-		ErrorHandler: func(resp *nethttp.Response, err error, numTries int) (*nethttp.Response, error) {
-			return resp, err
-		},
-	}
-
-	retryableReq, err := retryablehttp.FromRequest(req.Request)
+func NewRequest(ctx context.Context, target duckv1.Addressable) (*Request, error) {
+	nethttpReqest, err := nethttp.NewRequestWithContext(ctx, "POST", target.URL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return retryableClient.Do(retryableReq)
+	return &Request{
+		Request: nethttpReqest,
+		target:  target,
+	}, nil
 }
 
-// generateBackoffFunction returns a valid retryablehttp.Backoff implementation which
-// wraps the provided RetryConfig.Backoff implementation with optional "Retry-After"
-// header support.
-func generateBackoffFn(config *RetryConfig) retryablehttp.Backoff {
-	return func(_, _ time.Duration, attemptNum int, resp *nethttp.Response) time.Duration {
-
-		//
-		// NOTE - The following logic will need to be altered slightly once the "delivery-retryafter"
-		//        experimental-feature graduates from Alpha/Beta to Stable/GA.  This is according to
-		//        plan as described in https://github.com/knative/eventing/issues/5811.
-		//
-		//        During the Alpha/Beta stages the ability to respect Retry-After headers is "opt-in"
-		//        requiring the DeliverySpec.RetryAfterMax to be populated.  The Stable/GA behavior
-		//        will be "opt-out" where Retry-After headers are always respected (in the context of
-		//        calculating backoff durations for 429 / 503 responses) unless the
-		//        DeliverySpec.RetryAfterMax is set to "PT0S".
-		//
-		//        While this might seem unnecessarily complex, it achieves the following design goals...
-		//          - Does not require an explicit "enabled" flag in the DeliverySpec.
-		//          - Does not require implementations calling the message_sender to be aware of experimental-features.
-		//          - Does not modify existing Knative CRs with arbitrary default "max" values.
-		//
-		//        The intended behavior of RetryConfig.RetryAfterMaxDuration is as follows...
-		//
-		//          RetryAfterMaxDuration    Alpha/Beta                              Stable/GA
-		//          ---------------------    ----------                              ---------
-		//               nil                 Do NOT respect Retry-After headers      Respect Retry-After headers without Max
-		//                0                  Do NOT respect Retry-After headers      Do NOT respect Retry-After headers
-		//               >0                  Respect Retry-After headers with Max    Respect Retry-After headers with Max
-		//
-
-		// If Response is 429 / 503, Then Parse Any Retry-After Header Durations & Enforce Optional MaxDuration
-		var retryAfterDuration time.Duration
-		// TODO - Remove this check when experimental-feature moves to Stable/GA to convert behavior from opt-in to opt-out
-		if config.RetryAfterMaxDuration != nil {
-			// TODO - Keep this logic as is (no change required) when experimental-feature is Stable/GA
-			if resp != nil && (resp.StatusCode == nethttp.StatusTooManyRequests || resp.StatusCode == nethttp.StatusServiceUnavailable) {
-				retryAfterDuration = parseRetryAfterDuration(resp)
-				if config.RetryAfterMaxDuration != nil && *config.RetryAfterMaxDuration < retryAfterDuration {
-					retryAfterDuration = *config.RetryAfterMaxDuration
-				}
-			}
-		}
-
-		// Calculate The RetryConfig Backoff Duration
-		backoffDuration := config.Backoff(attemptNum, resp)
-
-		// Return The Larger Of The Two Backoff Durations
-		if retryAfterDuration > backoffDuration {
-			return retryAfterDuration
-		}
-		return backoffDuration
-	}
+func (req *Request) HTTPRequest() *nethttp.Request {
+	return req.Request
 }
 
-// parseRetryAfterDuration returns a Duration expressing the amount of time
-// requested to wait by a Retry-After header, or 0 if not present or invalid.
-// According to the spec (https://tools.ietf.org/html/rfc7231#section-7.1.3)
-// the Retry-After Header's value can be one of an HTTP-date or delay-seconds,
-// both of which are supported here.
-func parseRetryAfterDuration(resp *nethttp.Response) (retryAfterDuration time.Duration) {
+func (req *Request) BindEvent(ctx context.Context, event event.Event) error {
+	message := binding.ToMessage(&event)
+	defer message.Finish(nil)
 
-	// Return 0 Duration If No Response / Headers
-	if resp == nil || resp.Header == nil {
-		return
-	}
-
-	// Return 0 Duration If No Retry-After Header
-	retryAfterString := resp.Header.Get(RetryAfterHeader)
-	if len(retryAfterString) <= 0 {
-		return
-	}
-
-	// Attempt To Parse Retry-After Header As Seconds - Return If Successful
-	retryAfterInt, parseIntErr := strconv.ParseInt(retryAfterString, 10, 64)
-	if parseIntErr == nil {
-		return time.Duration(retryAfterInt) * time.Second
-	}
-
-	// Attempt To Parse Retry-After Header As Timestamp (RFC850 & ANSIC) - Return If Successful
-	retryAfterTime, parseTimeErr := nethttp.ParseTime(retryAfterString)
-	if parseTimeErr != nil {
-		fmt.Printf("failed to parse Retry-After header: ParseInt Error = %v, ParseTime Error = %v\n", parseIntErr, parseTimeErr)
-		return
-	}
-	return time.Until(retryAfterTime)
+	return http.WriteRequest(ctx, message, req.HTTPRequest())
 }

--- a/pkg/kncloudevents/request_test.go
+++ b/pkg/kncloudevents/request_test.go
@@ -96,8 +96,9 @@ func TestCloudEventRequest_SendWithRetries(t *testing.T) {
 				writer.WriteHeader(tt.wantStatus)
 			}))
 
+			client := newClientImpl()
 			target := urlstrToAddressable(t, server.URL)
-			request, err := NewCloudEventRequest(ctx, target)
+			request, err := client.NewRequest(ctx, target)
 			assert.Nil(t, err)
 			got, err := request.SendWithRetries(tt.config)
 			if err != nil {
@@ -137,8 +138,9 @@ func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
 		}
 	}))
 
+	client := newClientImpl()
 	target := urlstrToAddressable(t, server.URL)
-	request, err := NewCloudEventRequest(context.TODO(), target)
+	request, err := client.NewRequest(context.TODO(), target)
 	assert.Nil(t, err)
 
 	// Create a message similar to the one we send with channels
@@ -146,7 +148,7 @@ func TestCloudEventRequest_SendWithRetriesWithBufferedMessage(t *testing.T) {
 	bufferedMessage, err := buffering.BufferMessage(context.TODO(), mockMessage)
 	assert.Nil(t, err)
 
-	err = cehttp.WriteRequest(context.TODO(), bufferedMessage, request.Request)
+	err = cehttp.WriteRequest(context.TODO(), bufferedMessage, request.HTTPRequest())
 	assert.Nil(t, err)
 
 	got, err := request.SendWithRetries(config)
@@ -189,7 +191,8 @@ func TestCloudEventRequest_SendWithRetriesWithSingleRequestTimeout(t *testing.T)
 	}
 
 	target := urlstrToAddressable(t, server.URL)
-	request, err := NewCloudEventRequest(context.TODO(), target)
+	client := newClientImpl()
+	request, err := client.NewRequest(context.TODO(), target)
 	require.NoError(t, err)
 
 	got, err := request.SendWithRetries(config)
@@ -263,8 +266,9 @@ func TestCloudEventRequest_SendWithRetriesOnNetworkErrors(t *testing.T) {
 		return checkRetry(ctx, resp, err)
 	}
 
+	client := newClientImpl()
 	targetAddressable := urlstrToAddressable(t, "http://"+target)
-	request, err := NewCloudEventRequest(context.TODO(), targetAddressable)
+	request, err := client.NewRequest(context.TODO(), targetAddressable)
 	assert.Nil(t, err)
 
 	_, err = request.SendWithRetries(&r)

--- a/pkg/kncloudevents/test/client.go
+++ b/pkg/kncloudevents/test/client.go
@@ -27,25 +27,25 @@ import (
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
-var _ kncloudevents.Client = (*Client)(nil)
+var _ kncloudevents.Client = (*FakeClient)(nil)
 
-func NewClient() *Client {
-	return &Client{
+func NewFakeClient() *FakeClient {
+	return &FakeClient{
 		sentEvents: make([]event.Event, 0),
 	}
 }
 
-type Client struct {
+type FakeClient struct {
 	delay      time.Duration
 	sentEvents []event.Event
 }
 
 // SentEvents returns all events sent within all requests of this client.
-func (c *Client) SentEvents() []event.Event {
+func (c *FakeClient) SentEvents() []event.Event {
 	return c.sentEvents
 }
 
-func (c *Client) Send(request *kncloudevents.Request) (*nethttp.Response, error) {
+func (c *FakeClient) Send(request *kncloudevents.Request) (*nethttp.Response, error) {
 	if c.delay > 0 {
 		time.Sleep(c.delay)
 	}
@@ -64,6 +64,6 @@ func (c *Client) Send(request *kncloudevents.Request) (*nethttp.Response, error)
 	}, nil
 }
 
-func (req *Client) SendWithRetries(request *kncloudevents.Request, config *kncloudevents.RetryConfig) (*nethttp.Response, error) {
+func (req *FakeClient) SendWithRetries(request *kncloudevents.Request, config *kncloudevents.RetryConfig) (*nethttp.Response, error) {
 	return req.Send(request)
 }

--- a/pkg/kncloudevents/test/client.go
+++ b/pkg/kncloudevents/test/client.go
@@ -19,94 +19,44 @@ package test
 import (
 	"context"
 	nethttp "net/http"
-	"sync"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"knative.dev/eventing/pkg/kncloudevents"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var _ kncloudevents.Client = (*Client)(nil)
 
 func NewClient() *Client {
 	return &Client{
-		requests: make([]*inMemoryRequest, 0),
+		sentEvents: make([]event.Event, 0),
 	}
 }
 
 type Client struct {
-	delay       time.Duration
-	requests    []*inMemoryRequest
-	requestsMux sync.Mutex
-}
-
-func (c *Client) NewRequest(ctx context.Context, target duckv1.Addressable) (kncloudevents.Request, error) {
-	c.requestsMux.Lock()
-	defer c.requestsMux.Unlock()
-
-	nethttpReqest, err := nethttp.NewRequestWithContext(ctx, "POST", target.URL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	request := inMemoryRequest{
-		Target:     target,
-		Request:    nethttpReqest,
-		sentEvents: make([]event.Event, 0),
-		delay:      c.delay,
-	}
-	c.requests = append(c.requests, &request)
-
-	return &request, nil
-}
-
-// SentEvents returns all events sent within all requests of this client.
-func (c *Client) SentEvents() []event.Event {
-	events := make([]event.Event, 0)
-
-	for _, req := range c.requests {
-		events = append(events, req.SentEvents()...)
-	}
-
-	return events
-}
-
-var _ kncloudevents.Request = (*inMemoryRequest)(nil)
-
-type inMemoryRequest struct {
-	*nethttp.Request
-	Target duckv1.Addressable
-
 	delay      time.Duration
 	sentEvents []event.Event
 }
 
-func (req *inMemoryRequest) HTTPRequest() *nethttp.Request {
-	return req.Request
+// SentEvents returns all events sent within all requests of this client.
+func (c *Client) SentEvents() []event.Event {
+	return c.sentEvents
 }
 
-func (req *inMemoryRequest) BindEvent(ctx context.Context, event event.Event) error {
-	message := binding.ToMessage(&event)
-	defer message.Finish(nil)
-
-	err := http.WriteRequest(ctx, message, req.HTTPRequest())
-	return err
-}
-
-func (req *inMemoryRequest) Send() (*nethttp.Response, error) {
-	if req.delay > 0 {
-		time.Sleep(req.delay)
+func (c *Client) Send(request *kncloudevents.Request) (*nethttp.Response, error) {
+	if c.delay > 0 {
+		time.Sleep(c.delay)
 	}
 
-	message := http.NewMessageFromHttpRequest(req.HTTPRequest())
+	// get event from request to add to sentEvents
+	message := http.NewMessageFromHttpRequest(request.HTTPRequest())
 	defer message.Finish(nil)
 
 	event, err := binding.ToEvent(context.TODO(), message)
 	if err == nil {
-		req.sentEvents = append(req.sentEvents, *event)
+		c.sentEvents = append(c.sentEvents, *event)
 	}
 
 	return &nethttp.Response{
@@ -114,11 +64,6 @@ func (req *inMemoryRequest) Send() (*nethttp.Response, error) {
 	}, nil
 }
 
-func (req *inMemoryRequest) SendWithRetries(config *kncloudevents.RetryConfig) (*nethttp.Response, error) {
-	return req.Send()
-}
-
-// SentEvents returns all events sent within this request.
-func (req *inMemoryRequest) SentEvents() []event.Event {
-	return req.sentEvents
+func (req *Client) SendWithRetries(request *kncloudevents.Request, config *kncloudevents.RetryConfig) (*nethttp.Response, error) {
+	return req.Send(request)
 }

--- a/pkg/kncloudevents/test/client.go
+++ b/pkg/kncloudevents/test/client.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/protocol/http"
+	"knative.dev/eventing/pkg/kncloudevents"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+var _ kncloudevents.Client = (*Client)(nil)
+
+func NewClient() *Client {
+	return &Client{
+		requests: make([]*inMemoryRequest, 0),
+	}
+}
+
+type Client struct {
+	delay       time.Duration
+	requests    []*inMemoryRequest
+	requestsMux sync.Mutex
+}
+
+func (c *Client) NewRequest(ctx context.Context, target duckv1.Addressable) (kncloudevents.Request, error) {
+	c.requestsMux.Lock()
+	defer c.requestsMux.Unlock()
+
+	nethttpReqest, err := nethttp.NewRequestWithContext(ctx, "POST", target.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request := inMemoryRequest{
+		Target:     target,
+		Request:    nethttpReqest,
+		sentEvents: make([]event.Event, 0),
+		delay:      c.delay,
+	}
+	c.requests = append(c.requests, &request)
+
+	return &request, nil
+}
+
+// SentEvents returns all events sent within all requests of this client.
+func (c *Client) SentEvents() []event.Event {
+	events := make([]event.Event, 0)
+
+	for _, req := range c.requests {
+		events = append(events, req.SentEvents()...)
+	}
+
+	return events
+}
+
+var _ kncloudevents.Request = (*inMemoryRequest)(nil)
+
+type inMemoryRequest struct {
+	*nethttp.Request
+	Target duckv1.Addressable
+
+	delay      time.Duration
+	sentEvents []event.Event
+}
+
+func (req *inMemoryRequest) HTTPRequest() *nethttp.Request {
+	return req.Request
+}
+
+func (req *inMemoryRequest) BindEvent(ctx context.Context, event event.Event) error {
+	message := binding.ToMessage(&event)
+	defer message.Finish(nil)
+
+	err := http.WriteRequest(ctx, message, req.HTTPRequest())
+	return err
+}
+
+func (req *inMemoryRequest) Send() (*nethttp.Response, error) {
+	if req.delay > 0 {
+		time.Sleep(req.delay)
+	}
+
+	message := http.NewMessageFromHttpRequest(req.HTTPRequest())
+	defer message.Finish(nil)
+
+	event, err := binding.ToEvent(context.TODO(), message)
+	if err == nil {
+		req.sentEvents = append(req.sentEvents, *event)
+	}
+
+	return &nethttp.Response{
+		StatusCode: nethttp.StatusOK,
+	}, nil
+}
+
+func (req *inMemoryRequest) SendWithRetries(config *kncloudevents.RetryConfig) (*nethttp.Response, error) {
+	return req.Send()
+}
+
+// SentEvents returns all events sent within this request.
+func (req *inMemoryRequest) SentEvents() []event.Event {
+	return req.sentEvents
+}

--- a/pkg/kncloudevents/test/client_test.go
+++ b/pkg/kncloudevents/test/client_test.go
@@ -52,7 +52,7 @@ func Test_Client_SentEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			imClient := NewClient()
+			imClient := NewFakeClient()
 
 			for _, event := range tt.eventsToSend {
 				req, err := kncloudevents.NewRequest(ctx, duckv1.Addressable{

--- a/pkg/kncloudevents/test/client_test.go
+++ b/pkg/kncloudevents/test/client_test.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/stretchr/testify/require"
+	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-func Test_inMemoryRequest_SentEvents(t *testing.T) {
+func Test_Client_SentEvents(t *testing.T) {
 	tests := []struct {
 		name               string
 		eventsToSend       []event.Event
@@ -54,58 +53,21 @@ func Test_inMemoryRequest_SentEvents(t *testing.T) {
 			ctx := context.TODO()
 
 			imClient := NewClient()
-			req, err := imClient.NewRequest(ctx, duckv1.Addressable{
-				URL: apis.HTTP("foo.bar"),
-			})
-			require.Nil(t, err)
 
 			for _, event := range tt.eventsToSend {
-				message := binding.ToMessage(&event)
-				defer message.Finish(nil)
-
-				err = http.WriteRequest(ctx, message, req.HTTPRequest())
+				req, err := kncloudevents.NewRequest(ctx, duckv1.Addressable{
+					URL: apis.HTTP("foo.bar"),
+				})
 				require.Nil(t, err)
 
-				_, err = req.Send()
+				err = req.BindEvent(ctx, event)
+				require.Nil(t, err)
+
+				_, err = imClient.Send(req)
 				require.Nil(t, err)
 			}
 
-			imRequest := req.(*inMemoryRequest)
-			require.Equal(t, len(imRequest.SentEvents()), tt.wantReceivedEvents)
+			require.Equal(t, len(imClient.SentEvents()), tt.wantReceivedEvents)
 		})
 	}
-}
-
-func TestClient_SentEvents(t *testing.T) {
-	client := NewClient()
-	ctx := context.TODO()
-	target := duckv1.Addressable{
-		URL: apis.HTTP("foo.bar"),
-	}
-
-	// without any send requests it should be 0
-	require.Len(t, client.SentEvents(), 0)
-
-	req1, err := client.NewRequest(ctx, target)
-	require.Nil(t, err)
-	require.Len(t, client.SentEvents(), 0)
-
-	// now bind one event (not sent)
-	req1.BindEvent(ctx, test.FullEvent())
-	require.Len(t, client.SentEvents(), 0)
-
-	_, err = req1.Send()
-	require.Nil(t, err)
-	require.Len(t, client.SentEvents(), 1)
-
-	// do a 2nd request
-	req2, err := client.NewRequest(ctx, target)
-	require.Nil(t, err)
-	req2.BindEvent(ctx, test.FullEvent())
-	require.Len(t, client.SentEvents(), 1)
-
-	// send 2nd request
-	_, err = req2.Send()
-	require.Nil(t, err)
-	require.Len(t, client.SentEvents(), 2)
 }

--- a/pkg/kncloudevents/test/client_test.go
+++ b/pkg/kncloudevents/test/client_test.go
@@ -41,7 +41,7 @@ func Test_inMemoryRequest_SentEvents(t *testing.T) {
 			wantReceivedEvents: 0,
 		},
 		{
-			name: "Should count received events correclty",
+			name: "Should count received events correctly",
 			eventsToSend: []event.Event{
 				test.FullEvent(),
 				test.FullEvent(),

--- a/pkg/kncloudevents/test/client_test.go
+++ b/pkg/kncloudevents/test/client_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func Test_inMemoryRequest_SentEvents(t *testing.T) {
+	tests := []struct {
+		name               string
+		eventsToSend       []event.Event
+		wantReceivedEvents int
+	}{
+		{
+			name:               "No error on no events to send",
+			eventsToSend:       nil,
+			wantReceivedEvents: 0,
+		},
+		{
+			name: "Should count received events correclty",
+			eventsToSend: []event.Event{
+				test.FullEvent(),
+				test.FullEvent(),
+			},
+			wantReceivedEvents: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			imClient := NewClient()
+			req, err := imClient.NewRequest(ctx, duckv1.Addressable{
+				URL: apis.HTTP("foo.bar"),
+			})
+			require.Nil(t, err)
+
+			for _, event := range tt.eventsToSend {
+				message := binding.ToMessage(&event)
+				defer message.Finish(nil)
+
+				err = http.WriteRequest(ctx, message, req.HTTPRequest())
+				require.Nil(t, err)
+
+				_, err = req.Send()
+				require.Nil(t, err)
+			}
+
+			imRequest := req.(*inMemoryRequest)
+			require.Equal(t, len(imRequest.SentEvents()), tt.wantReceivedEvents)
+		})
+	}
+}
+
+func TestClient_SentEvents(t *testing.T) {
+	client := NewClient()
+	ctx := context.TODO()
+	target := duckv1.Addressable{
+		URL: apis.HTTP("foo.bar"),
+	}
+
+	// without any send requests it should be 0
+	require.Len(t, client.SentEvents(), 0)
+
+	req1, err := client.NewRequest(ctx, target)
+	require.Nil(t, err)
+	require.Len(t, client.SentEvents(), 0)
+
+	// now bind one event (not sent)
+	req1.BindEvent(ctx, test.FullEvent())
+	require.Len(t, client.SentEvents(), 0)
+
+	_, err = req1.Send()
+	require.Nil(t, err)
+	require.Len(t, client.SentEvents(), 1)
+
+	// do a 2nd request
+	req2, err := client.NewRequest(ctx, target)
+	require.Nil(t, err)
+	req2.BindEvent(ctx, test.FullEvent())
+	require.Len(t, client.SentEvents(), 1)
+
+	// send 2nd request
+	_, err = req2.Send()
+	require.Nil(t, err)
+	require.Len(t, client.SentEvents(), 2)
+}

--- a/pkg/kncloudevents/utils.go
+++ b/pkg/kncloudevents/utils.go
@@ -40,7 +40,7 @@ func WriteHTTPRequestWithAdditionalHeaders(ctx context.Context, message binding.
 	return nil
 }
 
-func WriteRequestWithAdditionalHeaders(ctx context.Context, message binding.Message, req Request,
+func WriteRequestWithAdditionalHeaders(ctx context.Context, message binding.Message, req *Request,
 	additionalHeaders nethttp.Header, transformers ...binding.Transformer) error {
 	return WriteHTTPRequestWithAdditionalHeaders(ctx, message, req.HTTPRequest(), additionalHeaders, transformers...)
 }

--- a/pkg/kncloudevents/utils.go
+++ b/pkg/kncloudevents/utils.go
@@ -40,9 +40,9 @@ func WriteHTTPRequestWithAdditionalHeaders(ctx context.Context, message binding.
 	return nil
 }
 
-func WriteRequestWithAdditionalHeaders(ctx context.Context, message binding.Message, req *CloudEventRequest,
+func WriteRequestWithAdditionalHeaders(ctx context.Context, message binding.Message, req Request,
 	additionalHeaders nethttp.Header, transformers ...binding.Transformer) error {
-	return WriteHTTPRequestWithAdditionalHeaders(ctx, message, req.Request, additionalHeaders, transformers...)
+	return WriteHTTPRequestWithAdditionalHeaders(ctx, message, req.HTTPRequest(), additionalHeaders, transformers...)
 }
 
 type TypeExtractorTransformer string

--- a/pkg/kncloudevents/utils_test.go
+++ b/pkg/kncloudevents/utils_test.go
@@ -40,8 +40,7 @@ func TestWriteRequestWithAdditionalHeadersWritesIntoRequest(t *testing.T) {
 	url, err := apis.ParseURL("http://foobar:12345")
 	assert.NoError(t, err)
 
-	client := newClientImpl()
-	request, err := client.NewRequest(ctx, duckv1.Addressable{URL: url})
+	request, err := NewRequest(ctx, duckv1.Addressable{URL: url})
 	assert.NoError(t, err)
 
 	ceEvent := cloudevents.NewEvent()
@@ -70,8 +69,7 @@ func TestWriteRequestWithAdditionalHeadersAddsHeadersToRequest(t *testing.T) {
 	url, err := apis.ParseURL("http://foobar:12345")
 	assert.NoError(t, err)
 
-	client := newClientImpl()
-	request, err := client.NewRequest(ctx, duckv1.Addressable{URL: url})
+	request, err := NewRequest(ctx, duckv1.Addressable{URL: url})
 	assert.NoError(t, err)
 
 	ceEvent := cloudevents.NewEvent()
@@ -87,7 +85,6 @@ func TestWriteRequestWithAdditionalHeadersAddsHeadersToRequest(t *testing.T) {
 
 	assert.Equal(t, additionalHeaders["Some-Key"], request.HTTPRequest().Header["Some-Key"])
 	assert.Equal(t, additionalHeaders["Another-Key"], request.HTTPRequest().Header["Another-Key"])
-
 }
 
 // If reader's message does have Type attribute

--- a/pkg/kncloudevents/utils_test.go
+++ b/pkg/kncloudevents/utils_test.go
@@ -40,7 +40,8 @@ func TestWriteRequestWithAdditionalHeadersWritesIntoRequest(t *testing.T) {
 	url, err := apis.ParseURL("http://foobar:12345")
 	assert.NoError(t, err)
 
-	request, err := NewCloudEventRequest(ctx, duckv1.Addressable{URL: url})
+	client := newClientImpl()
+	request, err := client.NewRequest(ctx, duckv1.Addressable{URL: url})
 	assert.NoError(t, err)
 
 	ceEvent := cloudevents.NewEvent()
@@ -54,10 +55,10 @@ func TestWriteRequestWithAdditionalHeadersWritesIntoRequest(t *testing.T) {
 	err = WriteRequestWithAdditionalHeaders(ctx, message, request, http.Header{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{ceSource}, request.Header["Ce-Source"])
-	assert.Equal(t, []string{ceType}, request.Header["Ce-Type"])
-	assert.Equal(t, []string{cloudevents.TextPlain}, request.Header["Content-Type"])
-	gotPayload, err := io.ReadAll(request.Body)
+	assert.Equal(t, []string{ceSource}, request.HTTPRequest().Header["Ce-Source"])
+	assert.Equal(t, []string{ceType}, request.HTTPRequest().Header["Ce-Type"])
+	assert.Equal(t, []string{cloudevents.TextPlain}, request.HTTPRequest().Header["Content-Type"])
+	gotPayload, err := io.ReadAll(request.HTTPRequest().Body)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(ceData), gotPayload)
 
@@ -69,7 +70,8 @@ func TestWriteRequestWithAdditionalHeadersAddsHeadersToRequest(t *testing.T) {
 	url, err := apis.ParseURL("http://foobar:12345")
 	assert.NoError(t, err)
 
-	request, err := NewCloudEventRequest(ctx, duckv1.Addressable{URL: url})
+	client := newClientImpl()
+	request, err := client.NewRequest(ctx, duckv1.Addressable{URL: url})
 	assert.NoError(t, err)
 
 	ceEvent := cloudevents.NewEvent()
@@ -83,8 +85,8 @@ func TestWriteRequestWithAdditionalHeadersAddsHeadersToRequest(t *testing.T) {
 	err = WriteRequestWithAdditionalHeaders(ctx, message, request, additionalHeaders)
 	assert.NoError(t, err)
 
-	assert.Equal(t, additionalHeaders["Some-Key"], request.Header["Some-Key"])
-	assert.Equal(t, additionalHeaders["Another-Key"], request.Header["Another-Key"])
+	assert.Equal(t, additionalHeaders["Some-Key"], request.HTTPRequest().Header["Some-Key"])
+	assert.Equal(t, additionalHeaders["Another-Key"], request.HTTPRequest().Header["Another-Key"])
 
 }
 


### PR DESCRIPTION
Currently the kncloudevents.NewRequest always uses an http(s) client to do the requests. This can make unit testing sometimes a bit harder.
This PR addresses it and refactors the package, so we abstract the current behavior behind a new interface (`Client`) and also adds a new testClient, which kind of mocks the behavior of the http client.