### PR TITLE
Enable storage of EventType v1b2

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -25,7 +25,7 @@ spec:
   - &version
     name: v1beta2
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
     schema:
@@ -157,7 +157,7 @@ spec:
   - <<: *version
     name: v1beta1
     served: true
-    storage: true
+    storage: false
     # This indicates the v1beta1 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -149,6 +149,12 @@ function install_knative_eventing() {
       -f "${EVENTING_CORE_NAME}" || return 1
     UNINSTALL_LIST+=( "${EVENTING_CORE_NAME}" )
 
+    local EVENTING_POST_INSTALL_NAME=${TMP_DIR}/${EVENTING_POST_INSTALL_YAML##*/}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_POST_INSTALL_YAML}" > "${EVENTING_POST_INSTALL_NAME=}"
+    kubectl create \
+          -f "${EVENTING_POST_INSTALL_NAME}" || return 1
+    UNINSTALL_LIST+=( "${EVENTING_POST_INSTALL_NAME}" )
+
     local EVENTING_TLS_REPLACES=${TMP_DIR}/${EVENTING_TLS_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_TLS_YAML}" > "${EVENTING_TLS_REPLACES}"
     if [[ ! -z "${CLUSTER_SUFFIX:-}" ]]; then

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -149,12 +149,6 @@ function install_knative_eventing() {
       -f "${EVENTING_CORE_NAME}" || return 1
     UNINSTALL_LIST+=( "${EVENTING_CORE_NAME}" )
 
-    local EVENTING_POST_INSTALL_NAME=${TMP_DIR}/${EVENTING_POST_INSTALL_YAML##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_POST_INSTALL_YAML}" > "${EVENTING_POST_INSTALL_NAME=}"
-    kubectl create \
-          -f "${EVENTING_POST_INSTALL_NAME}" || return 1
-    UNINSTALL_LIST+=( "${EVENTING_POST_INSTALL_NAME}" )
-
     local EVENTING_TLS_REPLACES=${TMP_DIR}/${EVENTING_TLS_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_TLS_YAML}" > "${EVENTING_TLS_REPLACES}"
     if [[ ! -z "${CLUSTER_SUFFIX:-}" ]]; then
@@ -227,7 +221,7 @@ function install_mt_broker() {
   if [[ -z "${EVENTING_MT_CHANNEL_BROKER_YAML:-}" ]]; then
     build_knative_from_source
   else
-    echo "use exist EVENTING_MT_CHANNEL_BROKER_YAML"
+    echo "use existing EVENTING_MT_CHANNEL_BROKER_YAML"
   fi
   local EVENTING_MT_CHANNEL_BROKER_NAME=${TMP_DIR}/${EVENTING_MT_CHANNEL_BROKER_YAML##*/}
   sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_MT_CHANNEL_BROKER_YAML}" > "${EVENTING_MT_CHANNEL_BROKER_NAME}"
@@ -237,6 +231,20 @@ function install_mt_broker() {
   scale_controlplane mt-broker-controller
 
   wait_until_pods_running "${SYSTEM_NAMESPACE}" || fail_test "Knative Eventing with MT Broker did not come up"
+}
+
+function install_post_install_job() {
+    # Var defined and populated by generate-yaml.sh
+    if [[ -z "${EVENTING_POST_INSTALL_YAML:-}" ]]; then
+        build_knative_from_source
+      else
+        echo "use existing EVENTING_POST_INSTALL_YAML"
+      fi
+    local EVENTING_POST_INSTALL_NAME=${TMP_DIR}/${EVENTING_POST_INSTALL_YAML##*/}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" "${EVENTING_POST_INSTALL_YAML}" > "${EVENTING_POST_INSTALL_NAME=}"
+    kubectl create \
+      -f "${EVENTING_POST_INSTALL_NAME}" || return 1
+    UNINSTALL_LIST+=( "${EVENTING_POST_INSTALL_NAME}" )
 }
 
 function enable_sugar() {

--- a/test/upgrade/installation/git_head.go
+++ b/test/upgrade/installation/git_head.go
@@ -26,6 +26,7 @@ func GitHead() pkgupgrade.Operation {
 			"install_head",
 			"install_channel_crds",
 			"install_mt_broker",
+			"install_post_install_job",
 			"enable_sugar",
 		}
 		for _, shellfunc := range ops {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Based on Slack thread: https://cloud-native.slack.com/archives/C04LMU33V1S/p1705560044668329.


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Enable storage of EventType v1b2


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Enable storage of EventType `v1beta2` instead of `v1beta1`
```

