### PR TITLE
Add TLS test for sequence

### DIFF
--- a/test/rekt/features/sequence/feature.go
+++ b/test/rekt/features/sequence/feature.go
@@ -19,9 +19,10 @@ package sequence
 import (
 	"context"
 	"fmt"
-
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
+	"knative.dev/eventing/test/rekt/features/featureflags"
+	"knative.dev/eventing/test/rekt/resources/addressable"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/eventing/test/rekt/resources/channel_template"
@@ -97,6 +98,79 @@ func SequenceTest(channelTemplate channel_template.ChannelTemplate) *feature.Fea
 			assert.OnStore(sink).MatchEvent(
 				test.HasType("dev.knative.sources.ping"),
 				test.HasDataContentType("text/plain"),
+				test.HasData([]byte(expectedMsg)),
+			).AtLeast(1))
+
+	return f
+}
+
+func SequenceTestTLS(channelTemplate channel_template.ChannelTemplate) *feature.Feature {
+	f := feature.NewFeatureNamed("Sequence test.")
+
+	f.Prerequisite("transport encryption is strict", featureflags.TransportEncryptionStrict())
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
+	sequenceName := feature.MakeRandomK8sName("sequence")
+	source := feature.MakeRandomK8sName("source")
+	sink := feature.MakeRandomK8sName("sink")
+	// Sequence's steps
+	step1 := feature.MakeRandomK8sName("step1")
+	step2 := feature.MakeRandomK8sName("step2")
+	step3 := feature.MakeRandomK8sName("step3")
+	msgAppender1 := "-step1"
+	msgAppender2 := "-step2"
+	msgAppender3 := "-step3"
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
+	// Construct steps with appended data
+	f.Setup("install subscriber1", eventshub.Install(step1, eventshub.ReplyWithAppendedData(msgAppender1), eventshub.StartReceiverTLS))
+	f.Setup("install subscriber2", eventshub.Install(step2, eventshub.ReplyWithAppendedData(msgAppender2), eventshub.StartReceiverTLS))
+	f.Setup("install subscriber", eventshub.Install(step3, eventshub.ReplyWithAppendedData(msgAppender3), eventshub.StartReceiverTLS))
+
+	// Install a Sequence with three steps
+	f.Setup("install Sequence", func(ctx context.Context, t feature.T) {
+
+		cfg := []manifest.CfgFn{
+			sequence.WithChannelTemplate(channelTemplate),
+
+			sequence.WithStepFromDestination(&duckv1.Destination{
+				Ref:     service.AsKReference(step1),
+				CACerts: eventshub.GetCaCerts(ctx),
+			}),
+			sequence.WithStepFromDestination(&duckv1.Destination{
+				Ref:     service.AsKReference(step2),
+				CACerts: eventshub.GetCaCerts(ctx),
+			}),
+			sequence.WithStepFromDestination(&duckv1.Destination{
+				Ref:     service.AsKReference(step3),
+				CACerts: eventshub.GetCaCerts(ctx),
+			}),
+
+			sequence.WithReplyFromDestination(&duckv1.Destination{
+				Ref:     service.AsKReference(sink),
+				CACerts: eventshub.GetCaCerts(ctx),
+			}),
+		}
+
+		sequence.Install(sequenceName, cfg...)(ctx, t)
+	})
+	f.Setup("Sequence goes ready", sequence.IsReady(sequenceName))
+	f.Setup("Sequence has HTTPS address", sequence.ValidateAddress(sequenceName, addressable.AssertHTTPSAddress))
+
+	event := test.FullEvent()
+	event.SetData("text/plain", "hello")
+	f.Requirement("install source", eventshub.Install(source,
+		eventshub.StartSenderToResourceTLS(sequence.GVR(), sequenceName, nil),
+		eventshub.InputEvent(event)))
+
+	expectedMsg := string(event.Data())
+	expectedMsg += msgAppender1
+	expectedMsg += msgAppender2
+	expectedMsg += msgAppender3
+
+	f.Stable("Sequence with steps and reply via HTTPS").
+		Must("Delivers events correctly to reply",
+			assert.OnStore(sink).MatchEvent(
 				test.HasData([]byte(expectedMsg)),
 			).AtLeast(1))
 

--- a/test/rekt/features/sequence/feature.go
+++ b/test/rekt/features/sequence/feature.go
@@ -19,6 +19,7 @@ package sequence
 import (
 	"context"
 	"fmt"
+
 	"github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
 	"knative.dev/eventing/test/rekt/features/featureflags"

--- a/test/rekt/sequence_test.go
+++ b/test/rekt/sequence_test.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/eventing/test/rekt/resources/channel_template"
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 )
@@ -43,4 +44,19 @@ func TestSequence(t *testing.T) {
 	t.Cleanup(env.Finish)
 
 	env.Test(ctx, t, sequence.SequenceTest(channel_template.ImmemoryChannelTemplate()))
+}
+
+func TestSequenceTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	env.Test(ctx, t, sequence.SequenceTestTLS(channel_template.ImmemoryChannelTemplate()))
 }


### PR DESCRIPTION
As we're missing a test for the sequences TLS functionality (discussed in todays eventing WG meeting).