### PR TITLE
Add deprecation warnings for EventType v1beta1

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -158,6 +158,11 @@ spec:
     name: v1beta1
     served: true
     storage: true
+    # This indicates the v1beta1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning header in the server response.
+    deprecated: true
+    # This overrides the default warning returned to API clients making v1beta1 API requests.
+    deprecationWarning: "eventing.knative.dev/v1beta1 EventType is deprecated; see https://knative.dev/docs/eventing/event-registry/ for instructions to migrate to eventing.knative.dev/v1beta2 EventType"
     # v1beta1 schema is identical to the v1beta2 schema
   names:
     kind: EventType

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -23,9 +23,9 @@ spec:
   group: eventing.knative.dev
   versions:
   - &version
-    name: v1beta1
+    name: v1beta2
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
     schema:
@@ -155,9 +155,9 @@ spec:
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
   - <<: *version
-    name: v1beta2
+    name: v1beta1
     served: true
-    storage: false
+    storage: true
     # v1beta1 schema is identical to the v1beta2 schema
   names:
     kind: EventType


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add deprecation warnings for EventType v1beta1
- change structure of the CRD (so that we have only on the old v1b1 the deprecation merged in)
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
EventType v1beta1 is deprecated. We now issue warning when those CRs are being created. V1beta1 will be removed in a future release.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

