### PR TITLE
Move new trigger tests to conformance suite

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -27,11 +27,14 @@ import (
 	"testing"
 
 	"knative.dev/pkg/system"
+	pkgtest "knative.dev/pkg/test"
 
 	"knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/setupclientoptions"
 	"knative.dev/pkg/test/zipkin"
+
+	"knative.dev/reconciler-test/pkg/environment"
 )
 
 const (
@@ -43,6 +46,8 @@ var channelTestRunner testlib.ComponentsTestRunner
 var sourcesTestRunner testlib.ComponentsTestRunner
 var brokerTestRunner testlib.ComponentsTestRunner
 var brokerClass string
+
+var global environment.GlobalEnvironment
 
 func TestMain(m *testing.M) {
 	os.Exit(func() int {
@@ -64,6 +69,12 @@ func TestMain(m *testing.M) {
 			ComponentNamespace:  test.EventingFlags.BrokerNamespace,
 		}
 		brokerClass = test.BrokerClass
+
+		cfg, err := pkgtest.Flags.GetRESTConfig()
+		if err != nil {
+			panic("failed to get rest config")
+		}
+		global = environment.NewGlobalEnvironmentWithRestConfig(cfg)
 
 		addSourcesInitializers()
 		// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY

--- a/test/conformance/new_trigger_filters_test.go
+++ b/test/conformance/new_trigger_filters_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package rekt
+package conformance
 
 import (
 	"testing"


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7625 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Move new trigger filter tests to conformance
- Update conformance main to use parsed rest config and pass it to the reconciler-test global environment
