### PR TITLE
feat: replace yaml merge tags

### DIFF
--- a/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-filter.yaml
@@ -39,7 +39,7 @@ spec:
       - name: filter
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/broker/filter
-        readinessProbe: &probe
+        readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
@@ -49,7 +49,14 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         livenessProbe:
-          <<: *probe
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
           initialDelaySeconds: 5
         resources:
           requests:

--- a/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
+++ b/config/brokers/mt-channel-broker/deployments/broker-ingress.yaml
@@ -39,7 +39,7 @@ spec:
       - name: ingress
         terminationMessagePolicy: FallbackToLogsOnError
         image: ko://knative.dev/eventing/cmd/broker/ingress
-        readinessProbe: &probe
+        readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
@@ -49,7 +49,14 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         livenessProbe:
-          <<: *probe
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
           initialDelaySeconds: 5
         resources:
           requests:

--- a/config/channels/in-memory-channel/deployments/controller.yaml
+++ b/config/channels/in-memory-channel/deployments/controller.yaml
@@ -24,13 +24,14 @@ metadata:
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
-    matchLabels: &labels
+    matchLabels:
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: controller
   template:
     metadata:
       labels:
-        <<: *labels
+        messaging.knative.dev/channel: in-memory-channel
+        messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -40,7 +41,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
-                matchLabels: *labels
+                matchLabels:
+                  messaging.knative.dev/channel: in-memory-channel
+                  messaging.knative.dev/role: controller
               topologyKey: kubernetes.io/hostname
             weight: 100
       serviceAccountName: imc-controller
@@ -88,7 +91,7 @@ spec:
         - name: https-webhook
           containerPort: 8443
 
-        readinessProbe: &probe
+        readinessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -97,7 +100,13 @@ spec:
               - name: k-kubelet-probe
                 value: "webhook"
         livenessProbe:
-          <<: *probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+              - name: k-kubelet-probe
+                value: "webhook"
           initialDelaySeconds: 120
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently

--- a/config/channels/in-memory-channel/deployments/dispatcher.yaml
+++ b/config/channels/in-memory-channel/deployments/dispatcher.yaml
@@ -24,13 +24,14 @@ metadata:
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
-    matchLabels: &labels
+    matchLabels:
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: dispatcher
   template:
     metadata:
       labels:
-        <<: *labels
+        messaging.knative.dev/channel: in-memory-channel
+        messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -40,7 +41,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
-                matchLabels: *labels
+                matchLabels:
+                  messaging.knative.dev/channel: in-memory-channel
+                  messaging.knative.dev/role: dispatcher
               topologyKey: kubernetes.io/hostname
             weight: 100
       serviceAccountName: imc-dispatcher
@@ -48,7 +51,7 @@ spec:
       containers:
       - name: dispatcher
         image: ko://knative.dev/eventing/cmd/in_memory/channel_dispatcher
-        readinessProbe: &probe
+        readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
@@ -58,7 +61,14 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         livenessProbe:
-          <<: *probe
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
           initialDelaySeconds: 5
         env:
           - name: CONFIG_LOGGING_NAME

--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -49,7 +49,7 @@ rules:
     resources:
       - services
       - serviceaccounts
-    verbs: &everything
+    verbs:
       - get
       - list
       - watch
@@ -68,12 +68,26 @@ rules:
       - "rbac.authorization.k8s.io"
     resources:
       - rolebindings
-    verbs: *everything
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+
   - apiGroups:
       - apps
     resources:
       - deployments
-    verbs: *everything
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+
   - apiGroups:
       - apps
     resources:
@@ -101,7 +115,14 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
-    verbs: *everything
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+
 
   # For actually registering our webhook.
   - apiGroups:
@@ -109,7 +130,7 @@ rules:
     resources:
       - "mutatingwebhookconfigurations"
       - "validatingwebhookconfigurations"
-    verbs: &everything
+    verbs:
       - "get"
       - "list"
       - "create"

--- a/config/core/deployments/pingsource-mt-adapter.yaml
+++ b/config/core/deployments/pingsource-mt-adapter.yaml
@@ -25,13 +25,14 @@ spec:
   # when set to 0 (and only 0) will be set to 1 when the first PingSource is created.
   replicas: 0
   selector:
-    matchLabels: &labels
+    matchLabels:
       eventing.knative.dev/source: ping-source-controller
       sources.knative.dev/role: adapter
   template:
     metadata:
       labels:
-        <<: *labels
+        eventing.knative.dev/source: ping-source-controller
+        sources.knative.dev/role: adapter
         app.kubernetes.io/component: pingsource-mt-adapter
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -41,7 +42,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               labelSelector:
-                matchLabels: *labels
+                matchLabels:
+                  eventing.knative.dev/source: ping-source-controller
+                  sources.knative.dev/role: adapter
               topologyKey: kubernetes.io/hostname
             weight: 100
       enableServiceLinks: false

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -23,13 +23,14 @@ metadata:
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
-    matchLabels: &labels
+    matchLabels:
       app: eventing-webhook
       role: eventing-webhook
   template:
     metadata:
       labels:
-        <<: *labels
+        app: eventing-webhook
+        role: eventing-webhook
         app.kubernetes.io/component: eventing-webhook
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-eventing
@@ -110,7 +111,7 @@ spec:
         - name: profiling
           containerPort: 8008
 
-        readinessProbe: &probe
+        readinessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -119,7 +120,13 @@ spec:
             - name: k-kubelet-probe
               value: "webhook"
         livenessProbe:
-          <<: *probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+              - name: k-kubelet-probe
+                value: "webhook"
           initialDelaySeconds: 120
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently

--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -22,8 +22,7 @@ metadata:
 spec:
   group: eventing.knative.dev
   versions:
-  - &version
-    name: v1beta2
+  - name: v1beta2
     served: true
     storage: true
     subresources:
@@ -154,10 +153,138 @@ spec:
     - name: Reason
       type: string
       jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
     served: true
     storage: false
+    subresources:
+      status: { }
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'EventType represents a type of event that can be consumed from a resource.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the EventType.'
+            type: object
+            properties:
+              broker:
+                type: string
+              reference:
+                description: Reference a resource. For example, Broker.
+                type: object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is an optional field, it gets defaulted to the object holding it if left out.'
+                    type: string
+              description:
+                description: 'Description is an optional field used to describe the
+                    EventType, in any meaningful way.'
+                type: string
+              schema:
+                description: 'Schema is a URI, it represents the CloudEvents schemaurl
+                    extension attribute. It may be a JSON schema, a protobuf schema,
+                    etc. It is optional.'
+                type: string
+              schemaData:
+                description: 'SchemaData allows the CloudEvents schema to be stored
+                    directly in the EventType. Content is dependent on the encoding.
+                    Optional attribute. The contents are not validated or manipulated
+                    by the system.'
+                type: string
+              source:
+                description: 'Source is a URI, it represents the CloudEvents source.'
+                type: string
+              type:
+                description: 'Type represents the CloudEvents type. It is authoritative.'
+                type: string
+          status:
+            description: 'Status represents the current state of the EventType. This data
+                may be out of date.'
+            type: object
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                    to save some additional State as well as convey more information
+                    to the user. This is roughly akin to Annotations on any k8s resource,
+                    just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                    current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                    - type
+                    - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                          transitioned from one status to another. We use VolatileTime
+                          in place of metav1.Time to exclude this from creating
+                          equality.Semantic differences (all other things held
+                          constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details
+                          about the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of
+                          this type of condition. When this is not specified,
+                          it defaults to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False,
+                          Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                    that was last processed by the controller.'
+                type: integer
+                format: int64
+    additionalPrinterColumns:
+      - name: Type
+        type: string
+        jsonPath: ".spec.type"
+      - name: Source
+        type: string
+        jsonPath: ".spec.source"
+      - name: Schema
+        type: string
+        jsonPath: ".spec.schema"
+      - name: Reference Name
+        type: string
+        jsonPath: ".spec.reference.name"
+      - name: Reference Kind
+        type: string
+        jsonPath: ".spec.reference.kind"
+      - name: Description
+        type: string
+        jsonPath: ".spec.description"
+      - name: Ready
+        type: string
+        jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+      - name: Reason
+        type: string
+        jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+
     # This indicates the v1beta1 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true

--- a/config/core/resources/parallel.yaml
+++ b/config/core/resources/parallel.yaml
@@ -67,7 +67,7 @@ spec:
                           description: DeadLetterSink is the sink receiving
                               event that could not be sent to a destination.
                           type: object
-                          properties: &addressableProperties
+                          properties:
                             ref:
                               description: Ref points to an Addressable.
                               type: object
@@ -116,20 +116,125 @@ spec:
                       description: Filter is the expression guarding the branch
                       type: object
                       properties:
-                        <<: *addressableProperties
+                        ref:
+                          description: Ref points to an Addressable.
+                          type: object
+                          properties:
+                            apiVersion:
+                              description: API version of the
+                                referent.
+                              type: string
+                            kind:
+                              description: 'Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the
+                                  referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                  This is optional field, it
+                                  gets defaulted to the object
+                                  holding it if left out.'
+                              type: string
+                        uri:
+                          description: URI can be an absolute URL(non-empty
+                            scheme and non-empty host) pointing
+                            to the target or a relative URI. Relative
+                            URIs will be resolved using the base
+                            URI retrieved from Ref.
+                          type: string
+                        CACerts:
+                          description: Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                          type: string
+                        audience:
+                          description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                          type: string
                     reply:
                         description: Reply is a Reference to where the result
                             of Subscriber of this case gets sent to. If not specified,
                             sent the result to the Parallel Reply
                         type: object
                         properties:
-                          <<: *addressableProperties
+                          ref:
+                            description: Ref points to an Addressable.
+                            type: object
+                            properties:
+                              apiVersion:
+                                description: API version of the
+                                  referent.
+                                type: string
+                              kind:
+                                description: 'Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the
+                                    referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    This is optional field, it
+                                    gets defaulted to the object
+                                    holding it if left out.'
+                                type: string
+                          uri:
+                            description: URI can be an absolute URL(non-empty
+                              scheme and non-empty host) pointing
+                              to the target or a relative URI. Relative
+                              URIs will be resolved using the base
+                              URI retrieved from Ref.
+                            type: string
+                          CACerts:
+                            description: Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                            type: string
+                          audience:
+                            description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                            type: string
                     subscriber:
                         description: Subscriber receiving the event when the filter
                             passes
                         type: object
                         properties:
-                          <<: *addressableProperties
+                          ref:
+                            description: Ref points to an Addressable.
+                            type: object
+                            properties:
+                              apiVersion:
+                                description: API version of the
+                                  referent.
+                                type: string
+                              kind:
+                                description: 'Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the
+                                    referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    This is optional field, it
+                                    gets defaulted to the object
+                                    holding it if left out.'
+                                type: string
+                          uri:
+                            description: URI can be an absolute URL(non-empty
+                              scheme and non-empty host) pointing
+                              to the target or a relative URI. Relative
+                              URIs will be resolved using the base
+                              URI retrieved from Ref.
+                            type: string
+                          CACerts:
+                            description: Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                            type: string
+                          audience:
+                            description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                            type: string
               channelTemplate:
                 description: ChannelTemplate specifies which Channel CRD to use. If
                     left unspecified, it is set to the default Channel CRD for the
@@ -159,7 +264,42 @@ spec:
                     gets sent to when the case does not have a Reply
                 type: object
                 properties:
-                  <<: *addressableProperties
+                  ref:
+                    description: Ref points to an Addressable.
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the
+                          referent.
+                        type: string
+                      kind:
+                        description: 'Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the
+                            referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            This is optional field, it
+                            gets defaulted to the object
+                            holding it if left out.'
+                        type: string
+                  uri:
+                    description: URI can be an absolute URL(non-empty
+                      scheme and non-empty host) pointing
+                      to the target or a relative URI. Relative
+                      URIs will be resolved using the base
+                      URI retrieved from Ref.
+                    type: string
+                  CACerts:
+                    description: Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                    type: string
+                  audience:
+                    description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                    type: string
           status:
             description: Status represents the current state of the Parallel. This data
                 may be out of date.
@@ -216,12 +356,12 @@ spec:
                       description: FilterChannelStatus corresponds to the filter
                           channel status.
                       type: object
-                      properties: &channelProperties
+                      properties:
                         channel:
                           description: Channel is the reference to the underlying
                               channel.
                           type: object
-                          properties: &referentProperties
+                          properties:
                             apiVersion:
                               description: API version of the referent.
                               type: string
@@ -268,7 +408,7 @@ spec:
                               the Channel is ready or not.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
-                          properties: &readyConditionProperties
+                          properties:
                             message:
                               description: A human readable message
                                   indicating details about the transition.
@@ -300,13 +440,73 @@ spec:
                               the Subscription is ready or not.
                           type: object
                           properties:
-                            <<: *readyConditionProperties
+                            message:
+                              description: A human readable message
+                                indicating details about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's
+                                last transition.
+                              type: string
+                            severity:
+                              description: Severity with which to treat
+                                failures of this type of condition.
+                                When this is not specified, it defaults
+                                to Error.
+                              type: string
+                            status:
+                              description: Status of the condition,
+                                one of True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type of condition.
+                              type: string
                         subscription:
                           description: Subscription is the reference to
                               the underlying Subscription.
                           type: object
                           properties:
-                            <<: *referentProperties
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece
+                                  of an object instead of an entire
+                                  object, this string should contain
+                                  a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2].
+                                  For example, if the object reference
+                                  is to a container within a pod, this
+                                  would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of
+                                  the container that triggered the event)
+                                  or if no container name is specified
+                                  "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax
+                                  is chosen only to have some well-defined
+                                  way of referencing a part of an object.'
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More
+                                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More
+                                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion
+                                  to which this reference is made, if
+                                  any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More
+                                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
                     subscriberSubscriptionStatus:
                       description: SubscriptionStatus corresponds to the subscriber
                           subscription status.
@@ -317,13 +517,73 @@ spec:
                                 the Subscription is ready or not.
                             type: object
                             properties:
-                              <<: *readyConditionProperties
+                              message:
+                                description: A human readable message
+                                  indicating details about the transition.
+                                type: string
+                              reason:
+                                description: The reason for the condition's
+                                  last transition.
+                                type: string
+                              severity:
+                                description: Severity with which to treat
+                                  failures of this type of condition.
+                                  When this is not specified, it defaults
+                                  to Error.
+                                type: string
+                              status:
+                                description: Status of the condition,
+                                  one of True, False, Unknown.
+                                type: string
+                              type:
+                                description: Type of condition.
+                                type: string
                         subscription:
                             description: Subscription is the reference to
                                 the underlying Subscription.
                             type: object
                             properties:
-                              <<: *referentProperties
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece
+                                    of an object instead of an entire
+                                    object, this string should contain
+                                    a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2].
+                                    For example, if the object reference
+                                    is to a container within a pod, this
+                                    would take on a value like: "spec.containers{name}"
+                                    (where "name" refers to the name of
+                                    the container that triggered the event)
+                                    or if no container name is specified
+                                    "spec.containers[2]" (container with
+                                    index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined
+                                    way of referencing a part of an object.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More
+                                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More
+                                    info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion
+                                    to which this reference is made, if
+                                    any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More
+                                    info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
               conditions:
                 description: Conditions the latest available observations of a resource's
                     current state.
@@ -331,13 +591,105 @@ spec:
                 items:
                   type: object
                   properties:
-                    <<: *readyConditionProperties
+                    message:
+                      description: A human readable message
+                        indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's
+                        last transition.
+                      type: string
+                    severity:
+                      description: Severity with which to treat
+                        failures of this type of condition.
+                        When this is not specified, it defaults
+                        to Error.
+                      type: string
+                    status:
+                      description: Status of the condition,
+                        one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
               ingressChannelStatus:
                 description: IngressChannelStatus corresponds to the ingress channel
                     status.
                 type: object
                 properties:
-                  <<: *channelProperties
+                  channel:
+                    description: Channel is the reference to the underlying
+                      channel.
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece
+                            of an object instead of an entire
+                            object, this string should contain
+                            a valid JSON/Go field access statement,
+                            such as desiredState.manifest.containers[2].
+                            For example, if the object reference
+                            is to a container within a pod, this
+                            would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of
+                            the container that triggered the event)
+                            or if no container name is specified
+                            "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax
+                            is chosen only to have some well-defined
+                            way of referencing a part of an object.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More
+                            info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion
+                            to which this reference is made, if
+                            any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More
+                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                  ready:
+                    description: ReadyCondition indicates whether
+                      the Channel is ready or not.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      message:
+                        description: A human readable message
+                          indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's
+                          last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat
+                          failures of this type of condition.
+                          When this is not specified, it defaults
+                          to Error.
+                        type: string
+                      status:
+                        description: Status of the condition,
+                          one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
               observedGeneration:
                 description: ObservedGeneration is the 'Generation' of the Service
                     that was last processed by the controller.

--- a/config/core/resources/pingsource.yaml
+++ b/config/core/resources/pingsource.yaml
@@ -34,8 +34,7 @@ metadata:
 spec:
   group: sources.knative.dev
   versions:
-  - &version
-    name: v1
+  - name: v1
     served: true
     storage: true
     subresources:
@@ -216,10 +215,188 @@ spec:
     - name: Reason
       type: string
       jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
-  - <<: *version
-    name: v1beta2
+  - name: v1beta2
     served: true
     storage: false
+    subresources:
+      status: { }
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'PingSource describes an event source with a fixed payload produced on a specified cron schedule.'
+        properties:
+          spec:
+            type: object
+            description: 'PingSourceSpec defines the desired state of the PingSource (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                      output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or
+                              overridden on the outbound event. Each `Extensions` key-value
+                              pair are set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-kubernetes-preserve-unknown-fields: true
+              contentType:
+                description: 'ContentType is the media type of `data` or `dataBase64`. Default is empty.'
+                type: string
+              data:
+                description: 'Data is data used as the body of the event posted to the sink. Default is empty.
+                      Mutually exclusive with `dataBase64`.'
+                type: string
+              dataBase64:
+                description: "DataBase64 is the base64-encoded string of the actual event's body posted to the sink.
+                      Default is empty. Mutually exclusive with `data`."
+                type: string
+              schedule:
+                description: 'Schedule is the cron schedule. Defaults to `* * * * *`.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                      a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      This is optional field, it gets defaulted to the
+                                      object holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                              non-empty host) pointing to the target or a relative URI.
+                              Relative URIs will be resolved using the base URI retrieved
+                              from Ref.'
+                    type: string
+                  CACerts:
+                    description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                    type: string
+                  audience:
+                    description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                    type: string
+              timezone:
+                description: 'Timezone modifies the actual time relative to the specified
+                      timezone. Defaults to the system time zone. More general information
+                      about time zones: https://www.iana.org/time-zones List of valid
+                      timezone values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'
+                type: string
+          status:
+            type: object
+            description: 'PingSourceStatus defines the observed state of PingSource (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                        to save some additional State as well as convey more information
+                        to the user. This is roughly akin to Annotations on any k8s resource,
+                        just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              auth:
+                description: Auth provides the relevant information for OIDC authentication.
+                type: object
+                properties:
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the generated service account used for this components OIDC authentication.
+                    type: string
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                        the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                        current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                    - type
+                    - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                                    transitioned from one status to another. We use VolatileTime
+                                    in place of metav1.Time to exclude this from creating
+                                    equality.Semantic differences (all other things held
+                                    constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details
+                                    about the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of
+                                    this type of condition. When this is not specified,
+                                    it defaults to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False,
+                                    Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                        that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                        configured for the Source.'
+                type: string
+              sinkCACerts:
+                description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                type: string
+              sinkAudience:
+                description: sinkAudience is the OIDC audience of the sink.
+                type: string
+    additionalPrinterColumns:
+      - name: Sink
+        type: string
+        jsonPath: .status.sinkUri
+      - name: Schedule
+        type: string
+        jsonPath: .spec.schedule
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      - name: Ready
+        type: string
+        jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+      - name: Reason
+        type: string
+        jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+
     # This indicates the v1beta2 version of the custom resource is deprecated.
     # API requests to this version receive a warning header in the server response.
     deprecated: true

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -32,7 +32,7 @@ rules:
       - "serviceaccounts"
       - "pods"
       - "serviceaccounts/token"
-    verbs: &everything
+    verbs:
       - "get"
       - "list"
       - "create"
@@ -46,7 +46,14 @@ rules:
       - "apps"
     resources:
       - "deployments"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
   # PingSource controller manipulates Deployment owner reference
   - apiGroups:
@@ -62,7 +69,14 @@ rules:
     resources:
       - "rolebindings"
       - "roles"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
   # Our own resources and statuses we care about.
   - apiGroups:
@@ -74,7 +88,14 @@ rules:
       - "triggers/status"
       - "eventtypes"
       - "eventtypes/status"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
   # Eventing resources and finalizers we care about.
   - apiGroups:
@@ -97,7 +118,14 @@ rules:
       - "parallels/status"
       - "subscriptions"
       - "subscriptions/status"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
   # Flow resources and statuses we care about.
   - apiGroups:
@@ -107,7 +135,14 @@ rules:
       - "sequences/status"
       - "parallels"
       - "parallels/status"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
 
   # Messaging resources and finalizers we care about.
   - apiGroups:
@@ -143,4 +178,11 @@ rules:
       - "coordination.k8s.io"
     resources:
       - "leases"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/config/core/roles/sources-controller-clusterroles.yaml
+++ b/config/core/roles/sources-controller-clusterroles.yaml
@@ -26,7 +26,7 @@ rules:
       - "secrets"
       - "configmaps"
       - "services"
-    verbs: &everything
+    verbs:
       - "get"
       - "list"
       - "create"
@@ -40,7 +40,15 @@ rules:
       - "apps"
     resources:
       - "deployments"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # Source resources and statuses we care about.
   - apiGroups:
@@ -58,28 +66,60 @@ rules:
       - "containersources"
       - "containersources/status"
       - "containersources/finalizers"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # Knative Services admin
   - apiGroups:
       - serving.knative.dev
     resources:
       - services
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # EventTypes admin
   - apiGroups:
       - eventing.knative.dev
     resources:
       - eventtypes
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # Events admin
   - apiGroups:
       - ""
     resources:
       - events
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # Authorization checker
   - apiGroups:

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -75,7 +75,7 @@ rules:
     resources:
       - "mutatingwebhookconfigurations"
       - "validatingwebhookconfigurations"
-    verbs: &everything
+    verbs:
       - "get"
       - "list"
       - "create"
@@ -91,14 +91,30 @@ rules:
       - "sinkbindings"
       - "sinkbindings/status"
       - "sinkbindings/finalizers"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # For leader election
   - apiGroups:
       - "coordination.k8s.io"
     resources:
       - "leases"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # For creating events
   - apiGroups:
@@ -117,7 +133,15 @@ rules:
       - ""
     resources:
       - "serviceaccounts"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
   # For the SinkBinding reconciler creating the sinkbinding token secret
   - apiGroups:
       - ""
@@ -129,7 +153,15 @@ rules:
       - ""
     resources:
       - "secrets"
-    verbs: *everything
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+
 
   # Necessary for conversion webhook. These are copied from the serving
   # TODO: Do we really need all these permissions?


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

Merge keys are not officially supported in YAML according to its specifications. These keys are associated with an older version of YAML (1.1), which is now considered obsolete. Additionally, these merge keys haven't been updated or included in the current YAML version (1.2), so there's no guarantee that they will function as expected or be supported. In summary, using merge keys in YAML might not work reliably and is not recommended due to these limitations and lack of support in the latest YAML version.

I attempted to install the YAML mentioned using Kustomize, but the installation failed because Kustomize couldn't properly interpret or render the YAML file.

Similar merged proposal [PR for eventing-kafka-brokfer](https://github.com/knative-extensions/eventing-kafka-broker/pull/3654)

## Proposed Changes

- I suggest that we avoid utilizing merge tags to ensure compliance with YAML specifications, particularly in the latest versions like 1.2.x.

<!-- Please categorize your changes:
- :wastebasket: Remove feature or internal logic
-->



### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Merge keys, which were associated with an older version of YAML (1.1), are no longer officially supported in YAML according to its specifications. YAML version 1.2, the current standard, does not include support for merge keys, rendering them obsolete.
```
