### PR TITLE
Cleanup created resources in channel conformance tests between features

### DIFF
--- a/test/rekt/features/channel/control_plane.go
+++ b/test/rekt/features/channel/control_plane.go
@@ -128,6 +128,8 @@ func ControlPlaneChannel(channelName string) *feature.Feature {
 		Should("Set the Channel status.deadLetterSinkURI if there is a valid spec.delivery.deadLetterSink defined",
 			readyChannelWithDLSHaveStatusUpdated(cName))
 
+	f.Teardown("cleanup created resources", f.DeleteResources)
+
 	return f
 }
 

--- a/test/rekt/features/channel/data_plane.go
+++ b/test/rekt/features/channel/data_plane.go
@@ -102,6 +102,8 @@ func DataPlaneChannel(channelName string) *feature.Feature {
 		// messaging.protocol: the name of the underlying transport protocol
 		// messaging.message_id: the event ID
 
+	f.Teardown("cleanup created resources", f.DeleteResources)
+
 	return f
 }
 


### PR DESCRIPTION
The Channel conformance tests are running control- and data plane tests together in one test:
https://github.com/knative/eventing/blob/bdca23daa788078b470a514a16f21363d820c580/test/rekt/channel_test.go#L59-L60

As both run in the same namespace and create resources without cleaning them up, this can lead to issues. E.g. as currently both use the same channel for their tests (`mychannelimpl`). Then a control plane test creates a subscription for an existing channel. Later a data plane test runs and sends an event to the channel (`mychannelimpl`), but the channel still has a subscriber reference through the subscription from the control plane test. See for example https://github.com/knative-extensions/eventing-istio/pull/158#issuecomment-1845093861.

This PR addresses it and adds a teardown to the features to clean their resources up, after the feature was tested.