### PR TITLE
Fix event dispatcher library data race

### DIFF
--- a/pkg/kncloudevents/event_dispatcher.go
+++ b/pkg/kncloudevents/event_dispatcher.go
@@ -111,7 +111,11 @@ type senderConfig struct {
 
 // SendEvent sends the given event to the given destination.
 func SendEvent(ctx context.Context, event event.Event, destination duckv1.Addressable, options ...SendOption) (*DispatchInfo, error) {
-	message := binding.ToMessage(&event)
+	// clone the event since:
+	// - we mutate the event and the callers might not expect this
+	// - it might produce data races if the caller is trying to read the event in different go routines
+	c := event.Clone()
+	message := binding.ToMessage(&c)
 
 	return SendMessage(ctx, message, destination, options...)
 }


### PR DESCRIPTION
Clone the event since:
- we mutate the event and the callers might not expect this
- it might produce data races if the caller is trying to read the event in different go routines

Fixes #7193 

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix dispatcher data race

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

