### PR TITLE
Update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,8 +47,8 @@ require (
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	knative.dev/hack v0.0.0-20231016131700-2c938d4918da
 	knative.dev/hack/schema v0.0.0-20231016131700-2c938d4918da
-	knative.dev/pkg v0.0.0-20231016185203-283df0be0668
-	knative.dev/reconciler-test v0.0.0-20231016143156-93ac412266a6
+	knative.dev/pkg v0.0.0-20231017113806-d6ab72900ea5
+	knative.dev/reconciler-test v0.0.0-20231017131250-999d077826b7
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -848,10 +848,10 @@ knative.dev/hack v0.0.0-20231016131700-2c938d4918da h1:xy+fvuz2LDOMsZ5UwXRaMF70N
 knative.dev/hack v0.0.0-20231016131700-2c938d4918da/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/hack/schema v0.0.0-20231016131700-2c938d4918da h1:euBj0+2eY7BryoQe6aVg6R40dkbsGHULu6wjBsB3Vf8=
 knative.dev/hack/schema v0.0.0-20231016131700-2c938d4918da/go.mod h1:3pWwBLnTZSM9psSgCAvhKOHIPTzqfEMlWRpDu6IYhK0=
-knative.dev/pkg v0.0.0-20231016185203-283df0be0668 h1:rYlTKNUZbMsSHQID0A7sZbrtXlD+REKN6F94ceMnA5c=
-knative.dev/pkg v0.0.0-20231016185203-283df0be0668/go.mod h1:khuxKBM4WqjcCIeCIm+4VDNBmzMsl0ZspXGMm5i/fFA=
-knative.dev/reconciler-test v0.0.0-20231016143156-93ac412266a6 h1:LWzcmhs8DYm8qN2c3b5Rxjn918GfTgp+eCIoEU+4hTg=
-knative.dev/reconciler-test v0.0.0-20231016143156-93ac412266a6/go.mod h1:PzN9CQhlo33hA8VYE+NA9FpkrZwOjJdXTGRwxzLbkVI=
+knative.dev/pkg v0.0.0-20231017113806-d6ab72900ea5 h1:9AvFZdEtuwKWDcTV1VSwmrgrRR9f38wbIAm+sNwLivQ=
+knative.dev/pkg v0.0.0-20231017113806-d6ab72900ea5/go.mod h1:HHRXEd7ZlFpthgE+rwAZ6MUVnuJOAeolnaFSthXloUQ=
+knative.dev/reconciler-test v0.0.0-20231017131250-999d077826b7 h1:zcFdS5167SauAvKmmPPUmXJtUxlBdKUWmO/a+F67+IM=
+knative.dev/reconciler-test v0.0.0-20231017131250-999d077826b7/go.mod h1:0jsKqMXLCIQNdceLuL2SL1LaAZSFtqUY7cLyHt0V2xY=
 pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1209,7 +1209,7 @@ knative.dev/hack/schema/commands
 knative.dev/hack/schema/docs
 knative.dev/hack/schema/registry
 knative.dev/hack/schema/schema
-# knative.dev/pkg v0.0.0-20231016185203-283df0be0668
+# knative.dev/pkg v0.0.0-20231017113806-d6ab72900ea5
 ## explicit; go 1.18
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1347,7 +1347,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20231016143156-93ac412266a6
+# knative.dev/reconciler-test v0.0.0-20231017131250-999d077826b7
 ## explicit; go 1.20
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Currently the eventing [releasability job](https://github.com/knative/release/actions/runs/6547646572/job/17808975727) fails due to:
```
...
The following files are changed: go.mod
go.sum
vendor/modules.txt
```

I rerun ./hack/update-deps.sh.