### PR TITLE
Run Prow tests on K8s 1.28

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -31,6 +31,9 @@ if [ "$(uname)" == "Darwin" ]; then
   grep=ggrep
 fi
 
+# GKE cluster version
+readonly K8S_CLUSTER_VERSION=1.28
+
 # Eventing main config.
 readonly EVENTING_CONFIG="config/"
 

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize "$@"
+initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
 
 echo "Running Conformance tests for: Multi Tenant Channel Based Broker (v1), Channel (v1), InMemoryChannel (v1) , ApiServerSource (v1), ContainerSource (v1) and PingSource (v1beta2)"
 go_test_e2e -timeout=30m -parallel=12 ./test/conformance \

--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize "$@" --num-nodes=4
+initialize --cluster-version=${K8S_CLUSTER_VERSION} --num-nodes=4 "$@"
 
 export SKIP_UPLOAD_TEST_IMAGES="true"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize "$@"
+initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
 
 echo "Running E2E tests for: Multi Tenant Channel Based Broker, Channel (v1), InMemoryChannel (v1) , ApiServerSource (v1), ContainerSource (v1) and PingSource (v1beta2)"
 go_test_e2e -timeout=1h -parallel=20 ./test/e2e \

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -39,7 +39,7 @@ function uninstall_test_resources {
   true
 }
 
-initialize "$@"
+initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
 
 TIMEOUT=${TIMEOUT:-60m}
 


### PR DESCRIPTION
Currently GKE deploys by default a 1.27.x cluster. With Knative requiring min 1.28 as Kubernetes version (https://github.com/knative/eventing/blob/7d444176489a36e0cd1ac3685fe83f6772abc3e2/vendor/knative.dev/pkg/version/version.go#L36), we need to run our tests on >= 1.28.
This PR addresses it and sets the version for the GKE cluster to 1.28.

This should then fix #7712 too

Related to #7713