### PR TITLE
Refactor new filters tests to use single feature set

### DIFF
--- a/test/rekt/features/new_trigger_filters/feature.go
+++ b/test/rekt/features/new_trigger_filters/feature.go
@@ -18,18 +18,40 @@ package new_trigger_filters
 
 import (
 	"fmt"
-
 	. "github.com/cloudevents/sdk-go/v2/test"
 	"knative.dev/reconciler-test/pkg/feature"
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 )
 
-// FiltersFeatureSet creates a feature set for testing the broker implementation of the new trigger filters experimental feature
-// (aka Cloud Events Subscriptions API filters). It requires a created and ready Broker resource with brokerName.
-//
-// The feature set tests four filter dialects: exact, prefix, suffix and cesql (aka CloudEvents SQL).
-func FiltersFeatureSet(brokerName string) *feature.FeatureSet {
+type InstallBrokerFunc func(f *feature.Feature) string
+
+type CloudEventsContext struct {
+	eventType            string
+	eventSource          string
+	eventSubject         string
+	eventID              string
+	eventDataSchema      string
+	eventDataContentType string
+	shouldDeliver        bool
+}
+
+// NewFiltersFeatureSet creates a feature set which runs tests for the new trigger filters
+// It requires a function which installs a broker implementation into the current feature for testing.
+// All new triggers tests should be registered in this feature set so that they can be easily included in other
+// broker implementations for testing.
+func NewFiltersFeatureSet(installBroker InstallBrokerFunc) *feature.FeatureSet {
+	features := SingleDialectFilterFeatures(installBroker)
+	features = append(features, AllFilterFeature(installBroker), AnyFilterFeature(installBroker), MultipleTriggersAndSinksFeature(installBroker))
+	return &feature.FeatureSet{
+		Name:     "New Trigger Filters",
+		Features: features,
+	}
+}
+
+// SingleDialectFilterFeatures creates an array of features which each test a single dialect of the new filters.
+// It requires a function which installs a broker implementation into the current feature for testing.
+func SingleDialectFilterFeatures(installBroker InstallBrokerFunc) []*feature.Feature {
 	matchedEvent := FullEvent()
 	unmatchedEvent := MinEvent()
 	unmatchedEvent.SetType("org.wrong.type")
@@ -48,7 +70,7 @@ func FiltersFeatureSet(brokerName string) *feature.FeatureSet {
 		},
 	}
 
-	features := make([]*feature.Feature, 0, 8)
+	features := make([]*feature.Feature, 8)
 	tests := map[string]struct {
 		filters []eventingv1.SubscriptionsAPIFilter
 	}{
@@ -93,27 +115,14 @@ func FiltersFeatureSet(brokerName string) *feature.FeatureSet {
 
 	for name, fs := range tests {
 		f := feature.NewFeatureNamed(name)
-		f = newEventFilterFeature(eventContexts, fs.filters, f, brokerName)
+		createNewFiltersFeature(f, eventContexts, fs.filters, installBroker)
 		features = append(features, f)
 	}
 
-	return &feature.FeatureSet{
-		Name:     "New trigger filters",
-		Features: features,
-	}
+	return features
 }
 
-type CloudEventsContext struct {
-	eventType            string
-	eventSource          string
-	eventSubject         string
-	eventID              string
-	eventDataSchema      string
-	eventDataContentType string
-	shouldDeliver        bool
-}
-
-func AnyFilterFeature(brokerName string) *feature.Feature {
+func AnyFilterFeature(installBroker InstallBrokerFunc) *feature.Feature {
 	f := feature.NewFeature()
 
 	eventContexts := []CloudEventsContext{
@@ -173,12 +182,12 @@ func AnyFilterFeature(brokerName string) *feature.Feature {
 		},
 	}
 
-	f = newEventFilterFeature(eventContexts, filters, f, brokerName)
+	createNewFiltersFeature(f, eventContexts, filters, installBroker)
 
 	return f
 }
 
-func AllFilterFeature(brokerName string) *feature.Feature {
+func AllFilterFeature(installBroker InstallBrokerFunc) *feature.Feature {
 	f := feature.NewFeature()
 
 	eventContexts := []CloudEventsContext{
@@ -229,12 +238,12 @@ func AllFilterFeature(brokerName string) *feature.Feature {
 		},
 	}
 
-	f = newEventFilterFeature(eventContexts, filters, f, brokerName)
+	createNewFiltersFeature(f, eventContexts, filters, installBroker)
 
 	return f
 }
 
-func MultipleTriggersAndSinksFeature(brokerName string) *feature.Feature {
+func MultipleTriggersAndSinksFeature(installBroker InstallBrokerFunc) *feature.Feature {
 	f := feature.NewFeature()
 
 	eventContextsFirstSink := []CloudEventsContext{
@@ -309,8 +318,8 @@ func MultipleTriggersAndSinksFeature(brokerName string) *feature.Feature {
 		},
 	}
 
-	f = newEventFilterFeature(eventContextsFirstSink, filtersFirstTrigger, f, brokerName)
-	f = newEventFilterFeature(eventContextsSecondSink, filtersSecondTrigger, f, brokerName)
+	createNewFiltersFeature(f, eventContextsFirstSink, filtersFirstTrigger, installBroker)
+	createNewFiltersFeature(f, eventContextsSecondSink, filtersSecondTrigger, installBroker)
 
 	return f
 }

--- a/test/rekt/features/new_trigger_filters/feature.go
+++ b/test/rekt/features/new_trigger_filters/feature.go
@@ -71,7 +71,7 @@ func SingleDialectFilterFeatures(installBroker InstallBrokerFunc) []*feature.Fea
 		},
 	}
 
-	features := make([]*feature.Feature, 8)
+	features := make([]*feature.Feature, 0, 8)
 	tests := map[string]struct {
 		filters []eventingv1.SubscriptionsAPIFilter
 	}{
@@ -319,8 +319,14 @@ func MultipleTriggersAndSinksFeature(installBroker InstallBrokerFunc) *feature.F
 		},
 	}
 
-	createNewFiltersFeature(f, eventContextsFirstSink, filtersFirstTrigger, installBroker)
-	createNewFiltersFeature(f, eventContextsSecondSink, filtersSecondTrigger, installBroker)
+	// We need to create the broker here and mock it later so that the test uses the same broke for both filters
+	brokerName := installBroker(f)
+	fakeInstallBroker := func(_ *feature.Feature) string {
+		return brokerName
+	}
+
+	createNewFiltersFeature(f, eventContextsFirstSink, filtersFirstTrigger, fakeInstallBroker)
+	createNewFiltersFeature(f, eventContextsSecondSink, filtersSecondTrigger, fakeInstallBroker)
 
 	return f
 }

--- a/test/rekt/features/new_trigger_filters/feature.go
+++ b/test/rekt/features/new_trigger_filters/feature.go
@@ -18,6 +18,7 @@ package new_trigger_filters
 
 import (
 	"fmt"
+
 	. "github.com/cloudevents/sdk-go/v2/test"
 	"knative.dev/reconciler-test/pkg/feature"
 

--- a/test/rekt/features/new_trigger_filters/feature.go
+++ b/test/rekt/features/new_trigger_filters/feature.go
@@ -319,7 +319,7 @@ func MultipleTriggersAndSinksFeature(installBroker InstallBrokerFunc) *feature.F
 		},
 	}
 
-	// We need to create the broker here and mock it later so that the test uses the same broke for both filters
+	// We need to create the broker here and mock it later so that the test uses the same broker for both filters
 	brokerName := installBroker(f)
 	fakeInstallBroker := func(_ *feature.Feature) string {
 		return brokerName

--- a/test/rekt/features/new_trigger_filters/filters.go
+++ b/test/rekt/features/new_trigger_filters/filters.go
@@ -23,7 +23,6 @@ import (
 	"knative.dev/reconciler-test/pkg/eventshub"
 	. "knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
@@ -47,7 +46,6 @@ func createNewFiltersFeature(f *feature.Feature, eventContexts []CloudEventsCont
 
 	f.Setup("Install trigger", trigger.Install(triggerName, brokerName, cfg...))
 	f.Setup("Wait for trigger to become ready", trigger.IsReady(triggerName))
-	f.Setup("Broker is addressable", k8s.IsAddressable(broker.GVR(), brokerName))
 
 	asserter := f.Beta("New filters")
 

--- a/test/rekt/features/new_trigger_filters/filters.go
+++ b/test/rekt/features/new_trigger_filters/filters.go
@@ -33,9 +33,10 @@ import (
 	"knative.dev/eventing/test/rekt/resources/trigger"
 )
 
-func newEventFilterFeature(eventContexts []CloudEventsContext, filters []eventingv1.SubscriptionsAPIFilter, f *feature.Feature, brokerName string) *feature.Feature {
+func createNewFiltersFeature(f *feature.Feature, eventContexts []CloudEventsContext, filters []eventingv1.SubscriptionsAPIFilter, installBroker InstallBrokerFunc) {
 	subscriberName := feature.MakeRandomK8sName("subscriber")
 	triggerName := feature.MakeRandomK8sName("trigger")
+	brokerName := installBroker(f)
 
 	f.Setup("Install trigger subscriber", eventshub.Install(subscriberName, eventshub.StartReceiver))
 
@@ -51,45 +52,43 @@ func newEventFilterFeature(eventContexts []CloudEventsContext, filters []eventin
 	asserter := f.Beta("New filters")
 
 	for _, eventCtx := range eventContexts {
-		event := newEventFromEventContext(eventCtx)
+		e := newEventFromEventContext(eventCtx)
 		eventSender := feature.MakeRandomK8sName("sender")
 
 		f.Requirement(fmt.Sprintf("Install event sender %s", eventSender), eventshub.Install(eventSender,
 			eventshub.StartSenderToResource(broker.GVR(), brokerName),
-			eventshub.InputEvent(event),
+			eventshub.InputEvent(e),
 		))
 
 		if eventCtx.shouldDeliver {
-			asserter.Must("must deliver matched event", OnStore(subscriberName).MatchEvent(HasId(event.ID())).AtLeast(1))
+			asserter.Must("must deliver matched event", OnStore(subscriberName).MatchEvent(HasId(e.ID())).AtLeast(1))
 		} else {
-			asserter.MustNot("must not deliver unmatched event", OnStore(subscriberName).MatchEvent(HasId(event.ID())).Not())
+			asserter.MustNot("must not deliver unmatched event", OnStore(subscriberName).MatchEvent(HasId(e.ID())).Not())
 		}
 	}
-
-	return f
 }
 
 func newEventFromEventContext(eventCtx CloudEventsContext) event.Event {
-	event := MinEvent()
+	e := MinEvent()
 	// Ensure that each event has a unique ID
-	event.SetID(feature.MakeRandomK8sName("event"))
+	e.SetID(feature.MakeRandomK8sName("event"))
 	if eventCtx.eventType != "" {
-		event.SetType(eventCtx.eventType)
+		e.SetType(eventCtx.eventType)
 	}
 	if eventCtx.eventSource != "" {
-		event.SetSource(eventCtx.eventSource)
+		e.SetSource(eventCtx.eventSource)
 	}
 	if eventCtx.eventSubject != "" {
-		event.SetSubject(eventCtx.eventSubject)
+		e.SetSubject(eventCtx.eventSubject)
 	}
 	if eventCtx.eventID != "" {
-		event.SetID(eventCtx.eventID)
+		e.SetID(eventCtx.eventID)
 	}
 	if eventCtx.eventDataSchema != "" {
-		event.SetDataSchema(eventCtx.eventDataSchema)
+		e.SetDataSchema(eventCtx.eventDataSchema)
 	}
 	if eventCtx.eventDataContentType != "" {
-		event.SetDataContentType(eventCtx.eventDataContentType)
+		e.SetDataContentType(eventCtx.eventDataContentType)
 	}
-	return event
+	return e
 }

--- a/test/rekt/new_trigger_filters_test.go
+++ b/test/rekt/new_trigger_filters_test.go
@@ -42,5 +42,5 @@ func TestMTChannelBrokerNewTriggerFilters(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.TestSet(ctx, t, newfilters.SingleDialectFilterFeatures(broker.InstallMTBrokerIntoFeature))
+	env.TestSet(ctx, t, newfilters.NewFiltersFeatureSet(broker.InstallMTBrokerIntoFeature))
 }

--- a/test/rekt/new_trigger_filters_test.go
+++ b/test/rekt/new_trigger_filters_test.go
@@ -20,10 +20,10 @@ limitations under the License.
 package rekt
 
 import (
-	"knative.dev/eventing/test/rekt/resources/broker"
 	"testing"
 
 	newfilters "knative.dev/eventing/test/rekt/features/new_trigger_filters"
+	"knative.dev/eventing/test/rekt/resources/broker"
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"

--- a/test/rekt/new_trigger_filters_test.go
+++ b/test/rekt/new_trigger_filters_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package rekt
 
 import (
+	"knative.dev/eventing/test/rekt/resources/broker"
 	"testing"
 
 	newfilters "knative.dev/eventing/test/rekt/features/new_trigger_filters"
@@ -28,8 +29,6 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
-
-	"knative.dev/eventing/test/rekt/resources/broker"
 )
 
 func TestMTChannelBrokerNewTriggerFilters(t *testing.T) {
@@ -42,56 +41,6 @@ func TestMTChannelBrokerNewTriggerFilters(t *testing.T) {
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
-	brokerName := "default"
 
-	env.Prerequisite(ctx, t, broker.InstallMTBroker(brokerName))
-	env.TestSet(ctx, t, newfilters.FiltersFeatureSet(brokerName))
-}
-
-func TestMTChannelBrokerAnyTriggerFilters(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-	brokerName := "default"
-
-	env.Prerequisite(ctx, t, broker.InstallMTBroker(brokerName))
-	env.Test(ctx, t, newfilters.AnyFilterFeature(brokerName))
-}
-
-func TestMTChannelBrokerAllTriggerFilters(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-	brokerName := "default"
-
-	env.Prerequisite(ctx, t, broker.InstallMTBroker(brokerName))
-	env.Test(ctx, t, newfilters.AllFilterFeature(brokerName))
-}
-
-func TestMultipleSinksMultipleTriggers(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-	brokerName := "default"
-
-	env.Prerequisite(ctx, t, broker.InstallMTBroker(brokerName))
-	env.Test(ctx, t, newfilters.MultipleTriggersAndSinksFeature(brokerName))
+	env.TestSet(ctx, t, newfilters.SingleDialectFilterFeatures(broker.InstallMTBrokerIntoFeature))
 }

--- a/test/rekt/new_trigger_filters_test.go
+++ b/test/rekt/new_trigger_filters_test.go
@@ -42,5 +42,5 @@ func TestMTChannelBrokerNewTriggerFilters(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.TestSet(ctx, t, newfilters.NewFiltersFeatureSet(broker.InstallMTBrokerIntoFeature))
+	env.ParallelTestSet(ctx, t, newfilters.NewFiltersFeatureSet(broker.InstallMTBrokerIntoFeature))
 }

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -277,3 +277,11 @@ func InstallMTBroker(name string) *feature.Feature {
 	f.Requirement("Broker is ready", IsReady(name))
 	return f
 }
+
+func InstallMTBrokerIntoFeature(f *feature.Feature) string {
+	brokerName := feature.MakeRandomK8sName("broker")
+	f.Setup(fmt.Sprintf("Install broker %q", brokerName), Install(brokerName, WithEnvConfig()...))
+	f.Setup("Broker is ready", IsReady(brokerName))
+	f.Setup("Broker is addressable", k8s.IsAddressable(GVR(), brokerName))
+	return brokerName
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7396 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Pass in a function which installs a broker in a given feature instead of installing it in the environment
- Put all of the features into one feature set so that future dependency sync PRs to ekb will add them to the ekb tests automatically


