### PR TITLE
Provision sequences CA cert in its status

### DIFF
--- a/pkg/apis/flows/v1/sequence_lifecycle.go
+++ b/pkg/apis/flows/v1/sequence_lifecycle.go
@@ -191,7 +191,11 @@ func (ss *SequenceStatus) setAddress(address *duckv1.Addressable) {
 		ss.Address = duckv1.Addressable{}
 		sCondSet.Manage(ss).MarkUnknown(SequenceConditionAddressable, "emptyAddress", "addressable is nil")
 	} else {
-		ss.Address = duckv1.Addressable{URL: address.URL, Audience: address.Audience}
+		ss.Address = duckv1.Addressable{
+			URL:      address.URL,
+			CACerts:  address.CACerts,
+			Audience: address.Audience,
+		}
 		sCondSet.Manage(ss).MarkTrue(SequenceConditionAddressable)
 	}
 }


### PR DESCRIPTION
Currently a Sequences CACert is not provided in its `.status.address`. This PR addresses it

/cc @pierDipi @Leo6Leo 