### PR TITLE
Improve trust bundle propagation

### DIFF
--- a/pkg/reconciler/containersource/controller.go
+++ b/pkg/reconciler/containersource/controller.go
@@ -95,30 +95,27 @@ func NewController(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
-	trustBundleConfigMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		Handler: controller.HandleAll(func(i interface{}) {
+	trustBundleConfigMapInformer.Informer().AddEventHandler(controller.HandleAll(func(i interface{}) {
+		obj, err := kmeta.DeletionHandlingAccessor(i)
+		if err != nil {
+			return
+		}
+		if obj.GetNamespace() == system.Namespace() {
+			globalResync(i)
+			return
+		}
 
-			obj, err := kmeta.DeletionHandlingAccessor(i)
-			if err != nil {
-				return
-			}
-			if obj.GetNamespace() == system.Namespace() {
-				globalResync(i)
-				return
-			}
-
-			sources, err := containersourceInformer.Lister().ContainerSources(obj.GetNamespace()).List(labels.Everything())
-			if err != nil {
-				return
-			}
-			for _, src := range sources {
-				impl.EnqueueKey(types.NamespacedName{
-					Namespace: src.Namespace,
-					Name:      src.Name,
-				})
-			}
-		}),
-	})
+		sources, err := containersourceInformer.Lister().ContainerSources(obj.GetNamespace()).List(labels.Everything())
+		if err != nil {
+			return
+		}
+		for _, src := range sources {
+			impl.EnqueueKey(types.NamespacedName{
+				Namespace: src.Namespace,
+				Name:      src.Name,
+			})
+		}
+	}))
 
 	return impl
 }

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 
 	"knative.dev/eventing/pkg/auth"
@@ -54,8 +55,6 @@ import (
 
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/sources/v1"
-
-	eventingreconciler "knative.dev/eventing/pkg/reconciler"
 )
 
 const (
@@ -83,6 +82,7 @@ func NewController(
 	oidcServiceaccountInformer := serviceaccountinformer.Get(ctx, auth.OIDCLabelSelector)
 	secretInformer := secretinformer.Get(ctx)
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector)
+	trustBundleConfigMapLister := trustBundleConfigMapInformer.Lister()
 
 	var globalResync func()
 	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
@@ -139,11 +139,11 @@ func NewController(
 		secretLister:               secretInformer.Lister(),
 		featureStore:               featureStore,
 		tokenProvider:              auth.NewOIDCTokenProvider(ctx),
-		trustBundleConfigMapLister: trustBundleConfigMapInformer.Lister(),
+		trustBundleConfigMapLister: trustBundleConfigMapLister,
 	}
 
 	c.WithContext = func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapInformer.Lister()), nil
+		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapLister), nil
 	}
 	c.Tracker = impl.Tracker
 	c.Factory = &duck.CachedInformerFactory{
@@ -163,8 +163,27 @@ func NewController(
 	go periodicResync(ctx, globalResync)
 
 	trustBundleConfigMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: eventingreconciler.FilterWithNamespace(system.Namespace()),
-		Handler:    controller.HandleAll(func(i interface{}) { globalResync() }),
+		Handler: controller.HandleAll(func(i interface{}) {
+			obj, err := kmeta.DeletionHandlingAccessor(i)
+			if err != nil {
+				return
+			}
+			if obj.GetNamespace() == system.Namespace() {
+				globalResync()
+				return
+			}
+
+			sbs, err := sbInformer.Lister().SinkBindings(obj.GetNamespace()).List(labels.Everything())
+			if err != nil {
+				return
+			}
+			for _, sb := range sbs {
+				impl.EnqueueKey(types.NamespacedName{
+					Namespace: sb.Namespace,
+					Name:      sb.Name,
+				})
+			}
+		}),
 	})
 
 	return impl

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -162,29 +162,27 @@ func NewController(
 	// do a periodic reync of all sinkbindings to renew the token secrets eventually
 	go periodicResync(ctx, globalResync)
 
-	trustBundleConfigMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		Handler: controller.HandleAll(func(i interface{}) {
-			obj, err := kmeta.DeletionHandlingAccessor(i)
-			if err != nil {
-				return
-			}
-			if obj.GetNamespace() == system.Namespace() {
-				globalResync()
-				return
-			}
+	trustBundleConfigMapInformer.Informer().AddEventHandler(controller.HandleAll(func(i interface{}) {
+		obj, err := kmeta.DeletionHandlingAccessor(i)
+		if err != nil {
+			return
+		}
+		if obj.GetNamespace() == system.Namespace() {
+			globalResync()
+			return
+		}
 
-			sbs, err := sbInformer.Lister().SinkBindings(obj.GetNamespace()).List(labels.Everything())
-			if err != nil {
-				return
-			}
-			for _, sb := range sbs {
-				impl.EnqueueKey(types.NamespacedName{
-					Namespace: sb.Namespace,
-					Name:      sb.Name,
-				})
-			}
-		}),
-	})
+		sbs, err := sbInformer.Lister().SinkBindings(obj.GetNamespace()).List(labels.Everything())
+		if err != nil {
+			return
+		}
+		for _, sb := range sbs {
+			impl.EnqueueKey(types.NamespacedName{
+				Namespace: sb.Namespace,
+				Name:      sb.Name,
+			})
+		}
+	}))
 
 	return impl
 }


### PR DESCRIPTION
- Add suffix to user's namespace trust bundles
- Only delete trust bundles we're owners
- Improve queue logic to re-reconcile objects based on which trust bundle changes and in which namespace