### PR TITLE
Add more benchmark test for All filter

### DIFF
--- a/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package benchmarks
 
 import (

--- a/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
@@ -1,0 +1,94 @@
+package benchmarks
+
+import (
+	"testing"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"knative.dev/eventing/pkg/eventfilter"
+	"knative.dev/eventing/pkg/eventfilter/subscriptionsapi"
+)
+
+func BenchmarkAllFilter(b *testing.B) {
+	// Full event with all possible fields filled
+	event := cetest.FullEvent()
+
+	filter, _ := subscriptionsapi.NewExactFilter(map[string]string{"id": event.ID()})
+	exactFilter2, _ := subscriptionsapi.NewExactFilter(map[string]string{"type": event.Type()})
+	exactFilter3, _ := subscriptionsapi.NewExactFilter(map[string]string{"source": event.Source()})
+
+	prefixFilter, _ := subscriptionsapi.NewPrefixFilter(map[string]string{"type": event.Type()[0:5]})
+	suffixFilter, _ := subscriptionsapi.NewSuffixFilter(map[string]string{"source": event.Source()[len(event.Source())-5:]})
+	prefixFilterNoMatch, _ := subscriptionsapi.NewPrefixFilter(map[string]string{"type": "qwertyuiop"})
+	suffixFilterNoMatch, _ := subscriptionsapi.NewSuffixFilter(map[string]string{"source": "qwertyuiop"})
+
+	largeMatchingFilters := make([]eventfilter.Filter, 1000)
+	largeNonMatchingFilters := make([]eventfilter.Filter, 1000)
+
+	for i := range largeMatchingFilters {
+		largeMatchingFilters[i] = filter
+		largeNonMatchingFilters[i] = prefixFilterNoMatch
+	}
+
+	alternatingFilters := []eventfilter.Filter{}
+	for i := 0; i < 500; i++ {
+		alternatingFilters = append(alternatingFilters, filter, prefixFilterNoMatch)
+	}
+
+	RunFilterBenchmarks(b,
+		func(i interface{}) eventfilter.Filter {
+			filters := i.([]eventfilter.Filter)
+			return subscriptionsapi.NewAllFilter(filters...)
+		},
+		FilterBenchmark{
+			name:  "All filter with exact filter test",
+			arg:   []eventfilter.Filter{filter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter match all subfilters",
+			arg:   []eventfilter.Filter{filter, prefixFilter, suffixFilter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter no 1 match at end of array",
+			arg:   []eventfilter.Filter{prefixFilterNoMatch, suffixFilterNoMatch, filter},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter no 1 match at start of array",
+			arg:   []eventfilter.Filter{filter, prefixFilterNoMatch, suffixFilterNoMatch},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with multiple exact filters that match",
+			arg:   []eventfilter.Filter{filter, exactFilter2, exactFilter3},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with one non-matching filter in the middle",
+			arg:   []eventfilter.Filter{filter, prefixFilterNoMatch, exactFilter2},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with all non-matching filters",
+			arg:   []eventfilter.Filter{prefixFilterNoMatch, suffixFilterNoMatch},
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with large number of sub-filters that match",
+			arg:   largeMatchingFilters,
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with large number of sub-filters that do not match",
+			arg:   largeNonMatchingFilters,
+			event: event,
+		},
+		FilterBenchmark{
+			name:  "All filter with alternating matching and non-matching filters",
+			arg:   alternatingFilters,
+			event: event,
+		},
+	)
+
+}


### PR DESCRIPTION
Fixes #7113 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
1. **All Filter with Exact Filter Test**:
    - Tests a single exact filter that matches.

2. **All Filter Match All Subfilters**:
    - Uses an exact filter, prefix filter, and suffix filter; all are set to match.

3. **All Filter No 1 Match at End of Array**:
    - Arranges filters so that two initial ones don't match, but the last one does.

4. **All Filter No 1 Match at Start of Array**:
    - Sets the first filter to match but follows it with two non-matching filters.

5. **All Filter with Multiple Exact Filters that Match**:
    - Tests with three exact filters that all match different attributes of the event.

6. **All Filter with One Non-Matching Filter in the Middle**:
    - Inserts a non-matching filter between two matching filters.

7. **All Filter with All Non-Matching Filters**:
    - Uses only two filters, and neither of them matches the event.

8. **All Filter with Large Number of Sub-filters that Match**:
    - Creates an array of 1,000 identical filters that all match.

9. **All Filter with Large Number of Sub-filters that Do Not Match**:
    - Fills an array with 1,000 non-matching filters.

10. **All Filter with Alternating Matching and Non-Matching Filters**:
    - An array of alternating matching and non-matching filters (500 each for a total of 1,000 filters).

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

