### PR TITLE
Increase expiration buffer time of OIDCTokenProviders cache to 5 minutes

### DIFF
--- a/pkg/auth/token_provider.go
+++ b/pkg/auth/token_provider.go
@@ -73,7 +73,7 @@ func (c *OIDCTokenProvider) GetJWT(serviceAccount types.NamespacedName, audience
 		return "", fmt.Errorf("could not request a token for %s: %w", serviceAccount, err)
 	}
 
-	// we need a duration until this token expires, use the expiry time - (now + 30s)
+	// we need a duration until this token expires, use the expiry time - (now + 5min)
 	// this gives us a buffer so that it doesn't expire between when we retrieve it and when we use it
 	expiryTtl := tokenRequestResponse.Status.ExpirationTimestamp.Time.Sub(time.Now().Add(expirationBufferTime))
 

--- a/pkg/auth/token_provider.go
+++ b/pkg/auth/token_provider.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	expirationBufferTime = time.Second * 30
+	expirationBufferTime = time.Second * 300
 )
 
 type OIDCTokenProvider struct {

--- a/pkg/auth/token_provider.go
+++ b/pkg/auth/token_provider.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	expirationBufferTime = time.Second * 300
+	expirationBufferTime = 5 * time.Minute
 )
 
 type OIDCTokenProvider struct {


### PR DESCRIPTION
…ers cache to 5 minuets

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7351 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- Increased OIDC token expiration time to 5 minuets

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

