### PR TITLE
Have link to adopters form in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+<!-- Are you using Knative? If you do, we would love to know!
+https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
+-->
+
 **Problem**
 A short explanation of the problem, including relevant restrictions.
 


### PR DESCRIPTION
Have link to adopters form in feature request template.

Context: https://github.com/knative/community/issues/1251#issuecomment-1714491458