### PR TITLE
Move containersource OIDC feature to test/auth

### DIFF
--- a/test/auth/features/oidc/containersource.go
+++ b/test/auth/features/oidc/containersource.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"github.com/cloudevents/sdk-go/v2/test"
+	"knative.dev/eventing/test/rekt/resources/containersource"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/resources/service"
+)
+
+func SendsEventsWithSinkRefOIDC() *feature.Feature {
+	source := feature.MakeRandomK8sName("containersource")
+	sink := feature.MakeRandomK8sName("sink")
+	sinkAudience := "audience"
+	f := feature.NewFeature()
+
+	f.Setup("install sink", eventshub.Install(sink,
+		eventshub.OIDCReceiverAudience(sinkAudience),
+		eventshub.StartReceiver))
+
+	f.Requirement("install containersource", containersource.Install(source,
+		containersource.WithSink(&duckv1.Destination{
+			Ref:      service.AsKReference(sink),
+			Audience: &sinkAudience,
+		})))
+	f.Requirement("containersource goes ready", containersource.IsReady(source))
+
+	f.Stable("containersource as event source").
+		Must("delivers events",
+			assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).AtLeast(1))
+
+	return f
+}

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/eventing/test/auth/features/oidc"
 	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
 	"knative.dev/eventing/test/rekt/features/channel"
-	"knative.dev/eventing/test/rekt/features/containersource"
 	parallelfeatures "knative.dev/eventing/test/rekt/features/parallel"
 	sequencefeatures "knative.dev/eventing/test/rekt/features/sequence"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -157,7 +156,7 @@ func TestContainerSourceSendsEventsWithOIDCSupport(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Test(ctx, t, containersource.SendsEventsWithSinkRefOIDC())
+	env.Test(ctx, t, oidc.SendsEventsWithSinkRefOIDC())
 }
 
 func TestSequenceSendsEventsWithOIDCSupport(t *testing.T) {

--- a/test/rekt/features/containersource/features.go
+++ b/test/rekt/features/containersource/features.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/manifest"
 
 	"knative.dev/reconciler-test/pkg/eventshub"
@@ -42,30 +41,6 @@ func SendsEventsWithSinkRef() *feature.Feature {
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
 	f.Requirement("install containersource", containersource.Install(source, containersource.WithSink(service.AsDestinationRef(sink))))
-	f.Requirement("containersource goes ready", containersource.IsReady(source))
-
-	f.Stable("containersource as event source").
-		Must("delivers events",
-			assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.eventing.samples.heartbeat")).AtLeast(1))
-
-	return f
-}
-
-func SendsEventsWithSinkRefOIDC() *feature.Feature {
-	source := feature.MakeRandomK8sName("containersource")
-	sink := feature.MakeRandomK8sName("sink")
-	sinkAudience := "audience"
-	f := feature.NewFeature()
-
-	f.Setup("install sink", eventshub.Install(sink,
-		eventshub.OIDCReceiverAudience(sinkAudience),
-		eventshub.StartReceiver))
-
-	f.Requirement("install containersource", containersource.Install(source,
-		containersource.WithSink(&duckv1.Destination{
-			Ref:      service.AsKReference(sink),
-			Audience: &sinkAudience,
-		})))
 	f.Requirement("containersource goes ready", containersource.IsReady(source))
 
 	f.Stable("containersource as event source").


### PR DESCRIPTION
Currently the OIDC test feature for the containersource is in the rekt/features directory. All other test features for OIDC tests are under auth/features.
This is nothing tragic, but by having all OIDC related features in auth/, this can make migration later more straight forward as all of them are in the same place.

/assign @mgencur 