### PR TITLE
Deprecate EventType v1b1 API

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -2417,7 +2417,8 @@ Resource Types:
 <h3 id="eventing.knative.dev/v1beta1.EventType">EventType
 </h3>
 <p>
-<p>EventType represents a type of event that can be consumed from a Broker.</p>
+<p>EventType represents a type of event that can be consumed from a Broker.
+Deprecated: use v1beta2.EventType instead.</p>
 </p>
 <table>
 <thead>

--- a/pkg/apis/eventing/v1beta1/eventtype_types.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_types.go
@@ -30,6 +30,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EventType represents a type of event that can be consumed from a Broker.
+// Deprecated: use v1beta2.EventType instead.
 type EventType struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Deprecate EventType v1b1 API in favor of EventType v1b2 API, in release 1.12

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
- EventType.v1b1 API is deprecated. Instead use the v1b2 version. In a future release the version will be removed

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

