### PR TITLE
Add reconciler test for EventType references

### DIFF
--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 
+	"knative.dev/eventing/pkg/reconciler/sugar/resources"
+
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/eventing/pkg/resolver"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/kresource"
@@ -46,6 +48,8 @@ const (
 	eventTypeName   = "test-eventtype"
 	eventTypeType   = "test-type"
 	eventTypeBroker = "test-broker"
+
+	eventTypeChannel = "test-channel"
 )
 
 var (
@@ -77,7 +81,7 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeDeletionTimestamp),
 		},
 	}, {
-		Name: "Broker not found",
+		Name: "Reference broker not found",
 		Key:  testKey,
 		Objects: []runtime.Object{
 			NewEventType(eventTypeName, testNS,
@@ -95,11 +99,81 @@ func TestReconcile(t *testing.T) {
 				WithEventTypeResourceDoesNotExist,
 			),
 		}},
+
 		WantErr: true,
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError failed to get object test-namespace/test-broker:", `brokers.eventing.knative.dev "test-broker" not found`),
 		},
-	}}
+	},
+		{
+			Name: "Reference Channel not found",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithEventTypeReference(channelReference(eventTypeChannel)),
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithInitEventTypeConditions,
+					WithEventTypeReference(channelReference(eventTypeChannel)),
+					WithEventTypeResourceDoesNotExist,
+				),
+			}},
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeWarning, "InternalError failed to get object test-namespace/test-channel:", `channels.messaging.knative.dev "test-channel" not found`),
+			},
+		},
+		{
+			Name: "Reference broker found",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithEventTypeReference(brokerReference(eventTypeBroker)),
+				),
+				resources.MakeBroker(testNS, eventTypeBroker),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithInitEventTypeConditions,
+					WithEventTypeReference(brokerReference(eventTypeBroker)),
+					WithEventTypeResourceExists,
+				),
+			}},
+			WantErr: false,
+		},
+		{
+			Name: "Reference channel found",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithEventTypeReference(channelReference(eventTypeChannel)),
+				),
+				NewInMemoryChannel(eventTypeChannel, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithInitEventTypeConditions,
+					WithEventTypeReference(channelReference(eventTypeChannel)),
+					WithEventTypeResourceExists,
+				),
+			}},
+			WantErr: false,
+		},
+	}
 
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -121,6 +195,15 @@ func brokerReference(brokerName string) *duckv1.KReference {
 		APIVersion: "eventing.knative.dev/v1",
 		Kind:       "Broker",
 		Name:       brokerName,
+		Namespace:  testNS,
+	}
+}
+
+func channelReference(channelName string) *duckv1.KReference {
+	return &duckv1.KReference{
+		APIVersion: "messaging.knative.dev/v1",
+		Kind:       "InMemoryChannel",
+		Name:       channelName,
 		Namespace:  testNS,
 	}
 }

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 			}},
 			WantErr: true,
 			WantEvents: []string{
-				Eventf(corev1.EventTypeWarning, "InternalError failed to get object test-namespace/test-channel:", `channels.messaging.knative.dev "test-channel" not found`),
+				Eventf(corev1.EventTypeWarning, "InternalError failed to get object test-namespace/test-channel:", `inmemorychannels.messaging.knative.dev "test-channel" not found`),
 			},
 		},
 		{


### PR DESCRIPTION


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7031

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- A test showing an `EventType` reconciling properly with a Broker reference
- A test showing an `EventType` reconciling properly with a Channel reference

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

