### PR TITLE
Install helm to install Cert- & Trustmanager

### DIFF
--- a/hack/update-cert-manager.sh
+++ b/hack/update-cert-manager.sh
@@ -11,10 +11,32 @@ function update_cert_manager() {
   rm -rf third_party/cert-manager
   mkdir -p third_party/cert-manager
 
+  ensure_helm_available
+
   helm repo add jetstack https://charts.jetstack.io --force-update
   kubectl create namespace --dry-run=client cert-manager -oyaml > third_party/cert-manager/00-namespace.yaml
   helm template -n cert-manager cert-manager jetstack/cert-manager --create-namespace --version "${cert_manager_version}" --set installCRDs=true > third_party/cert-manager/01-cert-manager.yaml
   helm template -n cert-manager cert-manager jetstack/trust-manager --create-namespace --version "${trust_manager_version}" --set installCRDs=true > third_party/cert-manager/02-trust-manager.yaml
+}
+
+function ensure_helm_available() {
+  helm_bin="$(which helm 2>/dev/null || echo "")"
+
+  if [ -n "$helm_bin" ]; then
+    echo "Helm already installed on system"
+  else
+    echo "Helm binary not found. Installing into tmp dir..."
+
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+    chmod 700 get_helm.sh
+
+    export HELM_INSTALL_DIR="$(mktemp -dt helm-XXXXXX)"
+    export PATH=$PATH:$HELM_INSTALL_DIR
+
+    ./get_helm.sh --no-sudo
+
+    rm -f ./get_helm.sh
+  fi
 }
 
 update_cert_manager "v1.13.3" "v0.7.1"


### PR DESCRIPTION
Currently we have some update-dependency job issues, as helm is not installed (see https://github.com/knative-extensions/knobots/actions/runs/7482975295/job/20367497039) and its needed to update the cert- and trust-manager resources:

https://github.com/knative/eventing/blob/bc89d285177775c5e287aea32e86a502eddac80e/hack/update-cert-manager.sh#L14-L17

This PR addresses it and installs helm into a tmp directory, if the helm binary is not found in PATH.


Alternatively, we could install it into the update-deps Dockerfile: https://github.com/knative-extensions/knobots/blob/main/actions/update-deps/Dockerfile. But this would then affect all jobs and not solve the issue locally :shrug: 