### PR TITLE
support: nodeselector in apiserversource

### DIFF
--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -61,6 +61,7 @@ func newDefaults() Flags {
 		TransportEncryption: Disabled,
 		OIDCAuthentication:  Disabled,
 		EvenTypeAutoCreate:  Disabled,
+		NodeSelectorLabel:   "",
 	}
 }
 
@@ -102,6 +103,28 @@ func (e Flags) String() string {
 	return fmt.Sprintf("%+v", map[string]Flag(e))
 }
 
+func (e Flags) NodeSelector() map[string]string {
+	// Check if NodeSelector is not nil
+	if string(e[NodeSelectorLabel]) == "" {
+		return map[string]string{}
+	}
+
+	// Convert NodeSelector to a string
+	nodeSelectorString := string(e[NodeSelectorLabel])
+
+	// Split the string into key-value pairs
+	pairs := strings.Split(nodeSelectorString, ":")
+
+	// Create a map to store key-value pairs
+	nodeSelectorMap := make(map[string]string)
+
+	key := strings.TrimSpace(pairs[0])
+	value := strings.TrimSpace(pairs[1])
+	nodeSelectorMap[key] = value
+
+	return nodeSelectorMap
+}
+
 // NewFlagsConfigFromMap creates a Flags from the supplied Map
 func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 	flags := newDefaults()
@@ -122,6 +145,8 @@ func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 			flags[sanitizedKey] = Permissive
 		} else if k == TransportEncryption && strings.EqualFold(v, string(Strict)) {
 			flags[sanitizedKey] = Strict
+		} else if k == NodeSelectorLabel {
+			flags[sanitizedKey] = Flag(v)
 		} else {
 			return flags, fmt.Errorf("cannot parse the feature flag '%s' = '%s'", k, v)
 		}

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -61,7 +61,6 @@ func newDefaults() Flags {
 		TransportEncryption: Disabled,
 		OIDCAuthentication:  Disabled,
 		EvenTypeAutoCreate:  Disabled,
-		NodeSelectorLabel:   "",
 	}
 }
 
@@ -105,22 +104,20 @@ func (e Flags) String() string {
 
 func (e Flags) NodeSelector() map[string]string {
 	// Check if NodeSelector is not nil
-	if string(e[NodeSelectorLabel]) == "" {
+	if e == nil {
 		return map[string]string{}
 	}
 
-	// Convert NodeSelector to a string
-	nodeSelectorString := string(e[NodeSelectorLabel])
-
-	// Split the string into key-value pairs
-	pairs := strings.Split(nodeSelectorString, ":")
-
-	// Create a map to store key-value pairs
 	nodeSelectorMap := make(map[string]string)
 
-	key := strings.TrimSpace(pairs[0])
-	value := strings.TrimSpace(pairs[1])
-	nodeSelectorMap[key] = value
+	for k, v := range e {
+		if strings.Contains(k, NodeSelectorLabel) {
+			key := strings.TrimPrefix(k, NodeSelectorLabel)
+			fmt.Println("value of k is",key)
+			value := strings.TrimSpace(string(v))
+			nodeSelectorMap[key] = value
+		}
+	}
 
 	return nodeSelectorMap
 }
@@ -145,7 +142,7 @@ func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 			flags[sanitizedKey] = Permissive
 		} else if k == TransportEncryption && strings.EqualFold(v, string(Strict)) {
 			flags[sanitizedKey] = Strict
-		} else if k == NodeSelectorLabel {
+		} else if strings.Contains(k, NodeSelectorLabel) {
 			flags[sanitizedKey] = Flag(v)
 		} else {
 			return flags, fmt.Errorf("cannot parse the feature flag '%s' = '%s'", k, v)

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -113,7 +113,6 @@ func (e Flags) NodeSelector() map[string]string {
 	for k, v := range e {
 		if strings.Contains(k, NodeSelectorLabel) {
 			key := strings.TrimPrefix(k, NodeSelectorLabel)
-			fmt.Println("value of k is",key)
 			value := strings.TrimSpace(string(v))
 			nodeSelectorMap[key] = value
 		}

--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -56,10 +56,12 @@ func TestGetFlags(t *testing.T) {
 	require.True(t, flags.IsAllowed("my-enabled-flag"))
 	require.True(t, flags.IsAllowed("my-allowed-flag"))
 	require.False(t, flags.IsAllowed("non-disabled-flag"))
+
+	nodeSelector := flags.NodeSelector()
+	require.Equal(t, map[string]string{"testkey": "testvalue"}, nodeSelector)
 }
 
 func TestShouldNotOverrideDefaults(t *testing.T) {
-
 	f, err := NewFlagsConfigFromMap(map[string]string{})
 	require.Nil(t, err)
 	require.NotNil(t, f)

--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -58,7 +58,8 @@ func TestGetFlags(t *testing.T) {
 	require.False(t, flags.IsAllowed("non-disabled-flag"))
 
 	nodeSelector := flags.NodeSelector()
-	require.Equal(t, map[string]string{"testkey": "testvalue"}, nodeSelector)
+	expectedNodeSelector := map[string]string{"testkey": "testvalue", "testkey1": "testvalue1", "testkey2": "testvalue2"}
+	require.Equal(t, expectedNodeSelector, nodeSelector)
 }
 
 func TestShouldNotOverrideDefaults(t *testing.T) {

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -25,5 +25,5 @@ const (
 	TransportEncryption = "transport-encryption"
 	EvenTypeAutoCreate  = "eventtype-auto-create"
 	OIDCAuthentication  = "authentication-oidc"
-	NodeSelectorLabel   = "apiserversources.nodeselecto"
+	NodeSelectorLabel   = "apiserversources.nodeselector."
 )

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -25,4 +25,5 @@ const (
 	TransportEncryption = "transport-encryption"
 	EvenTypeAutoCreate  = "eventtype-auto-create"
 	OIDCAuthentication  = "authentication-oidc"
+	NodeSelectorLabel   = "apiserversources.nodeselecto"
 )

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -26,4 +26,6 @@ data:
     my-disabled-flag: "disabled"
     my-allowed-flag: "allowed"
     apiserversources.nodeselector.testkey: testvalue
+    apiserversources.nodeselector.testkey1: testvalue1
+    apiserversources.nodeselector.testkey2: testvalue2
   

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -28,3 +28,4 @@ data:
     apiserversources.nodeselector.testkey: testvalue
     apiserversources.nodeselector.testkey1: testvalue1
     apiserversources.nodeselector.testkey2: testvalue2
+    

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -25,5 +25,5 @@ data:
     my-enabled-flag: "enabled"
     my-disabled-flag: "disabled"
     my-allowed-flag: "allowed"
-    apiserversources.nodeselecto: testkey:testvalue
+    apiserversources.nodeselector: testkey:testvalue
   

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -28,4 +28,3 @@ data:
     apiserversources.nodeselector.testkey: testvalue
     apiserversources.nodeselector.testkey1: testvalue1
     apiserversources.nodeselector.testkey2: testvalue2
-  

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -25,3 +25,5 @@ data:
     my-enabled-flag: "enabled"
     my-disabled-flag: "disabled"
     my-allowed-flag: "allowed"
+    apiserversources.nodeselecto: testkey:testvalue
+  

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -28,4 +28,3 @@ data:
     apiserversources.nodeselector.testkey: testvalue
     apiserversources.nodeselector.testkey1: testvalue1
     apiserversources.nodeselector.testkey2: testvalue2
-    

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -25,5 +25,5 @@ data:
     my-enabled-flag: "enabled"
     my-disabled-flag: "disabled"
     my-allowed-flag: "allowed"
-    apiserversources.nodeselector: testkey:testvalue
+    apiserversources.nodeselector.testkey: testvalue
   

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -102,7 +102,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 		// no Namespace defined in dest.Ref, we will use the Namespace of the source
 		// as the Namespace of dest.Ref.
 		if dest.Ref.Namespace == "" {
-			//TODO how does this work with deprecated fields
+			// TODO how does this work with deprecated fields
 			dest.Ref.Namespace = source.GetNamespace()
 		}
 	}
@@ -118,7 +118,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *v1.ApiServerSour
 	if featureFlags.IsOIDCAuthentication() {
 		// Create the role
 		err := r.createOIDCRole(ctx, source)
-
 		if err != nil {
 			logging.FromContext(ctx).Errorw("Failed when creating the OIDC Role for ApiServerSource", zap.Error(err))
 			return err
@@ -225,6 +224,8 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 	// 	return nil, err
 	// }
 
+	featureFlags := feature.FromContext(ctx)
+
 	adapterArgs := resources.ReceiveAdapterArgs{
 		Image:         r.receiveAdapterImage,
 		Source:        src,
@@ -235,6 +236,7 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 		Configs:       r.configs,
 		Namespaces:    namespaces,
 		AllNamespaces: allNamespaces,
+		NodeSelector:  featureFlags.NodeSelector(),
 	}
 
 	expected, err := resources.MakeReceiveAdapter(&adapterArgs)
@@ -357,7 +359,6 @@ func (r *Reconciler) runAccessCheck(ctx context.Context, src *v1.ApiServerSource
 
 	src.Status.MarkNoSufficientPermissions(lastReason, "User %s cannot %s", user, missing)
 	return fmt.Errorf("insufficient permissions: User %s cannot %s", user, missing)
-
 }
 
 func (r *Reconciler) createCloudEventAttributes(src *v1.ApiServerSource) ([]duckv1.CloudEventAttributes, error) {
@@ -385,7 +386,6 @@ func (r *Reconciler) createOIDCRole(ctx context.Context, source *v1.ApiServerSou
 	roleName := resources.GetOIDCTokenRoleName(source.Name)
 
 	expected, err := resources.MakeOIDCRole(source)
-
 	if err != nil {
 		return fmt.Errorf("Cannot create OIDC role for ApiServerSource %s/%s: %w", source.GetName(), source.GetNamespace(), err)
 	}
@@ -417,7 +417,6 @@ func (r *Reconciler) createOIDCRole(ctx context.Context, source *v1.ApiServerSou
 	}
 
 	return nil
-
 }
 
 // createOIDCRoleBinding:  this function will call resources package to get the rolebinding object

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -125,787 +125,800 @@ const (
 )
 
 func TestReconcile(t *testing.T) {
-	table := TableTest{{
-		Name: "not enough permissions",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapter(t),
+	table := TableTest{
+		{
+			Name: "not enough permissions",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceNoSufficientPermissions,
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceNoSufficientPermissions,
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
+		{
+			Name: "valid",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantErr: true,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
+		{
+			Name: "valid with namespace selector",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+				rttesting.NewNamespace("test-a", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
+				rttesting.NewNamespace("test-b", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
+				rttesting.NewNamespace("test-c", rttesting.WithNamespaceLabeled(map[string]string{"target": "no"})),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b"}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
+				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
+				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
+		{
+			Name: "valid with an empty namespace selector",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+				rttesting.NewNamespace("test-a"),
+				rttesting.NewNamespace("test-b"),
+				rttesting.NewNamespace("test-c"),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b", "test-c"}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
+				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
+				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
+				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
+				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-c"),
+				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-c"),
+				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-c"),
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapter(t),
+		{
+			Name: "valid with eventmode of resourcemode",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						EventMode:  sourcesv1.ResourceMode,
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapterWithEventMode(t, sourcesv1.ResourceMode),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						EventMode:  sourcesv1.ResourceMode,
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceResourceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
+		{
+			Name: "valid with sink URI",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		{
+			Name: "missing sink",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeWarning, "SinkNotFound",
+					`Sink not found: {"ref":{"kind":"Channel","namespace":"testnamespace","name":"testsink","apiVersion":"messaging.knative.dev/v1"}}`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceSinkNotFound,
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid with namespace selector",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapter(t),
-			rttesting.NewNamespace("test-a", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
-			rttesting.NewNamespace("test-b", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
-			rttesting.NewNamespace("test-c", rttesting.WithNamespaceLabeled(map[string]string{"target": "no"})),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b"}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
-			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
-			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid with an empty namespace selector",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapter(t),
-			rttesting.NewNamespace("test-a"),
-			rttesting.NewNamespace("test-b"),
-			rttesting.NewNamespace("test-c"),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b", "test-c"}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
-			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
-			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
-			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
-			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-c"),
-			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-c"),
-			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-c"),
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid with eventmode of resourcemode",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					EventMode:  sourcesv1.ResourceMode,
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapterWithEventMode(t, sourcesv1.ResourceMode),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					EventMode:  sourcesv1.ResourceMode,
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceResourceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid with sink URI",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapter(t),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "missing sink",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-		},
-		Key: testNS + "/" + sourceName,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeWarning, "SinkNotFound",
-				`Sink not found: {"ref":{"kind":"Channel","namespace":"testnamespace","name":"testsink","apiVersion":"messaging.knative.dev/v1"}}`),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceSinkNotFound,
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "receive adapter does not exist, fails to create",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-		},
-		Key:     testNS + "/" + sourceName,
-		WantErr: true,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, apiserversourceDeploymentCreated,
-				"Deployment created, error:inducing failure for create deployments"),
-			Eventf(corev1.EventTypeWarning, "InternalError",
-				"inducing failure for create deployments"),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-			makeReceiveAdapter(t),
-		},
-		WithReactors: []clientgotesting.ReactionFunc{
-			subjectAccessReviewCreateReactor(true),
-			InduceFailure("create", "Deployments"),
-		},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		{
+			Name: "receive adapter does not exist, fails to create",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+			},
+			Key:     testNS + "/" + sourceName,
+			WantErr: true,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, apiserversourceDeploymentCreated,
+					"Deployment created, error:inducing failure for create deployments"),
+				Eventf(corev1.EventTypeWarning, "InternalError",
+					"inducing failure for create deployments"),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+				makeReceiveAdapter(t),
+			},
+			WithReactors: []clientgotesting.ReactionFunc{
+				subjectAccessReviewCreateReactor(true),
+				InduceFailure("create", "Deployments"),
+			},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 
-	}, {
-		Name: "valid with relative uri reference",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{
-						Sink: duckv1.Destination{
-							Ref: sinkDest.Ref,
-							URI: &apis.URL{Path: sinkURIReference},
+		},
+		{
+			Name: "valid with relative uri reference",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{
+							Sink: duckv1.Destination{
+								Ref: sinkDest.Ref,
+								URI: &apis.URL{Path: sinkURIReference},
+							},
 						},
-					},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeAvailableReceiveAdapterWithTargetURI(t),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{
-						Sink: duckv1.Destination{
-							Ref: sinkDest.Ref,
-							URI: &apis.URL{Path: sinkURIReference},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapterWithTargetURI(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{
+							Sink: duckv1.Destination{
+								Ref: sinkDest.Ref,
+								URI: &apis.URL{Path: sinkURIReference},
+							},
 						},
-					},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkTargetURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkTargetURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		{
+			Name: "deployment update due to env",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeReceiveAdapterWithDifferentEnv(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceDeploymentUnavailable,
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeReceiveAdapter(t),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
+		{
+			Name: "deployment update due to service account",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{
+							Sink: sinkDest,
+						},
+						ServiceAccountName: "malin",
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeReceiveAdapterWithDifferentServiceAccount(t, "morgan"),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{
+							Sink: sinkDest,
+						},
+						ServiceAccountName: "malin",
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeploymentUnavailable,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeReceiveAdapterWithDifferentServiceAccount(t, "malin"),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "malin"),
+				makeSubjectAccessReview("namespaces", "list", "malin"),
+				makeSubjectAccessReview("namespaces", "watch", "malin"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "deployment update due to env",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeReceiveAdapterWithDifferentEnv(t),
+		{
+			Name: "deployment update due to container count",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeReceiveAdapterWithDifferentContainerCount(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeploymentUnavailable,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeReceiveAdapter(t),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		Key: testNS + "/" + sourceName,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		{
+			Name: "valid with broker sink",
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewBroker(sinkName, testNS,
+					rttestingv1.WithInitBrokerConditions,
+					rttestingv1.WithBrokerAddressURI(apis.HTTP(sinkDNS)),
+				),
+				makeAvailableReceiveAdapter(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceDeploymentUnavailable,
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeReceiveAdapter(t),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "deployment update due to service account",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{
-						Sink: sinkDest,
-					},
-					ServiceAccountName: "malin",
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeReceiveAdapterWithDifferentServiceAccount(t, "morgan"),
-		},
-		Key: testNS + "/" + sourceName,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{
-						Sink: sinkDest,
-					},
-					ServiceAccountName: "malin",
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeploymentUnavailable,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeReceiveAdapterWithDifferentServiceAccount(t, "malin"),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "malin"),
-			makeSubjectAccessReview("namespaces", "list", "malin"),
-			makeSubjectAccessReview("namespaces", "watch", "malin"),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "deployment update due to container count",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewChannel(sinkName, testNS,
-				rttestingv1.WithInitChannelConditions,
-				rttestingv1.WithChannelAddress(sinkAddressable),
-			),
-			makeReceiveAdapterWithDifferentContainerCount(t),
-		},
-		Key: testNS + "/" + sourceName,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeploymentUnavailable,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: makeReceiveAdapter(t),
-		}},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	}, {
-		Name: "valid with broker sink",
-		Objects: []runtime.Object{
-			rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-			),
-			rttestingv1.NewBroker(sinkName, testNS,
-				rttestingv1.WithInitBrokerConditions,
-				rttestingv1.WithBrokerAddressURI(apis.HTTP(sinkDNS)),
-			),
-			makeAvailableReceiveAdapter(t),
-		},
-		Key: testNS + "/" + sourceName,
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-					Resources: []sourcesv1.APIVersionKindSelector{{
-						APIVersion: "v1",
-						Kind:       "Namespace",
-					}},
-					SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
-				}),
-				rttestingv1.WithApiServerSourceUID(sourceUID),
-				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				// Status Update:
-				rttestingv1.WithInitApiServerSourceConditions,
-				rttestingv1.WithApiServerSourceDeployed,
-				rttestingv1.WithApiServerSourceSink(sinkURI),
-				rttestingv1.WithApiServerSourceSufficientPermissions,
-				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-			),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-		},
-		WantPatches: []clientgotesting.PatchActionImpl{
-			patchFinalizers(sourceName, testNS),
-		},
-		WantCreates: []runtime.Object{
-			makeSubjectAccessReview("namespaces", "get", "default"),
-			makeSubjectAccessReview("namespaces", "list", "default"),
-			makeSubjectAccessReview("namespaces", "watch", "default"),
-		},
-		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-	},
 		{
 			Name: "OIDC: creates OIDC service account",
 			Ctx: feature.ToContext(context.Background(), feature.Flags{
@@ -1081,6 +1094,76 @@ func TestReconcile(t *testing.T) {
 			},
 			WantEvents: []string{
 				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(sourceName, testNS),
+			},
+			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		},
+		{
+			Name: "valid with node selector",
+
+			Ctx: feature.ToContext(context.Background(), feature.Flags{
+				"apiserversources.nodeselector.testkey1": "testvalue1",
+				"apiserversources.nodeselector.testkey2": "testvalue2",
+			}),
+			Objects: []runtime.Object{
+				rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				),
+				rttestingv1.NewChannel(sinkName, testNS,
+					rttestingv1.WithInitChannelConditions,
+					rttestingv1.WithChannelAddress(sinkAddressable),
+				),
+				makeAvailableReceiveAdapter(t),
+			},
+			Key: testNS + "/" + sourceName,
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+						Resources: []sourcesv1.APIVersionKindSelector{{
+							APIVersion: "v1",
+							Kind:       "Namespace",
+						}},
+						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+					}),
+					rttestingv1.WithApiServerSourceUID(sourceUID),
+					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+					// Status Update:
+					rttestingv1.WithInitApiServerSourceConditions,
+					rttestingv1.WithApiServerSourceDeployed,
+					rttestingv1.WithApiServerSourceSink(sinkURI),
+					rttestingv1.WithApiServerSourceSufficientPermissions,
+					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+				),
+			}},
+			WantCreates: []runtime.Object{
+				makeSubjectAccessReview("namespaces", "get", "default"),
+				makeSubjectAccessReview("namespaces", "list", "default"),
+				makeSubjectAccessReview("namespaces", "watch", "default"),
+			},
+		
+			WantUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: makeAvailableReceiveAdapterWithNodeSelector(t, map[string]string{
+					"testkey1": "testvalue1",
+					"testkey2": "testvalue2",
+				}),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
 			},
 			WantPatches: []clientgotesting.PatchActionImpl{
 				patchFinalizers(sourceName, testNS),
@@ -1296,6 +1379,41 @@ func makeAvailableReceiveAdapterWithNamespaces(t *testing.T, namespaces []string
 		Configs:       &reconcilersource.EmptyVarsGenerator{},
 		Namespaces:    namespaces,
 		AllNamespaces: allNamespaces,
+	}
+
+	ra, err := resources.MakeReceiveAdapter(&args)
+	require.NoError(t, err)
+
+	rttesting.WithDeploymentAvailable()(ra)
+	return ra
+}
+
+func makeAvailableReceiveAdapterWithNodeSelector(t *testing.T, selector map[string]string) *appsv1.Deployment {
+	t.Helper()
+
+	src := rttestingv1.NewApiServerSource(sourceName, testNS,
+		rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+			Resources: []sourcesv1.APIVersionKindSelector{{
+				APIVersion: "v1",
+				Kind:       "Namespace",
+			}},
+			SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+		}),
+		rttestingv1.WithApiServerSourceUID(sourceUID),
+		// Status Update:
+		rttestingv1.WithInitApiServerSourceConditions,
+		rttestingv1.WithApiServerSourceDeployed,
+		rttestingv1.WithApiServerSourceSink(sinkURI),
+	)
+
+	args := resources.ReceiveAdapterArgs{
+		Image:         image,
+		Source:        src,
+		Labels:        resources.Labels(sourceName),
+		SinkURI:       sinkURI.String(),
+		Configs:       &reconcilersource.EmptyVarsGenerator{},
+		NodeSelector: selector,
+		Namespaces: []string{testNS},
 	}
 
 	ra, err := resources.MakeReceiveAdapter(&args)

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -125,800 +125,787 @@ const (
 )
 
 func TestReconcile(t *testing.T) {
-	table := TableTest{
-		{
-			Name: "not enough permissions",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapter(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceNoSufficientPermissions,
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WantErr: true,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	table := TableTest{{
+		Name: "not enough permissions",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapter(t),
 		},
-		{
-			Name: "valid",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapter(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceNoSufficientPermissions,
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
-		{
-			Name: "valid with namespace selector",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapter(t),
-				rttesting.NewNamespace("test-a", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
-				rttesting.NewNamespace("test-b", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
-				rttesting.NewNamespace("test-c", rttesting.WithNamespaceLabeled(map[string]string{"target": "no"})),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b"}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
-				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
-				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
-			},
-			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
-			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantErr: true,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeWarning, "InternalError", `insufficient permissions: User system:serviceaccount:testnamespace:default cannot get, list, watch resource "namespaces" in API group "" in Namespace "testnamespace"`),
 		},
-		{
-			Name: "valid with an empty namespace selector",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapter(t),
-				rttesting.NewNamespace("test-a"),
-				rttesting.NewNamespace("test-b"),
-				rttesting.NewNamespace("test-c"),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b", "test-c"}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
-				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
-				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
-				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
-				makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-c"),
-				makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-c"),
-				makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-c"),
-			},
-			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
-			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
-		{
-			Name: "valid with eventmode of resourcemode",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						EventMode:  sourcesv1.ResourceMode,
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapterWithEventMode(t, sourcesv1.ResourceMode),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						EventMode:  sourcesv1.ResourceMode,
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceResourceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(false)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapter(t),
 		},
-		{
-			Name: "valid with sink URI",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapter(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
-		{
-			Name: "missing sink",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-			},
-			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeWarning, "SinkNotFound",
-					`Sink not found: {"ref":{"kind":"Channel","namespace":"testnamespace","name":"testsink","apiVersion":"messaging.knative.dev/v1"}}`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceSinkNotFound,
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 		},
-		{
-			Name: "receive adapter does not exist, fails to create",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-			},
-			Key:     testNS + "/" + sourceName,
-			WantErr: true,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, apiserversourceDeploymentCreated,
-					"Deployment created, error:inducing failure for create deployments"),
-				Eventf(corev1.EventTypeWarning, "InternalError",
-					"inducing failure for create deployments"),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-				makeReceiveAdapter(t),
-			},
-			WithReactors: []clientgotesting.ReactionFunc{
-				subjectAccessReviewCreateReactor(true),
-				InduceFailure("create", "Deployments"),
-			},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid with namespace selector",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapter(t),
+			rttesting.NewNamespace("test-a", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
+			rttesting.NewNamespace("test-b", rttesting.WithNamespaceLabeled(map[string]string{"target": "yes"})),
+			rttesting.NewNamespace("test-c", rttesting.WithNamespaceLabeled(map[string]string{"target": "no"})),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{MatchLabels: map[string]string{"target": "yes"}}),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b"}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
+			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
+			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b"}, false),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid with an empty namespace selector",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapter(t),
+			rttesting.NewNamespace("test-a"),
+			rttesting.NewNamespace("test-b"),
+			rttesting.NewNamespace("test-c"),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceNamespaceSelector(metav1.LabelSelector{}),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{"test-a", "test-b", "test-c"}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-a"),
+			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-b"),
+			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-b"),
+			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-b"),
+			makeNamespacedSubjectAccessReview("namespaces", "get", "default", "test-c"),
+			makeNamespacedSubjectAccessReview("namespaces", "list", "default", "test-c"),
+			makeNamespacedSubjectAccessReview("namespaces", "watch", "default", "test-c"),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeAvailableReceiveAdapterWithNamespaces(t, []string{"test-a", "test-b", "test-c"}, true),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid with eventmode of resourcemode",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					EventMode:  sourcesv1.ResourceMode,
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapterWithEventMode(t, sourcesv1.ResourceMode),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					EventMode:  sourcesv1.ResourceMode,
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceResourceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid with sink URI",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapter(t),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "missing sink",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+		},
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeWarning, "SinkNotFound",
+				`Sink not found: {"ref":{"kind":"Channel","namespace":"testnamespace","name":"testsink","apiVersion":"messaging.knative.dev/v1"}}`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceSinkNotFound,
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "receive adapter does not exist, fails to create",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+		},
+		Key:     testNS + "/" + sourceName,
+		WantErr: true,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, apiserversourceDeploymentCreated,
+				"Deployment created, error:inducing failure for create deployments"),
+			Eventf(corev1.EventTypeWarning, "InternalError",
+				"inducing failure for create deployments"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+			makeReceiveAdapter(t),
+		},
+		WithReactors: []clientgotesting.ReactionFunc{
+			subjectAccessReviewCreateReactor(true),
+			InduceFailure("create", "Deployments"),
+		},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
 
-		},
-		{
-			Name: "valid with relative uri reference",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{
-							Sink: duckv1.Destination{
-								Ref: sinkDest.Ref,
-								URI: &apis.URL{Path: sinkURIReference},
-							},
+	}, {
+		Name: "valid with relative uri reference",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: sinkDest.Ref,
+							URI: &apis.URL{Path: sinkURIReference},
 						},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeAvailableReceiveAdapterWithTargetURI(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{
-							Sink: duckv1.Destination{
-								Ref: sinkDest.Ref,
-								URI: &apis.URL{Path: sinkURIReference},
-							},
+					},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeAvailableReceiveAdapterWithTargetURI(t),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{
+						Sink: duckv1.Destination{
+							Ref: sinkDest.Ref,
+							URI: &apis.URL{Path: sinkURIReference},
 						},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkTargetURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+					},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkTargetURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
 		},
-		{
-			Name: "deployment update due to env",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeReceiveAdapterWithDifferentEnv(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceDeploymentUnavailable,
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: makeReceiveAdapter(t),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
 		},
-		{
-			Name: "deployment update due to service account",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{
-							Sink: sinkDest,
-						},
-						ServiceAccountName: "malin",
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeReceiveAdapterWithDifferentServiceAccount(t, "morgan"),
-			},
-			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{
-							Sink: sinkDest,
-						},
-						ServiceAccountName: "malin",
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeploymentUnavailable,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: makeReceiveAdapterWithDifferentServiceAccount(t, "malin"),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "malin"),
-				makeSubjectAccessReview("namespaces", "list", "malin"),
-				makeSubjectAccessReview("namespaces", "watch", "malin"),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
 		},
-		{
-			Name: "deployment update due to container count",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewChannel(sinkName, testNS,
-					rttestingv1.WithInitChannelConditions,
-					rttestingv1.WithChannelAddress(sinkAddressable),
-				),
-				makeReceiveAdapterWithDifferentContainerCount(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-				Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeploymentUnavailable,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: makeReceiveAdapter(t),
-			}},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "deployment update due to env",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeReceiveAdapterWithDifferentEnv(t),
 		},
-		{
-			Name: "valid with broker sink",
-			Objects: []runtime.Object{
-				rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-				),
-				rttestingv1.NewBroker(sinkName, testNS,
-					rttestingv1.WithInitBrokerConditions,
-					rttestingv1.WithBrokerAddressURI(apis.HTTP(sinkDNS)),
-				),
-				makeAvailableReceiveAdapter(t),
-			},
-			Key: testNS + "/" + sourceName,
-			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-				Object: rttestingv1.NewApiServerSource(sourceName, testNS,
-					rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-						Resources: []sourcesv1.APIVersionKindSelector{{
-							APIVersion: "v1",
-							Kind:       "Namespace",
-						}},
-						SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
-					}),
-					rttestingv1.WithApiServerSourceUID(sourceUID),
-					rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
-					// Status Update:
-					rttestingv1.WithInitApiServerSourceConditions,
-					rttestingv1.WithApiServerSourceDeployed,
-					rttestingv1.WithApiServerSourceSink(sinkURI),
-					rttestingv1.WithApiServerSourceSufficientPermissions,
-					rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
-					rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
-					rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
-					rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
-				),
-			}},
-			WantEvents: []string{
-				Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
-			},
-			WantPatches: []clientgotesting.PatchActionImpl{
-				patchFinalizers(sourceName, testNS),
-			},
-			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("namespaces", "get", "default"),
-				makeSubjectAccessReview("namespaces", "list", "default"),
-				makeSubjectAccessReview("namespaces", "watch", "default"),
-			},
-			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
-			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
 		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceDeploymentUnavailable,
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeReceiveAdapter(t),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "deployment update due to service account",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{
+						Sink: sinkDest,
+					},
+					ServiceAccountName: "malin",
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeReceiveAdapterWithDifferentServiceAccount(t, "morgan"),
+		},
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{
+						Sink: sinkDest,
+					},
+					ServiceAccountName: "malin",
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeploymentUnavailable,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeReceiveAdapterWithDifferentServiceAccount(t, "malin"),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "malin"),
+			makeSubjectAccessReview("namespaces", "list", "malin"),
+			makeSubjectAccessReview("namespaces", "watch", "malin"),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "deployment update due to container count",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewChannel(sinkName, testNS,
+				rttestingv1.WithInitChannelConditions,
+				rttestingv1.WithChannelAddress(sinkAddressable),
+			),
+			makeReceiveAdapterWithDifferentContainerCount(t),
+		},
+		Key: testNS + "/" + sourceName,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+			Eventf(corev1.EventTypeNormal, "ApiServerSourceDeploymentUpdated", `Deployment "apiserversource-test-apiserver-source-1234" updated`),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeploymentUnavailable,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeReceiveAdapter(t),
+		}},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	}, {
+		Name: "valid with broker sink",
+		Objects: []runtime.Object{
+			rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+			),
+			rttestingv1.NewBroker(sinkName, testNS,
+				rttestingv1.WithInitBrokerConditions,
+				rttestingv1.WithBrokerAddressURI(apis.HTTP(sinkDNS)),
+			),
+			makeAvailableReceiveAdapter(t),
+		},
+		Key: testNS + "/" + sourceName,
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: rttestingv1.NewApiServerSource(sourceName, testNS,
+				rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+					Resources: []sourcesv1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Namespace",
+					}},
+					SourceSpec: duckv1.SourceSpec{Sink: brokerDest},
+				}),
+				rttestingv1.WithApiServerSourceUID(sourceUID),
+				rttestingv1.WithApiServerSourceObjectMetaGeneration(generation),
+				// Status Update:
+				rttestingv1.WithInitApiServerSourceConditions,
+				rttestingv1.WithApiServerSourceDeployed,
+				rttestingv1.WithApiServerSourceSink(sinkURI),
+				rttestingv1.WithApiServerSourceSufficientPermissions,
+				rttestingv1.WithApiServerSourceReferenceModeEventTypes(source),
+				rttestingv1.WithApiServerSourceStatusObservedGeneration(generation),
+				rttestingv1.WithApiServerSourceStatusNamespaces([]string{testNS}),
+				rttestingv1.WithApiServerSourceOIDCIdentityCreatedSucceededBecauseOIDCFeatureDisabled(),
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", sourceName),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchFinalizers(sourceName, testNS),
+		},
+		WantCreates: []runtime.Object{
+			makeSubjectAccessReview("namespaces", "get", "default"),
+			makeSubjectAccessReview("namespaces", "list", "default"),
+			makeSubjectAccessReview("namespaces", "watch", "default"),
+		},
+		WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
+		SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
+	},
 		{
 			Name: "OIDC: creates OIDC service account",
 			Ctx: feature.ToContext(context.Background(), feature.Flags{
@@ -1100,9 +1087,8 @@ func TestReconcile(t *testing.T) {
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-		},
-		{
-			Name: "valid with node selector",
+		},{
+			Name: "Valid with nodeSelector",
 
 			Ctx: feature.ToContext(context.Background(), feature.Flags{
 				"apiserversources.nodeselector.testkey1": "testvalue1",
@@ -1388,41 +1374,6 @@ func makeAvailableReceiveAdapterWithNamespaces(t *testing.T, namespaces []string
 	return ra
 }
 
-func makeAvailableReceiveAdapterWithNodeSelector(t *testing.T, selector map[string]string) *appsv1.Deployment {
-	t.Helper()
-
-	src := rttestingv1.NewApiServerSource(sourceName, testNS,
-		rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
-			Resources: []sourcesv1.APIVersionKindSelector{{
-				APIVersion: "v1",
-				Kind:       "Namespace",
-			}},
-			SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
-		}),
-		rttestingv1.WithApiServerSourceUID(sourceUID),
-		// Status Update:
-		rttestingv1.WithInitApiServerSourceConditions,
-		rttestingv1.WithApiServerSourceDeployed,
-		rttestingv1.WithApiServerSourceSink(sinkURI),
-	)
-
-	args := resources.ReceiveAdapterArgs{
-		Image:         image,
-		Source:        src,
-		Labels:        resources.Labels(sourceName),
-		SinkURI:       sinkURI.String(),
-		Configs:       &reconcilersource.EmptyVarsGenerator{},
-		NodeSelector: selector,
-		Namespaces: []string{testNS},
-	}
-
-	ra, err := resources.MakeReceiveAdapter(&args)
-	require.NoError(t, err)
-
-	rttesting.WithDeploymentAvailable()(ra)
-	return ra
-}
-
 func makeReceiveAdapterWithDifferentEnv(t *testing.T) *appsv1.Deployment {
 	ra := makeReceiveAdapter(t)
 	ra.Spec.Template.Spec.Containers[0].Env = append(ra.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
@@ -1562,4 +1513,39 @@ func makeApiServerSourceOIDCServiceAccountWithoutOwnerRef() *corev1.ServiceAccou
 	sa.OwnerReferences = nil
 
 	return sa
+}
+
+func makeAvailableReceiveAdapterWithNodeSelector(t *testing.T, selector map[string]string) *appsv1.Deployment {
+	t.Helper()
+
+	src := rttestingv1.NewApiServerSource(sourceName, testNS,
+		rttestingv1.WithApiServerSourceSpec(sourcesv1.ApiServerSourceSpec{
+			Resources: []sourcesv1.APIVersionKindSelector{{
+				APIVersion: "v1",
+				Kind:       "Namespace",
+			}},
+			SourceSpec: duckv1.SourceSpec{Sink: sinkDest},
+		}),
+		rttestingv1.WithApiServerSourceUID(sourceUID),
+		// Status Update:
+		rttestingv1.WithInitApiServerSourceConditions,
+		rttestingv1.WithApiServerSourceDeployed,
+		rttestingv1.WithApiServerSourceSink(sinkURI),
+	)
+
+	args := resources.ReceiveAdapterArgs{
+		Image:         image,
+		Source:        src,
+		Labels:        resources.Labels(sourceName),
+		SinkURI:       sinkURI.String(),
+		Configs:       &reconcilersource.EmptyVarsGenerator{},
+		NodeSelector: selector,
+		Namespaces: []string{testNS},
+	}
+
+	ra, err := resources.MakeReceiveAdapter(&args)
+	require.NoError(t, err)
+
+	rttesting.WithDeploymentAvailable()(ra)
+	return ra
 }

--- a/pkg/reconciler/apiserversource/apiserversource_test.go
+++ b/pkg/reconciler/apiserversource/apiserversource_test.go
@@ -1087,7 +1087,7 @@ func TestReconcile(t *testing.T) {
 			},
 			WithReactors:            []clientgotesting.ReactionFunc{subjectAccessReviewCreateReactor(true)},
 			SkipNamespaceValidation: true, // SubjectAccessReview objects are cluster-scoped.
-		},{
+		}, {
 			Name: "Valid with nodeSelector",
 
 			Ctx: feature.ToContext(context.Background(), feature.Flags{
@@ -1140,7 +1140,7 @@ func TestReconcile(t *testing.T) {
 				makeSubjectAccessReview("namespaces", "list", "default"),
 				makeSubjectAccessReview("namespaces", "watch", "default"),
 			},
-		
+
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: makeAvailableReceiveAdapterWithNodeSelector(t, map[string]string{
 					"testkey1": "testvalue1",
@@ -1534,13 +1534,13 @@ func makeAvailableReceiveAdapterWithNodeSelector(t *testing.T, selector map[stri
 	)
 
 	args := resources.ReceiveAdapterArgs{
-		Image:         image,
-		Source:        src,
-		Labels:        resources.Labels(sourceName),
-		SinkURI:       sinkURI.String(),
-		Configs:       &reconcilersource.EmptyVarsGenerator{},
+		Image:        image,
+		Source:       src,
+		Labels:       resources.Labels(sourceName),
+		SinkURI:      sinkURI.String(),
+		Configs:      &reconcilersource.EmptyVarsGenerator{},
 		NodeSelector: selector,
-		Namespaces: []string{testNS},
+		Namespaces:   []string{testNS},
 	}
 
 	ra, err := resources.MakeReceiveAdapter(&args)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7360 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Users can now configure nodeSelector via ```config-features``` by adding key-value pair in the format ```apiserversources.nodeselector.<key>: <value>```

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

Feature: Added the ability for users to configure `nodeSelector` when deploying `apiserversource` , Users can now configure nodeSelector via config-features by adding key-value pair in the format apiserversources.nodeselector.<key>: <value>
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

