### PR TITLE
Fixed eventtype create-delete loop on built in sources

### DIFF
--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -134,6 +134,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 	return nil
 }
 
+func (r *Reconciler) FinalizeKind(ctx context.Context, source *v1.ApiServerSource) pkgreconciler.Event {
+	logging.FromContext(ctx).Info("Deleting source")
+	// Allow for eventtypes to be cleaned up
+	source.Status.CloudEventAttributes = []duckv1.CloudEventAttributes{}
+	return nil
+}
+
 func (r *Reconciler) namespacesFromSelector(src *v1.ApiServerSource) ([]string, error) {
 	if src.Spec.NamespaceSelector == nil {
 		return []string{src.Namespace}, nil

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -142,7 +142,11 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -192,6 +196,12 @@ func TestReconcile(t *testing.T) {
 			makeSubjectAccessReview("namespaces", "get", "default"),
 			makeSubjectAccessReview("namespaces", "list", "default"),
 			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -254,7 +264,11 @@ func TestReconcile(t *testing.T) {
 			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -320,7 +334,11 @@ func TestReconcile(t *testing.T) {
 			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
 		}},
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
@@ -373,6 +391,12 @@ func TestReconcile(t *testing.T) {
 			makeSubjectAccessReview("namespaces", "list", "default"),
 			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 	}, {
@@ -422,6 +446,12 @@ func TestReconcile(t *testing.T) {
 			makeSubjectAccessReview("namespaces", "list", "default"),
 			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 	}, {
@@ -441,8 +471,12 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeWarning, "SinkNotFound",
 				`Sink not found: {"ref":{"kind":"Channel","namespace":"testnamespace","name":"testsink","apiVersion":"messaging.knative.dev/v1"}}`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -485,10 +519,14 @@ func TestReconcile(t *testing.T) {
 		Key:     testNS + "/" + sourceName,
 		WantErr: true,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, apiserversourceDeploymentCreated,
 				"Deployment created, error:inducing failure for create deployments"),
 			Eventf(corev1.EventTypeWarning, "InternalError",
 				"inducing failure for create deployments"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -578,6 +616,12 @@ func TestReconcile(t *testing.T) {
 			makeSubjectAccessReview("namespaces", "list", "default"),
 			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
 		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 	}, {
@@ -602,7 +646,11 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -660,7 +708,11 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -718,7 +770,11 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: testNS + "/" + sourceName,
 		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
@@ -793,6 +849,12 @@ func TestReconcile(t *testing.T) {
 				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
 			),
 		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
 		WantCreates: []runtime.Object{
 			makeSubjectAccessReview("namespaces", "get", "default"),
 			makeSubjectAccessReview("namespaces", "list", "default"),
@@ -1017,4 +1079,13 @@ func subjectAccessReviewCreateReactor(allowed bool) clientgotesting.ReactionFunc
 		}
 		return false, nil, nil
 	}
+}
+
+func patchFinalizers(name, namespace string) clientgotesting.PatchActionImpl {
+	action := clientgotesting.PatchActionImpl{}
+	action.Name = name
+	action.Namespace = namespace
+	patch := `{"metadata":{"finalizers":["apiserversources.sources.knative.dev"],"resourceVersion":""}}`
+	action.Patch = []byte(patch)
+	return action
 }

--- a/pkg/reconciler/pingsource/pingsource.go
+++ b/pkg/reconciler/pingsource/pingsource.go
@@ -135,6 +135,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1.PingSo
 	return nil
 }
 
+func (r *Reconciler) FinalizeKind(ctx context.Context, source *sourcesv1.PingSource) pkgreconciler.Event {
+	logging.FromContext(ctx).Info("Deleting source")
+	// Allow for eventtypes to be cleaned up
+	source.Status.CloudEventAttributes = []duckv1.CloudEventAttributes{}
+	return nil
+}
+
 func (r *Reconciler) reconcileReceiveAdapter(ctx context.Context, source *sourcesv1.PingSource) (*appsv1.Deployment, error) {
 	args := resources.Args{
 		ConfigEnvVars:   r.configAcc.ToEnvVars(),

--- a/pkg/reconciler/source/duck/duck.go
+++ b/pkg/reconciler/source/duck/duck.go
@@ -41,6 +41,10 @@ import (
 	"knative.dev/eventing/pkg/reconciler/source/duck/resources"
 )
 
+const (
+	defaultNamespace = "default"
+)
+
 type Reconciler struct {
 	// eventingClientSet allows us to configure Eventing objects
 	eventingClientSet clientset.Interface
@@ -211,6 +215,9 @@ func (r *Reconciler) makeEventTypes(ctx context.Context, src *duckv1.Source) []v
 			CeSchema:    schemaURL,
 			Description: description,
 		})
+		if eventType.Spec.Reference.Namespace == "" {
+			eventType.Spec.Reference.Namespace = defaultNamespace
+		}
 		eventTypes = append(eventTypes, *eventType)
 	}
 	return eventTypes

--- a/pkg/reconciler/source/duck/duck_test.go
+++ b/pkg/reconciler/source/duck/duck_test.go
@@ -345,6 +345,9 @@ func makeEventType(ceType, ceSource string) *v1beta2.EventType {
 
 func makeEventTypeWithReference(ceType, ceSource string, ref *duckv1.KReference) *v1beta2.EventType {
 	ceSourceURL, _ := apis.ParseURL(ceSource)
+	if ref.Namespace == "" {
+		ref.Namespace = "default"
+	}
 	return &v1beta2.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%x", md5.Sum([]byte(ceType+ceSource+sourceUID))),

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -256,7 +256,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 	})
 	f.Requirement("ApiServerSource goes ready", apiserversource.IsReady(source))
 
-	expectedCeTypes := sets.New(sources.ApiServerSourceEventReferenceModeTypes...)
+	expectedCeTypes := sets.New(sources.ApiServerSourceEventResourceModeTypes...)
 
 	f.Stable("ApiServerSource as event source").
 		Must("delivers events on broker with URI",


### PR DESCRIPTION
Fixes #7236 

It appears that the eventtypes KReference in the default namespace were being retrieved with `Namespace: ""`, while the eventtypes KReference they were being compared to had `Namespace: "default"`. This caused the deep equality to fail, so they were continually deleted and recreated in the duck reconciler.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Set `Namespace = "default"` if `Namespace == ""`


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Fixed bug where eventtypes for builtin sources were created and deleted in a loop
```


