### PR TITLE
feat: brokers can be added to event lineage graph

### DIFF
--- a/pkg/graph/constructor.go
+++ b/pkg/graph/constructor.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func (g *Graph) AddBroker(broker eventingv1.Broker) {
+	ref := &duckv1.KReference{
+		Name:       broker.Name,
+		Namespace:  broker.Namespace,
+		APIVersion: "eventing.knative.dev/v1",
+		Kind:       "Broker",
+	}
+	dest := &duckv1.Destination{Ref: ref}
+
+	// check if this vertex already exists
+	v, ok := g.vertices[makeComparableDestination(dest)]
+	if !ok {
+		v = &Vertex{
+			self: dest,
+		}
+		g.vertices[makeComparableDestination(dest)] = v
+	}
+
+	if broker.Spec.Delivery == nil || broker.Spec.Delivery.DeadLetterSink == nil {
+		// no DLS, we are done
+		return
+	}
+
+	// broker has a DLS, we need to add an edge to that
+	to, ok := g.vertices[makeComparableDestination(broker.Spec.Delivery.DeadLetterSink)]
+	if !ok {
+		to = &Vertex{
+			self: broker.Spec.Delivery.DeadLetterSink,
+		}
+		g.vertices[makeComparableDestination(broker.Spec.Delivery.DeadLetterSink)] = to
+	}
+
+	v.AddEdge(to, dest, NoTransform)
+}

--- a/pkg/graph/constructor_test.go
+++ b/pkg/graph/constructor_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package graph
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"

--- a/pkg/graph/constructor_test.go
+++ b/pkg/graph/constructor_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package graph
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+var (
+	sampleUri, _ = apis.ParseURL("https://knative.dev")
+)
+
+func TestAddBroker(t *testing.T) {
+	brokerWithEdge := &Vertex{
+		self: &duckv1.Destination{
+			Ref: &duckv1.KReference{
+				Name:       "my-broker",
+				Namespace:  "default",
+				APIVersion: "eventing.knative.dev/v1",
+				Kind:       "Broker",
+			},
+		},
+	}
+	destinationWithEdge := &Vertex{
+		self: &duckv1.Destination{
+			URI: sampleUri,
+		},
+	}
+	brokerWithEdge.AddEdge(destinationWithEdge, &duckv1.Destination{
+		Ref: &duckv1.KReference{
+			Name:       "my-broker",
+			Namespace:  "default",
+			APIVersion: "eventing.knative.dev/v1",
+			Kind:       "Broker",
+		},
+	}, NoTransform)
+	tests := []struct {
+		name     string
+		broker   eventingv1.Broker
+		expected map[comparableDestination]*Vertex
+	}{
+		{
+			name: "no DLS",
+			broker: eventingv1.Broker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-broker",
+					Namespace: "default",
+				},
+			},
+			expected: map[comparableDestination]*Vertex{
+				{
+					Ref: duckv1.KReference{
+						Name:       "my-broker",
+						Namespace:  "default",
+						APIVersion: "eventing.knative.dev/v1",
+						Kind:       "Broker",
+					},
+				}: {
+					self: &duckv1.Destination{
+						Ref: &duckv1.KReference{
+							Name:       "my-broker",
+							Namespace:  "default",
+							APIVersion: "eventing.knative.dev/v1",
+							Kind:       "Broker",
+						},
+					},
+				},
+			},
+		}, {
+			name: "DLS",
+			broker: eventingv1.Broker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-broker",
+					Namespace: "default",
+				},
+				Spec: eventingv1.BrokerSpec{
+					Delivery: &eventingduckv1.DeliverySpec{
+						DeadLetterSink: &duckv1.Destination{
+							URI: sampleUri,
+						},
+					},
+				},
+			},
+			expected: map[comparableDestination]*Vertex{
+				{
+					Ref: duckv1.KReference{
+						Name:       "my-broker",
+						Namespace:  "default",
+						APIVersion: "eventing.knative.dev/v1",
+						Kind:       "Broker",
+					},
+				}: brokerWithEdge,
+				{
+					URI: *sampleUri,
+				}: destinationWithEdge,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGraph()
+			g.AddBroker(test.broker)
+			assert.Len(t, g.vertices, len(test.expected))
+			for k, expected := range test.expected {
+				actual, ok := g.vertices[k]
+				assert.True(t, ok)
+				// assert.Equal can't do equality on function values, which edges have, so we need to do a more complicated check
+				assert.Equal(t, actual.self, expected.self)
+				assert.Len(t, actual.inEdges, len(expected.inEdges))
+				assert.Subset(t, makeComparableEdges(actual.inEdges), makeComparableEdges(expected.inEdges))
+				assert.Len(t, actual.outEdges, len(expected.outEdges))
+				assert.Subset(t, makeComparableEdges(actual.outEdges), makeComparableEdges(expected.outEdges))
+			}
+		})
+	}
+}
+
+func makeComparableEdges(edges []*Edge) []comparableEdge {
+	res := make([]comparableEdge, len(edges))
+
+	for _, e := range edges {
+		res = append(res, comparableEdge{
+			self: makeComparableDestination(e.self),
+			to:   makeComparableDestination(e.to.self),
+			from: makeComparableDestination(e.from.self),
+		})
+	}
+
+	return res
+}
+
+type comparableEdge struct {
+	self comparableDestination
+	to   comparableDestination
+	from comparableDestination
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7681 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Create graph method to add a broker to the graph
- Add some comparable types and conversion functions to use in testing, as edges aren't comparable
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Brokers are now supported in the event lineage graph
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

