### PR TITLE
Support for seconds field in PingSource schedule

### DIFF
--- a/pkg/adapter/mtping/adapter.go
+++ b/pkg/adapter/mtping/adapter.go
@@ -58,7 +58,12 @@ func NewEnvConfig() adapter.EnvConfigAccessor {
 
 func NewAdapter(ctx context.Context, env adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
 	logger := logging.FromContext(ctx)
-	runner := NewCronJobsRunner(adapter.GetClientConfig(ctx), kubeclient.Get(ctx), logging.FromContext(ctx))
+
+	opts := cron.WithParser(cron.NewParser(
+		cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+	))
+
+	runner := NewCronJobsRunner(adapter.GetClientConfig(ctx), kubeclient.Get(ctx), logging.FromContext(ctx), opts)
 
 	return &mtpingAdapter{
 		logger:    logger,

--- a/pkg/apis/sources/v1/ping_validation.go
+++ b/pkg/apis/sources/v1/ping_validation.go
@@ -46,7 +46,11 @@ func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		schedule = "CRON_TZ=" + cs.Timezone + " " + schedule
 	}
 
-	if _, err := cron.ParseStandard(schedule); err != nil {
+	parser := cron.NewParser(
+		cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+	)
+
+	if _, err := parser.Parse(schedule); err != nil {
 		if strings.HasPrefix(err.Error(), "provided bad location") {
 			fe := apis.ErrInvalidValue(err, "timezone")
 			errs = errs.Also(fe)

--- a/pkg/apis/sources/v1/ping_validation_test.go
+++ b/pkg/apis/sources/v1/ping_validation_test.go
@@ -56,6 +56,24 @@ func TestPingSourceValidation(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "valid spec with schedule including seconds",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "10 0/5 * * * ?",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: nil,
 		}, {
 			name: "valid spec with timezone",
 			source: PingSource{
@@ -107,7 +125,8 @@ func TestPingSourceValidation(t *testing.T) {
 			want: func() *apis.FieldError {
 				return apis.ErrGeneric("expected at least one, got none", "ref", "uri").ViaField("spec.sink")
 			}(),
-		}, {
+		},
+		{
 			name: "invalid schedule",
 			source: PingSource{
 				Spec: PingSourceSpec{
@@ -125,11 +144,12 @@ func TestPingSourceValidation(t *testing.T) {
 			},
 			want: func() *apis.FieldError {
 				var errs *apis.FieldError
-				fe := apis.ErrInvalidValue("expected exactly 5 fields, found 1: [2]", "spec.schedule")
+				fe := apis.ErrInvalidValue("expected 5 to 6 fields, found 1: [2]", "spec.schedule")
 				errs = errs.Also(fe)
 				return errs
 			}(),
-		}, {
+		},
+		{
 			name: "valid spec with data",
 			source: PingSource{
 				Spec: PingSourceSpec{

--- a/pkg/apis/sources/v1beta2/ping_validation.go
+++ b/pkg/apis/sources/v1beta2/ping_validation.go
@@ -46,7 +46,11 @@ func (cs *PingSourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		schedule = "CRON_TZ=" + cs.Timezone + " " + schedule
 	}
 
-	if _, err := cron.ParseStandard(schedule); err != nil {
+	parser := cron.NewParser(
+		cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+	)
+
+	if _, err := parser.Parse(schedule); err != nil {
 		if strings.HasPrefix(err.Error(), "provided bad location") {
 			fe := apis.ErrInvalidValue(err, "timezone")
 			errs = errs.Also(fe)

--- a/pkg/apis/sources/v1beta2/ping_validation_test.go
+++ b/pkg/apis/sources/v1beta2/ping_validation_test.go
@@ -56,6 +56,24 @@ func TestPingSourceValidation(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "valid spec with schedule including seconds",
+			source: PingSource{
+				Spec: PingSourceSpec{
+					Schedule: "10 0/5 * * * ?",
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: &duckv1.KReference{
+								APIVersion: "v1",
+								Kind:       "broker",
+								Name:       "default",
+							},
+						},
+					},
+				},
+			},
+			want: nil,
 		}, {
 			name: "valid spec with timezone",
 			source: PingSource{
@@ -125,7 +143,7 @@ func TestPingSourceValidation(t *testing.T) {
 			},
 			want: func() *apis.FieldError {
 				var errs *apis.FieldError
-				fe := apis.ErrInvalidValue("expected exactly 5 fields, found 1: [2]", "spec.schedule")
+				fe := apis.ErrInvalidValue("expected 5 to 6 fields, found 1: [2]", "spec.schedule")
 				errs = errs.Also(fe)
 				return errs
 			}(),

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -89,3 +89,17 @@ func TestPingSourceWithCloudEventData(t *testing.T) {
 
 	env.Test(ctx, t, pingsource.SendsEventsWithCloudEventData())
 }
+
+func TestPingSourceWithSecondsInSchedule(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, pingsource.SendsEventsWithSecondsInSchedule())
+}

--- a/test/rekt/resources/pingsource/pingsource_test.go
+++ b/test/rekt/resources/pingsource/pingsource_test.go
@@ -146,3 +146,48 @@ func Example_fullbase64() {
 	//     CACerts: |-
 	//       xyz
 }
+
+func Example_schedule_with_secs() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":        "foo",
+		"namespace":   "bar",
+		"schedule":    "10 0/5 * * * ?",
+		"contentType": "application/json",
+		"data":        `{"message": "Hello world!"}`,
+		"sink": map[string]interface{}{
+			"ref": map[string]string{
+				"kind":       "sinkkind",
+				"namespace":  "sinknamespace",
+				"name":       "sinkname",
+				"apiVersion": "sinkversion",
+			},
+			"uri": "uri/parts",
+		},
+	}
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: sources.knative.dev/v1
+	// kind: PingSource
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	// spec:
+	//   schedule: '10 0/5 * * * ?'
+	//   contentType: 'application/json'
+	//   data: '{"message": "Hello world!"}'
+	//   sink:
+	//     ref:
+	//       kind: sinkkind
+	//       namespace: sinknamespace
+	//       name: sinkname
+	//       apiVersion: sinkversion
+	//     uri: uri/parts
+}


### PR DESCRIPTION
## Proposed Changes


- :gift: Allows PingSource to fire at sub-minute intervals. Enabled by constructing [cron](https://github.com/robfig/cron) with a custom parser as detailed in the cron package's [README](https://github.com/robfig/cron#readme). Screenshot from this README is shown below. Their README explains that this is backwards compatible. The standard cron format will still continue to work whilst also allowing for the additional cron format used by [the Quartz Scheduler](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html) which supports a seconds field.

![image](https://github.com/knative/eventing/assets/7696671/f3a37875-997c-4b0e-b576-8eb1a6d43328)



### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

```release-note
:page_facing_up: PingSource `schedule` supports optional seconds field
```




