### PR TITLE
[WIP]: Auto create events in channels

### DIFF
--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -47,6 +47,7 @@ import (
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
 	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
+	"knative.dev/eventing/pkg/eventtype"
 	"knative.dev/eventing/pkg/reconciler/names"
 )
 
@@ -152,7 +153,7 @@ func main() {
 
 	// Init auto-create only if enabled, after ConfigMap watcher is started
 	if featureStore.IsEnabled(feature.EvenTypeAutoCreate) {
-		autoCreate := &broker.EventTypeAutoHandler{
+		autoCreate := &eventtype.EventTypeAutoHandler{
 			EventTypeLister: eventtypeinformer.Get(ctx).Lister(),
 			EventingClient:  eventingclient.Get(ctx).EventingV1beta2(),
 			FeatureStore:    featureStore,

--- a/pkg/broker/ingress/ingress_handler.go
+++ b/pkg/broker/ingress/ingress_handler.go
@@ -42,6 +42,7 @@ import (
 	"knative.dev/eventing/pkg/broker"
 	v1 "knative.dev/eventing/pkg/client/informers/externalversions/eventing/v1"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
+	"knative.dev/eventing/pkg/eventtype"
 	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/eventing/pkg/tracing"
 	"knative.dev/eventing/pkg/utils"
@@ -62,7 +63,7 @@ type Handler struct {
 	// BrokerLister gets broker objects
 	BrokerLister eventinglisters.BrokerLister
 
-	EvenTypeHandler *broker.EventTypeAutoHandler
+	EvenTypeHandler *eventtype.EventTypeAutoHandler
 
 	Logger *zap.Logger
 }

--- a/pkg/channel/fanout/fanout_message_handler.go
+++ b/pkg/channel/fanout/fanout_message_handler.go
@@ -32,11 +32,13 @@ import (
 	"github.com/cloudevents/sdk-go/v2/binding/buffering"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/eventing/pkg/apis"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/channel"
+	"knative.dev/eventing/pkg/eventtype"
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
@@ -85,19 +87,34 @@ type FanoutMessageHandler struct {
 	// rather than a member variable.
 	timeout time.Duration
 
-	reporter channel.StatsReporter
-	logger   *zap.Logger
+	reporter           channel.StatsReporter
+	logger             *zap.Logger
+	eventTypeHandler   *eventtype.EventTypeAutoHandler
+	channelAddressable *duckv1.KReference
+	channelUID         *types.UID
 }
 
 // NewMessageHandler creates a new fanout.MessageHandler.
 
-func NewFanoutMessageHandler(logger *zap.Logger, messageDispatcher channel.MessageDispatcher, config Config, reporter channel.StatsReporter, receiverOpts ...channel.MessageReceiverOptions) (*FanoutMessageHandler, error) {
+func NewFanoutMessageHandler(
+	logger *zap.Logger,
+	messageDispatcher channel.MessageDispatcher,
+	config Config,
+	reporter channel.StatsReporter,
+	eventTypeHandler *eventtype.EventTypeAutoHandler,
+	channelAddressable *duckv1.KReference,
+	channelUID *types.UID,
+	receiverOpts ...channel.MessageReceiverOptions,
+) (*FanoutMessageHandler, error) {
 	handler := &FanoutMessageHandler{
-		logger:       logger,
-		dispatcher:   messageDispatcher,
-		timeout:      defaultTimeout,
-		reporter:     reporter,
-		asyncHandler: config.AsyncHandler,
+		logger:             logger,
+		dispatcher:         messageDispatcher,
+		timeout:            defaultTimeout,
+		reporter:           reporter,
+		asyncHandler:       config.AsyncHandler,
+		eventTypeHandler:   eventTypeHandler,
+		channelAddressable: channelAddressable,
+		channelUID:         channelUID,
 	}
 	handler.subscriptions = make([]Subscription, len(config.Subscriptions))
 	copy(handler.subscriptions, config.Subscriptions)
@@ -163,9 +180,40 @@ func (f *FanoutMessageHandler) GetSubscriptions(ctx context.Context) []Subscript
 	return ret
 }
 
+func (f *FanoutMessageHandler) autoCreateEventType(ctx context.Context, bufferedMessage binding.Message, transformers []binding.Transformer) {
+	if f.channelAddressable == nil {
+		f.logger.Warn("No addressable for channel")
+		return
+	} else {
+		event, err := binding.ToEvent(ctx, bufferedMessage, transformers...)
+		if err != nil {
+			f.logger.Warn("Failed to extract event from message")
+			return
+		}
+		if f.channelUID == nil {
+			f.logger.Warn("No channelUID provided, unable to autocreate event type")
+			return
+		}
+		if err := f.eventTypeHandler.AutoCreateEventType(ctx, event, f.channelAddressable, *f.channelUID); err != nil {
+			f.logger.Warn("Event type auto create failed", zap.Error(err))
+			return
+		}
+	}
+}
+
 func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context, channel.ChannelReference, binding.Message, []binding.Transformer, nethttp.Header) error {
 	if f.asyncHandler {
 		return func(ctx context.Context, ref channel.ChannelReference, message binding.Message, transformers []binding.Transformer, additionalHeaders nethttp.Header) error {
+			if f.eventTypeHandler != nil {
+				bufferedMessage, err := buffering.CopyMessage(ctx, message, transformers...)
+				if err != nil {
+					f.logger.Warn("Failed to copy message")
+				} else {
+					// we don't need to block sending the message to create the event type
+					go f.autoCreateEventType(ctx, bufferedMessage, transformers)
+				}
+			}
+
 			subs := f.GetSubscriptions(ctx)
 
 			if len(subs) == 0 {
@@ -202,6 +250,16 @@ func createMessageReceiverFunction(f *FanoutMessageHandler) func(context.Context
 		}
 	}
 	return func(ctx context.Context, ref channel.ChannelReference, message binding.Message, transformers []binding.Transformer, additionalHeaders nethttp.Header) error {
+		if f.eventTypeHandler != nil {
+			bufferedMessage, err := buffering.CopyMessage(ctx, message, transformers...)
+			if err != nil {
+				f.logger.Warn("Failed to copy message")
+			} else {
+				// we don't need to block sending the message to create the event type
+				go f.autoCreateEventType(ctx, bufferedMessage, transformers)
+			}
+		}
+
 		subs := f.GetSubscriptions(ctx)
 		if len(subs) == 0 {
 			// Nothing to do here, finish the message and return

--- a/pkg/channel/fanout/fanout_message_handler_test.go
+++ b/pkg/channel/fanout/fanout_message_handler_test.go
@@ -373,6 +373,9 @@ func testFanoutMessageHandler(t *testing.T, async bool, receiverFunc channel.Unb
 			AsyncHandler:  async,
 		},
 		reporter,
+		nil,
+		nil,
+		nil,
 		recvOptionFunc,
 	)
 	<-calledChan

--- a/pkg/channel/multichannelfanout/config.go
+++ b/pkg/channel/multichannelfanout/config.go
@@ -17,7 +17,10 @@ limitations under the License.
 package multichannelfanout
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/eventing/pkg/channel/fanout"
+	"knative.dev/eventing/pkg/eventtype"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 type Config struct {
@@ -26,9 +29,12 @@ type Config struct {
 
 // ChannelConfig is the configuration for a single Channel.
 type ChannelConfig struct {
-	Namespace    string
-	Name         string
-	HostName     string
-	Path         string
-	FanoutConfig fanout.Config
+	Namespace          string
+	Name               string
+	HostName           string
+	Path               string
+	FanoutConfig       fanout.Config
+	EventTypeHandler   *eventtype.EventTypeAutoHandler
+	ChannelAddressable *duckv1.KReference
+	ChannelUID         *types.UID
 }

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler.go
@@ -73,7 +73,7 @@ func NewMessageHandlerWithConfig(_ context.Context, logger *zap.Logger, messageD
 			if key == "" {
 				continue
 			}
-			handler, err := fanout.NewFanoutMessageHandler(logger, messageDispatcher, cc.FanoutConfig, reporter, recvOptions...)
+			handler, err := fanout.NewFanoutMessageHandler(logger, messageDispatcher, cc.FanoutConfig, reporter, cc.EventTypeHandler, cc.ChannelAddressable, cc.ChannelUID, recvOptions...)
 			if err != nil {
 				logger.Error("Failed creating new fanout handler.", zap.Error(err))
 				return nil, err

--- a/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
+++ b/pkg/channel/multichannelfanout/multi_channel_fanout_message_handler_test.go
@@ -102,7 +102,7 @@ func TestNewMessageHandler(t *testing.T) {
 	if h != nil {
 		t.Errorf("Found handler for %q but not expected", handlerName)
 	}
-	f, err := fanout.NewFanoutMessageHandler(logger, channel.NewMessageDispatcher(logger), fanout.Config{}, reporter)
+	f, err := fanout.NewFanoutMessageHandler(logger, channel.NewMessageDispatcher(logger), fanout.Config{}, reporter, nil, nil, nil)
 	if err != nil {
 		t.Error("Failed to create FanoutMessagHandler: ", err)
 	}

--- a/pkg/eventtype/eventtypes.go
+++ b/pkg/eventtype/eventtypes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
+package eventtype
 
 import (
 	"context"

--- a/pkg/eventtype/eventtypes_test.go
+++ b/pkg/eventtype/eventtypes_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
+package eventtype
 
 import (
 	"context"

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -49,6 +49,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/channel"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
 	inmemorychannelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
 	"knative.dev/eventing/pkg/inmemorychannel"
@@ -122,7 +123,10 @@ func NewController(
 		multiChannelMessageHandler: sh,
 		reporter:                   reporter,
 		messagingClientSet:         eventingclient.Get(ctx).MessagingV1(),
+		eventingClient:             eventingclient.Get(ctx).EventingV1beta2(),
+		eventTypeLister:            eventtypeinformer.Get(ctx).Lister(),
 	}
+
 	impl := inmemorychannelreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{SkipStatusUpdates: true, FinalizerName: finalizerName}
 	})
@@ -141,6 +145,8 @@ func NewController(
 		impl.GlobalResync(inmemorychannelInformer.Informer())
 	})
 	featureStore.WatchConfigs(cmw)
+
+	r.featureStore = featureStore
 
 	httpArgs := &inmemorychannel.InMemoryMessageDispatcherArgs{
 		Port:         httpPort,

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
@@ -32,6 +32,7 @@ import (
 	// Fake injection client
 	_ "knative.dev/eventing/pkg/client/injection/client/fake"
 	// Fake injection informers
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel/fake"
 	_ "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
 )

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -35,12 +35,16 @@ import (
 	"knative.dev/pkg/reconciler"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	"knative.dev/eventing/pkg/channel/multichannelfanout"
+	eventingv1beta2 "knative.dev/eventing/pkg/client/clientset/versioned/typed/eventing/v1beta2"
 	messagingv1 "knative.dev/eventing/pkg/client/clientset/versioned/typed/messaging/v1"
 	reconcilerv1 "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
+	"knative.dev/eventing/pkg/client/listers/eventing/v1beta2"
+	"knative.dev/eventing/pkg/eventtype"
 	"knative.dev/eventing/pkg/kncloudevents"
 )
 
@@ -49,6 +53,9 @@ type Reconciler struct {
 	multiChannelMessageHandler multichannelfanout.MultiChannelMessageHandler
 	reporter                   channel.StatsReporter
 	messagingClientSet         messagingv1.MessagingV1Interface
+	eventTypeLister            v1beta2.EventTypeLister
+	eventingClient             eventingv1beta2.EventingV1beta2Interface
+	featureStore               *feature.Store
 }
 
 // Check the interfaces Reconciler should implement
@@ -85,6 +92,19 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 		logging.FromContext(ctx).Error("Error creating config for in memory channels", zap.Error(err))
 		return err
 	}
+	var eventTypeAutoHandler *eventtype.EventTypeAutoHandler
+	var channelReference *duckv1.KReference
+	var UID *types.UID
+	if r.featureStore.IsEnabled(feature.EvenTypeAutoCreate) {
+		eventTypeAutoHandler = &eventtype.EventTypeAutoHandler{
+			EventTypeLister: r.eventTypeLister,
+			EventingClient:  r.eventingClient,
+			FeatureStore:    r.featureStore,
+			Logger:          logging.FromContext(ctx).Desugar(),
+		}
+		channelReference = toKReference(imc)
+		UID = &imc.UID
+	}
 
 	// First grab the host based MultiChannelFanoutMessage httpHandler
 	httpHandler := r.multiChannelMessageHandler.GetChannelHandler(config.HostName)
@@ -95,6 +115,9 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			channel.NewMessageDispatcher(logging.FromContext(ctx).Desugar()),
 			config.FanoutConfig,
 			r.reporter,
+			eventTypeAutoHandler,
+			channelReference,
+			UID,
 		)
 		if err != nil {
 			logging.FromContext(ctx).Error("Failed to create a new fanout.MessageHandler", err)
@@ -121,6 +144,9 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			channel.NewMessageDispatcher(logging.FromContext(ctx).Desugar()),
 			config.FanoutConfig,
 			r.reporter,
+			eventTypeAutoHandler,
+			channelReference,
+			UID,
 			channel.ResolveMessageChannelFromPath(channel.ParseChannelFromPath),
 		)
 		if err != nil {
@@ -242,5 +268,15 @@ func handleSubscribers(subscribers []eventingduckv1.SubscriberSpec, handle func(
 				CACerts: sub.Delivery.DeadLetterSink.CACerts,
 			})
 		}
+	}
+}
+
+func toKReference(imc *v1.InMemoryChannel) *duckv1.KReference {
+	return &duckv1.KReference{
+		Kind:       imc.Kind,
+		Namespace:  imc.Namespace,
+		Name:       imc.Name,
+		APIVersion: imc.APIVersion,
+		Address:    imc.Status.Address.Name,
 	}
 }


### PR DESCRIPTION
Fixes #7044 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Refactor `eventtypes.go` and `eventtypes_test.go` out of the `broker` package into their own package to facilitate sharing code with channels.
- Use the auto create funcionality from the `eventtypes` package in the fanout message handler to autocreate event types.


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Even Type auto-create feature:
- Based on CloudEvents processed in an inmemorychannel corresponding `EventType` resources are created in the namespace  

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
Tracking issue for docs: https://github.com/knative/docs/issues/5612

