### PR TITLE
Added .env files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bazel-*
 *.swp
 .history
 tmp/
+*.env


### PR DESCRIPTION
Using telepresence creates *.env files which can be annoying to remember to not commit

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add `*.env` to the gitignore


