### PR TITLE
Increase KinD test timeout to 90 minutes

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -126,7 +126,7 @@ jobs:
       run: |
         export CLUSTER_DOMAIN=${CLUSTER_SUFFIX}
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -parallel=12 -timeout=50m -tags=e2e \
+        go test -race -count=1 -parallel=12 -timeout=90m -tags=e2e \
            ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
     - name: Collect system diagnostics


### PR DESCRIPTION
Follow up on https://github.com/knative/eventing/pull/7580#issuecomment-1893225565

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Increase the timeout in KinD tests to 90 minutes

/cc @creydr 

