### PR TITLE
Event Type: flip storage version to v1beta2 in EventType CRD and add deprecation warning

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -162,7 +162,7 @@ spec:
     # API requests to this version receive a warning header in the server response.
     deprecated: true
     # This overrides the default warning returned to API clients making v1beta1 API requests.
-    deprecationWarning: "eventing.knative.dev/v1beta1 EventType is deprecated; see http://knative.dev for instructions to migrate to eventing.knative.dev/v1beta2 EventType"
+    deprecationWarning: "eventing.knative.dev/v1beta1 EventType is deprecated; see https://knative.dev/docs/eventing/event-registry/ for instructions to migrate to eventing.knative.dev/v1beta2 EventType"
     # v1beta1 schema is identical to the v1beta2 schema
   names:
     kind: EventType

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -23,7 +23,7 @@ spec:
   group: eventing.knative.dev
   versions:
   - &version
-    name: v1beta1
+    name: v1beta2
     served: true
     storage: true
     subresources:
@@ -155,9 +155,14 @@ spec:
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
   - <<: *version
-    name: v1beta2
+    name: v1beta1
     served: true
     storage: false
+    # This indicates the v1beta1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning header in the server response.
+    deprecated: true
+    # This overrides the default warning returned to API clients making v1alpha1 API requests.
+    deprecationWarning: "eventing.knative.dev/v1beta1 EventType is deprecated; see http://knative.dev for instructions to migrate to eventing.knative.dev/v1beta2 EventType"
     # v1beta1 schema is identical to the v1beta2 schema
   names:
     kind: EventType

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -161,7 +161,7 @@ spec:
     # This indicates the v1beta1 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true
-    # This overrides the default warning returned to API clients making v1alpha1 API requests.
+    # This overrides the default warning returned to API clients making v1beta1 API requests.
     deprecationWarning: "eventing.knative.dev/v1beta1 EventType is deprecated; see http://knative.dev for instructions to migrate to eventing.knative.dev/v1beta2 EventType"
     # v1beta1 schema is identical to the v1beta2 schema
   names:


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #6994

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- flip storage version to v1beta2 in EventType CRD
- add deprecation warning for `v1b1`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
EventType storage set to TRUE for v1beta2 and adding deprecation note for v1beta1.
Action Required: You need to run the storage migration tool after the upgrade to migrate from v1beta1 to v1beta2 `eventtypes.eventing.knative.dev` resources.


```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

