### PR TITLE
Cache statefulset scale update/get requests

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -17,10 +17,18 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
+	"time"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/cache"
+	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	duckv1alpha1 "knative.dev/eventing/pkg/apis/duck/v1alpha1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
 type SchedulerPolicyType string
@@ -113,4 +121,74 @@ type VPod interface {
 	GetPlacements() []duckv1alpha1.Placement
 
 	GetResourceVersion() string
+}
+
+type ScaleCache struct {
+	entries              *cache.Expiring
+	statefulSetClient    clientappsv1.StatefulSetInterface
+	statefulSetNamespace string
+}
+
+type scaleEntry struct {
+	specReplicas int32
+	statReplicas int32
+}
+
+func NewScaleCache(ctx context.Context, namespace string) *ScaleCache {
+	return &ScaleCache{
+		entries:              cache.NewExpiring(),
+		statefulSetClient:    kubeclient.Get(ctx).AppsV1().StatefulSets(namespace),
+		statefulSetNamespace: namespace,
+	}
+}
+
+func (sc *ScaleCache) GetScale(ctx context.Context, statefulSetName string, options metav1.GetOptions) (*autoscalingv1.Scale, error) {
+	if entry, ok := sc.entries.Get(statefulSetName); ok {
+		entry := entry.(scaleEntry)
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      statefulSetName,
+				Namespace: sc.statefulSetNamespace,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: entry.specReplicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: entry.statReplicas,
+			},
+		}, nil
+	}
+
+	scale, err := sc.statefulSetClient.GetScale(ctx, statefulSetName, options)
+	if err != nil {
+		return scale, err
+	}
+
+	sc.setScale(statefulSetName, scale)
+
+	return scale, nil
+}
+
+func (sc *ScaleCache) UpdateScale(ctx context.Context, statefulSetName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	updatedScale, err := sc.statefulSetClient.UpdateScale(ctx, statefulSetName, scale, opts)
+	if err != nil {
+		return updatedScale, err
+	}
+
+	sc.setScale(statefulSetName, updatedScale)
+
+	return updatedScale, nil
+}
+
+func (sc *ScaleCache) Reset() {
+	sc.entries = cache.NewExpiring()
+}
+
+func (sc *ScaleCache) setScale(name string, scale *autoscalingv1.Scale) {
+	entry := scaleEntry{
+		specReplicas: scale.Spec.Replicas,
+		statReplicas: scale.Status.Replicas,
+	}
+
+	sc.entries.Set(name, entry, time.Minute*5)
 }

--- a/pkg/scheduler/state/state_test.go
+++ b/pkg/scheduler/state/state_test.go
@@ -642,7 +642,9 @@ func TestStateBuilder(t *testing.T) {
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
 
-			stateBuilder := NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, int32(10), tc.schedulerPolicyType, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister())
+			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+
+			stateBuilder := NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, int32(10), tc.schedulerPolicyType, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 			state, err := stateBuilder.State(tc.reserved)
 			if err != nil {
 				t.Fatal("unexpected error", err)

--- a/pkg/scheduler/state/state_test.go
+++ b/pkg/scheduler/state/state_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -642,7 +643,7 @@ func TestStateBuilder(t *testing.T) {
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
 
-			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			scaleCache := scheduler.NewScaleCache(ctx, testNs, kubeclient.Get(ctx).AppsV1().StatefulSets(testNs), scheduler.ScaleCacheConfig{RefreshPeriod: time.Minute * 5})
 
 			stateBuilder := NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, int32(10), tc.schedulerPolicyType, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 			state, err := stateBuilder.State(tc.reserved)

--- a/pkg/scheduler/statefulset/autoscaler_test.go
+++ b/pkg/scheduler/statefulset/autoscaler_test.go
@@ -449,7 +449,7 @@ func TestAutoscaler(t *testing.T) {
 				lsnn = lsn.GetNodeLister()
 			}
 
-			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			scaleCache := scheduler.NewScaleCache(ctx, testNs, kubeclient.Get(ctx).AppsV1().StatefulSets(testNs), scheduler.ScaleCacheConfig{RefreshPeriod: time.Minute * 5})
 
 			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lspp, lsnn, scaleCache)
 
@@ -511,7 +511,7 @@ func TestAutoscalerScaleDownToZero(t *testing.T) {
 
 	vpodClient := tscheduler.NewVPodClient()
 	ls := listers.NewListers(nil)
-	scaleCache := scheduler.NewScaleCache(ctx, testNs)
+	scaleCache := scheduler.NewScaleCache(ctx, testNs, kubeclient.Get(ctx).AppsV1().StatefulSets(testNs), scheduler.ScaleCacheConfig{RefreshPeriod: time.Minute * 5})
 	stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, scheduler.MAXFILLUP, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, nil, ls.GetNodeLister(), scaleCache)
 
 	sfsClient := kubeclient.Get(ctx).AppsV1().StatefulSets(testNs)
@@ -949,7 +949,7 @@ func TestCompactor(t *testing.T) {
 
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
-			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			scaleCache := scheduler.NewScaleCache(ctx, testNs, kubeclient.Get(ctx).AppsV1().StatefulSets(testNs), scheduler.ScaleCacheConfig{RefreshPeriod: time.Minute * 5})
 			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 
 			evictions := make(map[types.NamespacedName][]duckv1alpha1.Placement)

--- a/pkg/scheduler/statefulset/autoscaler_test.go
+++ b/pkg/scheduler/statefulset/autoscaler_test.go
@@ -449,7 +449,9 @@ func TestAutoscaler(t *testing.T) {
 				lsnn = lsn.GetNodeLister()
 			}
 
-			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lspp, lsnn)
+			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+
+			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lspp, lsnn, scaleCache)
 
 			sfsClient := kubeclient.Get(ctx).AppsV1().StatefulSets(testNs)
 			_, err := sfsClient.Create(ctx, tscheduler.MakeStatefulset(testNs, sfsName, tc.replicas), metav1.CreateOptions{})
@@ -472,7 +474,7 @@ func TestAutoscaler(t *testing.T) {
 					return tc.reserved
 				},
 			}
-			autoscaler := newAutoscaler(ctx, cfg, stateAccessor)
+			autoscaler := newAutoscaler(ctx, cfg, stateAccessor, scaleCache)
 			_ = autoscaler.Promote(reconciler.UniversalBucket(), nil)
 
 			for _, vpod := range tc.vpods {
@@ -509,7 +511,8 @@ func TestAutoscalerScaleDownToZero(t *testing.T) {
 
 	vpodClient := tscheduler.NewVPodClient()
 	ls := listers.NewListers(nil)
-	stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, scheduler.MAXFILLUP, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, nil, ls.GetNodeLister())
+	scaleCache := scheduler.NewScaleCache(ctx, testNs)
+	stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, scheduler.MAXFILLUP, &scheduler.SchedulerPolicy{}, &scheduler.SchedulerPolicy{}, nil, ls.GetNodeLister(), scaleCache)
 
 	sfsClient := kubeclient.Get(ctx).AppsV1().StatefulSets(testNs)
 	_, err := sfsClient.Create(ctx, tscheduler.MakeStatefulset(testNs, sfsName, 10), metav1.CreateOptions{})
@@ -532,7 +535,7 @@ func TestAutoscalerScaleDownToZero(t *testing.T) {
 			return nil
 		},
 	}
-	autoscaler := newAutoscaler(ctx, cfg, stateAccessor)
+	autoscaler := newAutoscaler(ctx, cfg, stateAccessor, scaleCache)
 	_ = autoscaler.Promote(reconciler.UniversalBucket(), nil)
 
 	done := make(chan bool)
@@ -946,7 +949,8 @@ func TestCompactor(t *testing.T) {
 
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
-			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister())
+			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			stateAccessor := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 
 			evictions := make(map[types.NamespacedName][]duckv1alpha1.Placement)
 			recordEviction := func(pod *corev1.Pod, vpod scheduler.VPod, from *duckv1alpha1.Placement) error {
@@ -962,7 +966,7 @@ func TestCompactor(t *testing.T) {
 				RefreshPeriod:        10 * time.Second,
 				PodCapacity:          10,
 			}
-			autoscaler := newAutoscaler(ctx, cfg, stateAccessor)
+			autoscaler := newAutoscaler(ctx, cfg, stateAccessor, scaleCache)
 			_ = autoscaler.Promote(reconciler.UniversalBucket(), func(bucket reconciler.Bucket, name types.NamespacedName) {})
 			assert.Equal(t, true, autoscaler.isLeader.Load())
 

--- a/pkg/scheduler/statefulset/scheduler.go
+++ b/pkg/scheduler/statefulset/scheduler.go
@@ -64,6 +64,7 @@ type Config struct {
 	StatefulSetNamespace string `json:"statefulSetNamespace"`
 	StatefulSetName      string `json:"statefulSetName"`
 
+	ScaleCacheConfig scheduler.ScaleCacheConfig `json:"scaleCacheConfig"`
 	// PodCapacity max capacity for each StatefulSet's pod.
 	PodCapacity int32 `json:"podCapacity"`
 	// Autoscaler refresh period
@@ -87,7 +88,7 @@ func New(ctx context.Context, cfg *Config) (scheduler.Scheduler, error) {
 	podInformer := podinformer.Get(ctx)
 	podLister := podInformer.Lister().Pods(cfg.StatefulSetNamespace)
 
-	scaleCache := scheduler.NewScaleCache(ctx, cfg.StatefulSetNamespace)
+	scaleCache := scheduler.NewScaleCache(ctx, cfg.StatefulSetNamespace, kubeclient.Get(ctx).AppsV1().StatefulSets(cfg.StatefulSetNamespace), cfg.ScaleCacheConfig)
 
 	stateAccessor := st.NewStateBuilder(ctx, cfg.StatefulSetNamespace, cfg.StatefulSetName, cfg.VPodLister, cfg.PodCapacity, cfg.SchedulerPolicy, cfg.SchedPolicy, cfg.DeschedPolicy, podLister, cfg.NodeLister, scaleCache)
 

--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -803,7 +803,8 @@ func TestStatefulsetScheduler(t *testing.T) {
 			}
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
-			sa := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister())
+			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			sa := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 			cfg := &Config{
 				StatefulSetNamespace: testNs,
 				StatefulSetName:      sfsName,

--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -803,7 +803,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			}
 			lsp := listers.NewListers(podlist)
 			lsn := listers.NewListers(nodelist)
-			scaleCache := scheduler.NewScaleCache(ctx, testNs)
+			scaleCache := scheduler.NewScaleCache(ctx, testNs, kubeclient.Get(ctx).AppsV1().StatefulSets(testNs), scheduler.ScaleCacheConfig{RefreshPeriod: time.Minute * 5})
 			sa := state.NewStateBuilder(ctx, testNs, sfsName, vpodClient.List, 10, tc.schedulerPolicyType, tc.schedulerPolicy, tc.deschedulerPolicy, lsp.GetPodLister().Pods(testNs), lsn.GetNodeLister(), scaleCache)
 			cfg := &Config{
 				StatefulSetNamespace: testNs,


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Helps to fix the consumergroup issues we are seeing in ekb. At least some of the slow reconciliation is due to errors such as: 
```
failed to schedule consumers: failed to unschedule consumer group: failed to schedule consumers: Get \"[https://10.88.0.1:443/apis/apps/v1/namespaces/knative-eventing/statefulsets/kafka-broker-dispatcher/scale](https://10.88.0.1/apis/apps/v1/namespaces/knative-eventing/statefulsets/kafka-broker-dispatcher/scale)\": context canceled
```

When we increased the client rate limit, these error logs were no longer present
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Cache the scale of statefulsets whenever we get/update them, reusing the cached value where possible
- Expire the keys in the cache to force refresh every once in a while
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
StatefulSet scheduling now makes fewer API server requests, reducing APIServer load.
```
