### PR TITLE
Support auto generation of Sequence identity service account

### DIFF
--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -28,7 +28,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, 
+var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable,
 	SequenceConditionOIDCIdentityCreated)
 
 const (
@@ -215,4 +215,3 @@ func (ss *SequenceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat st
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkUnknown(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
-

--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -17,20 +17,19 @@ limitations under the License.
 package v1
 
 import (
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	"knative.dev/eventing/pkg/apis/feature"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, SequenceConditionOIDCIdentityCreated)
+var sCondSet = apis.NewLivingConditionSet(SequenceConditionReady, SequenceConditionChannelsReady, SequenceConditionSubscriptionsReady, SequenceConditionAddressable, 
+	SequenceConditionOIDCIdentityCreated)
 
 const (
 	// SequenceConditionReady has status True when all subconditions below have been set to True.
@@ -48,6 +47,8 @@ const (
 	// the Addressable contract and has a non-empty hostname.
 	SequenceConditionAddressable apis.ConditionType = "Addressable"
 
+	// SequenceConditionOIDCIdentityCreated has status True when the OIDCIdentity has been created.
+	// This condition is only relevant if the OIDC feature is enabled.
 	SequenceConditionOIDCIdentityCreated apis.ConditionType = "OIDCIdentityCreated"
 )
 
@@ -195,23 +196,23 @@ func (ss *SequenceStatus) setAddress(address *duckv1.Addressable) {
 	}
 }
 
+// MarkOIDCIdentityCreatedSucceeded marks the OIDCIdentityCreated condition as true.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedSucceeded() {
 	sCondSet.Manage(ss).MarkTrue(SequenceConditionOIDCIdentityCreated)
 }
 
+// MarkOIDCIdentityCreatedSucceededWithReason marks the OIDCIdentityCreated condition as true with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedSucceededWithReason(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkTrueWithReason(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
+// MarkOIDCIdentityCreatedFailed marks the OIDCIdentityCreated condition as false with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedFailed(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkFalse(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
+// MarkOIDCIdentityCreatedUnknown marks the OIDCIdentityCreated condition as unknown with the given reason.
 func (ss *SequenceStatus) MarkOIDCIdentityCreatedUnknown(reason, messageFormat string, messageA ...interface{}) {
 	sCondSet.Manage(ss).MarkUnknown(SequenceConditionOIDCIdentityCreated, reason, messageFormat, messageA...)
 }
 
-func (ss *SequenceStatus) MarkOIDCIdentityCreatedNotSupported() {
-	// in case the OIDC feature is not supported, we mark the condition as true, to not mark the SinkBinding unready.
-	sCondSet.Manage(ss).MarkTrueWithReason(SequenceConditionOIDCIdentityCreated, fmt.Sprintf("%s feature not yet supported for SinkBinding", feature.OIDCAuthentication), "")
-}

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -59,6 +59,7 @@ func NewController(
 		serviceAccountLister: serviceaccountInformer.Lister(),
 		kubeclient: kubeclient.Get(ctx),
 	}
+
 	impl := sequencereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
 		return controller.Options{
 			ConfigStore: featureStore,
@@ -75,7 +76,7 @@ func NewController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	// Reconciler Sequence when the OIDC service account changes
+	// Reconcile Sequence when the OIDC service account changes
 	serviceaccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterController(&v1.Sequence{}),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/sequence/controller.go
+++ b/pkg/reconciler/sequence/controller.go
@@ -32,9 +32,9 @@ import (
 	"knative.dev/eventing/pkg/client/injection/informers/flows/v1/sequence"
 	"knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
 	sequencereconciler "knative.dev/eventing/pkg/client/injection/reconciler/flows/v1/sequence"
-	"knative.dev/pkg/injection/clients/dynamicclient"
-	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	"knative.dev/pkg/injection/clients/dynamicclient"
 )
 
 // NewController initializes the controller and is called by the generated code
@@ -52,12 +52,12 @@ func NewController(
 	featureStore.WatchConfigs(cmw)
 
 	r := &Reconciler{
-		sequenceLister:     sequenceInformer.Lister(),
-		subscriptionLister: subscriptionInformer.Lister(),
-		dynamicClientSet:   dynamicclient.Get(ctx),
-		eventingClientSet:  eventingclient.Get(ctx),
+		sequenceLister:       sequenceInformer.Lister(),
+		subscriptionLister:   subscriptionInformer.Lister(),
+		dynamicClientSet:     dynamicclient.Get(ctx),
+		eventingClientSet:    eventingclient.Get(ctx),
 		serviceAccountLister: serviceaccountInformer.Lister(),
-		kubeclient: kubeclient.Get(ctx),
+		kubeclient:           kubeclient.Get(ctx),
 	}
 
 	impl := sequencereconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/sequence/controller_test.go
+++ b/pkg/reconciler/sequence/controller_test.go
@@ -19,19 +19,28 @@ package sequence
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
 	. "knative.dev/pkg/reconciler/testing"
 
 	// Fake injection informers
+	"knative.dev/eventing/pkg/apis/feature"
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/flows/v1/sequence/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
 )
 
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := NewController(ctx, configmap.NewStaticWatcher(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: feature.FlagsConfigName,
+			},
+		}))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -62,9 +62,9 @@ type Reconciler struct {
 	eventingClientSet clientset.Interface
 
 	// dynamicClientSet allows us to configure pluggable Build objects
-	dynamicClientSet dynamic.Interface
+	dynamicClientSet     dynamic.Interface
 	serviceAccountLister corev1listers.ServiceAccountLister
-	kubeclient        kubernetes.Interface
+	kubeclient           kubernetes.Interface
 }
 
 // Check that our Reconciler implements sequencereconciler.Interface

--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/kmeta"
 
 	duckapis "knative.dev/pkg/apis/duck"
@@ -45,6 +46,7 @@ import (
 	"knative.dev/eventing/pkg/duck"
 
 	"knative.dev/eventing/pkg/reconciler/sequence/resources"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 type Reconciler struct {
@@ -58,6 +60,8 @@ type Reconciler struct {
 
 	// dynamicClientSet allows us to configure pluggable Build objects
 	dynamicClientSet dynamic.Interface
+	serviceAccountLister corev1listers.ServiceAccountLister
+	kubeclient        kubernetes.Interface
 }
 
 // Check that our Reconciler implements sequencereconciler.Interface

--- a/pkg/reconciler/testing/v1/sequence.go
+++ b/pkg/reconciler/testing/v1/sequence.go
@@ -18,9 +18,11 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -111,5 +113,33 @@ func WithSequenceSubscriptionsNotReady(reason, message string) SequenceOption {
 func WithSequenceAddressableNotReady(reason, message string) SequenceOption {
 	return func(p *flowsv1.Sequence) {
 		p.Status.MarkAddressableNotReady(reason, message)
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedSucceeded() SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedSucceeded()
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled() SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedSucceededWithReason(fmt.Sprintf("%s feature disabled", feature.OIDCAuthentication), "")
+	}
+}
+
+func WithSequenceOIDCIdentityCreatedFailed(reason, message string) SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		s.Status.MarkOIDCIdentityCreatedFailed(reason, message)
+	}
+}
+
+func WithSequenceOIDCServiceAccountName(name string) SequenceOption {
+	return func(s *flowsv1.Sequence) {
+		if s.Status.Auth == nil {
+			s.Status.Auth = &duckv1.AuthStatus{}
+		}
+
+		s.Status.Auth.ServiceAccountName = &name
 	}
 }


### PR DESCRIPTION
Fixes #7224

In #7361 the functionality for creating a Sequences OIDC service account was added. Unfortunately the PR missed some tests and is not finished yet. 
This PR here is the same as #7361 but with added tests. Alternatively we can merge #7361 without the tests and use this PR here only for adding tests (but we should agree before merging #7361 IMO).

## Proposed Changes

- 🎁 Expose the name of the OIDC service account in the Sequence .status.auth.serviceAccountName
- 🎁 Create the OIDC service account of the Sequence
- 🎁 Add tests

**Release Note**

```release-note
Expose the Sequence OIDC service account name in the Sequences .status.auth.serviceAccountName.
```