### PR TITLE
Don't override default values when applying partial features.yaml configmap 

### DIFF
--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -59,6 +59,8 @@ func newDefaults() Flags {
 		KReferenceMapping:   Disabled,
 		NewTriggerFilters:   Enabled,
 		TransportEncryption: Disabled,
+		OIDCAuthentication:  Disabled,
+		EvenTypeAutoCreate:  Disabled,
 	}
 }
 

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -51,9 +51,25 @@ const (
 // Missing entry in the map means feature is equal to feature not enabled.
 type Flags map[string]Flag
 
+func newDefaults() Flags {
+	return map[string]Flag{
+		KReferenceGroup:     Disabled,
+		DeliveryRetryAfter:  Disabled,
+		DeliveryTimeout:     Enabled,
+		KReferenceMapping:   Disabled,
+		NewTriggerFilters:   Enabled,
+		TransportEncryption: Disabled,
+	}
+}
+
 // IsEnabled returns true if the feature is enabled
 func (e Flags) IsEnabled(featureName string) bool {
 	return e != nil && e[featureName] == Enabled
+}
+
+// IsDisabled returns true if the feature is disabled
+func (e Flags) IsDisabled(featureName string) bool {
+	return e != nil && e[featureName] == Disabled
 }
 
 // IsAllowed returns true if the feature is enabled or allowed
@@ -86,7 +102,7 @@ func (e Flags) String() string {
 
 // NewFlagsConfigFromMap creates a Flags from the supplied Map
 func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
-	flags := Flags{}
+	flags := newDefaults()
 
 	for k, v := range data {
 		if strings.HasPrefix(k, "_") {
@@ -100,12 +116,12 @@ func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 			flags[sanitizedKey] = Disabled
 		} else if strings.EqualFold(v, string(Enabled)) {
 			flags[sanitizedKey] = Enabled
-		} else if strings.EqualFold(v, string(Permissive)) {
+		} else if k == TransportEncryption && strings.EqualFold(v, string(Permissive)) {
 			flags[sanitizedKey] = Permissive
-		} else if strings.EqualFold(v, string(Strict)) {
+		} else if k == TransportEncryption && strings.EqualFold(v, string(Strict)) {
 			flags[sanitizedKey] = Strict
 		} else {
-			return Flags{}, fmt.Errorf("cannot parse the boolean flag '%s' = '%s'. Allowed values: [true, false]", k, v)
+			return flags, fmt.Errorf("cannot parse the feature flag '%s' = '%s'", k, v)
 		}
 	}
 

--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -67,4 +67,7 @@ func TestShouldNotOverrideDefaults(t *testing.T) {
 	if !f.IsDisabled(KReferenceGroup) && !f.IsEnabled(KReferenceGroup) {
 		t.Errorf("Expected default value for %s in flags %+v", KReferenceGroup, f)
 	}
+	if !f.IsEnabled(NewTriggerFilters) {
+		t.Errorf("Expected default value for %s to be %s in flags %+v", NewTriggerFilters, Enabled, f)
+	}
 }

--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -22,8 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 	_ "knative.dev/pkg/system/testing"
 
-	. "knative.dev/eventing/pkg/apis/feature"
 	. "knative.dev/pkg/configmap/testing"
+
+	. "knative.dev/eventing/pkg/apis/feature"
 )
 
 func TestFlags_IsEnabled_NilMap(t *testing.T) {
@@ -55,4 +56,15 @@ func TestGetFlags(t *testing.T) {
 	require.True(t, flags.IsAllowed("my-enabled-flag"))
 	require.True(t, flags.IsAllowed("my-allowed-flag"))
 	require.False(t, flags.IsAllowed("non-disabled-flag"))
+}
+
+func TestShouldNotOverrideDefaults(t *testing.T) {
+
+	f, err := NewFlagsConfigFromMap(map[string]string{})
+	require.Nil(t, err)
+	require.NotNil(t, f)
+
+	if !f.IsDisabled(KReferenceGroup) && !f.IsEnabled(KReferenceGroup) {
+		t.Errorf("Expected default value for %s in flags %+v", KReferenceGroup, f)
+	}
 }


### PR DESCRIPTION
Fixes #7254 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Don't override default values when applying partial features.yaml configmap 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
It is now possible to specify a subset of features in `config-features` without overriding default values
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

