### PR TITLE
Prefix filter optimizations

### DIFF
--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	PassFilter FilterResult = "pass"
-	FailFilter FilterResult = "fail"
-	NoFilter   FilterResult = "no_filter"
+	PassFilter FilterResult = iota
+	FailFilter
+	NoFilter
 )
 
 // FilterResult has the result of the filtering operation.
-type FilterResult string
+type FilterResult int
 
 func (x FilterResult) And(y FilterResult) FilterResult {
 	if x == NoFilter {

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -57,6 +57,17 @@ func (x FilterResult) Or(y FilterResult) FilterResult {
 	return FailFilter
 }
 
+func (x FilterResult) String() string {
+	switch x {
+	case PassFilter:
+		return "PassFilter"
+	case FailFilter:
+		return "FailFilter"
+	default:
+		return "NoFilter"
+	}
+}
+
 // Filter is an interface representing an event filter of the trigger filter
 type Filter interface {
 	// Filter compute the predicate on the provided event and returns the result of the matching

--- a/pkg/eventfilter/subscriptionsapi/prefix_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/prefix_filter.go
@@ -50,13 +50,9 @@ func (filter *prefixFilter) Filter(ctx context.Context, event cloudevents.Event)
 	if filter == nil {
 		return eventfilter.NoFilter
 	}
-	result := eventfilter.NoFilter
 	logger := logging.FromContext(ctx)
 	logger.Debugw("Performing a prefix match ", zap.Any("filters", filter.filters), zap.Any("event", event))
 	for k, v := range filter.filters {
-		if k == "" || v == "" {
-			continue
-		}
 		value, ok := attributes.LookupAttribute(event, k)
 		if !ok {
 			logger.Debugw("Couldn't find attribute in event. Prefix match failed.", zap.String("attribute", k), zap.String("prefix", v),
@@ -67,13 +63,11 @@ func (filter *prefixFilter) Filter(ctx context.Context, event cloudevents.Event)
 		if s, ok = value.(string); !ok {
 			s = fmt.Sprintf("%v", value)
 		}
-		if strings.HasPrefix(s, v) {
-			result = eventfilter.PassFilter
-		} else {
+		if !strings.HasPrefix(s, v) {
 			return eventfilter.FailFilter
 		}
 	}
-	return result
+	return eventfilter.PassFilter
 }
 
 func (filter *prefixFilter) Cleanup() {}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7305 
Fixes #7308 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Only copy the event attribute into a string with Sprintf if that attribute needs to be converted to a string
- Only loop over the event attributes once, instead of twice
- use int instead of string for eventfilter result types

Performance improvements after these changes:
```
benchmark                                                                                 old ns/op     new ns/op     delta
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_id-8                            53.5          54.1          +1.07%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_id-8                                 558           439           -21.34%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes-8        89.6          89.7          +0.11%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes-8             1923          1194          -37.91%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes#01-8     89.6          89.7          +0.11%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes#01-8          1929          1167          -39.50%
BenchmarkPrefixFilter/Creation:_No_pass_with_prefix_match_of_id_and_source-8              61.7          61.9          +0.26%
BenchmarkPrefixFilter/Run:_No_pass_with_prefix_match_of_id_and_source-8                   639           428           -32.99%

benchmark                                                                                 old allocs     new allocs     delta
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_id-8                            1              1              +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_id-8                                 5              4              -20.00%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes-8        1              1              +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes-8             21             15             -28.57%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes#01-8     1              1              +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes#01-8          21             15             -28.57%
BenchmarkPrefixFilter/Creation:_No_pass_with_prefix_match_of_id_and_source-8              1              1              +0.00%
BenchmarkPrefixFilter/Run:_No_pass_with_prefix_match_of_id_and_source-8                   5              4              -20.00%

benchmark                                                                                 old bytes     new bytes     delta
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_id-8                            8             8             +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_id-8                                 224           208           -7.14%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes-8        8             8             +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes-8             571           448           -21.54%
BenchmarkPrefixFilter/Creation:_Pass_with_prefix_match_of_all_context_attributes#01-8     8             8             +0.00%
BenchmarkPrefixFilter/Run:_Pass_with_prefix_match_of_all_context_attributes#01-8          571           448           -21.54%
BenchmarkPrefixFilter/Creation:_No_pass_with_prefix_match_of_id_and_source-8              8             8             +0.00%
BenchmarkPrefixFilter/Run:_No_pass_with_prefix_match_of_id_and_source-8                   236           218           -7.63%
```

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The prefix filter just got a whole lot faster!
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

