### PR TITLE
Update Kubernetes min version in KinD e2e tests to 1.26.6

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
+        - v1.26.6
         - v1.27.3
 
         test-suite:
@@ -29,6 +30,9 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
         include:
+        - k8s-version: v1.26.6
+          kind-version: v0.20.0
+          kind-image-sha: sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
         - k8s-version: v1.27.3
           kind-version: v0.20.0
           kind-image-sha: sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.11
         - v1.27.3
 
         test-suite:
@@ -30,9 +29,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
         include:
-        - k8s-version: v1.25.11
-          kind-version: v0.20.0
-          kind-image-sha: sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
         - k8s-version: v1.27.3
           kind-version: v0.20.0
           kind-image-sha: sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72


### PR DESCRIPTION
Since https://github.com/knative/pkg/pull/2832 the K8s min version for Knative is 1.26. This leads to failing KinD e2e tests in CI.
This PR remove the 1.25 jobs and updates it to 1.26 to have jobs testing the min version.

## Proposed Changes

- :broom: Remove KinD e2e tests on Kubernetes 1.25
- :gift: Add KinD e2e tests for Kubernetes 1.26