### PR TITLE
Expose a Brokers audience in its status

### DIFF
--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -74,16 +74,14 @@ func (bs *BrokerStatus) GetTopLevelCondition() *apis.Condition {
 
 // SetAddress makes this Broker addressable by setting the URI. It also
 // sets the BrokerConditionAddressable to true.
-func (bs *BrokerStatus) SetAddress(url *apis.URL) {
+func (bs *BrokerStatus) SetAddress(address *v1.Addressable) {
 	bs.AddressStatus = v1.AddressStatus{
-		Address: &v1.Addressable{
-			URL: url,
-		},
+		Address: address,
 	}
 
-	if url != nil {
+	if address != nil && address.URL != nil {
 		bs.GetConditionSet().Manage(bs).MarkTrue(BrokerConditionAddressable)
-		bs.AddressStatus.Address.Name = &url.Scheme
+		bs.AddressStatus.Address.Name = &address.URL.Scheme
 	} else {
 		bs.GetConditionSet().Manage(bs).MarkFalse(BrokerConditionAddressable, "nil URL", "URL is nil")
 	}

--- a/pkg/apis/eventing/v1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle_test.go
@@ -501,7 +501,9 @@ func TestBrokerIsReady(t *testing.T) {
 			if test.markAddressable == nil && test.address == nil {
 				bs.MarkBrokerAddressableUnknown("", "")
 			}
-			bs.SetAddress(test.address)
+			bs.SetAddress(&duckv1.Addressable{
+				URL: test.address,
+			})
 
 			b := Broker{Status: bs}
 			got := b.IsReady()

--- a/pkg/apis/eventing/v1/test_helper.go
+++ b/pkg/apis/eventing/v1/test_helper.go
@@ -61,7 +61,9 @@ func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
 	bs.PropagateIngressAvailability(t.AvailableEndpoints())
 	bs.PropagateTriggerChannelReadiness(t.ReadyChannelStatus())
 	bs.PropagateFilterAvailability(t.AvailableEndpoints())
-	bs.SetAddress(apis.HTTP("example.com"))
+	bs.SetAddress(&duckv1.Addressable{
+		URL: apis.HTTP("example.com"),
+	})
 	bs.MarkDeadLetterSinkResolvedSucceeded(eventingduckv1.DeliveryStatus{})
 	return bs
 }
@@ -71,7 +73,9 @@ func (t testHelper) ReadyBrokerStatusWithoutDLS() *BrokerStatus {
 	bs.PropagateIngressAvailability(t.AvailableEndpoints())
 	bs.PropagateTriggerChannelReadiness(t.ReadyChannelStatus())
 	bs.PropagateFilterAvailability(t.AvailableEndpoints())
-	bs.SetAddress(apis.HTTP("example.com"))
+	bs.SetAddress(&duckv1.Addressable{
+		URL: apis.HTTP("example.com"),
+	})
 	bs.MarkDeadLetterSinkNotConfigured()
 	return bs
 }

--- a/pkg/auth/audience.go
+++ b/pkg/auth/audience.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/auth/audience.go
+++ b/pkg/auth/audience.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"knative.dev/pkg/kmeta"
+)
+
+// GetAudience returns the audience string for the given object in the format <group>/<kind>/<namespace>/<name>
+func GetAudience(obj kmeta.Accessor) string {
+	aud := fmt.Sprintf("%s/%s/%s/%s", obj.GroupVersionKind().Group, obj.GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+
+	return strings.ToLower(aud)
+}

--- a/pkg/auth/audience.go
+++ b/pkg/auth/audience.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"knative.dev/pkg/kmeta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GetAudience returns the audience string for the given object in the format <group>/<kind>/<namespace>/<name>
-func GetAudience(obj kmeta.Accessor) string {
-	aud := fmt.Sprintf("%s/%s/%s/%s", obj.GroupVersionKind().Group, obj.GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+func GetAudience(gvk schema.GroupVersionKind, objectMeta metav1.ObjectMeta) string {
+	aud := fmt.Sprintf("%s/%s/%s/%s", gvk.Group, gvk.Kind, objectMeta.Namespace, objectMeta.Name)
 
 	return strings.ToLower(aud)
 }

--- a/pkg/auth/audience_test.go
+++ b/pkg/auth/audience_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (

--- a/pkg/auth/audience_test.go
+++ b/pkg/auth/audience_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/pkg/kmeta"
+)
+
+func TestGetAudience(t *testing.T) {
+
+	tests := []struct {
+		name string
+		obj  kmeta.Accessor
+		want string
+	}{
+		{
+			name: "should return audience in correct format",
+			obj: &v1.Broker{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "kind",
+					APIVersion: "group/version",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			},
+			want: "group/kind/namespace/name",
+		},
+		{
+			name: "should return audience in lower case",
+			obj: &v1.Broker{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Broker",
+					APIVersion: "Eventing.knative.dev/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-Broker",
+					Namespace: "my-Namespace",
+				},
+			},
+			want: "eventing.knative.dev/broker/my-namespace/my-broker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAudience(tt.obj); got != tt.want {
+				t.Errorf("GetAudience() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/audience_test.go
+++ b/pkg/auth/audience_test.go
@@ -4,49 +4,44 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
-	"knative.dev/pkg/kmeta"
 )
 
 func TestGetAudience(t *testing.T) {
 
 	tests := []struct {
-		name string
-		obj  kmeta.Accessor
-		want string
+		name       string
+		gvk        schema.GroupVersionKind
+		objectMeta metav1.ObjectMeta
+		want       string
 	}{
 		{
 			name: "should return audience in correct format",
-			obj: &v1.Broker{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "kind",
-					APIVersion: "group/version",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "name",
-					Namespace: "namespace",
-				},
+			gvk: schema.GroupVersionKind{
+				Group:   "group",
+				Version: "version",
+				Kind:    "kind",
+			},
+			objectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
 			},
 			want: "group/kind/namespace/name",
 		},
 		{
 			name: "should return audience in lower case",
-			obj: &v1.Broker{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Broker",
-					APIVersion: "Eventing.knative.dev/v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-Broker",
-					Namespace: "my-Namespace",
-				},
+			gvk:  v1.SchemeGroupVersion.WithKind("Broker"),
+			objectMeta: metav1.ObjectMeta{
+				Name:      "my-Broker",
+				Namespace: "my-Namespace",
 			},
 			want: "eventing.knative.dev/broker/my-namespace/my-broker",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetAudience(tt.obj); got != tt.want {
+			if got := GetAudience(tt.gvk, tt.objectMeta); got != tt.want {
 				t.Errorf("GetAudience() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -767,7 +767,7 @@ func TestReconcile(t *testing.T) {
 			),
 			rttestingv1.NewBroker(sinkName, testNS,
 				rttestingv1.WithInitBrokerConditions,
-				rttestingv1.WithBrokerAddress(sinkDNS),
+				rttestingv1.WithBrokerAddressURI(apis.HTTP(sinkDNS)),
 			),
 			makeAvailableReceiveAdapter(t),
 		},

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -47,6 +47,7 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/pkg/auth"
 	clientset "knative.dev/eventing/pkg/client/clientset/versioned"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
@@ -192,8 +193,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 
 	// Route everything to shared ingress, just tack on the namespace/name as path
 	// so we can route there appropriately.
-	transportEncryptionFlags := feature.FromContext(ctx)
-	if transportEncryptionFlags.IsPermissiveTransportEncryption() {
+	featureFlags := feature.FromContext(ctx)
+	if featureFlags.IsPermissiveTransportEncryption() {
 		caCerts, err := r.getCaCerts()
 		if err != nil {
 			return err
@@ -208,7 +209,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 		//   - http address with path-based routing
 		b.Status.Addresses = []pkgduckv1.Addressable{httpsAddress, httpAddress}
 		b.Status.Address = &httpAddress
-	} else if transportEncryptionFlags.IsStrictTransportEncryption() {
+	} else if featureFlags.IsStrictTransportEncryption() {
 		// Strict mode: (only https addresses)
 		// - status.address https address with path-based routing
 		// - status.addresses:
@@ -224,6 +225,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 	} else {
 		httpAddress := r.httpAddress(b)
 		b.Status.Address = &httpAddress
+	}
+
+	if featureFlags.IsOIDCAuthentication() {
+		audience := auth.GetAudience(b)
+		logging.FromContext(ctx).Debugw("Setting the brokers audience", zap.String("audience", audience))
+		b.Status.Address.Audience = &audience
+	} else {
+		logging.FromContext(ctx).Debug("Clearing the brokers audience as OIDC is not enabled")
+		b.Status.Address.Audience = nil
 	}
 
 	b.GetConditionSet().Manage(b.GetStatus()).MarkTrue(eventingv1.BrokerConditionAddressable)

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -228,7 +228,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 	}
 
 	if featureFlags.IsOIDCAuthentication() {
-		audience := auth.GetAudience(b)
+		audience := auth.GetAudience(eventingv1.SchemeGroupVersion.WithKind("Broker"), b.ObjectMeta)
 		logging.FromContext(ctx).Debugw("Setting the brokers audience", zap.String("audience", audience))
 		b.Status.Address.Audience = &audience
 	} else {

--- a/pkg/reconciler/testing/v1/broker.go
+++ b/pkg/reconciler/testing/v1/broker.go
@@ -88,19 +88,19 @@ func WithBrokerConfig(config *duckv1.KReference) BrokerOption {
 }
 
 // WithBrokerAddress sets the Broker's address.
-func WithBrokerAddress(address string) BrokerOption {
+func WithBrokerAddress(address *duckv1.Addressable) BrokerOption {
 	return func(b *v1.Broker) {
-		b.Status.SetAddress(&apis.URL{
-			Scheme: "http",
-			Host:   address,
-		})
+		b.Status.SetAddress(address)
 	}
 }
 
 // WithBrokerAddressURI sets the Broker's address as URI.
 func WithBrokerAddressURI(uri *apis.URL) BrokerOption {
 	return func(b *v1.Broker) {
-		b.Status.SetAddress(uri)
+		b.Status.SetAddress(&duckv1.Addressable{
+			Name: &uri.Scheme,
+			URL:  uri,
+		})
 	}
 }
 

--- a/test/experimental/auth_test.go
+++ b/test/experimental/auth_test.go
@@ -1,0 +1,45 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing/test/experimental/features/auth"
+)
+
+func TestBrokerAudiencePopulated(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, auth.BrokerGetsAudiencePopulated(env.Namespace()))
+}

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -26,3 +26,4 @@ data:
   delivery-timeout: "enabled"
   new-trigger-filters: "enabled"
   eventtype-auto-create: "enabled"
+  authentication.oidc: "enabled"

--- a/test/experimental/features/auth/features.go
+++ b/test/experimental/features/auth/features.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/auth"
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func BrokerGetsAudiencePopulated(namespace string) *feature.Feature {
+	f := feature.NewFeature()
+
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("broker is ready", broker.IsReady(brokerName))
+	f.Setup("broker is addressable", broker.IsAddressable(brokerName))
+
+	expectedAudience := auth.GetAudience(broker.GVR().GroupVersion().WithKind("Broker"), v1.ObjectMeta{
+		Name:      brokerName,
+		Namespace: namespace,
+	})
+
+	f.Alpha("Broker").Must("have audience set", broker.ValidateAddress(brokerName, addressable.AssertAddressWithAudience(expectedAudience)))
+
+	return f
+}

--- a/test/rekt/resources/addressable/addressable.go
+++ b/test/rekt/resources/addressable/addressable.go
@@ -61,3 +61,13 @@ func AssertHTTPSAddress(addr *duckv1.Addressable) error {
 	}
 	return nil
 }
+
+func AssertAddressWithAudience(audience string) func(*duckv1.Addressable) error {
+	return func(addressable *duckv1.Addressable) error {
+		if (addressable.Audience == nil && audience != "") || (addressable.Audience != nil && *addressable.Audience != audience) {
+			return fmt.Errorf("audience of address (%v) does not match expected audience %s", addressable, audience)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Fixes #7184

## Proposed Changes

- :gift: Expose audience in Broker status

## Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Hints:**
* Actually `auth.GetAudience()` should have only accepted a `kmeta.Accessor` (includes `metav1.TypeMeta` and `metav1.ObjectMeta`), to construct the audience string. Anyhow `broker.ReconcileKind()` does not always get a broker object with provisioned `TypeMeta`, so I had to pass the `Group` and `Kind` directly.

**Release Note**
```release-note
Expose OIDC audience of a Broker in its status
```
