### PR TITLE
Set cluster domain suffix in TLS manifests correctly

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -147,11 +147,14 @@ function install_knative_eventing() {
       -f "${EVENTING_CORE_NAME}" || return 1
     UNINSTALL_LIST+=( "${EVENTING_CORE_NAME}" )
 
-    local EVENTING_TLS_NAME=${TMP_DIR}/${EVENTING_TLS_YAML##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${EVENTING_TLS_YAML} > ${EVENTING_TLS_NAME}
+    local EVENTING_TLS_REPLACES=${TMP_DIR}/${EVENTING_TLS_YAML##*/}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${EVENTING_TLS_YAML} > ${EVENTING_TLS_REPLACES}
+    if [[ ! -z "${CLUSTER_SUFFIX}" ]]; then
+      sed -i "s/cluster.local/${CLUSTER_SUFFIX}/g" ${EVENTING_TLS_REPLACES}
+    fi
     kubectl apply \
-      -f "${EVENTING_TLS_NAME}" || return 1
-    UNINSTALL_LIST+=( "${EVENTING_TLS_NAME}" )
+      -f "${EVENTING_TLS_REPLACES}" || return 1
+    UNINSTALL_LIST+=( "${EVENTING_TLS_REPLACES}" )
 
     kubectl patch horizontalpodautoscalers.autoscaling -n ${SYSTEM_NAMESPACE} eventing-webhook -p '{"spec": {"minReplicas": '${REPLICAS}'}}' || return 1
 


### PR DESCRIPTION
Follow up on https://github.com/knative/eventing/pull/7103#discussion_r1282954880

Currently in the TLS manifests, the cluster domain suffix of `cluster.local` is hard coded. In some environments (e.g. in the KinD e2e test), the cluster domain suffix differs:

https://github.com/knative/eventing/blob/8a09756d76b10697bbd1a24ac924ce144ffcf91a/.github/workflows/kind-e2e.yaml#L46-L51

This PR addresses it, and sets the cluster domain suffix in the TLS manifests before they get applied to the value provided in the `CLUSTER_SUFFIX` env var.