### PR TITLE
Revert "Run Prow tests on K8s 1.28 (#7714)"

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -31,9 +31,6 @@ if [ "$(uname)" == "Darwin" ]; then
   grep=ggrep
 fi
 
-# GKE cluster version
-readonly K8S_CLUSTER_VERSION=1.28
-
 # Eventing main config.
 readonly EVENTING_CONFIG="config/"
 

--- a/test/e2e-conformance-tests.sh
+++ b/test/e2e-conformance-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
+initialize "$@"
 
 echo "Running Conformance tests for: Multi Tenant Channel Based Broker (v1), Channel (v1), InMemoryChannel (v1) , ApiServerSource (v1), ContainerSource (v1) and PingSource (v1beta2)"
 go_test_e2e -timeout=30m -parallel=12 ./test/conformance \

--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize --cluster-version=${K8S_CLUSTER_VERSION} --num-nodes=4 "$@"
+initialize "$@" --num-nodes=4
 
 export SKIP_UPLOAD_TEST_IMAGES="true"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,7 @@ source "$(dirname "$0")/e2e-common.sh"
 
 # Script entry point.
 
-initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
+initialize "$@"
 
 echo "Running E2E tests for: Multi Tenant Channel Based Broker, Channel (v1), InMemoryChannel (v1) , ApiServerSource (v1), ContainerSource (v1) and PingSource (v1beta2)"
 go_test_e2e -timeout=1h -parallel=20 ./test/e2e \

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -39,7 +39,7 @@ function uninstall_test_resources {
   true
 }
 
-initialize --cluster-version=${K8S_CLUSTER_VERSION} "$@"
+initialize "$@"
 
 TIMEOUT=${TIMEOUT:-60m}
 


### PR DESCRIPTION
This reverts commit fcadaaa335b161e443759af36cded525de5e03dc.

As we have https://github.com/knative/hack/pull/370 and default the GKE version for all repos, we don't need to define it explicitly in eventing anymore.