### PR TITLE
Add a Prerequisite helper to check if the OIDC authentication feature flag is enabled

### DIFF
--- a/test/rekt/features/featureflags/featureflags.go
+++ b/test/rekt/features/featureflags/featureflags.go
@@ -60,6 +60,20 @@ func TransportEncryptionStrict() feature.ShouldRun {
 	}
 }
 
+func AuthenticationOIDCEnabled() feature.ShouldRun {
+	return func(ctx context.Context, t feature.T) (feature.PrerequisiteResult, error) {
+		flags, err := getFeatureFlags(ctx, "config-features")
+		if err != nil {
+			return feature.PrerequisiteResult{}, err
+		}
+
+		return feature.PrerequisiteResult{
+			ShouldRun: flags.IsOIDCAuthentication(),
+			Reason:    flags.String(),
+		}, nil
+	}
+}
+
 func IstioDisabled() feature.ShouldRun {
 	return func(ctx context.Context, t feature.T) (feature.PrerequisiteResult, error) {
 		flags, err := getFeatureFlags(ctx, "config-features")


### PR DESCRIPTION
Allows to add a Prerequiste check in an e2e test, so the test runs only in case the `authorization-oidc` feature flag is enabled.

Usage:

```
f.Prerequisite("OIDC authentication is enabled", featureflags.AuthenticationOIDCEnabled())
```