### PR TITLE
Provision PingSources sink OIDC audience in PingSource status

### DIFF
--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -197,6 +197,9 @@ spec:
               sinkCACerts:
                 description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
                 type: string
+              sinkAudience:
+                description: sinkAudience is the OIDC audience of the sink.
+                type: string
     additionalPrinterColumns:
     - name: Sink
       type: string

--- a/pkg/apis/sources/v1/ping_lifecycle.go
+++ b/pkg/apis/sources/v1/ping_lifecycle.go
@@ -95,6 +95,7 @@ func (s *PingSourceStatus) MarkSink(uri *duckv1.Addressable) {
 	if uri != nil {
 		s.SinkURI = uri.URL
 		s.SinkCACerts = uri.CACerts
+		s.SinkAudience = uri.Audience
 		PingSourceCondSet.Manage(s).MarkTrue(PingSourceConditionSinkProvided)
 	} else {
 		PingSourceCondSet.Manage(s).MarkFalse(PingSourceConditionSinkProvided, "SinkEmpty", "Sink has resolved to empty.")


### PR DESCRIPTION
Currently we're missing the sinks audience in the PingSource status. This PR addresses it and sets `.status.sinkAudience` of the PingSource.