### PR TITLE
Trigger create and expose OIDC service account

### DIFF
--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -23,7 +23,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var triggerCondSet = apis.NewLivingConditionSet(TriggerConditionBroker, TriggerConditionSubscribed, TriggerConditionDependency, TriggerConditionSubscriberResolved, TriggerConditionDeadLetterSinkResolved)
+var triggerCondSet = apis.NewLivingConditionSet(TriggerConditionBroker, TriggerConditionSubscribed, TriggerConditionDependency, TriggerConditionSubscriberResolved, TriggerConditionDeadLetterSinkResolved, TriggerConditionOIDCServiceAccountResolved)
 
 const (
 	// TriggerConditionReady has status True when all subconditions below have been set to True.
@@ -38,6 +38,8 @@ const (
 	TriggerConditionSubscriberResolved apis.ConditionType = "SubscriberResolved"
 
 	TriggerConditionDeadLetterSinkResolved apis.ConditionType = "DeadLetterSinkResolved"
+
+	TriggerConditionOIDCServiceAccountResolved apis.ConditionType = "OIDCServiceAccountResolved"
 
 	// TriggerAnyFilter Constant to represent that we should allow anything.
 	TriggerAnyFilter = ""
@@ -198,4 +200,20 @@ func (ts *TriggerStatus) PropagateDependencyStatus(ks *duckv1.Source) {
 	default:
 		ts.MarkDependencyUnknown("DependencyUnknown", "The status of Dependency is invalid: %v", kc.Status)
 	}
+}
+
+func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedSucceeded() {
+	triggerCondSet.Manage(ts).MarkTrue(TriggerConditionOIDCServiceAccountResolved)
+}
+
+func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkTrueWithReason(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
+}
+
+func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedFailed(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkFalse(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
+}
+
+func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedUnknown(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkUnknown(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
 }

--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -23,7 +23,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var triggerCondSet = apis.NewLivingConditionSet(TriggerConditionBroker, TriggerConditionSubscribed, TriggerConditionDependency, TriggerConditionSubscriberResolved, TriggerConditionDeadLetterSinkResolved, TriggerConditionOIDCServiceAccountResolved)
+var triggerCondSet = apis.NewLivingConditionSet(TriggerConditionBroker, TriggerConditionSubscribed, TriggerConditionDependency, TriggerConditionSubscriberResolved, TriggerConditionDeadLetterSinkResolved, TriggerConditionOIDCIdentityCreated)
 
 const (
 	// TriggerConditionReady has status True when all subconditions below have been set to True.
@@ -39,7 +39,7 @@ const (
 
 	TriggerConditionDeadLetterSinkResolved apis.ConditionType = "DeadLetterSinkResolved"
 
-	TriggerConditionOIDCServiceAccountResolved apis.ConditionType = "OIDCServiceAccountResolved"
+	TriggerConditionOIDCIdentityCreated apis.ConditionType = "OIDCIdentityCreated"
 
 	// TriggerAnyFilter Constant to represent that we should allow anything.
 	TriggerAnyFilter = ""
@@ -202,18 +202,18 @@ func (ts *TriggerStatus) PropagateDependencyStatus(ks *duckv1.Source) {
 	}
 }
 
-func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedSucceeded() {
-	triggerCondSet.Manage(ts).MarkTrue(TriggerConditionOIDCServiceAccountResolved)
+func (ts *TriggerStatus) MarkOIDCIdentityCreatedSucceeded() {
+	triggerCondSet.Manage(ts).MarkTrue(TriggerConditionOIDCIdentityCreated)
 }
 
-func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
-	triggerCondSet.Manage(ts).MarkTrueWithReason(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
+func (ts *TriggerStatus) MarkOIDCIdentityCreatedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkTrueWithReason(TriggerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
-func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedFailed(reason, messageFormat string, messageA ...interface{}) {
-	triggerCondSet.Manage(ts).MarkFalse(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
+func (ts *TriggerStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkFalse(TriggerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
-func (ts *TriggerStatus) MarkOIDCServiceAccountResolvedUnknown(reason, messageFormat string, messageA ...interface{}) {
-	triggerCondSet.Manage(ts).MarkUnknown(TriggerConditionOIDCServiceAccountResolved, reason, messageFormat, messageA...)
+func (ts *TriggerStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
+	triggerCondSet.Manage(ts).MarkUnknown(TriggerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }

--- a/pkg/apis/eventing/v1/trigger_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle_test.go
@@ -154,6 +154,9 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Type:   TriggerConditionDependency,
 					Status: corev1.ConditionUnknown,
 				}, {
+					Type:   TriggerConditionOIDCServiceAccountResolved,
+					Status: corev1.ConditionUnknown,
+				}, {
 					Type:   TriggerConditionReady,
 					Status: corev1.ConditionUnknown,
 				}, {
@@ -187,17 +190,19 @@ func TestTriggerInitializeConditions(t *testing.T) {
 				}, {
 					Type:   TriggerConditionDependency,
 					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   TriggerConditionOIDCServiceAccountResolved,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   TriggerConditionReady,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   TriggerConditionSubscriberResolved,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   TriggerConditionSubscribed,
+					Status: corev1.ConditionUnknown,
 				},
-					{
-						Type:   TriggerConditionReady,
-						Status: corev1.ConditionUnknown,
-					}, {
-						Type:   TriggerConditionSubscriberResolved,
-						Status: corev1.ConditionUnknown,
-					}, {
-						Type:   TriggerConditionSubscribed,
-						Status: corev1.ConditionUnknown,
-					},
 				},
 			},
 		},
@@ -221,6 +226,9 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionDependency,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   TriggerConditionOIDCServiceAccountResolved,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionReady,
@@ -257,6 +265,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriberResolvedStatus    bool
 		dlsResolvedStatus           bool
 		dependencyAnnotationExists  bool
+		oidcServiceAccountStatus    bool
 		dependencyStatus            corev1.ConditionStatus
 		wantConditionStatus         corev1.ConditionStatus
 	}{{
@@ -267,6 +276,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    true,
 		dlsResolvedStatus:           true,
+		oidcServiceAccountStatus:    true,
 		dependencyAnnotationExists:  false,
 		wantConditionStatus:         corev1.ConditionTrue,
 	}, {
@@ -277,6 +287,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    true,
 		dlsResolvedStatus:           true,
+		oidcServiceAccountStatus:    true,
 		dependencyAnnotationExists:  false,
 		wantConditionStatus:         corev1.ConditionUnknown,
 	}, {
@@ -286,6 +297,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		markVirtualServiceExists:    true,
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    true,
+		oidcServiceAccountStatus:    true,
 		dependencyAnnotationExists:  false,
 		wantConditionStatus:         corev1.ConditionFalse,
 	}, {
@@ -295,6 +307,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		markVirtualServiceExists:    true,
 		subscriptionCondition:       TestHelper.FalseSubscriptionCondition(),
 		subscriberResolvedStatus:    true,
+		oidcServiceAccountStatus:    true,
 		dependencyAnnotationExists:  false,
 		wantConditionStatus:         corev1.ConditionFalse,
 	}, {
@@ -304,6 +317,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		markVirtualServiceExists:    true,
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    false,
+		oidcServiceAccountStatus:    true,
 		dependencyAnnotationExists:  true,
 		dependencyStatus:            corev1.ConditionTrue,
 		wantConditionStatus:         corev1.ConditionFalse,
@@ -316,6 +330,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriberResolvedStatus:    true,
 		dependencyAnnotationExists:  true,
 		dlsResolvedStatus:           true,
+		oidcServiceAccountStatus:    true,
 		dependencyStatus:            corev1.ConditionUnknown,
 		wantConditionStatus:         corev1.ConditionUnknown,
 	}, {
@@ -326,6 +341,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    true,
 		dependencyAnnotationExists:  true,
+		oidcServiceAccountStatus:    true,
 		dependencyStatus:            corev1.ConditionFalse,
 		wantConditionStatus:         corev1.ConditionFalse,
 	}, {
@@ -335,6 +351,7 @@ func TestTriggerConditionStatus(t *testing.T) {
 		markVirtualServiceExists:    false,
 		subscriptionCondition:       TestHelper.FalseSubscriptionCondition(),
 		subscriberResolvedStatus:    false,
+		oidcServiceAccountStatus:    false,
 		dependencyAnnotationExists:  true,
 		dependencyStatus:            corev1.ConditionFalse,
 		wantConditionStatus:         corev1.ConditionFalse,
@@ -346,9 +363,22 @@ func TestTriggerConditionStatus(t *testing.T) {
 		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
 		subscriberResolvedStatus:    true,
 		dependencyAnnotationExists:  true,
+		oidcServiceAccountStatus:    true,
 		dlsResolvedStatus:           false,
 		wantConditionStatus:         corev1.ConditionFalse,
+	}, {
+		name:                        "oidc status false",
+		brokerStatus:                TestHelper.ReadyBrokerStatus(),
+		markKubernetesServiceExists: true,
+		markVirtualServiceExists:    true,
+		subscriptionCondition:       TestHelper.ReadySubscriptionCondition(),
+		subscriberResolvedStatus:    true,
+		dlsResolvedStatus:           true,
+		oidcServiceAccountStatus:    false,
+		dependencyAnnotationExists:  false,
+		wantConditionStatus:         corev1.ConditionFalse,
 	}}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ts := &TriggerStatus{}
@@ -378,6 +408,11 @@ func TestTriggerConditionStatus(t *testing.T) {
 				} else {
 					ts.MarkDependencyFailed("The status of dependency is false", "The status of dependency is unknown: nil")
 				}
+			}
+			if test.oidcServiceAccountStatus {
+				ts.MarkOIDCServiceAccountResolvedSucceeded()
+			} else {
+				ts.MarkOIDCServiceAccountResolvedFailed("Unable to ...", "")
 			}
 			got := ts.GetTopLevelCondition().Status
 			if test.wantConditionStatus != got {

--- a/pkg/apis/eventing/v1/trigger_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle_test.go
@@ -154,7 +154,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Type:   TriggerConditionDependency,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   TriggerConditionOIDCServiceAccountResolved,
+					Type:   TriggerConditionOIDCIdentityCreated,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionReady,
@@ -191,7 +191,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Type:   TriggerConditionDependency,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   TriggerConditionOIDCServiceAccountResolved,
+					Type:   TriggerConditionOIDCIdentityCreated,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionReady,
@@ -228,7 +228,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Type:   TriggerConditionDependency,
 					Status: corev1.ConditionUnknown,
 				}, {
-					Type:   TriggerConditionOIDCServiceAccountResolved,
+					Type:   TriggerConditionOIDCIdentityCreated,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionReady,
@@ -410,9 +410,9 @@ func TestTriggerConditionStatus(t *testing.T) {
 				}
 			}
 			if test.oidcServiceAccountStatus {
-				ts.MarkOIDCServiceAccountResolvedSucceeded()
+				ts.MarkOIDCIdentityCreatedSucceeded()
 			} else {
-				ts.MarkOIDCServiceAccountResolvedFailed("Unable to ...", "")
+				ts.MarkOIDCIdentityCreatedFailed("Unable to ...", "")
 			}
 			got := ts.GetTopLevelCondition().Status
 			if test.wantConditionStatus != got {

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -89,7 +89,7 @@ func EnsureOIDCServiceAccountExistsForResource(ctx context.Context, serviceAccou
 	}
 
 	if !metav1.IsControlledBy(&sa.ObjectMeta, &objectMeta) {
-		return fmt.Errorf("%s %s does not own service account %s", gvk.Kind, objectMeta.Name, sa.Name)
+		return fmt.Errorf("service account %s not owned by %s %s", sa.Name, gvk.Kind, objectMeta.Name)
 	}
 
 	return nil

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -72,7 +72,7 @@ func EnsureOIDCServiceAccountExistsForResource(ctx context.Context, serviceAccou
 
 	// If the resource doesn't exist, we'll create it.
 	if apierrs.IsNotFound(err) {
-		logging.FromContext(ctx).Infow("Creating OIDC service account", zap.Error(err))
+		logging.FromContext(ctx).Debugw("Creating OIDC service account", zap.Error(err))
 
 		expected := GetOIDCServiceAccountForResource(gvk, objectMeta)
 

--- a/pkg/auth/serviceaccount_test.go
+++ b/pkg/auth/serviceaccount_test.go
@@ -84,7 +84,7 @@ func TestGetOIDCServiceAccountForResource(t *testing.T) {
 					Kind:               "Broker",
 					Name:               "my-broker",
 					UID:                "my-uuid",
-					Controller:         ptr.Bool(false),
+					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(false),
 				},
 			},

--- a/pkg/reconciler/broker/trigger/controller.go
+++ b/pkg/reconciler/broker/trigger/controller.go
@@ -66,14 +66,15 @@ func NewController(
 
 	triggerLister := triggerInformer.Lister()
 	r := &Reconciler{
-		eventingClientSet:  eventingclient.Get(ctx),
-		dynamicClientSet:   dynamicclient.Get(ctx),
-		kubeclient:         kubeclient.Get(ctx),
-		subscriptionLister: subscriptionInformer.Lister(),
-		brokerLister:       brokerInformer.Lister(),
-		triggerLister:      triggerLister,
-		configmapLister:    configmapInformer.Lister(),
-		secretLister:       secretInformer.Lister(),
+		eventingClientSet:    eventingclient.Get(ctx),
+		dynamicClientSet:     dynamicclient.Get(ctx),
+		kubeclient:           kubeclient.Get(ctx),
+		subscriptionLister:   subscriptionInformer.Lister(),
+		brokerLister:         brokerInformer.Lister(),
+		triggerLister:        triggerLister,
+		configmapLister:      configmapInformer.Lister(),
+		secretLister:         secretInformer.Lister(),
+		serviceAccountLister: serviceaccountInformer.Lister(),
 	}
 	impl := triggerreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{

--- a/pkg/reconciler/broker/trigger/controller_test.go
+++ b/pkg/reconciler/broker/trigger/controller_test.go
@@ -44,6 +44,7 @@ import (
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -47,9 +47,11 @@ import (
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/eventing"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/apis/sources/v1beta2"
+	"knative.dev/eventing/pkg/auth"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/trigger"
@@ -57,6 +59,7 @@ import (
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/pkg/reconciler/broker/resources"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
 	. "knative.dev/pkg/reconciler/testing"
@@ -273,7 +276,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
-					WithTriggerStatusSubscriberURI(subscriberURI)),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "Creates subscription with retry from trigger",
@@ -306,7 +310,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
-					WithTriggerStatusSubscriberURI(subscriberURI)),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "Creates subscription with dls from trigger",
@@ -340,7 +345,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
-					WithTriggerDeadLetterSinkResolvedSucceeded()),
+					WithTriggerDeadLetterSinkResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "TLS: Creates subscription with dls from trigger",
@@ -395,6 +401,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -456,6 +463,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -517,6 +525,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -574,6 +583,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -604,7 +614,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberURI(subscriberURI),
-					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions")),
+					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create subscriptions"),
@@ -633,7 +644,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscriberResolvedSucceeded(),
-					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions")),
+					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantCreates: []runtime.Object{
 				makeFilterSubscription(testNS),
@@ -659,7 +671,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerNotSubscribed("NotSubscribed", `trigger "test-trigger" does not own subscription "test-broker-test-trigger-test-trigger-uid"`),
-					WithTriggerStatusSubscriberURI(subscriberURI)),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `trigger "test-trigger" does not own subscription "test-broker-test-trigger-test-trigger-uid"`),
@@ -686,7 +699,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerDependencyReady()),
+					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				ActionImpl: clientgotesting.ActionImpl{
@@ -722,7 +736,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerStatusSubscriberURI(subscriberURI),
-					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for delete subscriptions")),
+					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for delete subscriptions"),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				ActionImpl: clientgotesting.ActionImpl{
@@ -759,7 +774,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerStatusSubscriberURI(subscriberURI),
-					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions")),
+					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "SubscriptionCreateFailed", `Create Trigger's subscription failed: inducing failure for create subscriptions`),
@@ -797,6 +813,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -825,6 +842,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -853,6 +871,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -935,6 +954,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -1034,6 +1054,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1095,6 +1116,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1158,6 +1180,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1225,6 +1248,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1250,6 +1274,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1279,6 +1304,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyFailed("DependencyDoesNotExist", `Dependency does not exist: pingsources.sources.knative.dev "test-ping-source" not found`),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantErr: true,
@@ -1308,6 +1334,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyFailed("NotFound", ""),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1336,6 +1363,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyUnknown("", ""),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		},
@@ -1364,7 +1392,8 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The dependency's metadata.generation, %q, is not equal to its status.observedGeneration, %q.", currentGeneration, outdatedGeneration))),
+					WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The dependency's metadata.generation, %q, is not equal to its status.observedGeneration, %q.", currentGeneration, outdatedGeneration)),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		},
 		{
@@ -1393,6 +1422,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		},
@@ -1419,6 +1449,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -1448,10 +1479,81 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
+					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
 				makeFilterSubscription(subscriberNameNamespace),
+			},
+		},
+		{
+			Name: "OIDC: creates OIDC service account",
+			Key:  testKey,
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.OIDCAuthentication: feature.Enabled,
+			}),
+			Objects: allBrokerObjectsReadyPlus([]runtime.Object{
+				makeReadySubscription(testNS),
+				NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(triggerUID),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithInitTriggerConditions,
+				)}...),
+			WantErr: false,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(triggerUID),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithTriggerBrokerReady(),
+					// The first reconciliation will initialize the status conditions.
+					WithInitTriggerConditions,
+					WithTriggerDependencyReady(),
+					WithTriggerSubscribed(),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerSubscriberResolvedSucceeded(),
+					WithTriggerDeadLetterSinkNotConfigured(),
+					WithTriggerOIDCServiceAccountResolvedSucceeded(),
+					WithTriggerOIDCServiceAccountName(makeTriggerOIDCServiceAccount().Name),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeTriggerOIDCServiceAccount(),
+			},
+		},
+		{
+			Name: "OIDC: Trigger not ready on invalid OIDC service account",
+			Key:  testKey,
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				feature.OIDCAuthentication: feature.Enabled,
+			}),
+			Objects: allBrokerObjectsReadyPlus([]runtime.Object{
+				makeReadySubscription(testNS),
+				makeTriggerOIDCServiceAccountWithoutOwnerRef(),
+				NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(triggerUID),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithInitTriggerConditions,
+				)}...),
+			WantErr: true,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewTrigger(triggerName, testNS, brokerName,
+					WithTriggerUID(triggerUID),
+					WithTriggerSubscriberURI(subscriberURI),
+					WithTriggerBrokerReady(),
+					// The first reconciliation will initialize the status conditions.
+					WithInitTriggerConditions,
+					WithTriggerDependencyUnknown("", ""),
+					WithTriggerSubscribed(),
+					WithTriggerStatusSubscriberURI(subscriberURI),
+					WithTriggerSubscriberResolvedSucceeded(),
+					WithTriggerDeadLetterSinkNotConfigured(),
+					WithTriggerOIDCServiceAccountResolvedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("Trigger %q does not own service account %q", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
+					WithTriggerOIDCServiceAccountName(makeTriggerOIDCServiceAccountWithoutOwnerRef().Name),
+					WithTriggerSubscribedUnknown("", ""),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("Trigger %q does not own service account %q", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
 			},
 		},
 	}
@@ -1466,6 +1568,7 @@ func TestReconcile(t *testing.T) {
 		r := &Reconciler{
 			eventingClientSet:  fakeeventingclient.Get(ctx),
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
+			kubeclient:         fakekubeclient.Get(ctx),
 			subscriptionLister: listers.GetSubscriptionLister(),
 			triggerLister:      listers.GetTriggerLister(),
 			secretLister:       listers.GetSecretLister(),
@@ -1812,4 +1915,23 @@ func makeDLSServiceAsUnstructured() *unstructured.Unstructured {
 			},
 		},
 	}
+}
+
+func makeTriggerOIDCServiceAccount() *corev1.ServiceAccount {
+	return auth.GetOIDCServiceAccountForResource(v1.SchemeGroupVersion.WithKind("Trigger"), metav1.ObjectMeta{
+		Name:      triggerName,
+		Namespace: testNS,
+		UID:       triggerUID,
+	})
+}
+
+func makeTriggerOIDCServiceAccountWithoutOwnerRef() *corev1.ServiceAccount {
+	sa := auth.GetOIDCServiceAccountForResource(v1.SchemeGroupVersion.WithKind("Trigger"), metav1.ObjectMeta{
+		Name:      triggerName,
+		Namespace: testNS,
+		UID:       triggerUID,
+	})
+	sa.OwnerReferences = nil
+
+	return sa
 }

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -1547,13 +1547,13 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerOIDCIdentityCreatedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("Trigger %s does not own service account %s", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
+					WithTriggerOIDCIdentityCreatedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("service account %s not owned by Trigger %s", makeTriggerOIDCServiceAccountWithoutOwnerRef().Name, triggerName)),
 					WithTriggerOIDCServiceAccountName(makeTriggerOIDCServiceAccountWithoutOwnerRef().Name),
 					WithTriggerSubscribedUnknown("", ""),
 				),
 			}},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("Trigger %s does not own service account %s", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
+				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("service account %s not owned by Trigger %s", makeTriggerOIDCServiceAccountWithoutOwnerRef().Name, triggerName)),
 			},
 		},
 	}

--- a/pkg/reconciler/broker/trigger/trigger_test.go
+++ b/pkg/reconciler/broker/trigger/trigger_test.go
@@ -277,7 +277,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
 					WithTriggerStatusSubscriberURI(subscriberURI),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "Creates subscription with retry from trigger",
@@ -311,7 +311,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscribedUnknown("SubscriptionNotConfigured", "Subscription has not yet been reconciled."),
 					WithTriggerStatusSubscriberURI(subscriberURI),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "Creates subscription with dls from trigger",
@@ -346,7 +346,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		}, {
 			Name: "TLS: Creates subscription with dls from trigger",
@@ -401,7 +401,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -463,7 +463,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -525,7 +525,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -583,7 +583,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusDeadLetterSinkURI(duckv1.Addressable{URL: dlsURL}),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
 					WithTriggerDeadLetterSinkCACerts(string(eventingtlstesting.CA)),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -615,7 +615,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberURI(subscriberURI),
 					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for create subscriptions"),
@@ -645,7 +645,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantCreates: []runtime.Object{
 				makeFilterSubscription(testNS),
@@ -672,7 +672,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerNotSubscribed("NotSubscribed", `trigger "test-trigger" does not own subscription "test-broker-test-trigger-test-trigger-uid"`),
 					WithTriggerStatusSubscriberURI(subscriberURI),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "InternalError", `trigger "test-trigger" does not own subscription "test-broker-test-trigger-test-trigger-uid"`),
@@ -700,7 +700,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				ActionImpl: clientgotesting.ActionImpl{
@@ -737,7 +737,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for delete subscriptions"),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantDeletes: []clientgotesting.DeleteActionImpl{{
 				ActionImpl: clientgotesting.ActionImpl{
@@ -775,7 +775,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerNotSubscribed("NotSubscribed", "inducing failure for create subscriptions"),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeWarning, "SubscriptionCreateFailed", `Create Trigger's subscription failed: inducing failure for create subscriptions`),
@@ -813,7 +813,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -842,7 +842,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -871,7 +871,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -954,7 +954,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -1054,7 +1054,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1116,7 +1116,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1180,7 +1180,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerStatusDeadLetterSinkURI(brokerDLS),
 					WithTriggerDeadLetterSinkResolvedSucceeded(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1248,7 +1248,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1274,7 +1274,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1304,7 +1304,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyFailed("DependencyDoesNotExist", `Dependency does not exist: pingsources.sources.knative.dev "test-ping-source" not found`),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantErr: true,
@@ -1334,7 +1334,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyFailed("NotFound", ""),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		}, {
@@ -1363,7 +1363,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyUnknown("", ""),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		},
@@ -1393,7 +1393,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyUnknown("GenerationNotEqual", fmt.Sprintf("The dependency's metadata.generation, %q, is not equal to its status.observedGeneration, %q.", currentGeneration, outdatedGeneration)),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled()),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled()),
 			}},
 		},
 		{
@@ -1422,7 +1422,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 		},
@@ -1449,7 +1449,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -1479,7 +1479,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
 					WithTriggerDependencyReady(),
-					WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled(),
+					WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
 				),
 			}},
 			WantCreates: []runtime.Object{
@@ -1512,7 +1512,7 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerOIDCServiceAccountResolvedSucceeded(),
+					WithTriggerOIDCIdentityCreatedSucceeded(),
 					WithTriggerOIDCServiceAccountName(makeTriggerOIDCServiceAccount().Name),
 				),
 			}},
@@ -1547,13 +1547,13 @@ func TestReconcile(t *testing.T) {
 					WithTriggerStatusSubscriberURI(subscriberURI),
 					WithTriggerSubscriberResolvedSucceeded(),
 					WithTriggerDeadLetterSinkNotConfigured(),
-					WithTriggerOIDCServiceAccountResolvedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("Trigger %q does not own service account %q", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
+					WithTriggerOIDCIdentityCreatedFailed("Unable to resolve service account for OIDC authentication", fmt.Sprintf("Trigger %s does not own service account %s", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
 					WithTriggerOIDCServiceAccountName(makeTriggerOIDCServiceAccountWithoutOwnerRef().Name),
 					WithTriggerSubscribedUnknown("", ""),
 				),
 			}},
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("Trigger %q does not own service account %q", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
+				Eventf(corev1.EventTypeWarning, "InternalError", fmt.Sprintf("Trigger %s does not own service account %s", triggerName, makeTriggerOIDCServiceAccountWithoutOwnerRef().Name)),
 			},
 		},
 	}
@@ -1566,12 +1566,13 @@ func TestReconcile(t *testing.T) {
 		ctx = v1addr.WithDuck(ctx)
 		ctx = source.WithDuck(ctx)
 		r := &Reconciler{
-			eventingClientSet:  fakeeventingclient.Get(ctx),
-			dynamicClientSet:   fakedynamicclient.Get(ctx),
-			kubeclient:         fakekubeclient.Get(ctx),
-			subscriptionLister: listers.GetSubscriptionLister(),
-			triggerLister:      listers.GetTriggerLister(),
-			secretLister:       listers.GetSecretLister(),
+			eventingClientSet:    fakeeventingclient.Get(ctx),
+			dynamicClientSet:     fakedynamicclient.Get(ctx),
+			kubeclient:           fakekubeclient.Get(ctx),
+			subscriptionLister:   listers.GetSubscriptionLister(),
+			triggerLister:        listers.GetTriggerLister(),
+			secretLister:         listers.GetSecretLister(),
+			serviceAccountLister: listers.GetServiceAccountLister(),
 
 			brokerLister:    listers.GetBrokerLister(),
 			configmapLister: listers.GetConfigMapLister(),

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -261,6 +261,34 @@ func WithTriggerSubscriberResolvedFailed(reason, message string) TriggerOption {
 	}
 }
 
+func WithTriggerOIDCServiceAccountResolvedSucceeded() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkOIDCServiceAccountResolvedSucceeded()
+	}
+}
+
+func WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkOIDCServiceAccountResolvedSucceededWithReason("OIDC authentication feature disabled", "")
+	}
+}
+
+func WithTriggerOIDCServiceAccountResolvedFailed(reason, message string) TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkOIDCServiceAccountResolvedFailed(reason, message)
+	}
+}
+
+func WithTriggerOIDCServiceAccountName(name string) TriggerOption {
+	return func(t *v1.Trigger) {
+		if t.Status.Auth == nil {
+			t.Status.Auth = &duckv1.AuthStatus{}
+		}
+
+		t.Status.Auth.ServiceAccountName = &name
+	}
+}
+
 func WithTriggerDeadLetterSinkResolvedFailed(reason, message string) TriggerOption {
 	return func(t *v1.Trigger) {
 		t.Status.MarkDeadLetterSinkResolvedFailed(reason, message)

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,7 @@ import (
 
 	eventingv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	v1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 )
 
 // TriggerOption enables further configuration of a Trigger.
@@ -261,21 +263,21 @@ func WithTriggerSubscriberResolvedFailed(reason, message string) TriggerOption {
 	}
 }
 
-func WithTriggerOIDCServiceAccountResolvedSucceeded() TriggerOption {
+func WithTriggerOIDCIdentityCreatedSucceeded() TriggerOption {
 	return func(t *v1.Trigger) {
-		t.Status.MarkOIDCServiceAccountResolvedSucceeded()
+		t.Status.MarkOIDCIdentityCreatedSucceeded()
 	}
 }
 
-func WithTriggerOIDCServiceAccountResolvedSucceededBecauseOIDCFeatureDisabled() TriggerOption {
+func WithTriggerOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled() TriggerOption {
 	return func(t *v1.Trigger) {
-		t.Status.MarkOIDCServiceAccountResolvedSucceededWithReason("OIDC authentication feature disabled", "")
+		t.Status.MarkOIDCIdentityCreatedSucceededWithReason(fmt.Sprintf("%s feature disabled", feature.OIDCAuthentication), "")
 	}
 }
 
-func WithTriggerOIDCServiceAccountResolvedFailed(reason, message string) TriggerOption {
+func WithTriggerOIDCIdentityCreatedFailed(reason, message string) TriggerOption {
 	return func(t *v1.Trigger) {
-		t.Status.MarkOIDCServiceAccountResolvedFailed(reason, message)
+		t.Status.MarkOIDCIdentityCreatedFailed(reason, message)
 	}
 }
 


### PR DESCRIPTION
Fixes #7222

# Proposed Changes

- :gift: Expose the name of the OIDC service account in the Triggers `.status.auth.serviceAccountName`
- :gift: Create the OIDC service account of the Trigger

**Release Note**
```release-note
Expose the Triggers OIDC service account name in the Triggers .status.auth.serviceAccountName
```