### PR TITLE
Convert tls secret names to constants

### DIFF
--- a/pkg/broker/filter/server_manager.go
+++ b/pkg/broker/filter/server_manager.go
@@ -30,10 +30,6 @@ import (
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 )
 
-const (
-	tlsSecretName = "mt-broker-filter-server-tls" //nolint:gosec // This is not a hardcoded credential
-)
-
 func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Watcher, httpPort, httpsPort int, handler *Handler) (*eventingtls.ServerManager, error) {
 	tlsConfig, err := getServerTLSConfig(ctx)
 	if err != nil {
@@ -49,7 +45,7 @@ func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Wat
 func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 	secret := types.NamespacedName{
 		Namespace: "knative-eventing",
-		Name:      tlsSecretName,
+		Name:      eventingtls.BrokerFilterServerTLSSecretName,
 	}
 
 	serverTLSConfig := eventingtls.NewDefaultServerConfig()

--- a/pkg/broker/ingress/server_manager.go
+++ b/pkg/broker/ingress/server_manager.go
@@ -30,10 +30,6 @@ import (
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 )
 
-const (
-	tlsSecretName = "mt-broker-ingress-server-tls" //nolint:gosec // This is not a hardcoded credential
-)
-
 func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Watcher, httpPort, httpsPort int, handler *Handler) (*eventingtls.ServerManager, error) {
 	tlsConfig, err := getServerTLSConfig(ctx)
 	if err != nil {
@@ -49,7 +45,7 @@ func NewServerManager(ctx context.Context, logger *zap.Logger, cmw configmap.Wat
 func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 	secret := types.NamespacedName{
 		Namespace: "knative-eventing",
-		Name:      tlsSecretName,
+		Name:      eventingtls.BrokerIngressServerTLSSecretName,
 	}
 
 	serverTLSConfig := eventingtls.NewDefaultServerConfig()

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -47,8 +47,6 @@ const (
 	SecretCACert = "ca.crt"
 	// IMCDispatcherServerTLSSecretName is the name of the tls secret for the imc dispatcher server
 	IMCDispatcherServerTLSSecretName = "imc-dispatcher-server-tls" //nolint:gosec // This is not a hardcoded credential
-	// IMCDispatcherTLSSecretName is the name of the tls secret for the imc dispatcher
-	IMCDispatcherTLSSecretName = "imc-dispatcher-tls" //nolint:gosec // This is not a hardcoded credential
 	// BrokerFilterServerTLSSecretName is the name of the tls secret for the broker filter server
 	BrokerFilterServerTLSSecretName = "mt-broker-filter-server-tls" //nolint:gosec // This is not a hardcoded credential
 	// BrokerIngressServerTLSSecretName is the name of the tls secret for the broker ingress server

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -46,9 +46,13 @@ const (
 	// SecretCACrt is the name of the CA Cert in the secret
 	SecretCACert = "ca.crt"
 	// IMCDispatcherServerTLSSecretName is the name of the tls secret for the imc dispatcher server
-	IMCDispatcherServerTLSSecretName = "imc-dispatcher-server-tls"
+	IMCDispatcherServerTLSSecretName = "imc-dispatcher-server-tls" //nolint:gosec // This is not a hardcoded credential
 	// IMCDispatcherTLSSecretName is the name of the tls secret for the imc dispatcher
-	IMCDispatcherTLSSecretName = "imc-dispatcher-tls"
+	IMCDispatcherTLSSecretName = "imc-dispatcher-tls" //nolint:gosec // This is not a hardcoded credential
+	// BrokerFilterServerTLSSecretName is the name of the tls secret for the broker filter server
+	BrokerFilterServerTLSSecretName = "mt-broker-filter-server-tls" //nolint:gosec // This is not a hardcoded credential
+	// BrokerIngressServerTLSSecretName is the name of the tls secret for the broker ingress server
+	BrokerIngressServerTLSSecretName = "mt-broker-ingress-server-tls" //nolint:gosec // This is not a hardcoded credential
 )
 
 type ClientConfig struct {

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -45,6 +45,10 @@ const (
 	DefaultMinTLSVersion = tls.VersionTLS12
 	// SecretCACrt is the name of the CA Cert in the secret
 	SecretCACert = "ca.crt"
+	// IMCDispatcherServerTLSSecretName is the name of the tls secret for the imc dispatcher server
+	IMCDispatcherServerTLSSecretName = "imc-dispatcher-server-tls"
+	// IMCDispatcherTLSSecretName is the name of the tls secret for the imc dispatcher
+	IMCDispatcherTLSSecretName = "imc-dispatcher-tls"
 )
 
 type ClientConfig struct {

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -57,10 +57,9 @@ var brokerGVK = eventingv1.SchemeGroupVersion.WithKind("Broker")
 
 const (
 	// Name of the corev1.Events emitted from the Trigger reconciliation process.
-	subscriptionDeleteFailed  = "SubscriptionDeleteFailed"
-	subscriptionCreateFailed  = "SubscriptionCreateFailed"
-	subscriptionGetFailed     = "SubscriptionGetFailed"
-	filterServerTLSSecretName = "mt-broker-filter-server-tls" //nolint:gosec // This is not a hardcoded credential
+	subscriptionDeleteFailed = "SubscriptionDeleteFailed"
+	subscriptionCreateFailed = "SubscriptionCreateFailed"
+	subscriptionGetFailed    = "SubscriptionGetFailed"
 )
 
 type Reconciler struct {
@@ -349,13 +348,13 @@ func getBrokerChannelRef(b *eventingv1.Broker) (*corev1.ObjectReference, error) 
 }
 
 func (r *Reconciler) getCaCerts() (string, error) {
-	secret, err := r.secretLister.Secrets(system.Namespace()).Get(filterServerTLSSecretName)
+	secret, err := r.secretLister.Secrets(system.Namespace()).Get(eventingtls.BrokerFilterServerTLSSecretName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", system.Namespace(), filterServerTLSSecretName, err)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", system.Namespace(), eventingtls.BrokerFilterServerTLSSecretName, err)
 	}
 	caCerts, ok := secret.Data[eventingtls.SecretCACert]
 	if !ok {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", system.Namespace(), filterServerTLSSecretName, eventingtls.SecretCACert)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", system.Namespace(), eventingtls.BrokerFilterServerTLSSecretName, eventingtls.SecretCACert)
 	}
 	return string(caCerts), nil
 }

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -54,6 +54,7 @@ import (
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/duck"
+	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
 
@@ -412,7 +413,7 @@ func TestReconcile(t *testing.T) {
 					WithChannelAPIVersionAnnotation(triggerChannelAPIVersion),
 					WithChannelKindAnnotation(triggerChannelKind),
 					WithChannelNameAnnotation(triggerChannelName)),
-				NewSecret(filterServerTLSSecretName, systemNS, WithSecretData(map[string][]byte{
+				NewSecret(eventingtls.BrokerFilterServerTLSSecretName, systemNS, WithSecretData(map[string][]byte{
 					"ca.crt": eventingtlstesting.CA,
 				})),
 				NewTrigger(triggerName, testNS, brokerName,
@@ -473,7 +474,7 @@ func TestReconcile(t *testing.T) {
 					WithChannelAPIVersionAnnotation(triggerChannelAPIVersion),
 					WithChannelKindAnnotation(triggerChannelKind),
 					WithChannelNameAnnotation(triggerChannelName)),
-				NewSecret(filterServerTLSSecretName, systemNS, WithSecretData(map[string][]byte{
+				NewSecret(eventingtls.BrokerFilterServerTLSSecretName, systemNS, WithSecretData(map[string][]byte{
 					"ca.crt": eventingtlstesting.CA,
 				})),
 				NewTrigger(triggerName, testNS, brokerName,

--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -30,6 +30,7 @@ import (
 
 	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
+	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/config"
 	"knative.dev/pkg/resolver"
 
@@ -120,7 +121,7 @@ func NewController(
 		Handler:    controller.HandleAll(grCh),
 	})
 	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterWithName(dispatcherTLSSecretName),
+		FilterFunc: controller.FilterWithName(eventingtls.IMCDispatcherTLSSecretName),
 		Handler:    controller.HandleAll(grCh),
 	})
 

--- a/pkg/reconciler/inmemorychannel/controller/controller.go
+++ b/pkg/reconciler/inmemorychannel/controller/controller.go
@@ -121,7 +121,7 @@ func NewController(
 		Handler:    controller.HandleAll(grCh),
 	})
 	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterWithName(eventingtls.IMCDispatcherTLSSecretName),
+		FilterFunc: controller.FilterWithName(eventingtls.IMCDispatcherServerTLSSecretName),
 		Handler:    controller.HandleAll(grCh),
 	})
 

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -222,13 +222,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel)
 
 func (r *Reconciler) getCaCerts() (string, error) {
 	// Getting the secret called "imc-dispatcher-tls" from system namespace
-	secret, err := r.secretLister.Secrets(r.systemNamespace).Get(eventingtls.IMCDispatcherTLSSecretName)
+	secret, err := r.secretLister.Secrets(r.systemNamespace).Get(eventingtls.IMCDispatcherServerTLSSecretName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", r.systemNamespace, eventingtls.IMCDispatcherTLSSecretName, err)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", r.systemNamespace, eventingtls.IMCDispatcherServerTLSSecretName, err)
 	}
 	caCerts, ok := secret.Data[caCertsSecretKey]
 	if !ok {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", r.systemNamespace, eventingtls.IMCDispatcherTLSSecretName, caCertsSecretKey)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", r.systemNamespace, eventingtls.IMCDispatcherServerTLSSecretName, caCertsSecretKey)
 	}
 	return string(caCerts), nil
 }

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -58,7 +58,6 @@ const (
 	dispatcherRoleBindingCreated    = "DispatcherRoleBindingCreated"
 	dispatcherDeploymentCreated     = "DispatcherDeploymentCreated"
 	dispatcherServiceCreated        = "DispatcherServiceCreated"
-	dispatcherTLSSecretName         = "imc-dispatcher-tls"
 	caCertsSecretKey                = eventingtls.SecretCACert
 )
 
@@ -223,13 +222,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel)
 
 func (r *Reconciler) getCaCerts() (string, error) {
 	// Getting the secret called "imc-dispatcher-tls" from system namespace
-	secret, err := r.secretLister.Secrets(r.systemNamespace).Get(dispatcherTLSSecretName)
+	secret, err := r.secretLister.Secrets(r.systemNamespace).Get(eventingtls.IMCDispatcherTLSSecretName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", r.systemNamespace, dispatcherTLSSecretName, err)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: %w", r.systemNamespace, eventingtls.IMCDispatcherTLSSecretName, err)
 	}
 	caCerts, ok := secret.Data[caCertsSecretKey]
 	if !ok {
-		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", r.systemNamespace, dispatcherTLSSecretName, caCertsSecretKey)
+		return "", fmt.Errorf("failed to get CA certs from %s/%s: missing %s key", r.systemNamespace, eventingtls.IMCDispatcherTLSSecretName, caCertsSecretKey)
 	}
 	return string(caCerts), nil
 }

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -34,6 +34,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/feature"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/config"
@@ -942,7 +943,7 @@ func makeTLSSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNS,
-			Name:      "imc-dispatcher-tls",
+			Name:      eventingtls.IMCDispatcherServerTLSSecretName,
 		},
 		Data: map[string][]byte{
 			"ca.crt": []byte(testCaCerts),

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -62,7 +62,6 @@ const (
 	httpPort      = 8080
 	httpsPort     = 8443
 	finalizerName = "imc-dispatcher"
-	tlsSecretName = "imc-dispatcher-server-tls"
 )
 
 type envConfig struct {
@@ -158,7 +157,7 @@ func NewController(
 
 	secret := types.NamespacedName{
 		Namespace: system.Namespace(),
-		Name:      tlsSecretName,
+		Name:      eventingtls.IMCDispatcherServerTLSSecretName,
 	}
 	serverTLSConfig := eventingtls.NewDefaultServerConfig()
 	serverTLSConfig.GetCertificate = eventingtls.GetCertificateFromSecret(ctx, secretinformer.Get(ctx), kubeclient.Get(ctx), secret)


### PR DESCRIPTION
Fixes #7084 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Refactor the hardcoded tls secret names in the in memory channel into the `eventingtls` package
- Refactor the hardcoded tls secret names in the broker into the `eventingtls` package


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

