### PR TITLE
Allow configuring whether to allow cross namespaces Brokers configuration references

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -85,6 +85,8 @@ type Defaults struct {
 type ClassAndBrokerConfig struct {
 	BrokerClass   string `json:"brokerClass,omitempty"`
 	*BrokerConfig `json:",inline"`
+
+	DisallowDifferentNamespaceConfig *bool `json:"disallowDifferentNamespaceConfig,omitempty"`
 }
 
 // BrokerConfig contains configuration for a given namespace for broker. Allows

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -60,6 +60,11 @@ func (in *ClassAndBrokerConfig) DeepCopyInto(out *ClassAndBrokerConfig) {
 		*out = new(BrokerConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisallowDifferentNamespaceConfig != nil {
+		in, out := &in.DisallowDifferentNamespaceConfig, &out.DisallowDifferentNamespaceConfig
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/eventing/v1/broker_validation.go
+++ b/pkg/apis/eventing/v1/broker_validation.go
@@ -23,6 +23,8 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
+
+	"knative.dev/eventing/pkg/apis/config"
 )
 
 const (
@@ -30,7 +32,22 @@ const (
 )
 
 func (b *Broker) Validate(ctx context.Context) *apis.FieldError {
-	withNS := apis.AllowDifferentNamespace(apis.WithinParent(ctx, b.ObjectMeta))
+	ctx = apis.WithinParent(ctx, b.ObjectMeta)
+
+	cfg := config.FromContextOrDefaults(ctx)
+	var brConfig *config.ClassAndBrokerConfig
+	if cfg.Defaults != nil {
+		if c, ok := cfg.Defaults.NamespaceDefaultsConfig[b.GetNamespace()]; ok {
+			brConfig = c
+		} else {
+			brConfig = cfg.Defaults.ClusterDefault
+		}
+	}
+
+	withNS := ctx
+	if brConfig == nil || brConfig.DisallowDifferentNamespaceConfig == nil || !*brConfig.DisallowDifferentNamespaceConfig {
+		withNS = apis.AllowDifferentNamespace(ctx)
+	}
 
 	// Make sure a BrokerClassAnnotation exists
 	var errs *apis.FieldError


### PR DESCRIPTION
Instead of always allowing to specify cross namespace configuration references for Broker allow users to configure whether to disallow such references as it might be problematic in multi tenant environments.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Allow configuring whether to allow cross namespaces Brokers configuration references

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Allow configuring whether to allow cross namespaces Brokers configuration using the `config-br-defaults` ConfigMap.

For example, to disallow cross namespaces Brokers configuration references cluster wide, the following ConfigMap can be applied:


`
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-br-defaults
  namespace: knative-eventing
  labels:
    app.kubernetes.io/version: devel
    app.kubernetes.io/name: knative-eventing
data:
  # Configures the default for any Broker that does not specify a spec.config or Broker class.
  default-br-config: |
    clusterDefault:
      disallowDifferentNamespaceConfig: true
      # ...
`

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

