### PR TITLE
Don't compare CE extensions when checking routing spec

### DIFF
--- a/test/rekt/features/broker/topology.go
+++ b/test/rekt/features/broker/topology.go
@@ -172,7 +172,7 @@ func assertExpectedRoutedEvents(prober *eventshub.EventProber, expected map[stri
 			if len(want) != 0 && len(got) != 0 {
 				// ID is adjusted by eventshub.
 				except := []cmp.Option{
-					cmpopts.IgnoreFields(conformanceevent.ContextAttributes{}, "ID"),
+					cmpopts.IgnoreFields(conformanceevent.ContextAttributes{}, "ID", "Extensions"),
 					cmpopts.IgnoreMapEntries(func(k, v string) bool { return k == "knativearrivaltime" }),
 				}
 				if diff := cmp.Diff(want, got, except...); diff != "" {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7463 

This change was tested by editing the vendor directory on https://github.com/knative-extensions/eventing-kafka-broker/pull/3464, and the broker conformance rekt routing tests passed, when they were failing before (there is still some flaky CI there, but that is failing kafka source stuff as normal)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Don't compare CE extensions when evaluating the routing spec
