### PR TITLE
Use expiring cache with the OIDC tokens

### DIFF
--- a/pkg/auth/token_provider.go
+++ b/pkg/auth/token_provider.go
@@ -19,25 +19,33 @@ package auth
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	authv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 )
 
+const (
+	expirationBufferTime = time.Second * 30
+)
+
 type OIDCTokenProvider struct {
 	logger     *zap.SugaredLogger
 	kubeClient kubernetes.Interface
+	tokenCache cache.Expiring
 }
 
 func NewOIDCTokenProvider(ctx context.Context) *OIDCTokenProvider {
 	tokenProvider := &OIDCTokenProvider{
 		logger:     logging.FromContext(ctx).With("component", "oidc-token-provider"),
 		kubeClient: kubeclient.Get(ctx),
+		tokenCache: *cache.NewExpiring(),
 	}
 
 	return tokenProvider
@@ -45,7 +53,9 @@ func NewOIDCTokenProvider(ctx context.Context) *OIDCTokenProvider {
 
 // GetJWT returns a JWT from the given service account for the given audience.
 func (c *OIDCTokenProvider) GetJWT(serviceAccount types.NamespacedName, audience string) (string, error) {
-	// TODO: check the cache
+	if val, ok := c.tokenCache.Get(cacheKey(serviceAccount, audience)); ok {
+		return val.(string), nil
+	}
 
 	// if not found in cache: request new token
 	tokenRequest := authv1.TokenRequest{
@@ -63,5 +73,15 @@ func (c *OIDCTokenProvider) GetJWT(serviceAccount types.NamespacedName, audience
 		return "", fmt.Errorf("could not request a token for %s: %w", serviceAccount, err)
 	}
 
+	// we need a duration until this token expires, use the expiry time - (now + 30s)
+	// this gives us a buffer so that it doesn't expire between when we retrieve it and when we use it
+	expiryTtl := tokenRequestResponse.Status.ExpirationTimestamp.Time.Sub(time.Now().Add(expirationBufferTime))
+
+	c.tokenCache.Set(cacheKey(serviceAccount, audience), tokenRequestResponse.Status.Token, expiryTtl)
+
 	return tokenRequestResponse.Status.Token, nil
+}
+
+func cacheKey(serviceAccount types.NamespacedName, audience string) string {
+	return fmt.Sprintf("%s.%s.%s", serviceAccount.Namespace, serviceAccount.Name, audience)
 }

--- a/pkg/auth/token_provider.go
+++ b/pkg/auth/token_provider.go
@@ -83,5 +83,5 @@ func (c *OIDCTokenProvider) GetJWT(serviceAccount types.NamespacedName, audience
 }
 
 func cacheKey(serviceAccount types.NamespacedName, audience string) string {
-	return fmt.Sprintf("%s.%s.%s", serviceAccount.Namespace, serviceAccount.Name, audience)
+	return fmt.Sprintf("%s/%s/%s", serviceAccount.Namespace, serviceAccount.Name, audience)
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7331

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use the k8s apimachinery expiring cache to keep the tokens and evict them when they expire


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
OIDC tokens are now cached to improve performance.
```
