### PR TITLE
Add deprecation warnings for v1b2

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -217,6 +217,11 @@ spec:
     name: v1beta2
     served: true
     storage: false
+    # This indicates the v1beta2 version of the custom resource is deprecated.
+    # API requests to this version receive a warning header in the server response.
+    deprecated: true
+    # This overrides the default warning returned to API clients making v1beta2 API requests.
+    deprecationWarning: "sources.knative.dev/v1beta2 PingSource is deprecated; see https://knative.dev/docs/eventing/sources/ping-source/ for instructions to migrate to sources.knative.dev/v1 PingSource"
     # v1 schema is identical to the v1beta2 schema
   names:
     categories:

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -35,9 +35,9 @@ spec:
   group: sources.knative.dev
   versions:
   - &version
-    name: v1beta2
+    name: v1
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
     schema:
@@ -214,9 +214,9 @@ spec:
       type: string
       jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
   - <<: *version
-    name: v1
+    name: v1beta2
     served: true
-    storage: true
+    storage: false
     # v1 schema is identical to the v1beta2 schema
   names:
     categories:


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- add deprecation warnings to v1b2 and change the structore of the CRD, so that we have _only_ on v1b2 those deprecation warnings

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
V1Beta2 is deprecation, we now issue warnings when the type is created
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

