### PR TITLE
Add graph types

### DIFF
--- a/pkg/graph/lineage.go
+++ b/pkg/graph/lineage.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
+)
+
+// computes the lineage from the given vertex with the given input eventtype
+func (v *Vertex) Lineage(et *eventingv1beta2.EventType, tfc TransformFunctionContext) *Vertex {
+	toExplore := v.OutEdges()
+	v.Visit()
+	res := v.NewWithSameRef()
+	for i := 0; i < len(toExplore); i++ {
+		e := toExplore[i]
+		if e.To().Visited() {
+			continue
+		}
+
+		// transform -> nil implies that the path can't be traversed with the current transform and/or context
+		if et, tfc := e.Transform(et, tfc); et != nil {
+			res.AddEdge(e.To().Lineage(et, tfc), e.Reference(), NoTransform)
+		}
+	}
+	// the narrowed eventtype and/or transform function context could be different from a different path, so we have to unvisit before exploring another path
+	v.Unvisit()
+	return res
+}

--- a/pkg/graph/lineage_test.go
+++ b/pkg/graph/lineage_test.go
@@ -27,28 +27,38 @@ import (
 
 func TestSingleVertexLineage(t *testing.T) {
 	a := &Vertex{
-		self: &duckv1.KReference{
-			Name: "A",
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name: "A",
+			},
 		},
 	}
 	b := &Vertex{
-		self: &duckv1.KReference{
-			Name: "B",
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name: "B",
+			},
 		},
 	}
 	c := &Vertex{
-		self: &duckv1.KReference{
-			Name: "C",
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name: "C",
+			},
 		},
 	}
 	d := &Vertex{
-		self: &duckv1.KReference{
-			Name: "D",
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name: "D",
+			},
 		},
 	}
 	e := &Vertex{
-		self: &duckv1.KReference{
-			Name: "E",
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name: "E",
+			},
 		},
 	}
 
@@ -81,25 +91,25 @@ func TestSingleVertexLineage(t *testing.T) {
 	e.AddEdge(c, nil, NoTransform)
 
 	lineageFromA := a.Lineage(MakeEmptyEventType(), TransformFunctionContext{})
-	assert.Equal(t, "A", lineageFromA.Reference().Name)
+	assert.Equal(t, "A", lineageFromA.Reference().Ref.Name)
 	assert.Equal(t, 1, lineageFromA.OutDegree())
 
 	lineageFromB := lineageFromA.OutEdges()[0].To()
-	assert.Equal(t, "B", lineageFromB.Reference().Name)
+	assert.Equal(t, "B", lineageFromB.Reference().Ref.Name)
 	assert.Equal(t, 2, lineageFromB.OutDegree())
 
 	// two paths, we don't make guarantees on the order the lineage algorithm traverses them so we need to figure out which is which
 	var lineageFromC *Vertex
 	var lineageFromD *Vertex
-	if lineageFromB.OutEdges()[0].To().Reference().Name == "C" {
+	if lineageFromB.OutEdges()[0].To().Reference().Ref.Name == "C" {
 		lineageFromC = lineageFromB.OutEdges()[0].To()
-	} else if lineageFromB.OutEdges()[1].To().Reference().Name == "C" {
+	} else if lineageFromB.OutEdges()[1].To().Reference().Ref.Name == "C" {
 		lineageFromC = lineageFromB.OutEdges()[1].To()
 	}
 
-	if lineageFromB.OutEdges()[0].To().Reference().Name == "D" {
+	if lineageFromB.OutEdges()[0].To().Reference().Ref.Name == "D" {
 		lineageFromD = lineageFromB.OutEdges()[0].To()
-	} else if lineageFromB.OutEdges()[1].To().Reference().Name == "D" {
+	} else if lineageFromB.OutEdges()[1].To().Reference().Ref.Name == "D" {
 		lineageFromD = lineageFromB.OutEdges()[1].To()
 	}
 
@@ -108,27 +118,27 @@ func TestSingleVertexLineage(t *testing.T) {
 
 	// assert that the path from C goes to E but not D, it should also have the loop back to C but not go further
 	assert.Equal(t, 1, lineageFromC.OutDegree())
-	assert.Equal(t, "E", lineageFromC.OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, "E", lineageFromC.OutEdges()[0].To().Reference().Ref.Name)
 	assert.Equal(t, 1, lineageFromC.OutEdges()[0].To().OutDegree())
-	assert.Equal(t, "C", lineageFromC.OutEdges()[0].To().OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, "C", lineageFromC.OutEdges()[0].To().OutEdges()[0].To().Reference().Ref.Name)
 	assert.Equal(t, 0, lineageFromC.OutEdges()[0].To().OutEdges()[0].To().OutDegree())
 
 	// assert that the path from D goes to E and then C
 	assert.Equal(t, 1, lineageFromD.OutDegree())
-	assert.Equal(t, "E", lineageFromD.OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, "E", lineageFromD.OutEdges()[0].To().Reference().Ref.Name)
 	assert.Equal(t, 1, lineageFromD.OutEdges()[0].To().OutDegree())
-	assert.Equal(t, "C", lineageFromD.OutEdges()[0].To().OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, "C", lineageFromD.OutEdges()[0].To().OutEdges()[0].To().Reference().Ref.Name)
 
 	// once back to C, we should have two cycles: one back to E, and one to D
 	lineageFromCFromD := lineageFromD.OutEdges()[0].To().OutEdges()[0].To()
 	assert.Equal(t, 2, lineageFromCFromD.OutDegree())
 	expectedVertices := []string{"E", "D"}
 	for _, edge := range lineageFromCFromD.OutEdges() {
-		assert.Contains(t, expectedVertices, edge.To().Reference().Name)
+		assert.Contains(t, expectedVertices, edge.To().Reference().Ref.Name)
 		assert.Equal(t, 0, edge.To().OutDegree())
 
 		// remove the vertex from the expected set, so that we know that both expected vertices are there
-		idx := slices.Index(expectedVertices, edge.To().Reference().Name)
+		idx := slices.Index(expectedVertices, edge.To().Reference().Ref.Name)
 		expectedVertices = slices.Delete(expectedVertices, idx, idx+1)
 	}
 }

--- a/pkg/graph/lineage_test.go
+++ b/pkg/graph/lineage_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	eventingv1beta3 "knative.dev/eventing/pkg/apis/eventing/v1beta3"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestSingleVertexLineage(t *testing.T) {
+	a := &Vertex{
+		self: &duckv1.KReference{
+			Name: "A",
+		},
+	}
+	b := &Vertex{
+		self: &duckv1.KReference{
+			Name: "B",
+		},
+	}
+	c := &Vertex{
+		self: &duckv1.KReference{
+			Name: "C",
+		},
+	}
+	d := &Vertex{
+		self: &duckv1.KReference{
+			Name: "D",
+		},
+	}
+	e := &Vertex{
+		self: &duckv1.KReference{
+			Name: "E",
+		},
+	}
+
+	a.AddEdge(b, nil, NoTransform)
+	b.AddEdge(c, nil, func(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext) {
+		if et.Spec.Type == "" {
+			et.Spec.Type = "example.type"
+		}
+
+		if et.Spec.Type != "example.type" {
+			return nil, tfc
+		}
+
+		return et, tfc
+	})
+	b.AddEdge(d, nil, NoTransform)
+	c.AddEdge(d, nil, func(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext) {
+		if et.Spec.Type == "" {
+			et.Spec.Type = "some.other.type"
+		}
+
+		if et.Spec.Type != "some.other.type" {
+			return nil, tfc
+		}
+
+		return et, tfc
+	})
+	c.AddEdge(e, nil, NoTransform)
+	d.AddEdge(e, nil, NoTransform)
+	e.AddEdge(c, nil, NoTransform)
+
+	lineageFromA := a.Lineage(MakeEmptyEventType(), TransformFunctionContext{})
+	assert.Equal(t, "A", lineageFromA.Reference().Name)
+	assert.Equal(t, 1, lineageFromA.OutDegree())
+
+	lineageFromB := lineageFromA.OutEdges()[0].To()
+	assert.Equal(t, "B", lineageFromB.Reference().Name)
+	assert.Equal(t, 2, lineageFromB.OutDegree())
+
+	// two paths, we don't make guarantees on the order the lineage algorithm traverses them so we need to figure out which is which
+	var lineageFromC *Vertex
+	var lineageFromD *Vertex
+	if lineageFromB.OutEdges()[0].To().Reference().Name == "C" {
+		lineageFromC = lineageFromB.OutEdges()[0].To()
+	} else if lineageFromB.OutEdges()[1].To().Reference().Name == "C" {
+		lineageFromC = lineageFromB.OutEdges()[1].To()
+	}
+
+	if lineageFromB.OutEdges()[0].To().Reference().Name == "D" {
+		lineageFromD = lineageFromB.OutEdges()[0].To()
+	} else if lineageFromB.OutEdges()[1].To().Reference().Name == "D" {
+		lineageFromD = lineageFromB.OutEdges()[1].To()
+	}
+
+	assert.NotNil(t, lineageFromC)
+	assert.NotNil(t, lineageFromD)
+
+	// assert that the path from C goes to E but not D, it should also have the loop back to C but not go further
+	assert.Equal(t, 1, lineageFromC.OutDegree())
+	assert.Equal(t, "E", lineageFromC.OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, 1, lineageFromC.OutEdges()[0].To().OutDegree())
+	assert.Equal(t, "C", lineageFromC.OutEdges()[0].To().OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, 0, lineageFromC.OutEdges()[0].To().OutEdges()[0].To().OutDegree())
+
+	// assert that the path from D goes to E and then C
+	assert.Equal(t, 1, lineageFromD.OutDegree())
+	assert.Equal(t, "E", lineageFromD.OutEdges()[0].To().Reference().Name)
+	assert.Equal(t, 1, lineageFromD.OutEdges()[0].To().OutDegree())
+	assert.Equal(t, "C", lineageFromD.OutEdges()[0].To().OutEdges()[0].To().Reference().Name)
+
+	// once back to C, we should have two cycles: one back to E, and one to D
+	lineageFromCFromD := lineageFromD.OutEdges()[0].To().OutEdges()[0].To()
+	assert.Equal(t, 2, lineageFromCFromD.OutDegree())
+	expectedVertices := []string{"E", "D"}
+	for _, edge := range lineageFromCFromD.OutEdges() {
+		assert.Contains(t, expectedVertices, edge.To().Reference().Name)
+		assert.Equal(t, 0, edge.To().OutDegree())
+
+		// remove the vertex from the expected set, so that we know that both expected vertices are there
+		idx := slices.Index(expectedVertices, edge.To().Reference().Name)
+		expectedVertices = slices.Delete(expectedVertices, idx, idx+1)
+	}
+}

--- a/pkg/graph/types.go
+++ b/pkg/graph/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package graph
 
 import (
-	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	eventingv1beta3 "knative.dev/eventing/pkg/apis/eventing/v1beta3"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -39,10 +39,12 @@ type Edge struct {
 	to        *Vertex
 }
 
-type TransformFunction func(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext)
+type TransformFunction func(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext)
 
 // TODO(cali0707): flesh this out more, know we need it, not sure what needs to be in it yet
-type TransformFunctionContext interface{}
+type TransformFunctionContext struct{}
+
+func (t TransformFunctionContext) DeepCopy() TransformFunctionContext { return t } // TODO(cali0707) implement this once we have fleshed out the transform function context struct
 
 func (g *Graph) Vertices() []*Vertex {
 	return g.vertices
@@ -97,7 +99,7 @@ func (v *Vertex) AddEdge(to *Vertex, edgeRef *duckv1.KReference, transform Trans
 
 }
 
-func (e *Edge) Transform(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext) {
+func (e *Edge) Transform(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext) {
 	if et == nil {
 		return nil, tfc
 	}
@@ -117,6 +119,6 @@ func (e *Edge) Reference() *duckv1.KReference {
 	return e.self
 }
 
-func NoTransform(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext) {
+func NoTransform(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext) {
 	return et, tfc
 }

--- a/pkg/graph/types.go
+++ b/pkg/graph/types.go
@@ -26,7 +26,7 @@ type Graph struct {
 }
 
 type Vertex struct {
-	self     *duckv1.KReference
+	self     *duckv1.Destination
 	inEdges  []*Edge
 	outEdges []*Edge
 	visited  bool
@@ -34,7 +34,7 @@ type Vertex struct {
 
 type Edge struct {
 	transform TransformFunction
-	self      *duckv1.KReference
+	self      *duckv1.Destination
 	from      *Vertex
 	to        *Vertex
 }
@@ -64,7 +64,7 @@ func (v *Vertex) OutDegree() int {
 	return len(v.outEdges)
 }
 
-func (v *Vertex) Reference() *duckv1.KReference {
+func (v *Vertex) Reference() *duckv1.Destination {
 	return v.self
 }
 
@@ -94,7 +94,7 @@ func (v *Vertex) NewWithSameRef() *Vertex {
 	}
 }
 
-func (v *Vertex) AddEdge(to *Vertex, edgeRef *duckv1.KReference, transform TransformFunction) {
+func (v *Vertex) AddEdge(to *Vertex, edgeRef *duckv1.Destination, transform TransformFunction) {
 	v.outEdges = append(v.outEdges, &Edge{from: v, to: to, transform: transform, self: edgeRef})
 
 }
@@ -115,7 +115,7 @@ func (e *Edge) To() *Vertex {
 	return e.to
 }
 
-func (e *Edge) Reference() *duckv1.KReference {
+func (e *Edge) Reference() *duckv1.Destination {
 	return e.self
 }
 

--- a/pkg/graph/types.go
+++ b/pkg/graph/types.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+type Graph struct {
+	vertices []*Vertex
+}
+
+type Vertex struct {
+	self     *duckv1.KReference
+	inEdges  []*Edge
+	outEdges []*Edge
+	visited  bool
+}
+
+type Edge struct {
+	transform TransformFunction
+	self      *duckv1.KReference
+	from      *Vertex
+	to        *Vertex
+}
+
+type TransformFunction func(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext)
+
+// TODO(cali0707): flesh this out more, know we need it, not sure what needs to be in it yet
+type TransformFunctionContext interface{}
+
+func (g *Graph) Vertices() []*Vertex {
+	return g.vertices
+}
+
+func (g *Graph) UnvisitAll() {
+	for _, v := range g.vertices {
+		v.visited = false
+	}
+}
+
+func (v *Vertex) InDegree() int {
+	return len(v.inEdges)
+}
+
+func (v *Vertex) OutDegree() int {
+	return len(v.outEdges)
+}
+
+func (v *Vertex) Reference() *duckv1.KReference {
+	return v.self
+}
+
+func (v *Vertex) InEdges() []*Edge {
+	return v.inEdges
+}
+
+func (v *Vertex) OutEdges() []*Edge {
+	return v.outEdges
+}
+
+func (v *Vertex) Visit() {
+	v.visited = true
+}
+
+func (v *Vertex) Unvisit() {
+	v.visited = false
+}
+
+func (v *Vertex) Visited() bool {
+	return v.visited
+}
+
+func (v *Vertex) NewWithSameRef() *Vertex {
+	return &Vertex{
+		self: v.self,
+	}
+}
+
+func (v *Vertex) AddEdge(to *Vertex, edgeRef *duckv1.KReference, transform TransformFunction) {
+	v.outEdges = append(v.outEdges, &Edge{from: v, to: to, transform: transform, self: edgeRef})
+
+}
+
+func (e *Edge) Transform(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext) {
+	if et == nil {
+		return nil, tfc
+	}
+
+	return e.transform(et, tfc)
+}
+
+func (e *Edge) From() *Vertex {
+	return e.from
+}
+
+func (e *Edge) To() *Vertex {
+	return e.to
+}
+
+func (e *Edge) Reference() *duckv1.KReference {
+	return e.self
+}
+
+func NoTransform(et *eventingv1beta2.EventType, tfc TransformFunctionContext) (*eventingv1beta2.EventType, TransformFunctionContext) {
+	return et, tfc
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7676 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add graph types
- Add method to calculate lineage from a single vertex (this helps validate the types, and is useful for figuring out the full lineage graph - which will be added in #7677 )
- Add unit tests for lineage from a single vertex on a graph which will test that transform functions are propagated properly, and cycles are handled properly

