### PR TITLE
fix: Inconsistent OIDC auth feature flag name

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -52,6 +52,6 @@ data:
   # For more details: https://github.com/knative/eventing/issues/6909
   eventtype-auto-create: "disabled"
 
-  # ALPHA feature: The authentication.oidc flag allows you to use OIDC authentication for Eventing.
+  # ALPHA feature: The aauthentication-oidc flag allows you to use OIDC authentication for Eventing.
   # For more details: https://github.com/knative/eventing/issues/7174
-  authentication.oidc: "disabled"
+  authentication-oidc: "disabled"

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -24,5 +24,5 @@ const (
 	NewTriggerFilters   = "new-trigger-filters"
 	TransportEncryption = "transport-encryption"
 	EvenTypeAutoCreate  = "eventtype-auto-create"
-	OIDCAuthentication  = "authentication.oidc"
+	OIDCAuthentication  = "authentication-oidc"
 )

--- a/test/auth/config/features.yaml
+++ b/test/auth/config/features.yaml
@@ -18,4 +18,4 @@ metadata:
   name: config-features
   namespace: knative-eventing
 data:
-  authentication.oidc: "enabled"
+  authentication-oidc: "enabled"


### PR DESCRIPTION
Correct the OIDC auth feature flag name is inconsistent as it uses a dot while other feature flags use - to separate words, In this pr change it to authentication-oidc instead of authentication.oidc.
#7420 