### PR TITLE
Use kmeta.ChildName() to generate OIDC service account name

### DIFF
--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -23,6 +23,7 @@ import (
 
 	"knative.dev/eventing/pkg/apis/feature"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
 	"go.uber.org/zap"
@@ -39,8 +40,9 @@ import (
 // GetOIDCServiceAccountNameForResource returns the service account name to use
 // for OIDC authentication for the given resource.
 func GetOIDCServiceAccountNameForResource(gvk schema.GroupVersionKind, objectMeta metav1.ObjectMeta) string {
-	sa := fmt.Sprintf("oidc-%s-%s-%s", gvk.GroupKind().Group, gvk.GroupKind().Kind, objectMeta.GetName())
-
+	suffix := fmt.Sprintf("-oidc-%s-%s", gvk.Group, gvk.Kind)
+	parent := objectMeta.GetName()
+	sa := kmeta.ChildName(parent, suffix)
 	return strings.ToLower(sa)
 }
 

--- a/pkg/auth/serviceaccount_test.go
+++ b/pkg/auth/serviceaccount_test.go
@@ -53,7 +53,7 @@ func TestGetOIDCServiceAccountNameForResource(t *testing.T) {
 				Name:      "name",
 				Namespace: "namespace",
 			},
-			want: "oidc-group-kind-name",
+			want: "name-oidc-group-kind",
 		},
 		{
 			name: "should return SA name in lower case",
@@ -62,7 +62,16 @@ func TestGetOIDCServiceAccountNameForResource(t *testing.T) {
 				Name:      "my-Broker",
 				Namespace: "my-Namespace",
 			},
-			want: "oidc-eventing.knative.dev-broker-my-broker",
+			want: "my-broker-oidc-eventing.knative.dev-broker",
+		},
+		{
+			name: "long Broker name",
+			gvk:  eventingv1.SchemeGroupVersion.WithKind("Broker"),
+			objectMeta: metav1.ObjectMeta{
+				Name:      "my-loooooooooooooooooooooooooooooooooooooog-Broker",
+				Namespace: "my-Namespace",
+			},
+			want: "my-looooooooooooooooooooooooooo2dfc2a3825b8d82077b0f25518b36884",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7470 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Use kmeta.ChildName() to generate OIDC service account name
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

