### PR TITLE
Add triggers OIDC identity to Reply & DLS requests

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -40,6 +40,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
 	"knative.dev/eventing/pkg/broker/filter"
+	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
 	triggerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger"
 	"knative.dev/eventing/pkg/reconciler/names"
 )
@@ -125,7 +126,7 @@ func main() {
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
 	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx)
-	handler, err := filter.NewHandler(logger, oidcTokenVerifier, oidcTokenProvider, triggerinformer.Get(ctx), reporter, ctxFunc)
+	handler, err := filter.NewHandler(logger, oidcTokenVerifier, oidcTokenProvider, triggerinformer.Get(ctx), brokerinformer.Get(ctx), reporter, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
@@ -22,6 +22,8 @@ rules:
   - apiGroups:
       - eventing.knative.dev
     resources:
+      - brokers
+      - brokers/status
       - triggers
       - triggers/status
     verbs:

--- a/config/channels/in-memory-channel/resources/in-memory-channel.yaml
+++ b/config/channels/in-memory-channel/resources/in-memory-channel.yaml
@@ -247,6 +247,9 @@ spec:
               deadLetterSinkCACerts:
                 description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                 type: string
+              deadLetterSinkAudience:
+                description: OIDC audience of the dead letter sink.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/config/core/resources/broker.yaml
+++ b/config/core/resources/broker.yaml
@@ -165,6 +165,9 @@ spec:
               deadLetterSinkCACerts:
                 description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                 type: string
+              deadLetterSinkAudience:
+                description: OIDC audience of the dead letter sink.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -285,6 +285,9 @@ spec:
               deadLetterSinkCACerts:
                 description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                 type: string
+              deadLetterSinkAudience:
+                description: OIDC audience of the dead letter sink.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/config/core/resources/subscription.yaml
+++ b/config/core/resources/subscription.yaml
@@ -207,6 +207,9 @@ spec:
                   deadLetterSinkCACerts:
                     description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                     type: string
+                  deadLetterSinkAudience:
+                    description: OIDC audience of the dead letter sink.
+                    type: string
                   replyUri:
                     description: ReplyURI is the fully resolved URI for the spec.reply.
                     type: string

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -186,6 +186,9 @@ spec:
               deadLetterSinkCACerts:
                 description: Certification Authority (CA) certificates in PEM format according to https://www.rfc-editor.org/rfc/rfc7468.
                 type: string
+              deadLetterSinkAudience:
+                description: OIDC audience of the dead letter sink.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                 type: integer

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -453,6 +453,18 @@ string
 according to <a href="https://www.rfc-editor.org/rfc/rfc7468">https://www.rfc-editor.org/rfc/rfc7468</a>.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>deadLetterSinkAudience</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterSinkAudience is the OIDC audience of the DeadLetterSink</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="duck.knative.dev/v1.Subscribable">Subscribable

--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -158,6 +158,9 @@ type DeliveryStatus struct {
 	// according to https://www.rfc-editor.org/rfc/rfc7468.
 	// +optional
 	DeadLetterSinkCACerts *string `json:"deadLetterSinkCACerts,omitempty"`
+	// DeadLetterSinkAudience is the OIDC audience of the DeadLetterSink
+	// +optional
+	DeadLetterSinkAudience *string `json:"deadLetterSinkAudience,omitempty"`
 }
 
 func (ds *DeliveryStatus) IsSet() bool {
@@ -166,14 +169,16 @@ func (ds *DeliveryStatus) IsSet() bool {
 
 func NewDeliveryStatusFromAddressable(addr *duckv1.Addressable) DeliveryStatus {
 	return DeliveryStatus{
-		DeadLetterSinkURI:     addr.URL,
-		DeadLetterSinkCACerts: addr.CACerts,
+		DeadLetterSinkURI:      addr.URL,
+		DeadLetterSinkCACerts:  addr.CACerts,
+		DeadLetterSinkAudience: addr.Audience,
 	}
 }
 
 func NewDestinationFromDeliveryStatus(status DeliveryStatus) duckv1.Destination {
 	return duckv1.Destination{
-		URI:     status.DeadLetterSinkURI,
-		CACerts: status.DeadLetterSinkCACerts,
+		URI:      status.DeadLetterSinkURI,
+		CACerts:  status.DeadLetterSinkCACerts,
+		Audience: status.DeadLetterSinkAudience,
 	}
 }

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -189,6 +189,11 @@ func (in *DeliveryStatus) DeepCopyInto(out *DeliveryStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DeadLetterSinkAudience != nil {
+		in, out := &in.DeadLetterSinkAudience, &out.DeadLetterSinkAudience
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -44,7 +44,7 @@ import (
 
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
-	"knative.dev/eventing/pkg/broker"
+	eventingbroker "knative.dev/eventing/pkg/broker"
 	v1 "knative.dev/eventing/pkg/client/informers/externalversions/eventing/v1"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	"knative.dev/eventing/pkg/eventfilter"
@@ -66,6 +66,7 @@ const (
 	defaultMaxIdleConnectionsPerHost = 100
 
 	FilterAudience = "mt-broker-filter"
+	skipTTL        = -1
 )
 
 // Handler parses Cloud Events, determines if they pass a filter, and sends them to a subscriber.
@@ -76,6 +77,7 @@ type Handler struct {
 	eventDispatcher *kncloudevents.Dispatcher
 
 	triggerLister eventinglisters.TriggerLister
+	brokerLister  eventinglisters.BrokerLister
 	logger        *zap.Logger
 	withContext   func(ctx context.Context) context.Context
 	filtersMap    *subscriptionsapi.FiltersMap
@@ -83,7 +85,7 @@ type Handler struct {
 }
 
 // NewHandler creates a new Handler and its associated EventReceiver.
-func NewHandler(logger *zap.Logger, tokenVerifier *auth.OIDCTokenVerifier, oidcTokenProvider *auth.OIDCTokenProvider, triggerInformer v1.TriggerInformer, reporter StatsReporter, wc func(ctx context.Context) context.Context) (*Handler, error) {
+func NewHandler(logger *zap.Logger, tokenVerifier *auth.OIDCTokenVerifier, oidcTokenProvider *auth.OIDCTokenProvider, triggerInformer v1.TriggerInformer, brokerInformer v1.BrokerInformer, reporter StatsReporter, wc func(ctx context.Context) context.Context) (*Handler, error) {
 	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
 		MaxIdleConns:        defaultMaxIdleConnections,
 		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,
@@ -134,6 +136,7 @@ func NewHandler(logger *zap.Logger, tokenVerifier *auth.OIDCTokenVerifier, oidcT
 		reporter:        reporter,
 		eventDispatcher: kncloudevents.NewDispatcher(oidcTokenProvider),
 		triggerLister:   triggerInformer.Lister(),
+		brokerLister:    brokerInformer.Lister(),
 		logger:          logger,
 		tokenVerifier:   tokenVerifier,
 		withContext:     wc,
@@ -141,13 +144,9 @@ func NewHandler(logger *zap.Logger, tokenVerifier *auth.OIDCTokenVerifier, oidcT
 	}, nil
 }
 
-// 1. validate request
-// 2. extract event from request
-// 3. get trigger from its trigger reference extracted from the request URI
-// 4. filter event
-// 5. send event to trigger's subscriber
-// 6. write the response
 func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	ctx := h.withContext(request.Context())
+
 	writer.Header().Set("Allow", "POST")
 
 	if request.Method != http.MethodPost {
@@ -162,7 +161,12 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	ctx := h.withContext(request.Context())
+	trigger, err := h.getTrigger(triggerRef)
+	if err != nil {
+		h.logger.Info("Unable to get the Trigger", zap.Error(err), zap.Any("triggerRef", triggerRef))
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	event, err := cehttp.NewEventFromHTTPRequest(request)
 	if err != nil {
@@ -170,6 +174,8 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
+
+	h.logger.Debug("Received message", zap.Any("trigger", triggerRef.NamespacedName), zap.Stringer("event", event))
 
 	ctx, span := trace.StartSpan(ctx, tracing.TriggerMessagingDestination(triggerRef.NamespacedName))
 	defer span.End()
@@ -182,30 +188,6 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 			tracing.MessagingMessageIDAttribute(event.ID()),
 		)
 		span.AddAttributes(opencensusclient.EventTraceAttributes(event)...)
-	}
-
-	// Remove the TTL attribute that is used by the Broker.
-	ttl, err := broker.GetTTL(event.Context)
-	if err != nil {
-		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
-		// event wasn't sent by the Broker, so we can drop it.
-		h.logger.Warn("No TTL seen, dropping", zap.Any("triggerRef", triggerRef), zap.Any("event", event))
-		// Return a BadRequest error, so the upstream can decide how to handle it, e.g. sending
-		// the message to a Dead Letter Sink.
-		writer.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	if err := broker.DeleteTTL(event.Context); err != nil {
-		h.logger.Warn("Failed to delete TTL.", zap.Error(err))
-	}
-
-	h.logger.Debug("Received message", zap.Any("triggerRef", triggerRef))
-
-	t, err := h.getTrigger(triggerRef)
-	if err != nil {
-		h.logger.Info("Unable to get the Trigger", zap.Error(err), zap.Any("triggerRef", triggerRef))
-		writer.WriteHeader(http.StatusBadRequest)
-		return
 	}
 
 	features := feature.FromContext(ctx)
@@ -227,14 +209,108 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		h.logger.Debug("Request contained a valid JWT. Continuing...")
 	}
 
-	reportArgs := &ReportArgs{
-		ns:         t.Namespace,
-		trigger:    t.Name,
-		broker:     t.Spec.Broker,
-		filterType: triggerFilterAttribute(t.Spec.Filter, "type"),
+	if triggerRef.IsReply {
+		h.handleDispatchToReplyRequest(ctx, trigger, writer, request, event)
+		return
 	}
 
-	subscriberURI := t.Status.SubscriberURI
+	if triggerRef.IsDLS {
+		h.handleDispatchToDLSRequest(ctx, trigger, writer, request, event)
+		return
+	}
+
+	h.handleDispatchToSubscriberRequest(ctx, trigger, writer, request, event)
+}
+
+func (h *Handler) handleDispatchToReplyRequest(ctx context.Context, trigger *eventingv1.Trigger, writer http.ResponseWriter, request *http.Request, event *event.Event) {
+	broker, err := h.brokerLister.Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
+	if err != nil {
+		h.logger.Info("Unable to get the Broker", zap.Error(err))
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	target := broker.Status.Address
+
+	reportArgs := &ReportArgs{
+		ns:          trigger.Namespace,
+		trigger:     trigger.Name,
+		broker:      trigger.Spec.Broker,
+		requestType: "reply_forward",
+	}
+
+	h.logger.Info("sending to reply", zap.Any("target", target))
+
+	// since the broker-filter acts here like a proxy, we don't filter headers
+	h.send(ctx, writer, request.Header, *target, reportArgs, event, trigger, skipTTL)
+}
+
+func (h *Handler) handleDispatchToDLSRequest(ctx context.Context, trigger *eventingv1.Trigger, writer http.ResponseWriter, request *http.Request, event *event.Event) {
+	broker, err := h.brokerLister.Brokers(trigger.Namespace).Get(trigger.Spec.Broker)
+	if err != nil {
+		h.logger.Info("Unable to get the Broker", zap.Error(err))
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var target *duckv1.Addressable
+	if trigger.Status.DeadLetterSinkURI != nil {
+		target = &duckv1.Addressable{
+			URL:      trigger.Status.DeadLetterSinkURI,
+			CACerts:  trigger.Status.DeadLetterSinkCACerts,
+			Audience: trigger.Status.DeadLetterSinkAudience,
+		}
+	} else if broker.Status.DeadLetterSinkURI != nil {
+		target = &duckv1.Addressable{
+			URL:      broker.Status.DeadLetterSinkURI,
+			CACerts:  broker.Status.DeadLetterSinkCACerts,
+			Audience: broker.Status.DeadLetterSinkAudience,
+		}
+	}
+
+	reportArgs := &ReportArgs{
+		ns:          trigger.Namespace,
+		trigger:     trigger.Name,
+		broker:      trigger.Spec.Broker,
+		requestType: "dls_forward",
+	}
+
+	h.logger.Info("sending to dls", zap.Any("target", target))
+
+	// since the broker-filter acts here like a proxy, we don't filter headers
+	h.send(ctx, writer, request.Header, *target, reportArgs, event, trigger, skipTTL)
+}
+
+func (h *Handler) handleDispatchToSubscriberRequest(ctx context.Context, trigger *eventingv1.Trigger, writer http.ResponseWriter, request *http.Request, event *event.Event) {
+	triggerRef := types.NamespacedName{
+		Name:      trigger.Name,
+		Namespace: trigger.Namespace,
+	}
+
+	// Remove the TTL attribute that is used by the Broker.
+	ttl, err := eventingbroker.GetTTL(event.Context)
+	if err != nil {
+		// Only messages sent by the Broker should be here. If the attribute isn't here, then the
+		// event wasn't sent by the Broker, so we can drop it.
+		h.logger.Warn("No TTL seen, dropping", zap.Any("triggerRef", triggerRef), zap.Any("event", event))
+		// Return a BadRequest error, so the upstream can decide how to handle it, e.g. sending
+		// the message to a Dead Letter Sink.
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := eventingbroker.DeleteTTL(event.Context); err != nil {
+		h.logger.Warn("Failed to delete TTL.", zap.Error(err))
+	}
+
+	reportArgs := &ReportArgs{
+		ns:          trigger.Namespace,
+		trigger:     trigger.Name,
+		broker:      trigger.Spec.Broker,
+		filterType:  triggerFilterAttribute(trigger.Spec.Filter, "type"),
+		requestType: "filter",
+	}
+
+	subscriberURI := trigger.Status.SubscriberURI
 	if subscriberURI == nil {
 		// Record the event count.
 		writer.WriteHeader(http.StatusBadRequest)
@@ -243,8 +319,8 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	// Check if the event should be sent.
-	ctx = logging.WithLogger(ctx, h.logger.Sugar().With(zap.String("trigger", fmt.Sprintf("%s/%s", t.GetNamespace(), t.GetName()))))
-	filterResult := h.filterEvent(ctx, t, *event)
+	ctx = logging.WithLogger(ctx, h.logger.Sugar().With(zap.String("trigger", fmt.Sprintf("%s/%s", trigger.GetNamespace(), trigger.GetName()))))
+	filterResult := h.filterEvent(ctx, trigger, *event)
 
 	if filterResult == eventfilter.FailFilter {
 		// We do not count the event. The event will be counted in the broker ingress.
@@ -255,11 +331,12 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	h.reportArrivalTime(event, reportArgs)
 
 	target := duckv1.Addressable{
-		URL:      t.Status.SubscriberURI,
-		CACerts:  t.Status.SubscriberCACerts,
-		Audience: t.Status.SubscriberAudience,
+		URL:      trigger.Status.SubscriberURI,
+		CACerts:  trigger.Status.SubscriberCACerts,
+		Audience: trigger.Status.SubscriberAudience,
 	}
-	h.send(ctx, writer, utils.PassThroughHeaders(request.Header), target, reportArgs, event, t, ttl)
+
+	h.send(ctx, writer, utils.PassThroughHeaders(request.Header), target, reportArgs, event, trigger, ttl)
 }
 
 func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers http.Header, target duckv1.Addressable, reportArgs *ReportArgs, event *cloudevents.Event, t *eventingv1.Trigger, ttl int32) {
@@ -295,7 +372,7 @@ func (h *Handler) send(ctx context.Context, writer http.ResponseWriter, headers 
 		writer.WriteHeader(dispatchInfo.ResponseCode)
 
 		// Read Response body to responseErr
-		errExtensionInfo := broker.ErrExtensionInfo{
+		errExtensionInfo := eventingbroker.ErrExtensionInfo{
 			ErrDestination:  target.URL,
 			ErrResponseBody: dispatchInfo.ResponseBody,
 		}
@@ -359,10 +436,12 @@ func (h *Handler) writeResponse(ctx context.Context, writer http.ResponseWriter,
 		return http.StatusBadGateway, err
 	}
 
-	// Reattach the TTL (with the same value) to the response event before sending it to the Broker.
-	if err := broker.SetTTL(event.Context, ttl); err != nil {
-		writer.WriteHeader(http.StatusInternalServerError)
-		return http.StatusInternalServerError, fmt.Errorf("failed to reset TTL: %w", err)
+	if ttl != skipTTL {
+		// Reattach the TTL (with the same value) to the response event before sending it to the Broker.
+		if err := eventingbroker.SetTTL(event.Context, ttl); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			return http.StatusInternalServerError, fmt.Errorf("failed to reset TTL: %w", err)
+		}
 	}
 
 	eventResponse := binding.ToMessage(event)
@@ -384,7 +463,7 @@ func (h *Handler) reportArrivalTime(event *event.Event, reportArgs *ReportArgs) 
 	// Record the event processing time. This might be off if the receiver and the filter pods are running in
 	// different nodes with different clocks.
 	var arrivalTimeStr string
-	if extErr := event.ExtensionAs(broker.EventArrivalTime, &arrivalTimeStr); extErr == nil {
+	if extErr := event.ExtensionAs(eventingbroker.EventArrivalTime, &arrivalTimeStr); extErr == nil {
 		arrivalTime, err := time.Parse(time.RFC3339, arrivalTimeStr)
 		if err == nil {
 			_ = h.reporter.ReportEventProcessingTime(reportArgs, time.Since(arrivalTime))

--- a/pkg/reconciler/broker/broker_test.go
+++ b/pkg/reconciler/broker/broker_test.go
@@ -33,6 +33,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	v1addr "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	v1a1addr "knative.dev/pkg/client/injection/ducks/duck/v1alpha1/addressable"
 	v1b1addr "knative.dev/pkg/client/injection/ducks/duck/v1beta1/addressable"
 	"knative.dev/pkg/configmap"
@@ -40,6 +41,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 
 	"knative.dev/eventing/pkg/apis/eventing"
@@ -788,6 +790,7 @@ func TestReconcile(t *testing.T) {
 		ctx = channelable.WithDuck(ctx)
 		ctx = v1a1addr.WithDuck(ctx)
 		ctx = v1b1addr.WithDuck(ctx)
+		ctx = v1addr.WithDuck(ctx)
 
 		cm, err := listers.GetConfigMapLister().ConfigMaps(testNS).Get("config-features")
 		if err == nil {
@@ -806,6 +809,7 @@ func TestReconcile(t *testing.T) {
 			configmapLister:    listers.GetConfigMapLister(),
 			secretLister:       listers.GetSecretLister(),
 			channelableTracker: duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0)),
+			uriResolver:        resolver.NewURIResolverFromTracker(ctx, tracker.New(func(types.NamespacedName) {}, 0)),
 		}
 		return broker.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetBrokerLister(),

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -30,6 +30,7 @@ import (
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
@@ -109,6 +110,7 @@ func NewController(
 	})
 
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
+	r.uriResolver = resolver.NewURIResolverFromTracker(ctx, impl.Tracker)
 
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: brokerFilter,

--- a/pkg/reconciler/broker/resources/subscription.go
+++ b/pkg/reconciler/broker/resources/subscription.go
@@ -33,7 +33,7 @@ import (
 
 // NewSubscription returns a placeholder subscription for trigger 't', from brokerTrigger to 'dest'
 // replying to brokerIngress.
-func NewSubscription(t *eventingv1.Trigger, brokerTrigger, brokerRef *corev1.ObjectReference, dest *duckv1.Destination, delivery *eventingduckv1.DeliverySpec) *messagingv1.Subscription {
+func NewSubscription(t *eventingv1.Trigger, brokerTrigger *corev1.ObjectReference, dest, reply *duckv1.Destination, delivery *eventingduckv1.DeliverySpec) *messagingv1.Subscription {
 	return &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: t.Namespace,
@@ -50,15 +50,8 @@ func NewSubscription(t *eventingv1.Trigger, brokerTrigger, brokerRef *corev1.Obj
 				Name:       brokerTrigger.Name,
 			},
 			Subscriber: dest,
-			Reply: &duckv1.Destination{
-				Ref: &duckv1.KReference{
-					APIVersion: brokerRef.APIVersion,
-					Kind:       brokerRef.Kind,
-					Name:       brokerRef.Name,
-					Namespace:  brokerRef.Namespace,
-				},
-			},
-			Delivery: delivery,
+			Reply:      reply,
+			Delivery:   delivery,
 		},
 	}
 }

--- a/pkg/reconciler/broker/resources/subscription_test.go
+++ b/pkg/reconciler/broker/resources/subscription_test.go
@@ -47,12 +47,6 @@ func TestNewSubscription(t *testing.T) {
 		Kind:       "tc-kind",
 		APIVersion: "tc-apiVersion",
 	}
-	brokerRef := &corev1.ObjectReference{
-		Name:       "broker-name",
-		Namespace:  "t-namespace",
-		Kind:       "broker-kind",
-		APIVersion: "broker-apiVersion",
-	}
 	delivery := &eventingduckv1.DeliverySpec{
 		DeadLetterSink: &duckv1.Destination{
 			URI: apis.HTTP("dlc.example.com"),
@@ -61,7 +55,15 @@ func TestNewSubscription(t *testing.T) {
 	dest := &duckv1.Destination{
 		URI: apis.HTTP("example.com"),
 	}
-	got := NewSubscription(trigger, triggerChannelRef, brokerRef, dest, delivery)
+	reply := &duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Name:       "broker-name",
+			Namespace:  "t-namespace",
+			Kind:       "broker-kind",
+			APIVersion: "broker-apiVersion",
+		},
+	}
+	got := NewSubscription(trigger, triggerChannelRef, dest, reply, delivery)
 	want := &messagingv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "t-namespace",

--- a/pkg/reconciler/sugar/trigger/path/path.go
+++ b/pkg/reconciler/sugar/trigger/path/path.go
@@ -18,6 +18,7 @@ package path
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -25,7 +26,9 @@ import (
 )
 
 const (
-	prefix = "triggers"
+	prefix      = "triggers"
+	replySuffix = "reply"
+	dlsSuffix   = "dls"
 )
 
 // Generate generates the Path portion of a URI to send events to the given Trigger.
@@ -33,17 +36,27 @@ func Generate(t *v1.Trigger) string {
 	return fmt.Sprintf("/%s/%s/%s/%s", prefix, t.Namespace, t.Name, t.UID)
 }
 
+func GenerateReply(t *v1.Trigger) string {
+	return path.Join(Generate(t), replySuffix)
+}
+
+func GenerateDLS(t *v1.Trigger) string {
+	return path.Join(Generate(t), dlsSuffix)
+}
+
 type NamespacedNameUID struct {
 	types.NamespacedName
-	UID types.UID
+	UID     types.UID
+	IsReply bool
+	IsDLS   bool
 }
 
 // Parse parses the Path portion of a URI to determine which Trigger the request corresponds to. It
-// is expected to be in the form "/triggers/namespace/name/uid".
+// is expected to be in the form "/triggers/namespace/name/uid" and eventually a "/reply" or "/dls" suffix.
 func Parse(path string) (NamespacedNameUID, error) {
 	parts := strings.Split(path, "/")
-	if len(parts) != 5 {
-		return NamespacedNameUID{}, fmt.Errorf("incorrect number of parts in the path, expected 5, actual %d, '%s'", len(parts), path)
+	if len(parts) != 5 && len(parts) != 6 {
+		return NamespacedNameUID{}, fmt.Errorf("incorrect number of parts in the path, expected 5 or 6, actual %d, '%s'", len(parts), path)
 	}
 	if parts[0] != "" {
 		return NamespacedNameUID{}, fmt.Errorf("text before the first slash, actual '%s'", path)
@@ -51,11 +64,14 @@ func Parse(path string) (NamespacedNameUID, error) {
 	if parts[1] != prefix {
 		return NamespacedNameUID{}, fmt.Errorf("incorrect prefix, expected '%s', actual '%s'", prefix, path)
 	}
+
 	return NamespacedNameUID{
 		NamespacedName: types.NamespacedName{
 			Namespace: parts[2],
 			Name:      parts[3],
 		},
-		UID: types.UID(parts[4]),
+		UID:     types.UID(parts[4]),
+		IsReply: len(parts) == 6 && parts[5] == replySuffix,
+		IsDLS:   len(parts) == 6 && parts[5] == dlsSuffix,
 	}, nil
 }

--- a/pkg/reconciler/sugar/trigger/path/path_test.go
+++ b/pkg/reconciler/sugar/trigger/path/path_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    NamespacedNameUID
+		wantErr bool
+	}{
+		{
+			path: "/triggers/namespace/name/uid",
+			want: NamespacedNameUID{
+				NamespacedName: types.NamespacedName{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				UID:     "uid",
+				IsReply: false,
+				IsDLS:   false,
+			},
+		},
+		{
+			path: "/triggers/namespace/name/uid/reply",
+			want: NamespacedNameUID{
+				NamespacedName: types.NamespacedName{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				UID:     "uid",
+				IsReply: true,
+				IsDLS:   false,
+			},
+		},
+		{
+			path: "/triggers/namespace/name/uid/dls",
+			want: NamespacedNameUID{
+				NamespacedName: types.NamespacedName{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+				UID:     "uid",
+				IsReply: false,
+				IsDLS:   true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Error("unexpected diff (-want, +got) =", diff)
+			}
+		})
+	}
+}

--- a/test/auth/features/oidc/broker.go
+++ b/test/auth/features/oidc/broker.go
@@ -18,16 +18,29 @@ package oidc
 
 import (
 	"github.com/cloudevents/sdk-go/v2/test"
+	"github.com/google/uuid"
 	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/delivery"
 	"knative.dev/eventing/test/rekt/resources/trigger"
-	v1 "knative.dev/pkg/apis/duck/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	eventassert "knative.dev/reconciler-test/pkg/eventshub/assert"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
-func BrokerSendEventWithOIDCToken() *feature.Feature {
+func BrokerSendEventWithOIDC() *feature.FeatureSet {
+	return &feature.FeatureSet{
+		Name: "Broker send events with OIDC support",
+		Features: []*feature.Feature{
+			BrokerSendEventWithOIDCTokenToSubscriber(),
+			BrokerSendEventWithOIDCTokenToReply(),
+			BrokerSendEventWithOIDCTokenToDLS(),
+		},
+	}
+}
+
+func BrokerSendEventWithOIDCTokenToSubscriber() *feature.Feature {
 	f := feature.NewFeatureNamed("Broker supports flow with OIDC tokens")
 
 	source := feature.MakeRandomK8sName("source")
@@ -53,7 +66,7 @@ func BrokerSendEventWithOIDCToken() *feature.Feature {
 	f.Setup("install trigger", trigger.Install(
 		triggerName,
 		brokerName,
-		trigger.WithSubscriberFromDestination(&v1.Destination{
+		trigger.WithSubscriberFromDestination(&duckv1.Destination{
 			Ref:      service.AsKReference(sink),
 			Audience: &sinkAudience,
 		}),
@@ -69,6 +82,113 @@ func BrokerSendEventWithOIDCToken() *feature.Feature {
 
 	f.Alpha("Broker").
 		Must("handles event with valid OIDC token", eventassert.OnStore(sink).MatchReceivedEvent(test.HasId(event.ID())).Exact(1))
+
+	return f
+}
+
+func BrokerSendEventWithOIDCTokenToDLS() *feature.Feature {
+	f := feature.NewFeature()
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	dls := feature.MakeRandomK8sName("dls")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	source := feature.MakeRandomK8sName("source")
+	dlsAudience := "dls-audience"
+
+	event := test.FullEvent()
+	event.SetID(uuid.New().String())
+
+	// Install DLS sink
+	f.Setup("install dead letter sink", eventshub.Install(dls,
+		eventshub.OIDCReceiverAudience(dlsAudience),
+		eventshub.StartReceiver))
+
+	// Install broker with DLS config
+	brokerConfig := append(
+		broker.WithEnvConfig(),
+		delivery.WithDeadLetterSinkFromDestination(&duckv1.Destination{
+			Ref:      service.AsKReference(dls),
+			Audience: &dlsAudience,
+		}),
+	)
+	f.Setup("install broker", broker.Install(brokerName, brokerConfig...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+
+	// Install Trigger
+	f.Setup("install trigger", trigger.Install(triggerName, brokerName,
+		trigger.WithSubscriber(nil, "bad://uri")))
+	f.Setup("trigger is ready", trigger.IsReady(triggerName))
+
+	// Send events after data plane is ready.
+	f.Requirement("install source", eventshub.Install(source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	// Assert events ended up where we expected.
+	f.Stable("broker with DLS").
+		Must("deliver event to DLQ", eventassert.OnStore(dls).MatchReceivedEvent(test.HasId(event.ID())).AtLeast(1))
+
+	return f
+}
+
+func BrokerSendEventWithOIDCTokenToReply() *feature.Feature {
+	f := feature.NewFeature()
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	subscriber := feature.MakeRandomK8sName("subscriber")
+	reply := feature.MakeRandomK8sName("reply")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	helperTriggerName := feature.MakeRandomK8sName("helper-trigger")
+	source := feature.MakeRandomK8sName("source")
+
+	event := test.FullEvent()
+	event.SetID(uuid.New().String())
+
+	replyEventType := "reply-type"
+	replyEventSource := "reply-source"
+
+	// Install subscriber
+	f.Setup("install subscriber", eventshub.Install(subscriber,
+		eventshub.ReplyWithTransformedEvent(replyEventType, replyEventSource, ""),
+		eventshub.StartReceiver))
+
+	// Install sink for reply
+	// Hint: we don't need to require OIDC auth at the reply sink, because the
+	// actual reply is sent to the broker ingress, which must support OIDC. This
+	// reply sink is only to check that the reply as sent and routed correctly.
+	f.Setup("install sink for reply", eventshub.Install(reply,
+		eventshub.StartReceiver))
+
+	// Install broker
+	f.Setup("install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+
+	// Install Trigger
+	f.Setup("install trigger", trigger.Install(triggerName, brokerName,
+		trigger.WithSubscriber(service.AsKReference(subscriber), ""),
+		trigger.WithFilter(map[string]string{
+			"type": event.Type(),
+		})))
+	f.Setup("trigger is ready", trigger.IsReady(triggerName))
+
+	// Install helper trigger to route replys to reply-sink
+	f.Setup("install helper trigger", trigger.Install(helperTriggerName, brokerName,
+		trigger.WithSubscriber(service.AsKReference(reply), ""),
+		trigger.WithFilter(map[string]string{
+			"type": replyEventType,
+		})))
+	f.Setup("helper trigger is ready", trigger.IsReady(helperTriggerName))
+
+	// Send events after data plane is ready.
+	f.Requirement("install source", eventshub.Install(source,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(event),
+	))
+
+	// Assert events ended up where we expected.
+	f.Stable("broker with reply").
+		Must("deliver event to reply sink", eventassert.OnStore(reply).MatchReceivedEvent(test.HasSource(replyEventSource)).AtLeast(1))
 
 	return f
 }

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -57,7 +57,20 @@ func TestBrokerSupportsOIDC(t *testing.T) {
 	env.Prerequisite(ctx, t, brokerfeatures.GoesReady(name, broker.WithEnvConfig()...))
 
 	env.TestSet(ctx, t, oidc.AddressableOIDCConformance(broker.GVR(), "Broker", name, env.Namespace()))
-	env.Test(ctx, t, oidc.BrokerSendEventWithOIDCToken())
+}
+
+func TestBrokerSendsEventsWithOIDCSupport(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.TestSet(ctx, t, oidc.BrokerSendEventWithOIDC())
 }
 
 func TestChannelImplSupportsOIDC(t *testing.T) {

--- a/test/rekt/resources/broker/broker.yaml
+++ b/test/rekt/resources/broker/broker.yaml
@@ -57,6 +57,13 @@ spec:
       {{ if .delivery.deadLetterSink.uri }}
       uri: {{ .delivery.deadLetterSink.uri }}
       {{ end }}
+      {{ if .delivery.deadLetterSink.CACerts }}
+      CACerts: |-
+        {{ .delivery.deadLetterSink.CACerts }}
+      {{ end }}
+      {{ if .delivery.deadLetterSink.audience }}
+      audience: {{ .delivery.deadLetterSink.audience }}
+      {{ end }}
     {{ end }}
     {{ if .delivery.retry }}
     retry: {{ .delivery.retry}}

--- a/test/rekt/resources/delivery/delivery.go
+++ b/test/rekt/resources/delivery/delivery.go
@@ -17,6 +17,8 @@ limitations under the License.
 package delivery
 
 import (
+	"strings"
+
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
 
@@ -48,6 +50,51 @@ func WithDeadLetterSink(ref *duckv1.KReference, uri string) manifest.CfgFn {
 				dref["namespace"] = ref.Namespace
 			}
 			dref["name"] = ref.Name
+		}
+	}
+}
+
+// WithDeadLetterSink adds the dead letter sink related config to the config.
+func WithDeadLetterSinkFromDestination(dest *duckv1.Destination) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		if _, set := cfg["delivery"]; !set {
+			cfg["delivery"] = map[string]interface{}{}
+		}
+
+		delivery := cfg["delivery"].(map[string]interface{})
+		if _, set := delivery["deadLetterSink"]; !set {
+			delivery["deadLetterSink"] = map[string]interface{}{}
+		}
+
+		uri := dest.URI
+		ref := dest.Ref
+
+		dls := delivery["deadLetterSink"].(map[string]interface{})
+		if uri != nil {
+			dls["uri"] = uri.String()
+		}
+
+		if ref != nil {
+			if _, set := dls["ref"]; !set {
+				dls["ref"] = map[string]interface{}{}
+			}
+			dref := dls["ref"].(map[string]interface{})
+			dref["apiVersion"] = ref.APIVersion
+			dref["kind"] = ref.Kind
+			if ref.Namespace != "" {
+				dref["namespace"] = ref.Namespace
+			}
+			dref["name"] = ref.Name
+		}
+
+		if dest.CACerts != nil {
+			// This is a multi-line string and should be indented accordingly.
+			// Replace "new line" with "new line + spaces".
+			dls["CACerts"] = strings.ReplaceAll(*dest.CACerts, "\n", "\n      ")
+		}
+
+		if dest.Audience != nil {
+			dls["audience"] = *dest.Audience
 		}
 	}
 }

--- a/test/rekt/resources/delivery/delivery.yaml
+++ b/test/rekt/resources/delivery/delivery.yaml
@@ -31,6 +31,13 @@ spec:
       {{ if .delivery.deadLetterSink.uri }}
       uri: {{ .delivery.deadLetterSink.uri }}
       {{ end }}
+      {{ if .delivery.deadLetterSink.CACerts }}
+      CACerts: |-
+        {{ .delivery.deadLetterSink.CACerts }}
+      {{ end }}
+      {{ if .delivery.deadLetterSink.audience }}
+      audience: {{ .delivery.deadLetterSink.audience }}
+      {{ end }}
     {{ end }}
     {{ if .delivery.retry }}
     retry: {{ .delivery.retry}}


### PR DESCRIPTION
Fixes #7480 

## Proposed Changes

- :gift: Use triggers OIDC identity in Reply & DLS requests
- Route mt-brokers Reply & DLS requests via the broker-filter, as this has the trigger object to get the used OIDC identity
