### PR TITLE
Add OIDC authentication to mt-broker-filter

### DIFF
--- a/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
@@ -36,3 +36,9 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - "serviceaccounts/token"
+    verbs:
+      - create

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -196,6 +196,9 @@ spec:
               subscriberCACerts:
                 description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                 type: string
+              subscriberAudience:
+                description: OIDC audience of the subscriber.
+                type: string
   names:
     kind: Trigger
     plural: triggers

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -2388,6 +2388,18 @@ according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-ed
 </tr>
 <tr>
 <td>
+<code>subscriberAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberAudience is the OIDC audience of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>DeliveryStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliveryStatus">

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -196,6 +196,10 @@ type TriggerStatus struct {
 	// +optional
 	SubscriberCACerts *string `json:"subscriberCACerts,omitempty"`
 
+	// SubscriberAudience is the OIDC audience of the subscriber.
+	// +optional
+	SubscriberAudience *string `json:"subscriberAudience,omitempty"`
+
 	// DeliveryStatus contains a resolved URL to the dead letter sink address, and any other
 	// resolved delivery options.
 	eventingduckv1.DeliveryStatus `json:",inline"`

--- a/pkg/apis/eventing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/eventing/v1/zz_generated.deepcopy.go
@@ -344,6 +344,11 @@ func (in *TriggerStatus) DeepCopyInto(out *TriggerStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubscriberAudience != nil {
+		in, out := &in.SubscriberAudience, &out.SubscriberAudience
+		*out = new(string)
+		**out = **in
+	}
 	in.DeliveryStatus.DeepCopyInto(&out.DeliveryStatus)
 	if in.Auth != nil {
 		in, out := &in.Auth, &out.Auth

--- a/pkg/reconciler/broker/trigger/trigger.go
+++ b/pkg/reconciler/broker/trigger/trigger.go
@@ -133,10 +133,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, t *eventingv1.Trigger) p
 		t.Status.MarkSubscriberResolvedFailed("Unable to get the Subscriber's URI", "%v", err)
 		t.Status.SubscriberURI = nil
 		t.Status.SubscriberCACerts = nil
+		t.Status.SubscriberAudience = nil
 		return err
 	}
 	t.Status.SubscriberURI = subscriberAddr.URL
 	t.Status.SubscriberCACerts = subscriberAddr.CACerts
+	t.Status.SubscriberAudience = subscriberAddr.Audience
 	t.Status.MarkSubscriberResolvedSucceeded()
 
 	if err := r.resolveDeadLetterSink(ctx, b, t); err != nil {

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -100,6 +100,10 @@ func WithSubscriberFromDestination(dest *duckv1.Destination) manifest.CfgFn {
 			subscriber["CACerts"] = strings.ReplaceAll(*dest.CACerts, "\n", "\n      ")
 		}
 
+		if dest.Audience != nil {
+			subscriber["audience"] = *dest.Audience
+		}
+
 		if uri != nil {
 			subscriber["uri"] = uri.String()
 		}

--- a/test/rekt/resources/trigger/trigger.yaml
+++ b/test/rekt/resources/trigger/trigger.yaml
@@ -54,6 +54,9 @@ spec:
     CACerts: |-
       {{ .subscriber.CACerts }}
     {{ end }}
+    {{ if .subscriber.audience }}
+    audience: {{ .subscriber.audience }}
+    {{ end }}
   {{ end }}
   {{ if .delivery }}
   delivery:


### PR DESCRIPTION
Fixes #7475

## Proposed Changes

- :gift: Add OIDC authentication to mt-broker-filter, so it adds the OIDC token to request to the subscriber