### PR TITLE
Revert "Add loopclosure linter"

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - prealloc
     - unconvert
     - unparam
-    - loopclosure
   disable:
     - errcheck
 


### PR DESCRIPTION
Reverts knative/eventing#7079

It causes

```
  Running [/home/runner/golangci-lint-1.52.0-linux-amd64/golangci-lint run --out-format=github-actions --new-from-patch=/tmp/tmp-1767-brlK8gkkRq5N/pull.patch --new=false --new-from-rev= --go=1.20] in [] ...
  level=error msg="Running error: unknown linters: 'loopclosure', run 'golangci-lint help linters' to see the list of supported linters"
  ```

Maybe the version we use in CI doesn't support this linter