### PR TITLE
enable the TLS feature for ContainerSource's OIDC tests

### DIFF
--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/reconciler-test/pkg/eventshub"
+
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -159,7 +161,7 @@ func TestApiserversourceSendEventWithJWT(t *testing.T) {
 	env.Test(ctx, t, oidc.ApiserversourceSendEventWithJWT())
 }
 
-func TestContainerSourceSendsEventsWithOIDCSupport(t *testing.T) {
+func TestContainerSourceSendsEventsWithOIDCSupportUnderTLS(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -168,6 +170,7 @@ func TestContainerSourceSendsEventsWithOIDCSupport(t *testing.T) {
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
+		eventshub.WithTLS(t),
 	)
 
 	env.Test(ctx, t, oidc.SendsEventsWithSinkRefOIDC())


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7558

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- EventsHub receiver/sender with enforced TLS and individual resources which deliver events with CACerts specified for Destination

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

