### PR TITLE
support auto generation of Sequence identity service account [OIDC]

### DIFF
--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -28,7 +28,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, 
+var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable,
 	SequenceConditionOIDCIdentityCreated)
 
 const (
@@ -215,4 +215,3 @@ func (ss *SequenceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat st
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkUnknown(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
-

--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -17,20 +17,19 @@ limitations under the License.
 package v1
 
 import (
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	"knative.dev/eventing/pkg/apis/feature"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, SequenceConditionOIDCIdentityCreated)
+var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, 
+	SequenceConditionOIDCIdentityCreated)
 
 const (
 	// SequenceConditionReady has status True when all subconditions below have been set to True.
@@ -48,6 +47,8 @@ const (
 	// the Addressable contract and has a non-empty hostname.
 	SequenceConditionAddressable apis.ConditionType = "Addressable"
 
+	// SequenceConditionOIDCIdentityCreated has status True when the OIDCIdentity has been created.
+	// This condition is only relevant if the OIDC feature is enabled.
 	SequenceConditionOIDCIdentityCreated apis.ConditionType = "OIDCIdentityCreated"
 )
 
@@ -195,23 +196,23 @@ func (ss *SequenceStatus) setAddress(address *duckv1.Addressable) {
 	}
 }
 
+// MarkOIDCIdentityCreatedSucceeded marks the OIDCIdentityCreated condition as true.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedSucceeded() {
 	sCondSet.Manage(ss).MarkTrue(SequenceConditionOIDCIdentityCreated)
 }
 
+// MarkOIDCIdentityCreatedSucceededWithReason marks the OIDCIdentityCreated condition as true with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkTrueWithReason(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
+// MarkOIDCIdentityCreatedFailed marks the OIDCIdentityCreated condition as false with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkFalse(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
+// MarkOIDCIdentityCreatedUnknown marks the OIDCIdentityCreated condition as unknown with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkUnknown(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
-func (ss *SequenceStatus) MarkOIDCIdentityCreatedNotSupported() {
-	// in case the OIDC feature is not supported, we mark the condition as true, to not mark the SinkBinding unready.
-	sCondSet.Manage(ss).MarkTrueWithReason(SequenceConditionOIDCIdentityCreated, fmt.Sprintf("%s feature not yet supported for SinkBinding", feature.OIDCAuthentication), "")
-}

--- a/pkg/apis/flows/v1/sequence_lifecycle_test.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle_test.go
@@ -139,6 +139,9 @@ func TestSequenceInitializeConditions(t *testing.T) {
 					Type:   SequenceConditionChannelsReady,
 					Status: corev1.ConditionUnknown,
 				}, {
+					Type:   SequenceConditionOIDCIdentityCreated,
+					Status: corev1.ConditionUnknown,
+				}, {
 					Type:   SequenceConditionReady,
 					Status: corev1.ConditionUnknown,
 				}, {
@@ -166,6 +169,9 @@ func TestSequenceInitializeConditions(t *testing.T) {
 					Type:   SequenceConditionChannelsReady,
 					Status: corev1.ConditionFalse,
 				}, {
+					Type:   SequenceConditionOIDCIdentityCreated,
+					Status: corev1.ConditionUnknown,
+				}, {
 					Type:   SequenceConditionReady,
 					Status: corev1.ConditionUnknown,
 				}, {
@@ -191,6 +197,9 @@ func TestSequenceInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   SequenceConditionChannelsReady,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   SequenceConditionOIDCIdentityCreated,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   SequenceConditionReady,
@@ -310,45 +319,59 @@ func TestSequencePropagateChannelStatuses(t *testing.T) {
 
 func TestSequenceReady(t *testing.T) {
 	tests := []struct {
-		name     string
-		subs     []*messagingv1.Subscription
-		channels []*eventingduckv1.Channelable
-		want     bool
+		name          string
+		subs          []*messagingv1.Subscription
+		channels      []*eventingduckv1.Channelable
+		oidcSACreated bool
+		want          bool
 	}{{
-		name:     "empty",
-		subs:     []*messagingv1.Subscription{},
-		channels: []*eventingduckv1.Channelable{},
-		want:     false,
+		name:          "empty",
+		subs:          []*messagingv1.Subscription{},
+		channels:      []*eventingduckv1.Channelable{},
+		oidcSACreated: false,
+		want:          false,
 	}, {
-		name:     "one channelable not ready, one subscription ready",
-		channels: []*eventingduckv1.Channelable{getChannelable(false)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", true)},
-		want:     false,
+		name:          "one channelable not ready, one subscription ready",
+		channels:      []*eventingduckv1.Channelable{getChannelable(false)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true)},
+		oidcSACreated: false,
+		want:          false,
 	}, {
-		name:     "one channelable ready, one subscription not ready",
-		channels: []*eventingduckv1.Channelable{getChannelable(true)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", false)},
-		want:     false,
+		name:          "one channelable ready, one subscription not ready",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", false)},
+		oidcSACreated: false,
+		want:          false,
 	}, {
-		name:     "one channelable ready, one subscription ready",
-		channels: []*eventingduckv1.Channelable{getChannelable(true)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", true)},
-		want:     true,
+		name:          "one channelable ready, one subscription ready, oidc SA created",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true)},
+		oidcSACreated: true,
+		want:          true,
 	}, {
-		name:     "one channelable ready, one not, two subscriptions ready",
-		channels: []*eventingduckv1.Channelable{getChannelable(true), getChannelable(false)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)},
-		want:     false,
+		name:          "one channelable ready, one not, two subscriptions ready",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true), getChannelable(false)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)},
+		oidcSACreated: false,
+		want:          false,
 	}, {
-		name:     "two channelables ready, one subscription ready, one not",
-		channels: []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", false)},
-		want:     false,
+		name:          "two channelables ready, one subscription ready, one not",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", false)},
+		oidcSACreated: false,
+		want:          false,
 	}, {
-		name:     "two channelables ready, two subscriptions ready",
-		channels: []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)},
-		subs:     []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)},
-		want:     true,
+		name:          "two channelables ready, two subscriptions ready, oidc SA not created",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)},
+		oidcSACreated: false,
+		want:          false,
+	}, {
+		name:          "two channelables ready, two subscriptions ready, oidc SA created",
+		channels:      []*eventingduckv1.Channelable{getChannelable(true), getChannelable(true)},
+		subs:          []*messagingv1.Subscription{getSubscription("sub0", true), getSubscription("sub1", true)},
+		oidcSACreated: true,
+		want:          true,
 	}}
 
 	for _, test := range tests {
@@ -356,6 +379,10 @@ func TestSequenceReady(t *testing.T) {
 			ps := SequenceStatus{}
 			ps.PropagateChannelStatuses(test.channels)
 			ps.PropagateSubscriptionStatuses(test.subs)
+			if test.oidcSACreated {
+				ps.MarkOIDCIdentityCreatedSucceeded()
+			}
+
 			got := ps.IsReady()
 			want := test.want
 			if want != got {

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -59,6 +59,7 @@ func NewController(
 		serviceAccountLister: serviceaccountInformer.Lister(),
 		kubeclient: kubeclient.Get(ctx),
 	}
+
 	impl := sequencereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{
 			ConfigStore: featureStore,
@@ -75,7 +76,7 @@ func NewController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	// Reconciler Sequence when the OIDC service account changes
+	// Reconcile Sequence when the OIDC service account changes
 	serviceaccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterController(&v1.Sequence{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -48,7 +48,7 @@ func NewController(
 	subscriptionInformer := subscription.Get(ctx)
 	serviceaccountInformer := serviceaccountinformer.Get(ctx)
 
-	var globalResync func(obj interface{}) 
+	var globalResync func(obj interface{})
 	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
 		if globalResync != nil {
 			globalResync(nil)

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -32,9 +32,9 @@ import (
 	"knative.dev/eventing/pkg/client/injection/informers/flows/v1/sequence"
 	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
 	sequencereconciler "knative.dev/eventing/pkg/client/injection/reconciler/flows/v1/sequence"
-	"knative.dev/pkg/injection/clients/dynamicclient"
-	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	"knative.dev/pkg/injection/clients/dynamicclient"
 )
 
 // NewController initializes the controller and is called by the generated code
@@ -52,12 +52,12 @@ func NewController(
 	featureStore.WatchConfigs(cmw)
 
 	r := &Reconciler{
-		sequenceLister:     sequenceInformer.Lister(),
-		subscriptionLister: subscriptionInformer.Lister(),
-		dynamicClientSet:   dynamicclient.Get(ctx),
-		eventingClientSet:  eventingclient.Get(ctx),
+		sequenceLister:       sequenceInformer.Lister(),
+		subscriptionLister:   subscriptionInformer.Lister(),
+		dynamicClientSet:     dynamicclient.Get(ctx),
+		eventingClientSet:    eventingclient.Get(ctx),
 		serviceAccountLister: serviceaccountInformer.Lister(),
-		kubeclient: kubeclient.Get(ctx),
+		kubeclient:           kubeclient.Get(ctx),
 	}
 
 	impl := sequencereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -48,7 +48,12 @@ func NewController(
 	subscriptionInformer := subscription.Get(ctx)
 	serviceaccountInformer := serviceaccountinformer.Get(ctx)
 
-	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"))
+	var globalResync func(obj interface{}) 
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
+		if globalResync != nil {
+			globalResync(nil)
+		}
+	})
 	featureStore.WatchConfigs(cmw)
 
 	r := &Reconciler{
@@ -65,6 +70,10 @@ func NewController(
 			ConfigStore: featureStore,
 		}
 	})
+
+	globalResync = func(_ interface{}) {
+		impl.GlobalResync(sequenceInformer.Informer())
+	}
 
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
 	sequenceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/sequence/controller_test.go
+++ b/pkg/reconciler/sequence/controller_test.go
@@ -19,19 +19,28 @@ package sequence
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
+	"knative.dev/eventing/pkg/apis/feature"
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/flows/v1/sequence/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := NewController(ctx, configmap.NewStaticWatcher(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: feature.FlagsConfigName,
+			},
+		}))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -62,9 +62,9 @@ type Reconciler struct {
 	eventingClientSet clientset.Interface
 
 	// dynamicClientSet allows us to configure pluggable Build objects
-	dynamicClientSet dynamic.Interface
+	dynamicClientSet     dynamic.Interface
 	serviceAccountLister corev1listers.ServiceAccountLister
-	kubeclient        kubernetes.Interface
+	kubeclient           kubernetes.Interface
 }
 
 // Check that our Reconciler implements sequencereconciler.Interface

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/kmeta"
 
 	duckapis "knative.dev/pkg/apis/duck"
@@ -45,6 +46,7 @@ import (
 	"knative.dev/eventing/pkg/duck"
 
 	"knative.dev/eventing/pkg/reconciler/sequence/resources"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type Reconciler struct {
@@ -58,6 +60,8 @@ type Reconciler struct {
 
 	// dynamicClientSet allows us to configure pluggable Build objects
 	dynamicClientSet dynamic.Interface
+	serviceAccountLister corev1listers.ServiceAccountLister
+	kubeclient        kubernetes.Interface
 }
 
 // Check that our Reconciler implements sequencereconciler.Interface

--- a/pkg/reconciler/testing/v1/sequence.go
+++ b/pkg/reconciler/testing/v1/sequence.go
@@ -18,9 +18,11 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -111,5 +113,33 @@ func WithSequenceSubscriptionsNotReady(reason, message string) SequenceOption {
 func WithSequenceAddressableNotReady(reason, message string) SequenceOption {
 	return func(p *flowsv1.Sequence) {
 		p.Status.MarkAddressableNotReady(reason, message)
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedSucceeded() SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedSucceeded()
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled() SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedSucceededWithReason(fmt.Sprintf("%s feature disabled", feature.OIDCAuthentication), "")
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedFailed(reason, message string) SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedFailed(reason, message)
+	}
+}
+
+func WithSequenceOIDCServiceAccountName(name string) SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		if s.Status.Auth == nil {
+			s.Status.Auth = &duckv1.AuthStatus{}
+		}
+
+		s.Status.Auth.ServiceAccountName = &name
 	}
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7224

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Expose the name of the OIDC service account in the Sequence .status.auth.serviceAccountName
- 🎁 Create the OIDC service account of the Sequence


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Expose the Sequence OIDC service account name in the Sequence .status.auth.serviceAccountName after created Service Account.
```