### PR TITLE
Remove OIDC service account, when OIDC feature is disabled again

### DIFF
--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -108,7 +108,7 @@ func DeleteOIDCServiceAccountIfExists(ctx context.Context, serviceAccountLister 
 	sa, err := serviceAccountLister.ServiceAccounts(objectMeta.Namespace).Get(saName)
 
 	// Service Account Found
-	if sa != nil {
+	if !apierrs.IsNotFound(err) {
 		logging.FromContext(ctx).Debugw("OIDC Service account already exists. Deleting OIDC service account")
 
 		err = kubeclient.CoreV1().ServiceAccounts(objectMeta.Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{})

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -108,7 +108,7 @@ func DeleteOIDCServiceAccountIfExists(ctx context.Context, serviceAccountLister 
 	sa, err := serviceAccountLister.ServiceAccounts(objectMeta.Namespace).Get(saName)
 
 	// Service Account Found
-	if !apierrs.IsNotFound(err) && metav1.IsControlledBy(&sa.ObjectMeta, &objectMeta) {
+	if err == nil && metav1.IsControlledBy(&sa.ObjectMeta, &objectMeta) {
 		logging.FromContext(ctx).Debugw("OIDC Service account already exists. Deleting OIDC service account")
 
 		err = kubeclient.CoreV1().ServiceAccounts(objectMeta.Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{})

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -115,9 +115,11 @@ func DeleteOIDCServiceAccountIfExists(ctx context.Context, serviceAccountLister 
 		if err != nil {
 			return fmt.Errorf("could not delete OIDC service account %s/%s for %s: %w", objectMeta.Name, objectMeta.Namespace, gvk.Kind, err)
 		}
+	} else if apierrs.IsNotFound(err) {
+		return nil
 	}
 
-	return nil
+	return err
 }
 
 type OIDCIdentityStatusMarker interface {

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -107,9 +107,8 @@ func DeleteOIDCServiceAccountIfExists(ctx context.Context, serviceAccountLister 
 	saName := GetOIDCServiceAccountNameForResource(gvk, objectMeta)
 	sa, err := serviceAccountLister.ServiceAccounts(objectMeta.Namespace).Get(saName)
 
-	// Service Account Found
 	if err == nil && metav1.IsControlledBy(&sa.ObjectMeta, &objectMeta) {
-		logging.FromContext(ctx).Debugw("OIDC Service account already exists. Deleting OIDC service account")
+		logging.FromContext(ctx).Debugf("OIDC Service account exists and has correct owner (%s/%s). Deleting OIDC service account", objectMeta.Name, objectMeta.Namespace)
 
 		err = kubeclient.CoreV1().ServiceAccounts(objectMeta.Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{})
 		if err != nil {

--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -108,7 +108,7 @@ func DeleteOIDCServiceAccountIfExists(ctx context.Context, serviceAccountLister 
 	sa, err := serviceAccountLister.ServiceAccounts(objectMeta.Namespace).Get(saName)
 
 	// Service Account Found
-	if !apierrs.IsNotFound(err) {
+	if !apierrs.IsNotFound(err) && metav1.IsControlledBy(&sa.ObjectMeta, &objectMeta) {
 		logging.FromContext(ctx).Debugw("OIDC Service account already exists. Deleting OIDC service account")
 
 		err = kubeclient.CoreV1().ServiceAccounts(objectMeta.Namespace).Delete(ctx, sa.Name, metav1.DeleteOptions{})


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7459 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Added `DeleteOIDCServiceAccountIfExists` function that checks whether service account exists or not when `authentication-oidc` feature is disabled. If they exist they are deleted.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

