### PR TITLE
Added hostnames to tls certificates

### DIFF
--- a/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
+++ b/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
@@ -40,7 +40,7 @@ spec:
 
   dnsNames:
     - broker-filter.knative-eventing.svc.cluster.local
-    - broker-filter.knative.eventing.svc
+    - broker-filter.knative-eventing.svc
 
   issuerRef:
     name: selfsigned-ca-issuer

--- a/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
+++ b/config/brokers/mt-channel-broker-tls/broker-filter-tls-certificate.yaml
@@ -40,6 +40,7 @@ spec:
 
   dnsNames:
     - broker-filter.knative-eventing.svc.cluster.local
+    - broker-filter.knative.eventing.svc
 
   issuerRef:
     name: selfsigned-ca-issuer

--- a/config/brokers/mt-channel-broker-tls/broker-ingress-tls-certificate.yaml
+++ b/config/brokers/mt-channel-broker-tls/broker-ingress-tls-certificate.yaml
@@ -40,6 +40,7 @@ spec:
 
   dnsNames:
     - broker-ingress.knative-eventing.svc.cluster.local
+    - broker-ingress.knative-eventing.svc
 
   issuerRef:
     name: selfsigned-ca-issuer

--- a/config/channels/in-memory-channel-tls/imc-dispatcher-tls-certificate.yaml
+++ b/config/channels/in-memory-channel-tls/imc-dispatcher-tls-certificate.yaml
@@ -40,6 +40,7 @@ spec:
 
   dnsNames:
     - imc-dispatcher.knative-eventing.svc.cluster.local
+    - imc-dispatcher.knative-eventing.svc
 
   issuerRef:
     name: selfsigned-ca-issuer


### PR DESCRIPTION
Fixes #7209 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add dns name to broker ingress certificate
- Add dns name to broker filter certificate
- Add dns name to imc dispatcher certificate

