### PR TITLE
Event type test logical error

### DIFF
--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -138,6 +138,9 @@ func SendsEventsWithEventTypes() *feature.Feature {
 
 	f := new(feature.Feature)
 
+	// Enable the eventtype auto-creation in configmap
+	f.Setup("enable eventtype auto-creation", eventtype.ApplyEventTypeConfigMap())
+
 	//Install the broker
 	brokerName := feature.MakeRandomK8sName("broker")
 	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -18,9 +18,8 @@ package eventtype
 
 import (
 	"context"
+	"embed"
 	"fmt"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,7 +28,12 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/manifest"
+	"time"
 )
+
+//go:embed eventtype.yaml
+var yaml embed.FS
 
 type EventType struct {
 	Name       string
@@ -99,4 +103,14 @@ func AssertReferenceMatch(expectedCeType string) EventType {
 		},
 	}
 
+}
+
+// The function will apply the config map eventtype.yaml file to enable auto creation of eventtype
+// The yaml file is in /test/eventtype.yaml
+// manifest.InstallYamlFS(ctx, yaml, cfg)
+func ApplyEventTypeConfigMap() feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+
+		manifest.InstallYamlFS(ctx, yaml, nil)
+	}
 }

--- a/test/rekt/resources/eventtype/eventtype.yaml
+++ b/test/rekt/resources/eventtype/eventtype.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-eventing
+  labels:
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+data:
+  # ALPHA feature: The eventtype-auto-create flag allows automatic creation of Even Type instances based on Event's type being processed.
+  # For more details: https://github.com/knative/eventing/issues/6909
+  eventtype-auto-create: "enabled"


### PR DESCRIPTION
Fixes #7158

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Rework with the logic to be
```
for each event type in the list:
  - remove it from expectedCeTypes (ideally after cloning the object to not change the caller object)

assert that expectedCeTypes is empty
```

And also add the support to enable the auto eventType creation. Currently PingSource doesn't support the auto eventType Creation. We are enable the broker side auto eventType creation for now. Otherwise, the test will be failing.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

