### PR TITLE
feat: add initial pathfinding algorithm

### DIFF
--- a/pkg/graph/lineage.go
+++ b/pkg/graph/lineage.go
@@ -20,6 +20,16 @@ import (
 	eventingv1beta3 "knative.dev/eventing/pkg/apis/eventing/v1beta3"
 )
 
+func (g *Graph) Lineage() []*Vertex {
+	sources := g.Sources()
+	lineagePaths := make(Vertices, len(sources))
+	for _, s := range sources {
+		lineagePaths = append(lineagePaths, s.Lineage(EmptyEventType(), TransformFunctionContext{}))
+	}
+
+	return lineagePaths
+}
+
 // computes the lineage from the given vertex with the given input eventtype
 func (v *Vertex) Lineage(et *eventingv1beta3.EventType, tfc TransformFunctionContext) *Vertex {
 	toExplore := v.OutEdges()
@@ -42,6 +52,6 @@ func (v *Vertex) Lineage(et *eventingv1beta3.EventType, tfc TransformFunctionCon
 	return res
 }
 
-func MakeEmptyEventType() *eventingv1beta3.EventType {
+func EmptyEventType() *eventingv1beta3.EventType {
 	return &eventingv1beta3.EventType{}
 }

--- a/pkg/graph/lineage_test.go
+++ b/pkg/graph/lineage_test.go
@@ -90,7 +90,7 @@ func TestSingleVertexLineage(t *testing.T) {
 	d.AddEdge(e, nil, NoTransform)
 	e.AddEdge(c, nil, NoTransform)
 
-	lineageFromA := a.Lineage(MakeEmptyEventType(), TransformFunctionContext{})
+	lineageFromA := a.Lineage(EmptyEventType(), TransformFunctionContext{})
 	assert.Equal(t, "A", lineageFromA.Reference().Ref.Name)
 	assert.Equal(t, 1, lineageFromA.OutDegree())
 

--- a/pkg/graph/types.go
+++ b/pkg/graph/types.go
@@ -33,6 +33,8 @@ type Vertex struct {
 	visited  bool
 }
 
+type Vertices []*Vertex
+
 type Edge struct {
 	transform TransformFunction
 	self      *duckv1.Destination
@@ -64,7 +66,7 @@ func NewGraph() *Graph {
 	}
 }
 
-func (g *Graph) Vertices() []*Vertex {
+func (g *Graph) Vertices() Vertices {
 	vertices := make([]*Vertex, len(g.vertices))
 	for _, v := range g.vertices {
 		vertices = append(vertices, v)
@@ -76,6 +78,19 @@ func (g *Graph) UnvisitAll() {
 	for _, v := range g.vertices {
 		v.visited = false
 	}
+}
+
+// Sources returns all of the sources vertices in a graph
+// A source vertex is defined as a graph with an in degree of 0 and an out degree >= 1
+// This means that there are only outward edges from the vertex, and no inward edges
+func (g *Graph) Sources() Vertices {
+	sources := Vertices{}
+	for _, v := range g.vertices {
+		if v.InDegree() == 0 && v.OutDegree() >= 1 {
+			sources = append(sources, v)
+		}
+	}
+	return sources
 }
 
 func (v *Vertex) InDegree() int {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7677 

Originally, I had planned to de-duplicate paths in the lineage graph on the backend, but I realized we may want to use some of the duplicated info when displaying on the frontend. As such, this PR adds an implementation that will find every possible path in the graph starting at the source vertices, but it won't de-duplicate repeated paths between two or more source vertices

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add method to find all source vertices in a graph
- Calculate lineage from each source vertex

