### PR TITLE
Don't use async handler

### DIFF
--- a/pkg/channel/fanout/fanout_event_handler.go
+++ b/pkg/channel/fanout/fanout_event_handler.go
@@ -55,7 +55,7 @@ type Subscription struct {
 // Config for a fanout.EventHandler.
 type Config struct {
 	Subscriptions []Subscription `json:"subscriptions"`
-	// AsyncHandler controls whether the Subscriptions are called synchronous or asynchronously.
+	// Deprecated: AsyncHandler controls whether the Subscriptions are called synchronous or asynchronously.
 	// It is expected to be false when used as a sidecar.
 	AsyncHandler bool `json:"asyncHandler,omitempty"`
 }
@@ -240,6 +240,7 @@ func createEventReceiverFunction(f *FanoutEventHandler) func(context.Context, ch
 		reportArgs := channel.ReportArgs{}
 		reportArgs.EventType = event.Type()
 		reportArgs.Ns = ref.Namespace
+		additionalHeaders.Set(apis.KnNamespaceHeader, ref.Namespace)
 		dispatchResultForFanout := f.dispatch(ctx, subs, event, additionalHeaders)
 		return ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
 	}
@@ -302,7 +303,6 @@ func (f *FanoutEventHandler) dispatch(ctx context.Context, subs []Subscription, 
 			if dispatchResult.err != nil {
 				f.logger.Error("Fanout had an error", zap.Error(dispatchResult.err))
 				dispatchResultForFanout.err = dispatchResult.err
-				return dispatchResultForFanout
 			}
 		case <-time.After(f.timeout):
 			f.logger.Error("Fanout timed out")

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -226,7 +226,7 @@ func newConfigForInMemoryChannel(imc *v1.InMemoryChannel) (*multichannelfanout.C
 		HostName:  imc.Status.Address.URL.Host,
 		Path:      fmt.Sprintf("%s/%s", imc.Namespace, imc.Name),
 		FanoutConfig: fanout.Config{
-			AsyncHandler:  true,
+			AsyncHandler:  false,
 			Subscriptions: subs,
 		},
 	}, nil

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -138,8 +138,8 @@ func TestBrokerConformance(t *testing.T) {
 
 	// Install and wait for a Ready Broker.
 	env.Prerequisite(ctx, t, broker.GoesReady("default", b.WithEnvConfig()...))
-	env.TestSet(ctx, t, broker.ControlPlaneConformance("default", b.WithEnvConfig()...))
 	env.TestSet(ctx, t, broker.DataPlaneConformance("default"))
+	env.TestSet(ctx, t, broker.ControlPlaneConformance("default", b.WithEnvConfig()...))
 }
 
 func TestBrokerDefaultDelivery(t *testing.T) {

--- a/test/rekt/features/broker/data_plane.go
+++ b/test/rekt/features/broker/data_plane.go
@@ -19,6 +19,8 @@ package broker
 import (
 	"context"
 
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+
 	"github.com/google/uuid"
 	"knative.dev/eventing/test/rekt/features/knconf"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -50,9 +52,11 @@ func DataPlaneIngress(brokerName string) *feature.Feature {
 		state.SetOrFail(ctx, t, "brokerName", brokerName)
 	})
 
+	f = withBrokerAcceptsCEVersions(f, brokerName)
+
 	f.Stable("Conformance").
-		Must("The ingress endpoint(s) MUST conform to at least one of the following versions of the specification: 0.3, 1.0",
-			brokerAcceptsCEVersions).
+		//Must("The ingress endpoint(s) MUST conform to at least one of the following versions of the specification: 0.3, 1.0",
+		//	brokerAcceptsCEVersions).
 		May("Other versions MAY be rejected.",
 			brokerRejectsUnknownCEVersion).
 		ShouldNot("The Broker SHOULD NOT perform an upgrade of the produced event's CloudEvents version.",
@@ -67,6 +71,42 @@ func DataPlaneIngress(brokerName string) *feature.Feature {
 			brokerAcceptResponseSuccess).
 		Must("If a Broker receives a produce request and is unable to parse a valid CloudEvent, then it MUST reject the request with HTTP status code `400 Bad Request`.",
 			brokerRejectsMalformedCE)
+	return f
+}
+
+func withBrokerAcceptsCEVersions(f *feature.Feature, brokerName string) *feature.Feature {
+	uuids := map[string]string{
+		uuid.New().String(): "1.0",
+		uuid.New().String(): "0.3",
+	}
+
+	for id, version := range uuids {
+		// We need to use a different source name, otherwise, it will try to update
+		// the pod, which is immutable.
+		source := feature.MakeRandomK8sName("source")
+		event := cetest.FullEvent()
+		event.SetID(id)
+		event.SetSpecVersion(version)
+		f.Setup("Install Source", eventshub.Install(source,
+			eventshub.StartSenderToResource(broker.GVR(), brokerName),
+			eventshub.InputEvent(event),
+		))
+
+		f.Stable("Conformance").Must("The ingress endpoint(s) MUST conform to at least one of the following versions of the specification: 0.3, 1.0", func(ctx context.Context, t feature.T) {
+			store := eventshub.StoreFromContext(ctx, source)
+			// We are looking for two events, one of them is the sent event and the other
+			// is Response, so correlate them first. We want to make sure the event was sent and that the
+			// response was what was expected.
+			events := knconf.Correlate(store.AssertAtLeast(ctx, t, 2, knconf.SentEventMatcher("")))
+			for _, e := range events {
+				// Make sure HTTP response code is 2XX
+				if e.Response.StatusCode < 200 || e.Response.StatusCode > 299 {
+					t.Errorf("Expected statuscode 2XX for sequence %d got %d", e.Response.Sequence, e.Response.StatusCode)
+				}
+			}
+		})
+	}
+
 	return f
 }
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

To try to improve the consistency of the system when using the IMC, this PR is testing switching to using the sync handler

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use the sync handler instead of the async handler
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The InMemoryChannel now sends a 202 response only after successfully delivering the event to all subscribers
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

