### PR TITLE
Eventing TLS: add tests for dynamically added CA trust bundles

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -214,13 +215,30 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			Value: ceOverrides,
 		})
 	}
-
-	pss, err := eventingtls.AddTrustBundleVolumes(GetTrustBundleConfigMapLister(ctx), sb, &ps.Spec.Template.Spec)
-	if err != nil {
-		logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes %s/%s: %+v", zap.Error(err))
-		return
+	gvk := schema.GroupVersionKind{
+		Group:   SchemeGroupVersion.Group,
+		Version: SchemeGroupVersion.Version,
+		Kind:    "SinkBinding",
 	}
-	ps.Spec.Template.Spec = *pss
+	bundles, err := eventingtls.PropagateTrustBundles(ctx, kubeclient.Get(ctx), GetTrustBundleConfigMapLister(ctx), gvk, sb)
+	if err != nil {
+		logging.FromContext(ctx).Errorw("Failed to propagate trust bundles", zap.Error(err))
+	}
+	if len(bundles) > 0 {
+		pss, err := eventingtls.AddTrustBundleVolumesFromConfigMaps(bundles, &ps.Spec.Template.Spec)
+		if err != nil {
+			logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes from configmaps %s/%s: %+v", zap.Error(err))
+			return
+		}
+		ps.Spec.Template.Spec = *pss
+	} else {
+		pss, err := eventingtls.AddTrustBundleVolumes(GetTrustBundleConfigMapLister(ctx), sb, &ps.Spec.Template.Spec)
+		if err != nil {
+			logging.FromContext(ctx).Errorw("Failed to add trust bundle volumes %s/%s: %+v", zap.Error(err))
+			return
+		}
+		ps.Spec.Template.Spec = *pss
+	}
 
 	if sb.Status.OIDCTokenSecretName != nil {
 		ps.Spec.Template.Spec.Volumes = append(ps.Spec.Template.Spec.Volumes, corev1.Volume{

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
+	kubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap/fake"
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/pkg/resolver"
@@ -926,6 +927,7 @@ func TestSinkBindingDo(t *testing.T) {
 			}
 			ctx = WithURIResolver(ctx, r)
 			ctx = WithTrustBundleConfigMapLister(ctx, configmapinformer.Get(ctx).Lister())
+			ctx = WithKubeClient(ctx, kubeclient.Get(ctx))
 
 			for _, cm := range test.configMaps {
 				_ = configmapinformer.Get(ctx).Informer().GetIndexer().Add(cm)

--- a/pkg/eventingtls/trust_bundle.go
+++ b/pkg/eventingtls/trust_bundle.go
@@ -66,16 +66,16 @@ var (
 
 // PropagateTrustBundles propagates Trust bundles ConfigMaps from the system.Namespace() to the
 // obj namespace.
-func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustBundleConfigMapLister corev1listers.ConfigMapLister, gvk schema.GroupVersionKind, obj kmeta.Accessor) error {
+func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustBundleConfigMapLister corev1listers.ConfigMapLister, gvk schema.GroupVersionKind, obj kmeta.Accessor) ([]*corev1.ConfigMap, error) {
 
 	systemNamespaceBundles, err := trustBundleConfigMapLister.ConfigMaps(system.Namespace()).List(TrustBundleSelector)
 	if err != nil {
-		return fmt.Errorf("failed to list trust bundle ConfigMaps in %q: %w", system.Namespace(), err)
+		return nil, fmt.Errorf("failed to list trust bundle ConfigMaps in %q: %w", system.Namespace(), err)
 	}
 
 	userNamespaceBundles, err := trustBundleConfigMapLister.ConfigMaps(obj.GetNamespace()).List(TrustBundleSelector)
 	if err != nil {
-		return fmt.Errorf("failed to list trust bundles ConfigMaps in %q: %w", obj.GetNamespace(), err)
+		return nil, fmt.Errorf("failed to list trust bundles ConfigMaps in %q: %w", obj.GetNamespace(), err)
 	}
 
 	logging.FromContext(ctx).Debugw("Existing bundles",
@@ -85,8 +85,10 @@ func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustB
 
 	var combinedBundle bytes.Buffer
 	if err := combineValidTrustBundles(systemNamespaceBundles, &combinedBundle); err != nil {
-		return err
+		return nil, err
 	}
+
+	outputUserNamespaceBundles := make([]*corev1.ConfigMap, 0, len(systemNamespaceBundles))
 
 	type Pair struct {
 		sysCM  *corev1.ConfigMap
@@ -153,7 +155,7 @@ func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustB
 				// Only delete the ConfigMap if the object owns it
 				if equality.Semantic.DeepDerivative(expectedOr, or) {
 					if err := deleteConfigMap(ctx, k8s, obj, p.userCm); err != nil {
-						return err
+						return nil, err
 					}
 				}
 			}
@@ -175,8 +177,9 @@ func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustB
 			// Update owner references
 			expected.OwnerReferences = withOwnerReferences(obj, gvk, []metav1.OwnerReference{})
 			if err := createConfigMap(ctx, k8s, expected); err != nil {
-				return err
+				return nil, err
 			}
+			outputUserNamespaceBundles = append(outputUserNamespaceBundles, expected)
 			continue
 		}
 
@@ -185,13 +188,17 @@ func PropagateTrustBundles(ctx context.Context, k8s kubernetes.Interface, trustB
 		// Update owner references
 		expected.OwnerReferences = withOwnerReferences(obj, gvk, p.userCm.OwnerReferences)
 
-		if !equality.Semantic.DeepDerivative(expected, p.userCm) {
+		if !equality.Semantic.DeepDerivative(expected.Data, p.userCm.Data) ||
+			!equality.Semantic.DeepDerivative(expected.BinaryData, p.userCm.BinaryData) ||
+			!equality.Semantic.DeepDerivative(expected.Labels, p.userCm.Labels) {
 			if err := updateConfigMap(ctx, k8s, expected); err != nil {
-				return err
+				return nil, err
 			}
 		}
+		outputUserNamespaceBundles = append(outputUserNamespaceBundles, expected)
 	}
-	return nil
+
+	return outputUserNamespaceBundles, nil
 }
 
 // CombinedBundlePresent will check if PropagateTrustBundles and AddTrustBundleVolumes will add the TrustBundleCombined
@@ -218,7 +225,10 @@ func AddTrustBundleVolumes(trustBundleLister corev1listers.ConfigMapLister, obj 
 	if err != nil {
 		return nil, fmt.Errorf("failed to list trust bundles ConfigMaps in %q: %w", obj.GetNamespace(), err)
 	}
+	return AddTrustBundleVolumesFromConfigMaps(cms, pt)
+}
 
+func AddTrustBundleVolumesFromConfigMaps(cms []*corev1.ConfigMap, pt *corev1.PodSpec) (*corev1.PodSpec, error) {
 	// Sort ConfigMaps by name to ensure consistent ordering
 	sort.SliceStable(cms, func(i, j int) bool {
 		return cms[i].Name < cms[j].Name

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -464,5 +464,6 @@ func (r *Reconciler) propagateTrustBundles(ctx context.Context, source *v1.ApiSe
 		Version: v1.SchemeGroupVersion.Version,
 		Kind:    "ApiServerSource",
 	}
-	return eventingtls.PropagateTrustBundles(ctx, r.kubeClientSet, r.trustBundleConfigMapLister, gvk, source)
+	_, err := eventingtls.PropagateTrustBundles(ctx, r.kubeClientSet, r.trustBundleConfigMapLister, gvk, source)
+	return err
 }

--- a/pkg/reconciler/sinkbinding/controller.go
+++ b/pkg/reconciler/sinkbinding/controller.go
@@ -150,8 +150,9 @@ func NewController(
 		trustBundleConfigMapLister: trustBundleConfigMapLister,
 	}
 
+	k8s := kubeclient.Get(ctx)
 	c.WithContext = func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapLister), nil
+		return v1.WithKubeClient(v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, sbResolver), trustBundleConfigMapLister), k8s), nil
 	}
 	c.Tracker = impl.Tracker
 	c.Factory = &duck.CachedInformerFactory{
@@ -225,9 +226,10 @@ func ListAll(ctx context.Context, handler cache.ResourceEventHandler) psbinding.
 
 func WithContextFactory(ctx context.Context, lister corev1listers.ConfigMapLister, handler func(types.NamespacedName)) psbinding.BindableContext {
 	r := resolver.NewURIResolverFromTracker(ctx, tracker.New(handler, controller.GetTrackerLease(ctx)))
+	k := kubeclient.Get(ctx)
 
 	return func(ctx context.Context, b psbinding.Bindable) (context.Context, error) {
-		return v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, r), lister), nil
+		return v1.WithKubeClient(v1.WithTrustBundleConfigMapLister(v1.WithURIResolver(ctx, r), lister), k), nil
 	}
 }
 

--- a/pkg/reconciler/sinkbinding/sinkbinding.go
+++ b/pkg/reconciler/sinkbinding/sinkbinding.go
@@ -240,5 +240,6 @@ func (s *SinkBindingSubResourcesReconciler) propagateTrustBundles(ctx context.Co
 		Version: v1.SchemeGroupVersion.Version,
 		Kind:    "SinkBinding",
 	}
-	return eventingtls.PropagateTrustBundles(ctx, s.kubeclient, s.trustBundleConfigMapLister, gvk, sb)
+	_, err := eventingtls.PropagateTrustBundles(ctx, s.kubeclient, s.trustBundleConfigMapLister, gvk, sb)
+	return err
 }

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -111,6 +111,7 @@ func TestApiServerSourceDataPlaneTLS(t *testing.T) {
 
 	env.ParallelTest(ctx, t, apiserversourcefeatures.SendsEventsWithTLS())
 	env.ParallelTest(ctx, t, apiserversourcefeatures.SendsEventsWithTLSTrustBundle())
+	env.ParallelTest(ctx, t, apiserversourcefeatures.SendsEventsWithTLSWithAdditionalTrustBundle())
 }
 
 func TestApiServerSourceDataPlane_EventModes(t *testing.T) {

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -105,7 +105,7 @@ func TestApiServerSourceDataPlaneTLS(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		//environment.Managed(t),
+		environment.Managed(t),
 		eventshub.WithTLS(t),
 	)
 

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -382,6 +382,7 @@ func TestInMemoryChannelTLS(t *testing.T) {
 
 	env.ParallelTest(ctx, t, channel.SubscriptionTLS())
 	env.ParallelTest(ctx, t, channel.SubscriptionTLSTrustBundle())
+	env.ParallelTest(ctx, t, channel.SubscriptionTLSWithAdditionalTrustBundle())
 }
 
 func TestChannelImplDispatcherAuthenticatesWithOIDC(t *testing.T) {

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
@@ -34,6 +35,7 @@ import (
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/test/rekt/resources/addressable"
 	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/configmap"
 	"knative.dev/eventing/test/rekt/resources/eventtype"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 
@@ -108,6 +110,48 @@ func SendsEventsTLSTrustBundle() *feature.Feature {
 		eventshub.IssuerRef(eventingtlstesting.IssuerKind, eventingtlstesting.IssuerName),
 		eventshub.StartReceiverTLS,
 	))
+
+	f.Requirement("install pingsource", func(ctx context.Context, t feature.T) {
+		d := &duckv1.Destination{
+			URI: &apis.URL{
+				Scheme: "https", // Force using https
+				Host:   network.GetServiceHostname(sink, environment.FromContext(ctx).Namespace()),
+			},
+			CACerts: nil, // CA certs are in the trust-bundle
+		}
+
+		pingsource.Install(src, pingsource.WithSink(d))(ctx, t)
+	})
+	f.Requirement("pingsource goes ready", pingsource.IsReady(src))
+
+	f.Stable("pingsource as event source").
+		Must("delivers events", assert.OnStore(sink).
+			Match(eventassert.MatchKind(eventshub.EventReceived)).
+			MatchEvent(test.HasType("dev.knative.sources.ping")).
+			AtLeast(1)).
+		Must("Set sinkURI to HTTPS endpoint", source.ExpectHTTPSSink(pingsource.Gvr(), src))
+
+	return f
+}
+
+func SendsEventsTLSWithAdditionalTrustBundle() *feature.Feature {
+	src := feature.MakeRandomK8sName("pingsource")
+	sink := feature.MakeRandomK8sName("sink")
+	trustBundle := feature.MakeRandomK8sName("trust-bundle")
+
+	f := feature.NewFeature()
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
+	f.Setup("install sink", eventshub.Install(sink, eventshub.StartReceiverTLS))
+
+	f.Setup("Add trust bundle to system namespace", func(ctx context.Context, t feature.T) {
+
+		configmap.Install(trustBundle, knative.KnativeNamespaceFromContext(ctx),
+			configmap.WithLabels(map[string]string{"networking.knative.dev/trust-bundle": "true"}),
+			configmap.WithData("ca.crt", *eventshub.GetCaCerts(ctx)),
+		)(ctx, t)
+	})
 
 	f.Requirement("install pingsource", func(ctx context.Context, t feature.T) {
 		d := &duckv1.Destination{

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
@@ -37,6 +38,7 @@ import (
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/configmap"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 )
@@ -272,6 +274,81 @@ func TriggerWithTLSSubscriberTrustBundle() *feature.Feature {
 	f.Assert("Trigger delivers events to TLS dead letter sink", assert.OnStore(dlsName).
 		MatchEvent(test.HasId(eventToSend.ID())).
 		Match(assert.MatchKind(eventshub.EventReceived)).
+		AtLeast(1))
+
+	return f
+}
+
+func TriggerWithTLSSubscriberWithAdditionalCATrustBundles() *feature.Feature {
+	f := feature.NewFeatureNamed("Trigger with TLS subscriber and additional trust bundle")
+
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	sourceName := feature.MakeRandomK8sName("source")
+	sinkName := feature.MakeRandomK8sName("sink")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	dlsName := feature.MakeRandomK8sName("dls")
+	dlsTriggerName := feature.MakeRandomK8sName("dls-trigger")
+	trustBundle := feature.MakeRandomK8sName("trust-bundle")
+
+	eventToSend := test.FullEvent()
+
+	// Install Broker
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+	f.Setup("Broker is addressable", broker.IsAddressable(brokerName))
+
+	// Install Sink
+	f.Setup("Install Sink", eventshub.Install(sinkName, eventshub.StartReceiverTLS))
+	f.Setup("Install dead letter sink service", eventshub.Install(dlsName, eventshub.StartReceiverTLS))
+
+	f.Setup("Add trust bundle to system namespace", func(ctx context.Context, t feature.T) {
+
+		configmap.Install(trustBundle, knative.KnativeNamespaceFromContext(ctx),
+			configmap.WithLabels(map[string]string{"networking.knative.dev/trust-bundle": "true"}),
+			configmap.WithData("ca.crt", *eventshub.GetCaCerts(ctx)),
+		)(ctx, t)
+	})
+
+	// Install Trigger
+	f.Setup("Install trigger", func(ctx context.Context, t feature.T) {
+		subscriber := &duckv1.Destination{
+			URI: &apis.URL{
+				Scheme: "https", // Force using https
+				Host:   network.GetServiceHostname(sinkName, environment.FromContext(ctx).Namespace()),
+			},
+			CACerts: nil, // CA certs are in the new trust-bundle
+		}
+
+		trigger.Install(triggerName, brokerName,
+			trigger.WithSubscriberFromDestination(subscriber))(ctx, t)
+	})
+	f.Setup("Wait for Trigger to become ready", trigger.IsReady(triggerName))
+
+	f.Setup("Install failing trigger", func(ctx context.Context, t feature.T) {
+		dls := service.AsDestinationRef(dlsName)
+
+		linear := eventingv1.BackoffPolicyLinear
+		trigger.Install(dlsTriggerName, brokerName,
+			trigger.WithRetry(10, &linear, pointer.String("PT1S")),
+			trigger.WithDeadLetterSinkFromDestination(dls),
+			trigger.WithSubscriber(nil, "http://127.0.0.1:2468"))(ctx, t)
+	})
+	f.Setup("Wait for failing Trigger to become ready", trigger.IsReady(dlsTriggerName))
+
+	// Install Source
+	f.Requirement("Install Source", eventshub.Install(
+		sourceName,
+		eventshub.StartSenderToResource(broker.GVR(), brokerName),
+		eventshub.InputEvent(eventToSend),
+	))
+
+	f.Assert("Trigger delivers events to TLS subscriber", assert.OnStore(sinkName).
+		MatchReceivedEvent(test.HasId(eventToSend.ID())).
+		AtLeast(1))
+	f.Assert("Trigger delivers events to TLS dead letter sink", assert.OnStore(dlsName).
+		MatchReceivedEvent(test.HasId(eventToSend.ID())).
 		AtLeast(1))
 
 	return f

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -321,7 +321,7 @@ func TriggerWithTLSSubscriberWithAdditionalCATrustBundles() *feature.Feature {
 			CACerts: nil, // CA certs are in the new trust-bundle
 		}
 
-		trigger.Install(triggerName, brokerName,
+		trigger.Install(triggerName, trigger.WithBrokerName(brokerName),
 			trigger.WithSubscriberFromDestination(subscriber))(ctx, t)
 	})
 	f.Setup("Wait for Trigger to become ready", trigger.IsReady(triggerName))
@@ -335,8 +335,8 @@ func TriggerWithTLSSubscriberWithAdditionalCATrustBundles() *feature.Feature {
 			CACerts: nil, // CA certs are in the new trust-bundle
 		}
 
-		linear := eventingv1.BackoffPolicyLinear
-		trigger.Install(dlsTriggerName, brokerName,
+		linear := eventingduckv1.BackoffPolicyLinear
+		trigger.Install(dlsTriggerName, trigger.WithBrokerName(brokerName),
 			trigger.WithRetry(2, &linear, pointer.String("PT1S")),
 			trigger.WithDeadLetterSinkFromDestination(dls),
 			trigger.WithSubscriber(nil, "http://127.0.0.1:2468"))(ctx, t)

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -337,7 +337,7 @@ func TriggerWithTLSSubscriberWithAdditionalCATrustBundles() *feature.Feature {
 
 		linear := eventingv1.BackoffPolicyLinear
 		trigger.Install(dlsTriggerName, brokerName,
-			trigger.WithRetry(10, &linear, pointer.String("PT1S")),
+			trigger.WithRetry(2, &linear, pointer.String("PT1S")),
 			trigger.WithDeadLetterSinkFromDestination(dls),
 			trigger.WithSubscriber(nil, "http://127.0.0.1:2468"))(ctx, t)
 	})

--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -327,7 +327,13 @@ func TriggerWithTLSSubscriberWithAdditionalCATrustBundles() *feature.Feature {
 	f.Setup("Wait for Trigger to become ready", trigger.IsReady(triggerName))
 
 	f.Setup("Install failing trigger", func(ctx context.Context, t feature.T) {
-		dls := service.AsDestinationRef(dlsName)
+		dls := &duckv1.Destination{
+			URI: &apis.URL{
+				Scheme: "https", // Force using https
+				Host:   network.GetServiceHostname(dlsName, environment.FromContext(ctx).Namespace()),
+			},
+			CACerts: nil, // CA certs are in the new trust-bundle
+		}
 
 		linear := eventingv1.BackoffPolicyLinear
 		trigger.Install(dlsTriggerName, brokerName,

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -61,6 +61,7 @@ func TestPingSourceTLS(t *testing.T) {
 
 	env.ParallelTest(ctx, t, pingsource.SendsEventsTLS())
 	env.ParallelTest(ctx, t, pingsource.SendsEventsTLSTrustBundle())
+	env.ParallelTest(ctx, t, pingsource.SendsEventsTLSWithAdditionalTrustBundle())
 }
 
 func TestPingSourceWithSinkURI(t *testing.T) {

--- a/test/rekt/trigger_test.go
+++ b/test/rekt/trigger_test.go
@@ -107,4 +107,5 @@ func TestTriggerTLSSubscriber(t *testing.T) {
 
 	env.ParallelTest(ctx, t, trigger.TriggerWithTLSSubscriber())
 	env.ParallelTest(ctx, t, trigger.TriggerWithTLSSubscriberTrustBundle())
+	env.ParallelTest(ctx, t, trigger.TriggerWithTLSSubscriberWithAdditionalCATrustBundles())
 }


### PR DESCRIPTION
This adds new tests for testing when CA trust bundles are dynamically added to the clients trust stores