### PR TITLE
Add helm as one of the development requirement

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,7 @@ You must install these tools:
    default bash is too old, you can use [Homebrew](https://brew.sh) to install a
    later version. For running some automations, such as dependencies updates and
    code generators.
+1. [`helm`](https://helm.sh/docs/intro/install/): v3.14 or higher for Kubernetes package managing.
 
 ### Create a cluster and a repo
 


### PR DESCRIPTION
https://github.com/knative/eventing/pull/7532/files#diff-76c1ad91357799de2676fe0c7c47b6ab6c6e491149a0813719d239ec344079f4R14

As updated in this PR, helm is used.

https://github.com/knative/eventing/pull/7532/files#r1471800554 explains why 3.14