### PR TITLE
Add marker for Trigger to mark `OIDCIdentity` condition as not supported

### DIFF
--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -81,6 +81,7 @@ func (ts *TriggerStatus) IsReady() bool {
 // InitializeConditions sets relevant unset conditions to Unknown state.
 func (ts *TriggerStatus) InitializeConditions() {
 	triggerCondSet.Manage(ts).InitializeConditions()
+	ts.MarkOIDCIdentityCreatedNotSupported()
 }
 
 func (ts *TriggerStatus) PropagateBrokerCondition(bc *apis.Condition) {

--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -17,8 +17,11 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -216,4 +219,9 @@ func (ts *TriggerStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat str
 
 func (ts *TriggerStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
 	triggerCondSet.Manage(ts).MarkUnknown(TriggerConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
+}
+
+func (ts *TriggerStatus) MarkOIDCIdentityCreatedNotSupported() {
+	// in case the OIDC feature is not supported, we mark the conditon as true, to not mark the Trigger unready.
+	triggerCondSet.Manage(ts).MarkTrueWithReason(TriggerConditionOIDCIdentityCreated, fmt.Sprintf("%s feature not yet supported for this Broker class", feature.OIDCAuthentication), "")
 }

--- a/pkg/apis/eventing/v1/trigger_lifecycle.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle.go
@@ -223,6 +223,6 @@ func (ts *TriggerStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat st
 }
 
 func (ts *TriggerStatus) MarkOIDCIdentityCreatedNotSupported() {
-	// in case the OIDC feature is not supported, we mark the conditon as true, to not mark the Trigger unready.
+	// in case the OIDC feature is not supported, we mark the condition as true, to not mark the Trigger unready.
 	triggerCondSet.Manage(ts).MarkTrueWithReason(TriggerConditionOIDCIdentityCreated, fmt.Sprintf("%s feature not yet supported for this Broker class", feature.OIDCAuthentication), "")
 }

--- a/pkg/apis/eventing/v1/trigger_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/trigger_lifecycle_test.go
@@ -155,7 +155,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionOIDCIdentityCreated,
-					Status: corev1.ConditionUnknown,
+					Status: corev1.ConditionTrue,
 				}, {
 					Type:   TriggerConditionReady,
 					Status: corev1.ConditionUnknown,
@@ -192,10 +192,10 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionOIDCIdentityCreated,
-					Status: corev1.ConditionUnknown,
+					Status: corev1.ConditionTrue,
 				}, {
 					Type:   TriggerConditionReady,
-					Status: corev1.ConditionUnknown,
+					Status: corev1.ConditionFalse,
 				}, {
 					Type:   TriggerConditionSubscriberResolved,
 					Status: corev1.ConditionUnknown,
@@ -229,7 +229,7 @@ func TestTriggerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   TriggerConditionOIDCIdentityCreated,
-					Status: corev1.ConditionUnknown,
+					Status: corev1.ConditionTrue,
 				}, {
 					Type:   TriggerConditionReady,
 					Status: corev1.ConditionUnknown,

--- a/pkg/reconciler/testing/v1/trigger.go
+++ b/pkg/reconciler/testing/v1/trigger.go
@@ -281,6 +281,12 @@ func WithTriggerOIDCIdentityCreatedFailed(reason, message string) TriggerOption 
 	}
 }
 
+func WithTriggerOIDCIdentityCreatedNotSupported() TriggerOption {
+	return func(t *v1.Trigger) {
+		t.Status.MarkOIDCIdentityCreatedNotSupported()
+	}
+}
+
 func WithTriggerOIDCServiceAccountName(name string) TriggerOption {
 	return func(t *v1.Trigger) {
 		if t.Status.Auth == nil {


### PR DESCRIPTION
## Proposed Changes

In #7299 we introduced a new Trigger condition type ( `OIDCIdentityCreated`) to mark if the Triggers OIDC identity was created successfully. 
Anyhow not all broker classes support the OIDC authentication yet and mark their Triggers `OIDCIdentityCreated` as true as they either created the identity or didn't create it as the feature is disabled.
These broker classes could mark their Triggers `OIDCIdentityCreated` condition as ready, but with the message "OIDC feature not supported yet".
This PR addresses it and adds helper methods to set the condition accordingly.