### PR TITLE
Add audience field for Subscriber and Reply to `SubscriberSpec` and `SubscriptionStatusPhysicalSubscription`

### DIFF
--- a/config/channels/in-memory-channel/resources/in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/resources/in-memory-channel.yaml
@@ -142,11 +142,17 @@ spec:
                     replyCACerts:
                       description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                       type: string
+                    replyAudience:
+                      description: ReplyAudience is the OIDC audience for the replyUri.
+                      type: string
                     subscriberUri:
                       description: SubscriberURI is the endpoint for the subscriber
                       type: string
                     subscriberCACerts:
                       description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    subscriberAudience:
+                      description: SubscriberAudience is the OIDC audience for the subscriberUri.
                       type: string
                     uid:
                       description: UID is used to understand the origin of the subscriber.

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -164,11 +164,17 @@ spec:
                     replyCACerts:
                       description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                       type: string
+                    replyAudience:
+                      description: ReplyAudience is the OIDC audience for the replyUri.
+                      type: string
                     subscriberUri:
                       description: SubscriberURI is the endpoint for the subscriber
                       type: string
                     subscriberCACerts:
                       description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    subscriberAudience:
+                      description: SubscriberAudience is the OIDC audience for the subscriberUri.
                       type: string
                     uid:
                       description: UID is used to understand the origin of the subscriber.

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -197,11 +197,17 @@ spec:
                   replyCACerts:
                     description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                     type: string
+                  replyAudience:
+                    description: ReplyAudience is the OIDC audience for the replyUri.
+                    type: string
                   subscriberUri:
                     description: SubscriberURI is the fully resolved URI for spec.subscriber.
                     type: string
                   subscriberCACerts:
                     description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
+                    type: string
+                  subscriberAudience:
+                    description: SubscriberAudience is the OIDC audience for the subscriberUri.
                     type: string
     additionalPrinterColumns:
     - name: Age

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -664,6 +664,18 @@ subscriberUri</p>
 </tr>
 <tr>
 <td>
+<code>subscriberAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberAudience is the OIDC audience for the subscriberUri.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replyUri</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
@@ -688,6 +700,18 @@ string
 <p>ReplyCACerts is the Certification Authority (CA) certificates in PEM
 format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
 replyUri.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyAudience is the OIDC audience for the replyUri.</p>
 </td>
 </tr>
 <tr>
@@ -4639,6 +4663,19 @@ resolved URI for spec.subscriber.</p>
 </tr>
 <tr>
 <td>
+<code>subscriberAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberAudience is the OIDC audience for the the resolved URI for
+spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>replyUri</code><br/>
 <em>
 <a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
@@ -4663,6 +4700,19 @@ string
 <p>ReplyCACerts is the Certification Authority (CA) certificates in PEM
 format according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a> for the
 resolved URI for the spec.reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyAudience is the OIDC audience for the the resolved URI for
+spec.reply.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/duck/v1/subscribable_types.go
+++ b/pkg/apis/duck/v1/subscribable_types.go
@@ -47,6 +47,9 @@ type SubscriberSpec struct {
 	// subscriberUri
 	// +optional
 	SubscriberCACerts *string `json:"subscriberCACerts,omitempty"`
+	// SubscriberAudience is the OIDC audience for the subscriberUri.
+	// +optional
+	SubscriberAudience *string `json:"subscriberAudience,omitempty"`
 	// ReplyURI is the endpoint for the reply
 	// +optional
 	ReplyURI *apis.URL `json:"replyUri,omitempty"`
@@ -55,6 +58,9 @@ type SubscriberSpec struct {
 	// replyUri.
 	// +optional
 	ReplyCACerts *string `json:"replyCACerts,omitempty"`
+	// ReplyAudience is the OIDC audience for the replyUri.
+	// +optional
+	ReplyAudience *string `json:"replyAudience,omitempty"`
 	// +optional
 	// DeliverySpec contains options controlling the event delivery
 	// +optional

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -320,6 +320,11 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubscriberAudience != nil {
+		in, out := &in.SubscriberAudience, &out.SubscriberAudience
+		*out = new(string)
+		**out = **in
+	}
 	if in.ReplyURI != nil {
 		in, out := &in.ReplyURI, &out.ReplyURI
 		*out = new(apis.URL)
@@ -327,6 +332,11 @@ func (in *SubscriberSpec) DeepCopyInto(out *SubscriberSpec) {
 	}
 	if in.ReplyCACerts != nil {
 		in, out := &in.ReplyCACerts, &out.ReplyCACerts
+		*out = new(string)
+		**out = **in
+	}
+	if in.ReplyAudience != nil {
+		in, out := &in.ReplyAudience, &out.ReplyAudience
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/apis/messaging/v1/subscription_types.go
+++ b/pkg/apis/messaging/v1/subscription_types.go
@@ -129,6 +129,11 @@ type SubscriptionStatusPhysicalSubscription struct {
 	// +optional
 	SubscriberCACerts *string `json:"subscriberCACerts,omitempty"`
 
+	// SubscriberAudience is the OIDC audience for the the resolved URI for
+	// spec.subscriber.
+	// +optional
+	SubscriberAudience *string `json:"subscriberAudience,omitempty"`
+
 	// ReplyURI is the fully resolved URI for the spec.reply.
 	// +optional
 	ReplyURI *apis.URL `json:"replyUri,omitempty"`
@@ -138,6 +143,11 @@ type SubscriptionStatusPhysicalSubscription struct {
 	// resolved URI for the spec.reply.
 	// +optional
 	ReplyCACerts *string `json:"replyCACerts,omitempty"`
+
+	// ReplyAudience is the OIDC audience for the the resolved URI for
+	// spec.reply.
+	// +optional
+	ReplyAudience *string `json:"replyAudience,omitempty"`
 
 	// DeliveryStatus contains a resolved URL to the dead letter sink address, and any other
 	// resolved delivery options.

--- a/pkg/apis/messaging/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1/zz_generated.deepcopy.go
@@ -382,6 +382,11 @@ func (in *SubscriptionStatusPhysicalSubscription) DeepCopyInto(out *Subscription
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubscriberAudience != nil {
+		in, out := &in.SubscriberAudience, &out.SubscriberAudience
+		*out = new(string)
+		**out = **in
+	}
 	if in.ReplyURI != nil {
 		in, out := &in.ReplyURI, &out.ReplyURI
 		*out = new(apis.URL)
@@ -389,6 +394,11 @@ func (in *SubscriptionStatusPhysicalSubscription) DeepCopyInto(out *Subscription
 	}
 	if in.ReplyCACerts != nil {
 		in, out := &in.ReplyCACerts, &out.ReplyCACerts
+		*out = new(string)
+		**out = **in
+	}
+	if in.ReplyAudience != nil {
+		in, out := &in.ReplyAudience, &out.ReplyAudience
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -230,9 +230,11 @@ func (r *Reconciler) resolveSubscriber(ctx context.Context, subscription *v1.Sub
 		logging.FromContext(ctx).Debugw("Resolved Subscriber", zap.Any("subscriber", subscriberAddr))
 		subscription.Status.PhysicalSubscription.SubscriberURI = subscriberAddr.URL
 		subscription.Status.PhysicalSubscription.SubscriberCACerts = subscriberAddr.CACerts
+		subscription.Status.PhysicalSubscription.SubscriberAudience = subscriberAddr.Audience
 	} else {
 		subscription.Status.PhysicalSubscription.SubscriberURI = nil
 		subscription.Status.PhysicalSubscription.SubscriberCACerts = nil
+		subscription.Status.PhysicalSubscription.SubscriberAudience = nil
 	}
 	return nil
 }
@@ -259,9 +261,11 @@ func (r *Reconciler) resolveReply(ctx context.Context, subscription *v1.Subscrip
 		logging.FromContext(ctx).Debugw("Resolved reply", zap.Any("reply", replyAddr))
 		subscription.Status.PhysicalSubscription.ReplyURI = replyAddr.URL
 		subscription.Status.PhysicalSubscription.ReplyCACerts = replyAddr.CACerts
+		subscription.Status.PhysicalSubscription.ReplyAudience = replyAddr.Audience
 	} else {
 		subscription.Status.PhysicalSubscription.ReplyURI = nil
 		subscription.Status.PhysicalSubscription.ReplyCACerts = nil
+		subscription.Status.PhysicalSubscription.ReplyAudience = nil
 	}
 	return nil
 }
@@ -492,21 +496,25 @@ func (r *Reconciler) updateChannelAddSubscription(channel *eventingduckv1.Channe
 			channel.Spec.Subscribers[i].Generation = sub.Generation
 			channel.Spec.Subscribers[i].SubscriberURI = sub.Status.PhysicalSubscription.SubscriberURI
 			channel.Spec.Subscribers[i].SubscriberCACerts = sub.Status.PhysicalSubscription.SubscriberCACerts
+			channel.Spec.Subscribers[i].SubscriberAudience = sub.Status.PhysicalSubscription.SubscriberAudience
 			channel.Spec.Subscribers[i].ReplyURI = sub.Status.PhysicalSubscription.ReplyURI
 			channel.Spec.Subscribers[i].ReplyCACerts = sub.Status.PhysicalSubscription.ReplyCACerts
+			channel.Spec.Subscribers[i].ReplyAudience = sub.Status.PhysicalSubscription.ReplyAudience
 			channel.Spec.Subscribers[i].Delivery = deliverySpec(sub, channel)
 			return
 		}
 	}
 
 	toAdd := eventingduckv1.SubscriberSpec{
-		UID:               sub.UID,
-		Generation:        sub.Generation,
-		SubscriberURI:     sub.Status.PhysicalSubscription.SubscriberURI,
-		SubscriberCACerts: sub.Status.PhysicalSubscription.SubscriberCACerts,
-		ReplyURI:          sub.Status.PhysicalSubscription.ReplyURI,
-		ReplyCACerts:      sub.Status.PhysicalSubscription.ReplyCACerts,
-		Delivery:          deliverySpec(sub, channel),
+		UID:                sub.UID,
+		Generation:         sub.Generation,
+		SubscriberURI:      sub.Status.PhysicalSubscription.SubscriberURI,
+		SubscriberCACerts:  sub.Status.PhysicalSubscription.SubscriberCACerts,
+		SubscriberAudience: sub.Status.PhysicalSubscription.SubscriberAudience,
+		ReplyURI:           sub.Status.PhysicalSubscription.ReplyURI,
+		ReplyCACerts:       sub.Status.PhysicalSubscription.ReplyCACerts,
+		ReplyAudience:      sub.Status.PhysicalSubscription.ReplyAudience,
+		Delivery:           deliverySpec(sub, channel),
 	}
 
 	// Must not have been found. Add it.

--- a/pkg/reconciler/testing/v1/subscription.go
+++ b/pkg/reconciler/testing/v1/subscription.go
@@ -208,6 +208,7 @@ func WithSubscriptionPhysicalSubscriptionSubscriber(subscriber *duckv1.Addressab
 		}
 		s.Status.PhysicalSubscription.SubscriberURI = subscriber.URL
 		s.Status.PhysicalSubscription.SubscriberCACerts = subscriber.CACerts
+		s.Status.PhysicalSubscription.SubscriberAudience = subscriber.Audience
 	}
 }
 
@@ -218,6 +219,7 @@ func WithSubscriptionPhysicalSubscriptionReply(reply *duckv1.Addressable) Subscr
 		}
 		s.Status.PhysicalSubscription.ReplyURI = reply.URL
 		s.Status.PhysicalSubscription.ReplyCACerts = reply.CACerts
+		s.Status.PhysicalSubscription.ReplyAudience = reply.Audience
 	}
 }
 


### PR DESCRIPTION
Fixes #7293

## Proposed Changes

As we need to provide the Audiences of the Subscriber and Reply in the Subscription, this PR adds the Audience of Subscriber and Reply to SubscriberSpec and SubscriptionStatusPhysicalSubscription.