### PR TITLE
Adding the rekt test for pingsource with broker as sink

### DIFF
--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -42,10 +42,6 @@ import (
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 )
 
-const (
-	exampleImage = "ko://knative.dev/eventing/test/test_images/print"
-)
-
 func SendsEventsWithSinkRef() *feature.Feature {
 	source := feature.MakeRandomK8sName("pingsource")
 	sink := feature.MakeRandomK8sName("sink")

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -21,7 +21,6 @@ package rekt
 
 import (
 	"testing"
-	"time"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -115,7 +114,6 @@ func TestPingSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
-		environment.WithPollTimings(5*time.Second, 2*time.Minute),
 	)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithBrokerAsSinkTLS())

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -21,6 +21,7 @@ package rekt
 
 import (
 	"testing"
+	"time"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -102,4 +103,20 @@ func TestPingSourceWithSecondsInSchedule(t *testing.T) {
 	)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithSecondsInSchedule())
+}
+
+func TestPingSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+		environment.WithPollTimings(5*time.Second, 2*time.Minute),
+	)
+
+	env.Test(ctx, t, pingsource.SendsEventsWithBrokerAsSinkTLS())
 }

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"knative.dev/eventing/test/rekt/resources/addressable"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -123,4 +125,9 @@ func WithSchedule(schedule string) manifest.CfgFn {
 			cfg["schedule"] = schedule
 		}
 	}
+}
+
+// ValidateAddress validates the address retured by Address
+func ValidateAddress(name string, validate addressable.ValidateAddressFn, timings ...time.Duration) feature.StepFn {
+	return addressable.ValidateAddress(Gvr(), name, validate, timings...)
 }

--- a/test/rekt/resources/pingsource/pingsource.go
+++ b/test/rekt/resources/pingsource/pingsource.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"knative.dev/eventing/test/rekt/resources/addressable"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/k8s"
@@ -125,9 +123,4 @@ func WithSchedule(schedule string) manifest.CfgFn {
 			cfg["schedule"] = schedule
 		}
 	}
-}
-
-// ValidateAddress validates the address retured by Address
-func ValidateAddress(name string, validate addressable.ValidateAddressFn, timings ...time.Duration) feature.StepFn {
-	return addressable.ValidateAddress(Gvr(), name, validate, timings...)
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #6932 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- A rekt-based e2e test for PingSource TLS support when using Broker as sink
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Added a rekt-based e2e test for PingSource TLS support when using Broker as sink
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

