### PR TITLE
Not filter properly calls cleanup on it's nested filter

### DIFF
--- a/pkg/eventfilter/subscriptionsapi/not_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/not_filter.go
@@ -48,6 +48,8 @@ func (filter *notFilter) Filter(ctx context.Context, event cloudevents.Event) ev
 	return eventfilter.NoFilter
 }
 
-func (filter *notFilter) Cleanup() {}
+func (filter *notFilter) Cleanup() {
+	filter.filter.Cleanup()
+}
 
 var _ eventfilter.Filter = &notFilter{}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes bug where the not filter does not call Cleanup on the nested filter. For the Any filter and All filter dialects, this cleanup method is needed to cleanup goroutines which are created, so without this the Not filter would create a memory leak.



```release-note
:bug: Memory leak in the not filter was fixed.
```


