### PR TITLE
Reflect on e2e flags that PingSource is now v1

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -36,7 +36,7 @@ const (
 		"must be (for now) 'MTChannelBasedBroker'."
 	SourceUsage = "The names of the source type metas, separated by comma. " +
 		`Example: "sources.knative.dev/v1:ApiServerSource,` +
-		`sources.knative.dev/v1beta2:PingSource".`
+		`sources.knative.dev/v1:PingSource".`
 	BrokerUsage = "The name of the broker type metas, separated by comma. " +
 		`Example: "eventing.knative.dev/v1:MTChannelBasedBroker`
 	BrokerNameUsage = "When testing a pre-existing broker, specify the Broker name so the conformance tests " +


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- PingSource is actually `v1` since a long time...

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

