### PR TITLE
Upgrade tests account for last event being interrupted

### DIFF
--- a/test/upgrade/prober/wathola/event/services.go
+++ b/test/upgrade/prober/wathola/event/services.go
@@ -108,7 +108,11 @@ func (f *finishedStore) RegisterFinished(finished *Finished) {
 	log.Infof("waiting additional %v to be sure all events came", d)
 	time.Sleep(d)
 	receivedEvents := f.steps.Count()
-	if receivedEvents != finished.EventsSent {
+
+	if receivedEvents != finished.EventsSent &&
+		// If sending was interrupted, tolerate one more received
+		// event as there's no way to check if the last event is delivered or not.
+		!(finished.SendingInterrupted && receivedEvents == finished.EventsSent+1) {
 		f.errors.throwUnexpected("expecting to have %v unique events received, "+
 			"but received %v unique events", finished.EventsSent, receivedEvents)
 		f.reportViolations(finished)

--- a/test/upgrade/prober/wathola/event/types.go
+++ b/test/upgrade/prober/wathola/event/types.go
@@ -46,6 +46,7 @@ type Finished struct {
 	EventsSent         int
 	TotalRequests      int
 	UnavailablePeriods []UnavailablePeriod
+	SendingInterrupted bool
 }
 
 // Type returns a type of a event

--- a/test/upgrade/prober/wathola/sender/services.go
+++ b/test/upgrade/prober/wathola/sender/services.go
@@ -100,7 +100,7 @@ func (s *sender) SendContinually() {
 				start = time.Now()
 			}
 			log.Warnf("Could not send step event %v, retrying (%d): %v",
-				s.eventsSent, retry, err)
+				currentStep.Number, retry, err)
 			retry++
 			lastErr = err
 		} else {

--- a/test/upgrade/prober/wathola/sender/services.go
+++ b/test/upgrade/prober/wathola/sender/services.go
@@ -58,6 +58,8 @@ type sender struct {
 	totalRequests int
 	// unavailablePeriods is an array for non-zero retries for each event
 	unavailablePeriods []event.UnavailablePeriod
+	// sendingInterrupted indicates whether sending last event was interrupted by shutdown
+	sendingInterrupted bool
 }
 
 func (s *sender) SendContinually() {
@@ -90,6 +92,7 @@ func (s *sender) SendContinually() {
 					Period:  time.Since(start),
 					LastErr: err.Error(),
 				})
+				s.sendingInterrupted = true
 			}
 			return
 		default:
@@ -219,7 +222,12 @@ func (s *sender) sendFinished() {
 	if s.eventsSent == 0 {
 		return
 	}
-	finished := event.Finished{EventsSent: s.eventsSent, TotalRequests: s.totalRequests, UnavailablePeriods: s.unavailablePeriods}
+	finished := event.Finished{
+		EventsSent:         s.eventsSent,
+		TotalRequests:      s.totalRequests,
+		UnavailablePeriods: s.unavailablePeriods,
+		SendingInterrupted: s.sendingInterrupted,
+	}
 	endpoint := senderConfig.Address
 	ce := NewCloudEvent(finished, event.FinishedType)
 	ctx, span := PopulateSpanWithEvent(context.Background(), ce, Name)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7446

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix reporting the index of the failed step
- Record if sending the last event was interrupted. In that case, tolerate one more event on receiver side because there's no way for the sender to know if the event was successfully sent (as the sender was interrupted and can't properly wait for confirmation)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

