### PR TITLE
[WIP]: POC of triggers in different namespace than broker

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -145,9 +145,14 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"))
 	featureStore.WatchConfigs(cmw)
 
+	cfg := injection.GetConfig(ctx)
+	if cfg == nil {
+		panic("cfg was nil")
+	}
+
 	// Decorate contexts with the current state of the config.
 	ctxFunc := func(ctx context.Context) context.Context {
-		return featureStore.ToContext(channelStore.ToContext(pingstore.ToContext(store.ToContext(ctx))))
+		return injection.WithConfig(featureStore.ToContext(channelStore.ToContext(pingstore.ToContext(store.ToContext(ctx)))), cfg)
 	}
 
 	return validation.NewAdmissionController(ctx,

--- a/config/core/resources/trigger.yaml
+++ b/config/core/resources/trigger.yaml
@@ -57,6 +57,9 @@ spec:
               broker:
                 description: Broker is the broker that this trigger receives events from.
                 type: string
+              brokerNamespace:
+                description: The namespace of the broker that this trigger receives events from.
+                type: string
               delivery:
                 description: Delivery contains the delivery spec for this specific trigger.
                 type: object

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -29,6 +29,14 @@ rules:
       - "get"
       - "list"
       - "watch"
+  
+  # for checking if user has permissions to make a cross namespace broker
+  - apiGroups:
+      - "authorization.k8s.io"
+    resources:
+      - "subjectaccessreviews"
+    verbs:
+      - "create"
 
   # For manipulating certs into secrets.
   - apiGroups:

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -1869,6 +1869,16 @@ string
 </tr>
 <tr>
 <td>
+<code>brokerNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>filter</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerFilter">
@@ -2270,6 +2280,16 @@ string
 </td>
 <td>
 <p>Broker is the broker that this trigger receives events from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>brokerNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/eventing/v1/trigger_defaults.go
+++ b/pkg/apis/eventing/v1/trigger_defaults.go
@@ -28,14 +28,17 @@ const (
 
 func (t *Trigger) SetDefaults(ctx context.Context) {
 	withNS := apis.WithinParent(ctx, t.ObjectMeta)
-	t.Spec.SetDefaults(withNS)
+	t.Spec.SetDefaults(withNS, t.GetNamespace())
 	setLabels(t)
 }
 
-func (ts *TriggerSpec) SetDefaults(ctx context.Context) {
+func (ts *TriggerSpec) SetDefaults(ctx context.Context, BrokerNamespace string) {
 	// Make a default filter that allows anything.
 	if ts.Filter == nil {
 		ts.Filter = &TriggerFilter{}
+	}
+	if ts.BrokerNamespace == "" {
+		ts.BrokerNamespace = BrokerNamespace
 	}
 	// Default the Subscriber namespace
 	ts.Subscriber.SetDefaults(ctx)

--- a/pkg/apis/eventing/v1/trigger_types.go
+++ b/pkg/apis/eventing/v1/trigger_types.go
@@ -77,6 +77,8 @@ type TriggerSpec struct {
 	// Broker is the broker that this trigger receives events from.
 	Broker string `json:"broker,omitempty"`
 
+	BrokerNamespace string `json:"brokerNamespace,omitempty"`
+
 	// Filter is the filter to apply against all events from the Broker. Only events that pass this
 	// filter will be sent to the Subscriber. If not specified, will default to allowing all events.
 	//


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This is a very rough POC of **just the RBAC** aspect of #7439 , all the reconciler and/or data plane changes still need to be made

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- use `SubjectAccessReview`s to check if the user creating a trigger has access to getting a broker in a different namespace than the trigger if the namespace is different than the trigger's namespace.
-
-

To test this, create a new user (I called mine `cmurray`), and given them the following role + rolebinding:
```
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: ns-test 
  name: trigger-broker-manager
rules:
  - apiGroups: 
      - "eventing.knative.dev"
    resources:
      - "triggers"
      - "brokers"
    verbs:
      - "get"
      - "watch"
      - "list"
      - "create"
      - "delete"
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: manager-trigger-broker
  namespace: ns-test 
subjects:
  - kind: User
    name: cmurray
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: Role
  name: trigger-broker-manager
  apiGroup: rbac.authorization.k8s.io
```

Then, create a broker in `default` namespace, and try to create a trigger in namespace `ns-test` with a user which has appropriate permissions (for me it was `minikube`). It should succeed. If you try again with the user without proper permissions, you will see it fails. For example, if I have a trigger in `tmp/trigger-other-namespace.yaml`, here are my outputs when running this locally:
```sh
cat tmp/trigger-other-namespace.yaml
apiVersion: eventing.knative.dev/v1
kind: Trigger
metadata:
  name : test1
  namespace: ns-test
spec:
  broker: my-broker
  brokerNamespace: default 
  subscriber:
    uri: "http://google.com"

kubectl apply -f tmp/trigger-other-namespace.yaml 
trigger.eventing.knative.dev/test1 created

kubectl delete -f tmp/trigger-other-namespace.yaml 
trigger.eventing.knative.dev "test1" deleted

kubectl config use-context cmurray
Switched to context "cmurray".

kubectl apply -f tmp/trigger-other-namespace.yaml 
Error from server (BadRequest): error when creating "tmp/trigger-other-namespace.yaml": admission webhook "validation.webhook.eventing.knative.dev" denied the request: validation failed: user cmurray is not authorized to get brokers in namespace: default: .spec.BrokerNamespace
```

Still TODO: verify that this RBAC approach is good enough, and deal with writing the actual reconciliation for the trigger when the broker is in a different namespace

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

