### PR TITLE
Update downstream tests to Go 1.21

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
     - name: Install Dependencies
       run: |
         go install github.com/google/go-licenses@latest


### PR DESCRIPTION
In some of the downstream tests, we get the following error:

```
go: errors parsing go.mod:
/home/runner/work/eventing/eventing/src/knative.dev/eventing-github/go.mod:5: unknown directive: toolchain
```
e.g. in https://github.com/knative/eventing/actions/runs/6970231399/job/18967714667?pr=7468

This is, because some of the downstream repos already updated to Go 1.21 and have the new `toolchain` directive: 
https://github.com/knative-extensions/eventing-github/blob/b8d0dae02ce1fec15a65199751eb712f64f3afc4/go.mod#L5

This PR addresses it and sets the environment for the downstream test to use Go 1.21 too.