### PR TITLE
provision sequence audience using channel audience

### DIFF
--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -186,7 +186,7 @@ func (ss *SequenceStatus) setAddress(address *duckv1.Addressable) {
 		ss.Address = duckv1.Addressable{}
 		sCondSet.Manage(ss).MarkUnknown(SequenceConditionAddressable, "emptyAddress", "addressable is nil")
 	} else {
-		ss.Address = duckv1.Addressable{URL: address.URL}
+		ss.Address = duckv1.Addressable{URL: address.URL, Audience: address.Audience}
 		sCondSet.Manage(ss).MarkTrue(SequenceConditionAddressable)
 	}
 }

--- a/pkg/apis/flows/v1/sequence_lifecycle_test.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle_test.go
@@ -379,7 +379,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 		want         duckv1.Addressable
 		wantStatus   corev1.ConditionStatus
 		wantAddress  string
-		wantAudience string
+		wantAudience *string
 	}{{
 		name:       "nil",
 		status:     SequenceStatus{},
@@ -433,7 +433,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 		want:         duckv1.Addressable{URL: URL, Audience: &channelAudience},
 		wantStatus:   corev1.ConditionTrue,
 		wantAddress:  "http://example.com",
-		wantAudience: "messaging.knative.dev/inmemorychannel/testNS/test-imc",
+		wantAudience: &channelAudience,
 	}}
 
 	for _, tt := range tests {
@@ -456,11 +456,7 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 			if diff := cmp.Diff(tt.wantAddress, gotAddress); diff != "" {
 				t.Error("unexpected address.url (-want, +got) =", diff)
 			}
-			gotAudience := ""
-			if got.Audience != nil {
-				gotAudience = *got.Audience
-			}
-			if diff := cmp.Diff(tt.wantAudience, gotAudience); diff != "" {
+			if diff := cmp.Diff(tt.wantAudience, got.Audience); diff != "" {
 				t.Error("unexpected address.audience (-want, +got) =", diff)
 			}
 		})

--- a/pkg/apis/flows/v1/sequence_lifecycle_test.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -69,6 +70,7 @@ func getSubscription(name string, ready bool) *messagingv1.Subscription {
 
 func getChannelable(ready bool) *eventingduckv1.Channelable {
 	URL := apis.HTTP("example.com")
+	channelAudience := fmt.Sprintf("messaging.knative.dev/inmemorychannel/%s/%s", "testNS", "test-imc")
 	c := eventingduckv1.Channelable{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "messaging.knative.dev/v1",
@@ -83,7 +85,7 @@ func getChannelable(ready bool) *eventingduckv1.Channelable {
 			Type:   apis.ConditionReady,
 			Status: corev1.ConditionTrue,
 		}})
-		c.Status.Address = &duckv1.Addressable{URL: URL}
+		c.Status.Address = &duckv1.Addressable{URL: URL, Audience: &channelAudience}
 	} else {
 		c.Status.SetConditions([]apis.Condition{{
 			Type:   apis.ConditionReady,
@@ -369,13 +371,15 @@ func TestSequenceReady(t *testing.T) {
 func TestSequencePropagateSetAddress(t *testing.T) {
 	URL := apis.HTTP("example.com")
 	URL2 := apis.HTTP("another.example.com")
+	channelAudience := fmt.Sprintf("messaging.knative.dev/inmemorychannel/%s/%s", "testNS", "test-imc")
 	tests := []struct {
-		name        string
-		status      SequenceStatus
-		address     *duckv1.Addressable
-		want        duckv1.Addressable
-		wantStatus  corev1.ConditionStatus
-		wantAddress string
+		name         string
+		status       SequenceStatus
+		address      *duckv1.Addressable
+		want         duckv1.Addressable
+		wantStatus   corev1.ConditionStatus
+		wantAddress  string
+		wantAudience string
 	}{{
 		name:       "nil",
 		status:     SequenceStatus{},
@@ -422,6 +426,14 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 		address:    &duckv1.Addressable{URL: nil},
 		want:       duckv1.Addressable{},
 		wantStatus: corev1.ConditionUnknown,
+	}, {
+		name:         "audience",
+		status:       SequenceStatus{},
+		address:      &duckv1.Addressable{URL: URL, Audience: &channelAudience},
+		want:         duckv1.Addressable{URL: URL, Audience: &channelAudience},
+		wantStatus:   corev1.ConditionTrue,
+		wantAddress:  "http://example.com",
+		wantAudience: "messaging.knative.dev/inmemorychannel/testNS/test-imc",
 	}}
 
 	for _, tt := range tests {
@@ -440,8 +452,16 @@ func TestSequencePropagateSetAddress(t *testing.T) {
 			if got.URL != nil {
 				gotAddress = got.URL.String()
 			}
+
 			if diff := cmp.Diff(tt.wantAddress, gotAddress); diff != "" {
 				t.Error("unexpected address.url (-want, +got) =", diff)
+			}
+			gotAudience := ""
+			if got.Audience != nil {
+				gotAudience = *got.Audience
+			}
+			if diff := cmp.Diff(tt.wantAudience, gotAudience); diff != "" {
+				t.Error("unexpected address.audience (-want, +got) =", diff)
 			}
 		})
 	}

--- a/pkg/apis/flows/v1/sequence_lifecycle_test.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle_test.go
@@ -35,6 +35,8 @@ var sequenceConditionReady = apis.Condition{
 	Status: corev1.ConditionTrue,
 }
 
+var channelAudience = fmt.Sprintf("messaging.knative.dev/inmemorychannel/%s/%s", "testNS", "test-imc")
+
 func TestSequenceGetConditionSet(t *testing.T) {
 	r := &Sequence{}
 
@@ -371,7 +373,7 @@ func TestSequenceReady(t *testing.T) {
 func TestSequencePropagateSetAddress(t *testing.T) {
 	URL := apis.HTTP("example.com")
 	URL2 := apis.HTTP("another.example.com")
-	channelAudience := fmt.Sprintf("messaging.knative.dev/inmemorychannel/%s/%s", "testNS", "test-imc")
+
 	tests := []struct {
 		name         string
 		status       SequenceStatus

--- a/test/auth/features/oidc/sequence.go
+++ b/test/auth/features/oidc/sequence.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/eventing/pkg/auth"
+	"knative.dev/eventing/pkg/reconciler/sequence/resources"
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/eventing/test/rekt/resources/sequence"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func SequenceHasAudienceOfInputChannel(sequenceName, sequenceNamespace string, channelGVR schema.GroupVersionResource, channelKind string) *feature.Feature {
+	f := feature.NewFeatureNamed("Parallel has audience of input channel")
+
+	f.Setup("Parallel goes ready", sequence.IsReady(sequenceName))
+
+	expectedAudience := auth.GetAudience(channelGVR.GroupVersion().WithKind(channelKind), metav1.ObjectMeta{
+		Name:      resources.SequenceChannelName(sequenceName, 0),
+		Namespace: sequenceNamespace,
+	})
+
+	f.Alpha("Parallel").Must("has audience set", sequence.ValidateAddress(sequenceName, addressable.AssertAddressWithAudience(expectedAudience)))
+
+	return f
+}

--- a/test/auth/features/oidc/sequence.go
+++ b/test/auth/features/oidc/sequence.go
@@ -27,16 +27,16 @@ import (
 )
 
 func SequenceHasAudienceOfInputChannel(sequenceName, sequenceNamespace string, channelGVR schema.GroupVersionResource, channelKind string) *feature.Feature {
-	f := feature.NewFeatureNamed("Parallel has audience of input channel")
+	f := feature.NewFeatureNamed("Sequence has audience of input channel")
 
-	f.Setup("Parallel goes ready", sequence.IsReady(sequenceName))
+	f.Setup("Sequence goes ready", sequence.IsReady(sequenceName))
 
 	expectedAudience := auth.GetAudience(channelGVR.GroupVersion().WithKind(channelKind), metav1.ObjectMeta{
 		Name:      resources.SequenceChannelName(sequenceName, 0),
 		Namespace: sequenceNamespace,
 	})
 
-	f.Alpha("Parallel").Must("has audience set", sequence.ValidateAddress(sequenceName, addressable.AssertAddressWithAudience(expectedAudience)))
+	f.Alpha("Sequence").Must("has audience set", sequence.ValidateAddress(sequenceName, addressable.AssertAddressWithAudience(expectedAudience)))
 
 	return f
 }

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -115,5 +115,5 @@ func TestSequenceSupportsOIDC(t *testing.T) {
 		Spec:     map[string]interface{}{},
 	})))
 
-	env.Test(ctx, t, oidc.SequenceHasAudienceOfInputChannel(sequence.GVR(), sequence.GVK().Kind, name, env.Namespace()))
+	env.Test(ctx, t, oidc.SequenceHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
 }

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -107,11 +107,13 @@ func TestSequenceSupportsOIDC(t *testing.T) {
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
-		environment.WithPollTimings(4*time.Second, 12*time.Minute),
 	)
 
 	name := feature.MakeRandomK8sName("sequence")
-	env.Prerequisite(ctx, t, sequencefeatures.GoesReady(name))
+	env.Prerequisite(ctx, t, sequencefeatures.GoesReady(name, sequence.WithChannelTemplate(channel_template.ChannelTemplate{
+		TypeMeta: channel_impl.TypeMeta(),
+		Spec:     map[string]interface{}{},
+	})))
 
 	env.Test(ctx, t, oidc.AddressableHasAudiencePopulated(sequence.GVR(), sequence.GVK().Kind, name, env.Namespace()))
 }

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -33,10 +33,12 @@ import (
 	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
 	"knative.dev/eventing/test/rekt/features/channel"
 	parallelfeatures "knative.dev/eventing/test/rekt/features/parallel"
+	sequencefeatures "knative.dev/eventing/test/rekt/features/sequence"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/channel_template"
 	"knative.dev/eventing/test/rekt/resources/parallel"
+	"knative.dev/eventing/test/rekt/resources/sequence"
 )
 
 func TestBrokerSupportsOIDC(t *testing.T) {
@@ -94,4 +96,22 @@ func TestParallelSupportsOIDC(t *testing.T) {
 	})))
 
 	env.Test(ctx, t, oidc.ParallelHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
+}
+
+func TestSequenceSupportsOIDC(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		environment.WithPollTimings(4*time.Second, 12*time.Minute),
+	)
+
+	name := feature.MakeRandomK8sName("sequence")
+	env.Prerequisite(ctx, t, sequencefeatures.GoesReady(name))
+
+	env.Test(ctx, t, oidc.AddressableHasAudiencePopulated(sequence.GVR(), sequence.GVK().Kind, name, env.Namespace()))
 }

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -115,5 +115,5 @@ func TestSequenceSupportsOIDC(t *testing.T) {
 		Spec:     map[string]interface{}{},
 	})))
 
-	env.Test(ctx, t, oidc.AddressableHasAudiencePopulated(sequence.GVR(), sequence.GVK().Kind, name, env.Namespace()))
+	env.Test(ctx, t, oidc.SequenceHasAudienceOfInputChannel(sequence.GVR(), sequence.GVK().Kind, name, env.Namespace()))
 }

--- a/test/rekt/resources/sequence/sequence.go
+++ b/test/rekt/resources/sequence/sequence.go
@@ -150,3 +150,8 @@ func WithChannelTemplate(template channel_template.ChannelTemplate) manifest.Cfg
 		channelTemplate["spec"] = template.Spec
 	}
 }
+
+// ValidateAddress validates the address retured by Address
+func ValidateAddress(name string, validate addressable.ValidateAddressFn, timings ...time.Duration) feature.StepFn {
+	return addressable.ValidateAddress(GVR(), name, validate, timings...)
+}


### PR DESCRIPTION

Fixes #7294 

## Proposed Changes
- Use channel audience in sequence `status.Address.Audience `

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Use underlying input channels audience as sequence audience
```