### PR TITLE
Remove Kubernetes 1.26 from KinD e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.26.6
         - v1.27.3
 
         test-suite:
@@ -31,9 +30,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
         include:
-        - k8s-version: v1.26.6
-          kind-version: v0.20.0
-          kind-image-sha: sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
         - k8s-version: v1.27.3
           kind-version: v0.20.0
           kind-image-sha: sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72


### PR DESCRIPTION
Remove Kubernetes 1.26 e2e tests, as Knative 1.13 requires at least 1.27

https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md

In #7524 we add 1.29 support