### PR TITLE
Option to specify different namespace for resources

### DIFF
--- a/test/rekt/resources/containersource/containersource.yaml
+++ b/test/rekt/resources/containersource/containersource.yaml
@@ -31,7 +31,11 @@ spec:
     {{ if .sink.ref }}
     ref:
       kind: {{ .sink.ref.kind }}
+      {{ if .sink.ref.namespace }}
       namespace: {{ .sink.ref.namespace }}
+      {{ else }}
+      namespace: {{ .namespace }}
+      {{ end }}
       name: {{ .sink.ref.name }}
       apiVersion: {{ .sink.ref.apiVersion }}
     {{ end }}

--- a/test/rekt/resources/delivery/delivery.go
+++ b/test/rekt/resources/delivery/delivery.go
@@ -44,7 +44,9 @@ func WithDeadLetterSink(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			dref := dls["ref"].(map[string]interface{})
 			dref["apiVersion"] = ref.APIVersion
 			dref["kind"] = ref.Kind
-			// Skip namespace.
+			if ref.Namespace != "" {
+				dref["namespace"] = ref.Namespace
+			}
 			dref["name"] = ref.Name
 		}
 	}

--- a/test/rekt/resources/delivery/delivery.yaml
+++ b/test/rekt/resources/delivery/delivery.yaml
@@ -20,7 +20,11 @@ spec:
       {{ if .delivery.deadLetterSink.ref }}
       ref:
         kind: {{ .delivery.deadLetterSink.ref.kind }}
+        {{ if .delivery.deadLetterSink.ref.namespace } }
+        namespace: {{ .delivery.deadLetterSink.ref.namespace }}
+        {{ else }}
         namespace: {{ .namespace }}
+        {{ end }}
         name: {{ .delivery.deadLetterSink.ref.name }}
         apiVersion: {{ .delivery.deadLetterSink.ref.apiVersion }}
       {{ end }}

--- a/test/rekt/resources/delivery/delivery.yaml
+++ b/test/rekt/resources/delivery/delivery.yaml
@@ -20,7 +20,7 @@ spec:
       {{ if .delivery.deadLetterSink.ref }}
       ref:
         kind: {{ .delivery.deadLetterSink.ref.kind }}
-        {{ if .delivery.deadLetterSink.ref.namespace } }
+        {{ if .delivery.deadLetterSink.ref.namespace }}
         namespace: {{ .delivery.deadLetterSink.ref.namespace }}
         {{ else }}
         namespace: {{ .namespace }}

--- a/test/rekt/resources/pingsource/pingsource.yaml
+++ b/test/rekt/resources/pingsource/pingsource.yaml
@@ -35,7 +35,11 @@ spec:
     {{ if .sink.ref }}
     ref:
       kind: {{ .sink.ref.kind }}
+      {{ if .sink.ref.namespace }}
+      namespace: {{ .sink.ref.namespace }}
+      {{ else }}
       namespace: {{ .namespace }}
+      {{ end }}
       name: {{ .sink.ref.name }}
       apiVersion: {{ .sink.ref.apiVersion }}
     {{ end }}

--- a/test/rekt/resources/pingsource/pingsource_test.go
+++ b/test/rekt/resources/pingsource/pingsource_test.go
@@ -93,7 +93,7 @@ func Example_full() {
 	//   sink:
 	//     ref:
 	//       kind: sinkkind
-	//       namespace: bar
+	//       namespace: sinknamespace
 	//       name: sinkname
 	//       apiVersion: sinkversion
 	//     uri: uri/parts
@@ -139,7 +139,7 @@ func Example_fullbase64() {
 	//   sink:
 	//     ref:
 	//       kind: sinkkind
-	//       namespace: bar
+	//       namespace: sinknamespace
 	//       name: sinkname
 	//       apiVersion: sinkversion
 	//     uri: uri/parts

--- a/test/rekt/resources/source/source.go
+++ b/test/rekt/resources/source/source.go
@@ -39,7 +39,9 @@ func WithSink(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			sref := sink["ref"].(map[string]interface{})
 			sref["apiVersion"] = ref.APIVersion
 			sref["kind"] = ref.Kind
-			// skip namespace
+			if ref.Namespace != "" {
+				sref["namespace"] = ref.Namespace
+			}
 			sref["name"] = ref.Name
 		}
 	}

--- a/test/rekt/resources/subscription/subscription.go
+++ b/test/rekt/resources/subscription/subscription.go
@@ -73,7 +73,9 @@ func WithSubscriber(ref *duckv1.KReference, uri string) manifest.CfgFn {
 			sref := subscriber["ref"].(map[string]interface{})
 			sref["apiVersion"] = ref.APIVersion
 			sref["kind"] = ref.Kind
-			// skip namespace
+			if ref.Namespace != "" {
+				sref["namespace"] = ref.Namespace
+			}
 			sref["name"] = ref.Name
 		}
 	}

--- a/test/rekt/resources/subscription/subscription.yaml
+++ b/test/rekt/resources/subscription/subscription.yaml
@@ -46,7 +46,11 @@ spec:
     {{ if .reply.ref }}
     ref:
       kind: {{ .reply.ref.kind }}
+      {{ if .reply.ref.namespace }}
+      namespace: {{ .reply.ref.namespace }}
+      {{ else }}
       namespace: {{ .namespace }}
+      {{ end }}
       name: {{ .reply.ref.name }}
       apiVersion: {{ .reply.ref.apiVersion }}
     {{ end }}
@@ -65,7 +69,11 @@ spec:
       {{ if .delivery.deadLetterSink.ref }}
       ref:
         kind: {{ .delivery.deadLetterSink.ref.kind }}
+        {{ if .delivery.deadLetterSink.ref.namespace }}
+        namespace: {{ .delivery.deadLetterSink.ref.namespace }}
+        {{ else }}
         namespace: {{ .namespace }}
+        {{ end }}
         name: {{ .delivery.deadLetterSink.ref.name }}
         apiVersion: {{ .delivery.deadLetterSink.ref.apiVersion }}
       {{ end }}


### PR DESCRIPTION
Affects ContainerSource, PingSource, Subscription.

The resources might point to Sinks that are in a different namespace than the current resource. It is especially useful for testing cross-namespace communication.
The changes do not affect current behaviour. By default the current/test namespace is used but the user can specify another namespace by passing extra properties.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

