### PR TITLE
Use input channels audience as audience of Parallel

### DIFF
--- a/pkg/apis/flows/v1/parallel_lifecycle_test.go
+++ b/pkg/apis/flows/v1/parallel_lifecycle_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -420,6 +421,7 @@ func TestParallelReady(t *testing.T) {
 
 func TestParallelPropagateSetAddress(t *testing.T) {
 	URL := apis.HTTP("example.com")
+	audience := pointer.String("foo-bar")
 	tests := []struct {
 		name       string
 		address    *duckv1.Addressable
@@ -444,6 +446,11 @@ func TestParallelPropagateSetAddress(t *testing.T) {
 		name:       "nil",
 		address:    &duckv1.Addressable{URL: nil},
 		want:       &duckv1.Addressable{},
+		wantStatus: corev1.ConditionTrue,
+	}, {
+		name:       "Audience",
+		address:    &duckv1.Addressable{Audience: audience},
+		want:       &duckv1.Addressable{Audience: audience},
 		wantStatus: corev1.ConditionTrue,
 	}}
 

--- a/test/auth/features/oidc/parallel.go
+++ b/test/auth/features/oidc/parallel.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/eventing/pkg/auth"
+	"knative.dev/eventing/pkg/reconciler/parallel/resources"
+	"knative.dev/eventing/test/rekt/resources/addressable"
+	"knative.dev/eventing/test/rekt/resources/parallel"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func ParallelHasAudienceOfInputChannel(parallelName, parallelNamespace string, channelGVR schema.GroupVersionResource, channelKind string) *feature.Feature {
+	f := feature.NewFeatureNamed("Parallel has audience of input channel")
+
+	f.Setup("Parallel goes ready", parallel.IsReady(parallelName))
+
+	expectedAudience := auth.GetAudience(channelGVR.GroupVersion().WithKind(channelKind), metav1.ObjectMeta{
+		Name:      resources.ParallelChannelName(parallelName),
+		Namespace: parallelNamespace,
+	})
+
+	f.Alpha("Parallel").Must("has audience set", parallel.ValidateAddress(parallelName, addressable.AssertAddressWithAudience(expectedAudience)))
+
+	return f
+}

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -32,8 +32,11 @@ import (
 	"knative.dev/eventing/test/auth/features/oidc"
 	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
 	"knative.dev/eventing/test/rekt/features/channel"
+	parallelfeatures "knative.dev/eventing/test/rekt/features/parallel"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/channel_template"
+	"knative.dev/eventing/test/rekt/resources/parallel"
 )
 
 func TestBrokerSupportsOIDC(t *testing.T) {
@@ -71,4 +74,24 @@ func TestChannelImplSupportsOIDC(t *testing.T) {
 	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
 
 	env.Test(ctx, t, oidc.AddressableHasAudiencePopulated(channel_impl.GVR(), channel_impl.GVK().Kind, name, env.Namespace()))
+}
+
+func TestParallelSupportsOIDC(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	name := feature.MakeRandomK8sName("parallel")
+	env.Prerequisite(ctx, t, parallelfeatures.GoesReady(name, parallel.WithChannelTemplate(channel_template.ChannelTemplate{
+		TypeMeta: channel_impl.TypeMeta(),
+		Spec:     map[string]interface{}{},
+	})))
+
+	env.Test(ctx, t, oidc.ParallelHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
 }

--- a/test/rekt/resources/parallel/parallel.go
+++ b/test/rekt/resources/parallel/parallel.go
@@ -232,3 +232,8 @@ func WithChannelTemplate(template channel_template.ChannelTemplate) manifest.Cfg
 		channelTemplate["spec"] = template.Spec
 	}
 }
+
+// ValidateAddress validates the address retured by Address
+func ValidateAddress(name string, validate addressable.ValidateAddressFn, timings ...time.Duration) feature.StepFn {
+	return addressable.ValidateAddress(GVR(), name, validate, timings...)
+}


### PR DESCRIPTION
Fixes #7295

A Parallel will have the same audience as its input channel. As this is [already implemented](https://github.com/knative/eventing/blob/e3b797031d76bbca6a18e7e576b14cd543fe86c6/pkg/apis/flows/v1/parallel_lifecycle.go#L199), this PR adds tests to ensure it gets set correctly.