### PR TITLE
Authenticate requests from mt-broker-ingress to underlying channel

### DIFF
--- a/config/brokers/mt-channel-broker/200-ingress-serviceaccount-oidc.yaml
+++ b/config/brokers/mt-channel-broker/200-ingress-serviceaccount-oidc.yaml
@@ -1,0 +1,1 @@
+roles/ingress-serviceaccount-oidc.yaml

--- a/config/brokers/mt-channel-broker/roles/ingress-serviceaccount-oidc.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-serviceaccount-oidc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Knative Authors
+# Copyright 2023 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/brokers/mt-channel-broker/roles/ingress-serviceaccount-oidc.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-serviceaccount-oidc.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,25 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: mt-broker-ingress
+  name: mt-broker-ingress-oidc
   namespace: knative-eventing
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - "serviceaccounts/token"
-    resourceNames:
-      - "mt-broker-ingress-oidc"
-    verbs:
-      - create
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing

--- a/pkg/apis/eventing/register.go
+++ b/pkg/apis/eventing/register.go
@@ -66,6 +66,10 @@ const (
 	// https://www.rfc-editor.org/rfc/rfc7468
 	BrokerChannelCACertsStatusAnnotationKey = "knative.dev/channelCACerts"
 
+	// BrokerChannelAudienceStatusAnnotationKey is the broker status annotation
+	// key used to specify the channels OIDC audience.
+	BrokerChannelAudienceStatusAnnotationKey = "knative.dev/channelAudience"
+
 	// BrokerChannelAPIVersionStatusAnnotationKey is the broker status
 	// annotation key used to specify the APIVersion of the channel for
 	// the triggers to subscribe to.

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -158,6 +158,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 		b.Status.Annotations[eventing.BrokerChannelCACertsStatusAnnotationKey] = *caCerts
 	}
 
+	if audience := triggerChan.Status.Address.Audience; audience != nil && *audience != "" {
+		b.Status.Annotations[eventing.BrokerChannelAudienceStatusAnnotationKey] = *audience
+	}
+
 	channelStatus := &duckv1.ChannelableStatus{
 		AddressStatus:  triggerChan.Status.AddressStatus,
 		DeliveryStatus: triggerChan.Status.DeliveryStatus,

--- a/pkg/reconciler/testing/v1/broker.go
+++ b/pkg/reconciler/testing/v1/broker.go
@@ -183,6 +183,15 @@ func WithChannelCACertsAnnotation(caCerts string) BrokerOption {
 	}
 }
 
+func WithChannelAudienceAnnotation(audience string) BrokerOption {
+	return func(b *v1.Broker) {
+		if b.Status.Annotations == nil {
+			b.Status.Annotations = make(map[string]string, 1)
+		}
+		b.Status.Annotations[eventing.BrokerChannelAudienceStatusAnnotationKey] = audience
+	}
+}
+
 func WithBrokerStatusDLS(dls duckv1.Addressable) BrokerOption {
 	return func(b *v1.Broker) {
 		b.Status.MarkDeadLetterSinkResolvedSucceeded(eventingv1.NewDeliveryStatusFromAddressable(&dls))


### PR DESCRIPTION
Fixes #7472

## Proposed Changes

- :gift: authenticate requests from mt-broker-filter to underlying channel (uses dedicated `mt-broker-ingress-oidc` service account and audience of channel)
