### PR TITLE
Set audience in .status.addresses fields too

### DIFF
--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -243,9 +243,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, b *eventingv1.Broker) pk
 		audience := auth.GetAudience(eventingv1.SchemeGroupVersion.WithKind("Broker"), b.ObjectMeta)
 		logging.FromContext(ctx).Debugw("Setting the brokers audience", zap.String("audience", audience))
 		b.Status.Address.Audience = &audience
+		for i := range b.Status.Addresses {
+			b.Status.Addresses[i].Audience = &audience
+		}
 	} else {
 		logging.FromContext(ctx).Debug("Clearing the brokers audience as OIDC is not enabled")
 		b.Status.Address.Audience = nil
+		for i := range b.Status.Addresses {
+			b.Status.Addresses[i].Audience = nil
+		}
 	}
 
 	b.GetConditionSet().Manage(b.GetStatus()).MarkTrue(eventingv1.BrokerConditionAddressable)

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
+	"knative.dev/eventing/pkg/auth"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/network"
 
@@ -46,7 +46,6 @@ import (
 	"knative.dev/eventing/pkg/apis/eventing"
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
-	"knative.dev/eventing/pkg/auth"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/reconciler/inmemorychannel/controller/config"
@@ -218,9 +217,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, imc *v1.InMemoryChannel)
 
 		logging.FromContext(ctx).Debugw("Setting the imc audience", zap.String("audience", audience))
 		imc.Status.Address.Audience = &audience
+		for i := range imc.Status.Addresses {
+			imc.Status.Addresses[i].Audience = &audience
+		}
 	} else {
 		logging.FromContext(ctx).Debug("Clearing the imc audience as OIDC is not enabled")
 		imc.Status.Address.Audience = nil
+		for i := range imc.Status.Addresses {
+			imc.Status.Addresses[i].Audience = nil
+		}
 	}
 
 	imc.GetConditionSet().Manage(imc.GetStatus()).MarkTrue(v1.InMemoryChannelConditionAddressable)

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	"knative.dev/eventing/pkg/auth"


### PR DESCRIPTION
Currently the audience is not set in .status.addresses field (only in .status.address) of a Broker and IMC. This PR addresses it.

/cc @pierDipi @Leo6Leo 