### PR TITLE
Used the kmeta.ChildName() to generate OIDC service account name

### DIFF
--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -36,7 +36,7 @@ import (
 // GetOIDCServiceAccountNameForResource returns the service account name to use
 // for OIDC authentication for the given resource.
 func GetOIDCServiceAccountNameForResource(gvk schema.GroupVersionKind, objectMeta metav1.ObjectMeta) string {
-	suffix := fmt.Sprintf("oidc-%s-%s", gvk.Group, gvk.Kind)
+	suffix := fmt.Sprintf("-oidc-%s-%s", gvk.Group, gvk.Kind)
 	parent := objectMeta.GetName()
 	sa := kmeta.ChildName(parent, suffix)
 	return strings.ToLower(sa)

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 )
@@ -35,8 +36,9 @@ import (
 // GetOIDCServiceAccountNameForResource returns the service account name to use
 // for OIDC authentication for the given resource.
 func GetOIDCServiceAccountNameForResource(gvk schema.GroupVersionKind, objectMeta metav1.ObjectMeta) string {
-	sa := fmt.Sprintf("oidc-%s-%s-%s", gvk.GroupKind().Group, gvk.GroupKind().Kind, objectMeta.GetName())
-
+	suffix := fmt.Sprintf("oidc-%s-%s", gvk.Group, gvk.Kind)
+	parent := objectMeta.GetName()
+	sa := kmeta.ChildName(parent, suffix)
 	return strings.ToLower(sa)
 }
 

--- a/pkg/auth/serviceaccount_test.go
+++ b/pkg/auth/serviceaccount_test.go
@@ -60,7 +60,7 @@ func TestGetOIDCServiceAccountNameForResource(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetOIDCServiceAccountNameForResource(tt.gvk, tt.objectMeta); got != tt.want {
-				t.Errorf("GetServiceAccountName() = %v, want %v", got, tt.want)
+				t.Errorf("GetOIDCServiceAccountNameForResource() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Refactor OIDC service account naming in GetOIDCServiceAccountNameForResource

This updates the method `GetOIDCServiceAccountNameForResource` in `eventing/pkg/auth/serviceaccount.go` to refactor the way OIDC service account names are generated. Instead of combining Group/Kind and the name of the parent object directly, it now uses `kmeta.ChildName` to generate the service account names. This change is made to prevent names from exceeding the maximum allowed length.
#7470 