### PR TITLE
Added benchmark for any filter

### DIFF
--- a/pkg/eventfilter/benchmarks/any_filter_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/any_filter_benchmark_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmarks
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"knative.dev/eventing/pkg/eventfilter"
+	"knative.dev/eventing/pkg/eventfilter/subscriptionsapi"
+)
+
+func BenchmarkAnyFilter(b *testing.B) {
+	// Full event with all possible fields filled
+	event := cetest.FullEvent()
+
+	filter, _ := subscriptionsapi.NewExactFilter(map[string]string{"id": event.ID()})
+	prefixFilter, _ := subscriptionsapi.NewPrefixFilter(map[string]string{"type": event.Type()[0:5]})
+	suffixFilter, _ := subscriptionsapi.NewSuffixFilter(map[string]string{"source": event.Source()[len(event.Source())-5:]})
+	prefixFilterNoMatch, _ := subscriptionsapi.NewPrefixFilter(map[string]string{"type": "qwertyuiop"})
+	suffixFilterNoMatch, _ := subscriptionsapi.NewSuffixFilter(map[string]string{"source": "qwertyuiop"})
+
+	RunFilterBenchmarks(b,
+		func(i interface{}) eventfilter.Filter {
+			filters := i.([]eventfilter.Filter)
+			return subscriptionsapi.NewAnyFilter(filters...)
+		},
+		FilterBenchmark{
+			name:  "Any filter with exact filter test",
+			arg:   []eventfilter.Filter{filter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "Any filter match all subfilters",
+			arg:   []eventfilter.Filter{filter, prefixFilter, suffixFilter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "Any filter no 1 match at end of array",
+			arg:   []eventfilter.Filter{prefixFilterNoMatch, suffixFilterNoMatch, filter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "Any filter no 1 match at start of array",
+			arg:   []eventfilter.Filter{filter, prefixFilterNoMatch, suffixFilterNoMatch},
+			event: event,
+		},
+	)
+}


### PR DESCRIPTION
Fixes #7112 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Benchmark the overhead of using the any filter with a single nested filter
- Benchmark performance when there is an early match
- Benchmark performance when there is no early match

The benchmark results are:
```
goos: linux
goarch: amd64
pkg: knative.dev/eventing/pkg/eventfilter/benchmarks
cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
BenchmarkAnyFilter
BenchmarkAnyFilter/Creation:_Any_filter_with_exact_filter_test
BenchmarkAnyFilter/Creation:_Any_filter_with_exact_filter_test-8         	14015557	        72.60 ns/op
BenchmarkAnyFilter/Run:_Any_filter_with_exact_filter_test
BenchmarkAnyFilter/Run:_Any_filter_with_exact_filter_test-8              	 1592767	       647.1 ns/op
BenchmarkAnyFilter/Creation:_Any_filter_match_all_subfilters
BenchmarkAnyFilter/Creation:_Any_filter_match_all_subfilters-8           	10254110	       105.0 ns/op
BenchmarkAnyFilter/Run:_Any_filter_match_all_subfilters
BenchmarkAnyFilter/Run:_Any_filter_match_all_subfilters-8                	 1759063	       657.1 ns/op
BenchmarkAnyFilter/Creation:_Any_filter_no_1_match_at_end_of_array
BenchmarkAnyFilter/Creation:_Any_filter_no_1_match_at_end_of_array-8     	10086103	       105.2 ns/op
BenchmarkAnyFilter/Run:_Any_filter_no_1_match_at_end_of_array
BenchmarkAnyFilter/Run:_Any_filter_no_1_match_at_end_of_array-8          	  725652	      1801 ns/op
BenchmarkAnyFilter/Creation:_Any_filter_no_1_match_at_start_of_array
BenchmarkAnyFilter/Creation:_Any_filter_no_1_match_at_start_of_array-8   	10491618	        97.71 ns/op
BenchmarkAnyFilter/Run:_Any_filter_no_1_match_at_start_of_array
BenchmarkAnyFilter/Run:_Any_filter_no_1_match_at_start_of_array-8        	 1780578	       656.0 ns/op
BenchmarkAttributesFilter
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_id
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_id-8        	583618110	         1.920 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_id
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_id-8             	12381978	        86.46 ns/op
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)
BenchmarkAttributesFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)-8         	611194980	         1.913 ns/op
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)
BenchmarkAttributesFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)-8              	 1412710	       832.3 ns/op
BenchmarkAttributesFilter/Creation:_No_pass_with_exact_match_of_id_and_source
BenchmarkAttributesFilter/Creation:_No_pass_with_exact_match_of_id_and_source-8                             	580129804	         1.898 ns/op
BenchmarkAttributesFilter/Run:_No_pass_with_exact_match_of_id_and_source
BenchmarkAttributesFilter/Run:_No_pass_with_exact_match_of_id_and_source-8                                  	 3586198	       317.9 ns/op
BenchmarkExactFilter
BenchmarkExactFilter/Creation:_Pass_with_exact_match_of_id
BenchmarkExactFilter/Creation:_Pass_with_exact_match_of_id-8                                                	12346545	        81.33 ns/op
BenchmarkExactFilter/Run:_Pass_with_exact_match_of_id
BenchmarkExactFilter/Run:_Pass_with_exact_match_of_id-8                                                     	 3054868	       377.2 ns/op
BenchmarkExactFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)
BenchmarkExactFilter/Creation:_Pass_with_exact_match_of_all_context_attributes_(except_time)-8              	 9777397	       115.4 ns/op
BenchmarkExactFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)
BenchmarkExactFilter/Run:_Pass_with_exact_match_of_all_context_attributes_(except_time)-8                   	  995092	      1124 ns/op
BenchmarkExactFilter/Creation:_No_pass_with_exact_match_of_id_and_source
BenchmarkExactFilter/Creation:_No_pass_with_exact_match_of_id_and_source-8                                  	12550750	        89.79 ns/op
BenchmarkExactFilter/Run:_No_pass_with_exact_match_of_id_and_source
BenchmarkExactFilter/Run:_No_pass_with_exact_match_of_id_and_source-8                                       	 1771851	       608.3 ns/op
BenchmarkNotFilter
BenchmarkNotFilter/Creation:_Not_filter_with_exact_filter_test
BenchmarkNotFilter/Creation:_Not_filter_with_exact_filter_test-8                                            	29736352	        39.58 ns/op
BenchmarkNotFilter/Run:_Not_filter_with_exact_filter_test
BenchmarkNotFilter/Run:_Not_filter_with_exact_filter_test-8                                                 	 2982740	       396.5 ns/op
BenchmarkNotFilter/Creation:_Not_filter_with_prefix_filter_test
BenchmarkNotFilter/Creation:_Not_filter_with_prefix_filter_test-8                                           	29168329	        38.16 ns/op
BenchmarkNotFilter/Run:_Not_filter_with_prefix_filter_test
BenchmarkNotFilter/Run:_Not_filter_with_prefix_filter_test-8                                                	 2407800	       483.4 ns/op
BenchmarkNotFilter/Creation:_Not_filter_with_suffix_filter_test
BenchmarkNotFilter/Creation:_Not_filter_with_suffix_filter_test-8                                           	35003146	        37.39 ns/op
BenchmarkNotFilter/Run:_Not_filter_with_suffix_filter_test
BenchmarkNotFilter/Run:_Not_filter_with_suffix_filter_test-8                                                	 1768186	       644.0 ns/op
BenchmarkPrefixFilter
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_id
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_id-8                                              	18324410	        60.21 ns/op
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_id
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_id-8                                                   	 2694043	       480.6 ns/op
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes-8                          	11593155	        94.42 ns/op
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes-8                               	  777190	      1713 ns/op
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes#01
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes#01-8                       	11401508	        96.07 ns/op
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes#01
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes#01-8                            	  753309	      1722 ns/op
BenchmarkPrefixFilter/Creation:_No_pass_with_prefix_match_of_id_and_source
BenchmarkPrefixFilter/Creation:_No_pass_with_prefix_match_of_id_and_source-8                                	15823159	        72.25 ns/op
BenchmarkPrefixFilter/Run:_No_pass_with_prefix_match_of_id_and_source
BenchmarkPrefixFilter/Run:_No_pass_with_prefix_match_of_id_and_source-8                                     	 2340697	       517.8 ns/op
BenchmarkSuffixFilter
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_id
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_id-8                                              	17811429	        60.96 ns/op
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_id
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_id-8                                                   	 2468887	       486.4 ns/op
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes-8                          	11337162	        95.67 ns/op
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes-8                               	  674100	      1733 ns/op
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes#01
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes#01-8                       	11199142	       101.6 ns/op
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes#01
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes#01-8                            	  677655	      1789 ns/op
BenchmarkSuffixFilter/Creation:_No_pass_with_suffix_match_of_id_and_source
BenchmarkSuffixFilter/Creation:_No_pass_with_suffix_match_of_id_and_source-8                                	15079150	        70.69 ns/op
BenchmarkSuffixFilter/Run:_No_pass_with_suffix_match_of_id_and_source
BenchmarkSuffixFilter/Run:_No_pass_with_suffix_match_of_id_and_source-8                                     	 2270575	       527.0 ns/op
PASS
```