### PR TITLE
Add kind e2e tests for Kubernetes v1.27.3

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         k8s-version:
         - v1.25.11
+        - v1.27.3
 
         test-suite:
         - ./test/rekt/...
@@ -32,6 +33,9 @@ jobs:
         - k8s-version: v1.25.11
           kind-version: v0.20.0
           kind-image-sha: sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
+        - k8s-version: v1.27.3
+          kind-version: v0.20.0
+          kind-image-sha: sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.3
+        - v1.25.11
 
         test-suite:
         - ./test/rekt/...
@@ -29,9 +29,9 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
         include:
-        - k8s-version: v1.25.3
+        - k8s-version: v1.25.11
           kind-version: v0.20.0
-          kind-image-sha: sha256:cd248d1438192f7814fbca8fede13cfe5b9918746dfa12583976158a834fd5c5
+          kind-image-sha: sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/e2e

--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -20,8 +20,8 @@ set -o nounset
 set -o pipefail
 
 CLUSTER_SUFFIX=${CLUSTER_SUFFIX:-"cluster.local"}
-NODE_VERSION=${NODE_VERSION:-"v1.20.0"}
-NODE_SHA=${NODE_SHA:-"sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040"}
+NODE_VERSION=${NODE_VERSION:-"v1.27.3"}
+NODE_SHA=${NODE_SHA:-"sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"}
 
 cat <<EOF | kind create cluster --config=-
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
Update Kubernetes version for KinD e2e test to 1.25.11 and add 1.27.3.

/hold
Needs to have #7138 merged first (and then needs rebase)