### PR TITLE
Add rekt test for containersource autocreate

### DIFF
--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package experimental
 
-
 import (
 	"testing"
 

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package experimental
 
+//go:generate go.work
+
 import (
 	"testing"
 
@@ -71,4 +73,18 @@ func TestPingSourceEventTypeMatch(t *testing.T) {
 	)
 
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypeEventsFromPingSource())
+}
+
+func TestContainerSourceEventTypeAutoCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnContainerSource())
 }

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package experimental
 
-//go:generate go.work
 
 import (
 	"testing"

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -22,6 +22,7 @@ import (
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/containersource"
 	"knative.dev/eventing/test/rekt/resources/eventtype"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/subscription"
@@ -136,6 +137,34 @@ func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
 			test.HasType(sourcesv1.PingSourceEventType)).AtLeast(1)).
 		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
 			eventtype.AssertPresent(expectedCeTypes)))
+
+	return f
+}
+
+func AutoCreateEventTypesOnContainerSource() *feature.Feature {
+	f := feature.NewFeature()
+
+	event := cetest.FullEvent()
+	event.SetType("test.containersource.custom.event.type")
+
+	sourceName := feature.MakeRandomK8sName("containersource")
+	sink := feature.MakeRandomK8sName("sink")
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
+
+	kref := service.AsKReference(sink)
+	destination := &duckv1.Destination{
+		Ref: kref,
+	}
+	f.Setup("install containersource", containersource.Install(sourceName, containersource.WithSink(destination)))
+
+	f.Setup("containersource is ready", containersource.IsReady(sourceName))
+
+	expectedTypes := sets.New(event.Type())
+
+	f.Stable("containersource").
+		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
+		Must("create event type", eventtype.WaitForEventType(eventtype.AssertExactPresent(expectedTypes)))
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -152,9 +152,8 @@ func AutoCreateEventTypesOnContainerSource() *feature.Feature {
 
 	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiver))
 
-	kref := service.AsKReference(sink)
 	destination := &duckv1.Destination{
-		Ref: kref,
+		Ref: service.AsKReference(sink),
 	}
 	f.Setup("install containersource", containersource.Install(sourceName, containersource.WithSink(destination)))
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7621

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Added a function `AutoCreateEventTypesOnContainer` in `features.go`
- Added a function `TestContainerSourceEventTypeAutoCreate` in`eventtype_autocreate_test.go`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

