### PR TITLE
All filter optimization

### DIFF
--- a/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/all_filter_benchmark_test.go
@@ -86,6 +86,11 @@ func BenchmarkAllFilter(b *testing.B) {
 			event: event,
 		},
 		FilterBenchmark{
+			name:  "All filter with one non-matching filter at the end",
+			arg:   []eventfilter.Filter{filter, exactFilter2, prefixFilterNoMatch},
+			event: event,
+		},
+		FilterBenchmark{
 			name:  "All filter with all non-matching filters",
 			arg:   []eventfilter.Filter{prefixFilterNoMatch, suffixFilterNoMatch},
 			event: event,

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -43,6 +43,7 @@ func RunFilterBenchmarks(b *testing.B, filterCtor func(interface{}) eventfilter.
 		b.Run("Creation: "+fb.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				Filter = filterCtor(fb.arg)
+				Filter.Cleanup()
 			}
 		})
 		// Filter to use for the run

--- a/pkg/eventfilter/benchmarks/common_benchmark_test.go
+++ b/pkg/eventfilter/benchmarks/common_benchmark_test.go
@@ -53,5 +53,6 @@ func RunFilterBenchmarks(b *testing.B, filterCtor func(interface{}) eventfilter.
 				Result = f.Filter(context.TODO(), fb.event)
 			}
 		})
+		f.Cleanup()
 	}
 }

--- a/pkg/eventfilter/subscriptionsapi/all_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/all_filter.go
@@ -18,34 +18,88 @@ package subscriptionsapi
 
 import (
 	"context"
+	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 
 	"knative.dev/eventing/pkg/eventfilter"
 )
 
-type allFilter []eventfilter.Filter
+type filterCount struct {
+	filter eventfilter.Filter
+	count  atomic.Uint64
+}
+
+type allFilter struct {
+	filters []filterCount
+	rwMutex sync.RWMutex
+	c       chan int
+	d       chan bool
+}
 
 // NewAllFilter returns an event filter which passes if all the contained filters pass
 func NewAllFilter(filters ...eventfilter.Filter) eventfilter.Filter {
-	return append(allFilter{}, filters...)
+	filterCounts := make([]filterCount, len(filters))
+	for i, filter := range filters {
+		filterCounts[i] = filterCount{
+			count:  *atomic.NewUint64(uint64(0)),
+			filter: filter,
+		}
+	}
+	f := &allFilter{
+		filters: filterCounts,
+		c:       make(chan int),
+		d:       make(chan bool),
+	}
+	go f.optimizeLoop()
+	return f
 }
 
-func (filter allFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
+func (filter *allFilter) Filter(ctx context.Context, event cloudevents.Event) eventfilter.FilterResult {
 	res := eventfilter.NoFilter
 	logging.FromContext(ctx).Debugw("Performing an ALL match ", zap.Any("filters", filter), zap.Any("event", event))
-	for _, f := range filter {
-		res = res.And(f.Filter(ctx, event))
+	filter.rwMutex.RLock()
+	defer filter.rwMutex.RUnlock()
+	for i, f := range filter.filters {
+		res = res.And(f.filter.Filter(ctx, event))
 		// Short circuit to optimize it
 		if res == eventfilter.FailFilter {
+			filter.c <- i
 			return eventfilter.FailFilter
 		}
 	}
 	return res
 }
 
-func (filter allFilter) Cleanup() {}
+func (filter *allFilter) optimizeLoop() {
+	for {
+		i, more := <-filter.c
+		if !more {
+			filter.d <- true
+			return
+		}
+		val := filter.filters[i].count.Inc()
+		if i != 0 && val > filter.filters[i-1].count.Load()*2 {
+			go filter.optimize(i)
+		}
+	}
+}
 
-var _ eventfilter.Filter = allFilter{}
+func (filter *allFilter) optimize(swapIdx int) {
+	filter.rwMutex.Lock()
+	defer filter.rwMutex.Unlock()
+	filter.filters[swapIdx-1], filter.filters[swapIdx] = filter.filters[swapIdx], filter.filters[swapIdx-1]
+}
+
+func (filter *allFilter) Cleanup() {
+	close(filter.c)
+	<-filter.d
+	for _, f := range filter.filters {
+		f.filter.Cleanup()
+	}
+}
+
+var _ eventfilter.Filter = &allFilter{}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7147 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Dynamically optimize the ordering of the All filter so that it fails faster when possible

The results of this optimization are:
```
benchmark                                                                                        old ns/op     new ns/op     delta
BenchmarkAllFilter/Creation:_All_filter_with_exact_filter_test-8                                 86.2          553           +541.31%
BenchmarkAllFilter/Run:_All_filter_with_exact_filter_test-8                                      892           847           -5.04%
BenchmarkAllFilter/Creation:_All_filter_match_all_subfilters-8                                   117           659           +461.41%
BenchmarkAllFilter/Run:_All_filter_match_all_subfilters-8                                        2416          2117          -12.38%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_end_of_array-8                             114           684           +497.82%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_end_of_array-8                                  1008          1091          +8.23%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_start_of_array-8                           102           706           +589.17%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_start_of_array-8                                1460          1086          -25.62%
BenchmarkAllFilter/Creation:_All_filter_with_multiple_exact_filters_that_match-8                 106           710           +569.72%
BenchmarkAllFilter/Run:_All_filter_with_multiple_exact_filters_that_match-8                      2488          1960          -21.22%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_in_the_middle-8             124           680           +448.91%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_in_the_middle-8                  1482          1098          -25.91%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_at_the_end-8                111           714           +541.15%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_at_the_end-8                     1940          1091          -43.76%
BenchmarkAllFilter/Creation:_All_filter_with_all_non-matching_filters-8                          93.7          691           +637.81%
BenchmarkAllFilter/Run:_All_filter_with_all_non-matching_filters-8                               1095          1098          +0.27%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_match-8            3487          10278         +194.75%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_match-8                 458423        520555        +13.55%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8     3736          10079         +169.78%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8          936           1097          +17.15%
BenchmarkAllFilter/Creation:_All_filter_with_alternating_matching_and_non-matching_filters-8     3723          10069         +170.45%
BenchmarkAllFilter/Run:_All_filter_with_alternating_matching_and_non-matching_filters-8          1487          1095          -26.36%

benchmark                                                                                        old allocs     new allocs     delta
BenchmarkAllFilter/Creation:_All_filter_with_exact_filter_test-8                                 2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_exact_filter_test-8                                      8              7              -12.50%
BenchmarkAllFilter/Creation:_All_filter_match_all_subfilters-8                                   2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_match_all_subfilters-8                                        21             20             -4.76%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_end_of_array-8                             2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_end_of_array-8                                  9              8              -11.11%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_start_of_array-8                           2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_start_of_array-8                                13             8              -38.46%
BenchmarkAllFilter/Creation:_All_filter_with_multiple_exact_filters_that_match-8                 2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_multiple_exact_filters_that_match-8                      19             18             -5.26%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_in_the_middle-8             2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_in_the_middle-8                  13             8              -38.46%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_at_the_end-8                2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_at_the_end-8                     17             8              -52.94%
BenchmarkAllFilter/Creation:_All_filter_with_all_non-matching_filters-8                          2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_all_non-matching_filters-8                               9              8              -11.11%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_match-8            2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_match-8                 4004           4003           -0.02%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8     2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8          9              8              -11.11%
BenchmarkAllFilter/Creation:_All_filter_with_alternating_matching_and_non-matching_filters-8     2              5              +150.00%
BenchmarkAllFilter/Run:_All_filter_with_alternating_matching_and_non-matching_filters-8          13             8              -38.46%

benchmark                                                                                        old bytes     new bytes     delta
BenchmarkAllFilter/Creation:_All_filter_with_exact_filter_test-8                                 40            296           +640.00%
BenchmarkAllFilter/Run:_All_filter_with_exact_filter_test-8                                      424           400           -5.66%
BenchmarkAllFilter/Creation:_All_filter_match_all_subfilters-8                                   72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_match_all_subfilters-8                                        976           952           -2.46%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_end_of_array-8                             72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_end_of_array-8                                  448           424           -5.36%
BenchmarkAllFilter/Creation:_All_filter_no_1_match_at_start_of_array-8                           72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_no_1_match_at_start_of_array-8                                656           424           -35.37%
BenchmarkAllFilter/Creation:_All_filter_with_multiple_exact_filters_that_match-8                 72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_with_multiple_exact_filters_that_match-8                      920           896           -2.61%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_in_the_middle-8             72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_in_the_middle-8                  656           424           -35.37%
BenchmarkAllFilter/Creation:_All_filter_with_one_non-matching_filter_at_the_end-8                72            352           +388.89%
BenchmarkAllFilter/Run:_All_filter_with_one_non-matching_filter_at_the_end-8                     864           424           -50.93%
BenchmarkAllFilter/Creation:_All_filter_with_all_non-matching_filters-8                          56            320           +471.43%
BenchmarkAllFilter/Run:_All_filter_with_all_non-matching_filters-8                               448           424           -5.36%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_match-8            16408         24848         +51.44%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_match-8                 208217        208193        -0.01%
BenchmarkAllFilter/Creation:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8     16408         24848         +51.44%
BenchmarkAllFilter/Run:_All_filter_with_large_number_of_sub-filters_that_do_not_match-8          448           424           -5.36%
BenchmarkAllFilter/Creation:_All_filter_with_alternating_matching_and_non-matching_filters-8     16408         24848         +51.44%
BenchmarkAllFilter/Run:_All_filter_with_alternating_matching_and_non-matching_filters-8          656           424           -35.37%

```

However, it is worth noting that the "Creation" time actually measures creation and deletion time because I needed to clean up the goroutines.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The all filter now dynamically optimizes its ordering to improve performance
```

