### PR TITLE
change the deprecated string

### DIFF
--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -255,7 +255,8 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.NewString(sources.ApiServerSourceEventReferenceModeTypes...)
+	expectedCeTypes := sets.New[string]()
+	expectedCeTypes.Insert(sources.ApiServerSourceEventReferenceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -255,8 +255,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.New[string]()
-	expectedCeTypes.Insert(sources.ApiServerSourceEventReferenceModeTypes...)
+	expectedCeTypes := sets.New(sources.ApiServerSourceEventReferenceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -160,8 +160,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
 
-	expectedCeTypes := sets.New[string]()
-	expectedCeTypes.Insert(sourcesv1.PingSourceEventType)
+	expectedCeTypes := sets.New(sourcesv1.PingSourceEventType)
 
 	f.Stable("pingsource as event source").
 		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -160,7 +160,8 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
 
-	expectedCeTypes := sets.NewString(sourcesv1.PingSourceEventType)
+	expectedCeTypes := sets.New[string]()
+	expectedCeTypes.Insert(sourcesv1.PingSourceEventType)
 
 	f.Stable("pingsource as event source").
 		Must("delivers events on broker with URI", assert.OnStore(sink).MatchEvent(

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -60,7 +60,7 @@ func WaitForEventType(eventtype EventType, timing ...time.Duration) feature.Step
 	}
 }
 
-func AssertPresent(expectedCeTypes sets.String) EventType {
+func AssertPresent(expectedCeTypes sets.Set[string]) EventType {
 	return EventType{
 		Name: "test eventtypes match or not",
 		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {


### PR DESCRIPTION
Fixes #7167 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Change the deprecated `sets.String` to `sets.Set`

### Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

