### PR TITLE
rekt test to verify only one EventType created for MTBroker

### DIFF
--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -95,7 +95,7 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 
 	f.Alpha("broker").
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
-		Must("create event type", eventtype.WaitForEventType(eventtype.AssertPresent(expectedTypes)))
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertExactPresent(expectedTypes)))
 
 	return f
 }

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -72,5 +72,21 @@ func AssertPresent(expectedCeTypes sets.Set[string]) EventType {
 			return clonedExpectedCeTypes.Len() == 0, nil
 		},
 	}
+}
 
+func AssertExactPresent(expectedCeTypes sets.Set[string]) EventType {
+	return EventType{
+		Name: "test eventtypes match or not",
+		EventTypes: func(etl eventingv1beta2.EventTypeList) (bool, error) {
+			// Clone the expectedCeTypes
+			clonedExpectedCeTypes := expectedCeTypes.Clone()
+			for _, et := range etl.Items {
+				if !clonedExpectedCeTypes.Has(et.Spec.Type) {
+					return false, nil
+				}
+				clonedExpectedCeTypes.Delete(et.Spec.Type) // remove from the cloned set
+			}
+			return clonedExpectedCeTypes.Len() == 0, nil
+		},
+	}
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7196 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Assert that there is exactly one eventtype created, rather than just checking that all required types were created
