### PR TITLE
Add e2e test if channel implementation exposes OIDC audience

### DIFF
--- a/test/auth/features/oidc/addressable_oidc_conformance.go
+++ b/test/auth/features/oidc/addressable_oidc_conformance.go
@@ -47,10 +47,10 @@ func AddressableOIDCTokenConformance(gvr schema.GroupVersionResource, kind, name
 	fs := feature.FeatureSet{
 		Name: fmt.Sprintf("%s handles requests with OIDC tokens correctly", kind),
 		Features: []*feature.Feature{
-			AddressableRejectInvalidAudience(gvr, kind, name),
-			AddressableRejectCorruptedSignature(gvr, kind, name),
-			AddressableRejectExpiredToken(gvr, kind, name),
-			AddressableAllowsValidRequest(gvr, kind, name),
+			addressableRejectInvalidAudience(gvr, kind, name),
+			addressableRejectCorruptedSignature(gvr, kind, name),
+			addressableRejectExpiredToken(gvr, kind, name),
+			addressableAllowsValidRequest(gvr, kind, name),
 		},
 	}
 
@@ -73,7 +73,7 @@ func AddressableHasAudiencePopulated(gvr schema.GroupVersionResource, kind, name
 	return f
 }
 
-func AddressableRejectInvalidAudience(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
+func addressableRejectInvalidAudience(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s reject event for wrong OIDC audience", kind))
 
 	source := feature.MakeRandomK8sName("source")
@@ -97,7 +97,7 @@ func AddressableRejectInvalidAudience(gvr schema.GroupVersionResource, kind, nam
 	return f
 }
 
-func AddressableRejectExpiredToken(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
+func addressableRejectExpiredToken(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s reject event with expired OIDC token", kind))
 
 	source := feature.MakeRandomK8sName("source")
@@ -121,7 +121,7 @@ func AddressableRejectExpiredToken(gvr schema.GroupVersionResource, kind, name s
 	return f
 }
 
-func AddressableRejectCorruptedSignature(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
+func addressableRejectCorruptedSignature(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s reject event with corrupted OIDC token signature", kind))
 
 	source := feature.MakeRandomK8sName("source")
@@ -145,7 +145,7 @@ func AddressableRejectCorruptedSignature(gvr schema.GroupVersionResource, kind, 
 	return f
 }
 
-func AddressableAllowsValidRequest(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
+func addressableAllowsValidRequest(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s handles event with valid OIDC token", kind))
 
 	source := feature.MakeRandomK8sName("source")

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -31,7 +31,9 @@ import (
 
 	"knative.dev/eventing/test/auth/features/oidc"
 	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
+	"knative.dev/eventing/test/rekt/features/channel"
 	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
 )
 
 func TestBrokerSupportsOIDC(t *testing.T) {
@@ -51,4 +53,22 @@ func TestBrokerSupportsOIDC(t *testing.T) {
 
 	env.TestSet(ctx, t, oidc.AddressableOIDCConformance(broker.GVR(), "Broker", name, env.Namespace()))
 	env.Test(ctx, t, oidc.BrokerSendEventWithOIDCToken())
+}
+
+func TestChannelImplSupportsOIDC(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		environment.WithPollTimings(4*time.Second, 12*time.Minute),
+	)
+
+	name := feature.MakeRandomK8sName("channelimpl")
+	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
+
+	env.Test(ctx, t, oidc.AddressableHasAudiencePopulated(channel_impl.GVR(), channel_impl.GVK().Kind, name, env.Namespace()))
 }


### PR DESCRIPTION
## Proposed Changes

- :gift: Add e2e test to check if channel implementation exposes OIDC audience in status (392b5354dbe799b40ff78693172183e73479eb3f)
- :broom: Make some OIDC conformance tests private as they are wrapped in a feature set (e3cdd6568c4a8dc5293f026bbedbc4a1657e0300)