### PR TITLE
Update knative.dev/hack to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	k8s.io/apiserver v0.28.5
 	k8s.io/client-go v0.28.5
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
-	knative.dev/hack v0.0.0-20240123162936-f3f03ac0ab1a
+	knative.dev/hack v0.0.0-20240123160146-ab9b69024c39
 	knative.dev/hack/schema v0.0.0-20240123162936-f3f03ac0ab1a
 	knative.dev/pkg v0.0.0-20240116073220-b488e7be5902
 	knative.dev/reconciler-test v0.0.0-20240116084801-50276dfba7b3

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5Ohx
 k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-knative.dev/hack v0.0.0-20240123162936-f3f03ac0ab1a h1:+4Mdk0Lt3LGAVEI6vYyhfjBlVBx7sqS4wECtTkuXoSY=
-knative.dev/hack v0.0.0-20240123162936-f3f03ac0ab1a/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
+knative.dev/hack v0.0.0-20240123160146-ab9b69024c39 h1:Or4ri7cAUQNEWwMPaGGaIe1hsPHGdVtr8lIaHh2JF7s=
+knative.dev/hack v0.0.0-20240123160146-ab9b69024c39/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/hack/schema v0.0.0-20240123162936-f3f03ac0ab1a h1:9FY/uq1m9K+Ig9tt4yAry1VA4YLgFYSkegnFBv4x0aE=
 knative.dev/hack/schema v0.0.0-20240123162936-f3f03ac0ab1a/go.mod h1:3pWwBLnTZSM9psSgCAvhKOHIPTzqfEMlWRpDu6IYhK0=
 knative.dev/pkg v0.0.0-20240116073220-b488e7be5902 h1:H6+JJN23fhwYWCHY1339sY6uhIyoUwDy1a8dN233fdk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1226,7 +1226,7 @@ k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# knative.dev/hack v0.0.0-20240123162936-f3f03ac0ab1a
+# knative.dev/hack v0.0.0-20240123160146-ab9b69024c39
 ## explicit; go 1.18
 knative.dev/hack
 # knative.dev/hack/schema v0.0.0-20240123162936-f3f03ac0ab1a


### PR DESCRIPTION
As per title to fix current update-deps issues with knative.dev/hack (https://cloud-native.slack.com/archives/C04LY4Y3EHF/p1706520424682969)