### PR TITLE
chore: Remove deprecated 'NewScheduler' func

### DIFF
--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -110,36 +110,6 @@ func New(ctx context.Context, cfg *Config) (scheduler.Scheduler, error) {
 	return s, nil
 }
 
-// NewScheduler creates a new scheduler with pod autoscaling enabled.
-// Deprecated: Use New
-func NewScheduler(ctx context.Context,
-	namespace, name string,
-	lister scheduler.VPodLister,
-	refreshPeriod time.Duration,
-	capacity int32,
-	schedulerPolicy scheduler.SchedulerPolicyType,
-	nodeLister corev1listers.NodeLister,
-	evictor scheduler.Evictor,
-	schedPolicy *scheduler.SchedulerPolicy,
-	deschedPolicy *scheduler.SchedulerPolicy) scheduler.Scheduler {
-
-	cfg := &Config{
-		StatefulSetNamespace: namespace,
-		StatefulSetName:      name,
-		PodCapacity:          capacity,
-		RefreshPeriod:        refreshPeriod,
-		SchedulerPolicy:      schedulerPolicy,
-		SchedPolicy:          schedPolicy,
-		DeschedPolicy:        deschedPolicy,
-		Evictor:              evictor,
-		VPodLister:           lister,
-		NodeLister:           nodeLister,
-	}
-
-	s, _ := New(ctx, cfg)
-	return s
-}
-
 type Pending map[types.NamespacedName]int32
 
 func (p Pending) Total() int32 {


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- removing a `func` that was deprecated since a couple of releases 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

