### PR TITLE
Switch filters to use rfc-3339 for time string encoding

### DIFF
--- a/pkg/eventfilter/attributes/filter.go
+++ b/pkg/eventfilter/attributes/filter.go
@@ -74,7 +74,11 @@ func LookupAttribute(event cloudevents.Event, attr string) (interface{}, bool) {
 	case "id":
 		return event.ID(), true
 	case "time":
-		return event.Time().String(), true
+		b, err := event.Time().MarshalText()
+		if err != nil {
+			return nil, false
+		}
+		return string(b), true
 	case "dataschema":
 		return event.DataSchema(), true
 	case "schemaurl":

--- a/pkg/eventfilter/attributes/filter_test.go
+++ b/pkg/eventfilter/attributes/filter_test.go
@@ -172,6 +172,7 @@ func TestAllSupportedAttributeFieldsV1(t *testing.T) {
 	e.SetDataSchema("wow")
 	e.SetSubject("cool")
 	e.SetDataContentType("cheers;mate")
+	timeBytes, _ := e.Time().MarshalText()
 
 	attributes := map[string]string{
 		"specversion":     e.SpecVersion(),
@@ -179,7 +180,7 @@ func TestAllSupportedAttributeFieldsV1(t *testing.T) {
 		"source":          e.Source(),
 		"subject":         e.Subject(),
 		"id":              e.ID(),
-		"time":            e.Time().String(),
+		"time":            string(timeBytes),
 		"dataschema":      e.DataSchema(),
 		"schemaurl":       e.DataSchema(),
 		"datacontenttype": e.DataContentType(),

--- a/pkg/eventfilter/subscriptionsapi/exact_filter_test.go
+++ b/pkg/eventfilter/subscriptionsapi/exact_filter_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cetest "github.com/cloudevents/sdk-go/v2/test"
 
 	"knative.dev/eventing/pkg/eventfilter"
 )
@@ -138,4 +139,29 @@ func makeEventWithExtension(extName, extValue string) *cloudevents.Event {
 	e := makeEvent()
 	e.SetExtension(extName, extValue)
 	return e
+}
+
+func TestExactTimeMatchIsStable(t *testing.T) {
+	event := cetest.FullEvent()
+	time, err := event.Time().MarshalText()
+	if err != nil {
+		t.Fatalf("error while marshalling time to text: %v", err)
+	}
+	f, err := NewExactFilter(map[string]string{
+		"time": string(time),
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter")
+	}
+	// the filter should consistently pass here, let's check that it does
+	failCount := 0
+	for i := 0; i < 10_000; i++ {
+		if got := f.Filter(context.TODO(), event); got != eventfilter.PassFilter {
+			failCount += 1
+		}
+	}
+	if failCount != 0 {
+		t.Errorf("exact filter match on time should be consistent, failed %d / 10,000 times for same event", failCount)
+	}
+
 }

--- a/pkg/eventfilter/subscriptionsapi/exact_filter_test.go
+++ b/pkg/eventfilter/subscriptionsapi/exact_filter_test.go
@@ -155,7 +155,7 @@ func TestExactTimeMatchIsStable(t *testing.T) {
 	}
 	// the filter should consistently pass here, let's check that it does
 	failCount := 0
-	for i := 0; i < 10_000; i++ {
+	for i := 0; i < 1000; i++ {
 		if got := f.Filter(context.TODO(), event); got != eventfilter.PassFilter {
 			failCount += 1
 		}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7465 

Currently, we are seeing some inconsistency on time comparisons with filters. This is because we are using a string representation of the time which is explicitly marked as:

> The returned string is meant for debugging; for a stable serialized representation, use t.MarshalText, t.MarshalBinary, or t.Format with an explicit format string. 



CloudEvents spec states that we should use RFC-3339 for encoding timestamps as strings:
https://github.com/cloudevents/spec/blob/130ba0d183f5e45c1d141f5c1f272cf71d898623/cloudevents/spec.md?plain=1#L244

This PR switches our `time.Time.String` calls with code that converts the `time.Time` to RFC-3339 compliant strings.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Use RFC 3339 encoding for all time strings in filter comparisons
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Filters now use RFC-3339 compliant string encodings for attributes of type time.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

