### PR TITLE
Mark new trigger filter tests as beta

### DIFF
--- a/test/rekt/features/new_trigger_filters/feature.go
+++ b/test/rekt/features/new_trigger_filters/feature.go
@@ -116,7 +116,7 @@ func FiltersFeatureSet(brokerName string) *feature.FeatureSet {
 			eventshub.InputEvent(unmatchedEvent)),
 		)
 
-		f.Alpha("Triggers with new filters").
+		f.Beta("Triggers with new filters").
 			Must("must deliver matched events", OnStore(subscriber).MatchEvent(HasId(matchedEvent.ID())).AtLeast(1)).
 			MustNot("must not deliver unmatched events", OnStore(subscriber).MatchEvent(HasId(unmatchedEvent.ID())).Not())
 		features = append(features, f)

--- a/test/rekt/features/new_trigger_filters/filters.go
+++ b/test/rekt/features/new_trigger_filters/filters.go
@@ -48,7 +48,7 @@ func newEventFilterFeature(eventContexts []CloudEventsContext, filters []eventin
 	f.Setup("Wait for trigger to become ready", trigger.IsReady(triggerName))
 	f.Setup("Broker is addressable", k8s.IsAddressable(broker.GVR(), brokerName))
 
-	asserter := f.Alpha("New filters")
+	asserter := f.Beta("New filters")
 
 	for _, eventCtx := range eventContexts {
 		event := newEventFromEventContext(eventCtx)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Currently, new trigger filters tests are marked as `Alpha`, when they should be marked as `Beta`

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- switch the asserts from `Alpha` to `Beta` for the new trigger filters tests
