### PR TITLE
[WIP] Run Prow tests on K8s 1.29

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,7 +32,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 # GKE cluster version
-readonly K8S_CLUSTER_VERSION=1.28
+readonly K8S_CLUSTER_VERSION=1.29
 
 # Eventing main config.
 readonly EVENTING_CONFIG="config/"


### PR DESCRIPTION
After the bump to K8s 1.28 for prow #7714, I see tests failing more often due to some infrastructure issues (e.g. `the server rejected our request for an unknown reason`).
Therefor this PR bumps to 1.29.
