### PR TITLE
Improved suffix benchmark performance

### DIFF
--- a/pkg/eventfilter/subscriptionsapi/suffix_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/suffix_filter.go
@@ -50,11 +50,6 @@ func (filter *suffixFilter) Filter(ctx context.Context, event cloudevents.Event)
 	if filter == nil {
 		return eventfilter.NoFilter
 	}
-	for attribute, value := range filter.filters {
-		if attribute == "" || value == "" {
-			return eventfilter.NoFilter
-		}
-	}
 	logger := logging.FromContext(ctx)
 	logger.Debugw("Performing a suffix match ", zap.Any("filters", filter.filters), zap.Any("event", event))
 	for k, v := range filter.filters {
@@ -64,7 +59,11 @@ func (filter *suffixFilter) Filter(ctx context.Context, event cloudevents.Event)
 				zap.Any("event", event))
 			return eventfilter.FailFilter
 		}
-		if !strings.HasSuffix(fmt.Sprintf("%v", value), v) {
+		var s string
+		if s, ok = value.(string); !ok {
+			s = fmt.Sprintf("%v", value)
+		}
+		if !strings.HasSuffix(s, v) {
 			return eventfilter.FailFilter
 		}
 	}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7306 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Don't copy strings if not needed when evaluating the suffix filter.

After these changes, the performance difference is:
```
benchmark                                                                                 old ns/op     new ns/op     delta
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_id-8                            53.3          54.4          +2.08%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_id-8                                 556           445           -19.95%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes-8        90.1          91.6          +1.73%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes-8             1755          1298          -26.04%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes#01-8     91.8          91.5          -0.33%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes#01-8          1865          1315          -29.49%
BenchmarkSuffixFilter/Creation:_No_pass_with_suffix_match_of_id_and_source-8              62.2          63.4          +1.87%
BenchmarkSuffixFilter/Run:_No_pass_with_suffix_match_of_id_and_source-8                   672           478           -28.83%

benchmark                                                                                 old allocs     new allocs     delta
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_id-8                            1              1              +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_id-8                                 5              4              -20.00%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes-8        1              1              +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes-8             21             15             -28.57%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes#01-8     1              1              +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes#01-8          21             15             -28.57%
BenchmarkSuffixFilter/Creation:_No_pass_with_suffix_match_of_id_and_source-8              1              1              +0.00%
BenchmarkSuffixFilter/Run:_No_pass_with_suffix_match_of_id_and_source-8                   5              4              -20.00%

benchmark                                                                                 old bytes     new bytes     delta
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_id-8                            8             8             +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_id-8                                 224           208           -7.14%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes-8        8             8             +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes-8             571           448           -21.54%
BenchmarkSuffixFilter/Creation:_Pass_with_suffix_match_of_all_context_attributes#01-8     8             8             +0.00%
BenchmarkSuffixFilter/Run:_Pass_with_suffix_match_of_all_context_attributes#01-8          571           448           -21.54%
BenchmarkSuffixFilter/Creation:_No_pass_with_suffix_match_of_id_and_source-8              8             8             +0.00%
BenchmarkSuffixFilter/Run:_No_pass_with_suffix_match_of_id_and_source-8                   236           217           -8.05%
```
### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The suffix filter is now faster!
```


