### PR TITLE
Introduce a script to build and deploy Eventing for local development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,6 +110,23 @@ _Adding the `upstream` remote sets you up nicely for regularly
 Once you reach this point you are ready to do a full build and deploy as
 follows.
 
+## Quick full build and install
+
+Eventing components are pluggable, and you can install specific components depending on your
+needs, however, for a full build and install, you can run:
+
+```shell
+./hack/install.sh
+```
+
+By default, it will build container images for the architecture of your local machine, if you need
+to build images for a different platform (OS and architecture), you can provide `KO_FLAGS` as
+follow:
+
+```shell
+KO_FLAGS=--platform="linux/amd64" ./hack/install.sh
+```
+
 ## Starting Eventing Controller
 
 Once you've [setup your development environment](#getting-started), stand up

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,7 @@ This doc explains how to setup a development environment so you can get started
 Also take a look at:
 
 - [The pull request workflow](https://www.knative.dev/contributing/contributing/#pull-requests)
+- [Quick full build and install](#quick-full-build-and-install)
 - [How to add and run tests](./test/README.md)
 - [Iterating](#iterating)
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script builds and installs Knative Eventing components from source for local development.
+
+set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export SCALE_CHAOSDUCK_TO_ZERO=1
+export REPLICAS=1
+export KO_FLAGS=${KO_FLAGS:-"--platform="""} # Default to current OS and arch
+
+source "$(dirname "$0")/../test/e2e-common.sh"
+
+knative_setup || exit $?

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
You can now just run:
```
hack/install.sh
```
to install Eventing for development.

It reuses the CI build process, so that's minimal maintenance