### PR TITLE
Fail when ApiServerSource adapter can't retrieve resources

### DIFF
--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -88,8 +89,7 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 
 		resources, err := a.discover.ServerResourcesForGroupVersion(configRes.GVR.GroupVersion().String())
 		if err != nil {
-			a.logger.Errorf("Could not retrieve information about resource %s: %s", configRes.GVR.String(), err.Error())
-			continue
+			return fmt.Errorf("failed to retrieve information about resource %s: %v", configRes.GVR.String(), err)
 		}
 
 		exists := false
@@ -120,7 +120,7 @@ func (a *apiServerAdapter) start(ctx context.Context, stopCh <-chan struct{}) er
 		}
 
 		if !exists {
-			a.logger.Errorf("Could not retrieve information about resource %s: %s", configRes.GVR.String())
+			a.logger.Errorf("could not retrieve information about resource %s: it doesn't exist", configRes.GVR.String())
 		}
 	}
 


### PR DESCRIPTION
This fixes the issue when istio proxy is injected and the adapter starts before it is ready:
```
{"level":"error","ts":"2023-09-21T13:29:17.711Z","caller":"apiserver/adapter.go:91","msg":"Could not retrieve information about resource /v1, Resource=events: Get \"[https://172.30.0.1:443/api/v1](https://172.30.0.1/api/v1)\": dial tcp 172.30.0.1:443: connect: connection refused","commit":"a16b045-dirty","stacktrace":"knative.dev/eventing/pkg/adapter/apiserver.(*apiServerAdapter).start\n\t/go/src/github.com/openshift/origin/pkg/adapter/apiserver/adapter.go:91\nknative.dev/eventing/pkg/adapter/apiserver.(*apiServerAdapter).Start\n\t/go/src/github.com/openshift/origin/pkg/adapter/apiserver/adapter.go:58\nknative.dev/eventing/pkg/adapter/v2.MainWithInformers\n\t/go/src/github.com/openshift/origin/pkg/adapter/v2/main.go:272\nknative.dev/eventing/pkg/adapter/v2.MainWithEnv\n\t/go/src/github.com/openshift/origin/pkg/adapter/v2/main.go:158\nknative.dev/eventing/pkg/adapter/v2.MainWithContext\n\t/go/src/github.com/openshift/origin/pkg/adapter/v2/main.go:133\nmain.main\n\t/go/src/github.com/openshift/origin/cmd/apiserver_receive_adapter/main.go:33\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

I've tried these changes and we get the pod eventually ready and sending events after a restart:

```
k get pods -n serverless-tests
NAME                                                              READY   STATUS    RESTARTS     AGE
apiserversource-apiserversourcede613119065bcdc06e6db7efacexvqk7   2/2     Running   1 (8m ago)   8m5s
```

```
$ k logs -n serverless-tests event-display-6ff45b9df5-pwbzr -f
2023/09/22 08:09:57 Failed to read tracing config, using the no-op default: empty json tracing config
☁️  cloudevents.Event
Context Attributes,
  specversion: 1.0
  type: dev.knative.apiserver.ref.update
  source: https://172.30.0.1:443
  subject: /apis/apps/v1/namespaces/serverless-tests/deployments/event-display
  id: 75ec25d0-0cdd-4b28-8c84-4378daf03b05
  time: 2023-09-22T08:09:55.639682753Z
  datacontenttype: application/json
Extensions,
  apiversion: apps/v1
  cluster: test-cluster
  env: env1
  kind: Deployment
  name: event-display
  namespace: test
  tenant: example1
Data,
  {
    "kind": "Deployment",
    "namespace": "serverless-tests",
    "name": "event-display",
    "apiVersion": "apps/v1"
  }
☁️  cloudevents.Event
Context Attributes,
  specversion: 1.0
  type: dev.knative.apiserver.ref.update
  source: https://172.30.0.1:443
  subject: /apis/apps/v1/namespaces/serverless-tests/deployments/event-display
  id: ac5bfc90-96ea-4fe6-9827-421163149c11
  time: 2023-09-22T08:09:58.767572644Z
  datacontenttype: application/json
Extensions,
  apiversion: apps/v1
  cluster: test-cluster
  env: env1
  kind: Deployment
  name: event-display
  namespace: test
  tenant: example1
Data,
  {
    "kind": "Deployment",
    "namespace": "serverless-tests",
    "name": "event-display",
    "apiVersion": "apps/v1"
  }
☁️  cloudevents.Event
Context Attributes,
  specversion: 1.0
  type: dev.knative.apiserver.ref.update
  source: https://172.30.0.1:443
  subject: /apis/apps/v1/namespaces/serverless-tests/deployments/event-display
  id: 9f1c1286-7798-4fba-ac50-f624a8753b42
  time: 2023-09-22T08:09:58.768926614Z
  datacontenttype: application/json
Extensions,
  apiversion: apps/v1
  cluster: test-cluster
  env: env1
  kind: Deployment
  name: event-display
  namespace: test
  tenant: example1
Data,
  {
    "kind": "Deployment",
    "namespace": "serverless-tests",
    "name": "event-display",
    "apiVersion": "apps/v1"
  }
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fail when ApiServerSource adapter can't retrieve resources
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Correctly handle networking errors when ApiServerSource adapter can't retrieve resources when starts.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

