### PR TITLE
Replace all usages of deprecated wait.PollImmediate with wait.PollUntilContextTimeout

### DIFF
--- a/pkg/adapter/mtping/runner_test.go
+++ b/pkg/adapter/mtping/runner_test.go
@@ -389,7 +389,7 @@ func TestStartStopCronDelayWait(t *testing.T) {
 }
 
 func validateSent(t *testing.T, events []cloudevents.Event, wantData []byte, wantContentType string, extensions map[string]string) {
-	err := wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		return len(events) == 1, nil
 	})
 	if err != nil {

--- a/pkg/adapter/v2/main.go
+++ b/pkg/adapter/v2/main.go
@@ -359,7 +359,7 @@ func flush(logger *zap.SugaredLogger) {
 //
 // The context is expected to be initialized with injection and namespace.
 func GetConfigMapByPolling(ctx context.Context, name string) (cm *corev1.ConfigMap, err error) {
-	err = wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		cm, err = kubeclient.Get(ctx).
 			CoreV1().ConfigMaps(NamespaceFromContext(ctx)).
 			Get(ctx, name, metav1.GetOptions{})

--- a/pkg/scheduler/state/helpers.go
+++ b/pkg/scheduler/state/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package state
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"strings"
@@ -54,7 +55,7 @@ func SatisfyZoneAvailability(feasiblePods []int32, states *State) bool {
 	var zoneName string
 	var err error
 	for _, podID := range feasiblePods {
-		wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			zoneName, _, err = states.GetPodInfo(PodNameFromOrdinal(states.StatefulSetName, podID))
 			return err == nil, nil
 		})
@@ -68,7 +69,7 @@ func SatisfyNodeAvailability(feasiblePods []int32, states *State) bool {
 	var nodeName string
 	var err error
 	for _, podID := range feasiblePods {
-		wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, nodeName, err = states.GetPodInfo(PodNameFromOrdinal(states.StatefulSetName, podID))
 			return err == nil, nil
 		})

--- a/pkg/scheduler/state/state.go
+++ b/pkg/scheduler/state/state.go
@@ -236,7 +236,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 
 	for podId := int32(0); podId < scale.Spec.Replicas && s.podLister != nil; podId++ {
 		var pod *v1.Pod
-		wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+		wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 			pod, err = s.podLister.Get(PodNameFromOrdinal(s.statefulSetName, podId))
 			return err == nil, nil
 		})
@@ -291,7 +291,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 			withPlacement[vpod.GetKey()][podName] = true
 
 			var pod *v1.Pod
-			wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+			wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 				pod, err = s.podLister.Get(podName)
 				return err == nil, nil
 			})
@@ -316,7 +316,7 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
 				}
 
 				var pod *v1.Pod
-				wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+				wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 					pod, err = s.podLister.Get(podName)
 					return err == nil, nil
 				})

--- a/pkg/scheduler/statefulset/autoscaler.go
+++ b/pkg/scheduler/statefulset/autoscaler.go
@@ -323,7 +323,7 @@ func (a *autoscaler) compact(s *st.State, scaleUpFactor int32) error {
 				ordinal := st.OrdinalFromPodName(placements[i].PodName)
 
 				if ordinal == s.LastOrdinal-j {
-					wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
+					wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 						if s.PodLister != nil {
 							pod, err = s.PodLister.Get(placements[i].PodName)
 						}

--- a/pkg/scheduler/statefulset/scheduler_test.go
+++ b/pkg/scheduler/statefulset/scheduler_test.go
@@ -813,7 +813,7 @@ func TestStatefulsetScheduler(t *testing.T) {
 			s := newStatefulSetScheduler(ctx, cfg, sa, nil, lsp.GetPodLister().Pods(testNs))
 
 			// Give some time for the informer to notify the scheduler and set the number of replicas
-			err = wait.PollImmediate(200*time.Millisecond, time.Second, func() (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, time.Second, true, func(ctx context.Context) (bool, error) {
 				s.lock.Lock()
 				defer s.lock.Unlock()
 				return s.replicas == tc.replicas, nil

--- a/test/lib/await.go
+++ b/test/lib/await.go
@@ -16,6 +16,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +64,7 @@ func AwaitForAll(log *zap.SugaredLogger) error {
 
 // WaitForReadiness will wait until readiness endpoint reports OK
 func WaitForReadiness(port int, log *zap.SugaredLogger) error {
-	return wait.PollImmediate(10*time.Millisecond, 5*time.Minute, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/healthz", port))
 		if err != nil {
 			log.Debugf("Error while connecting: %v", err)

--- a/test/lib/duck/resource_checks.go
+++ b/test/lib/duck/resource_checks.go
@@ -20,6 +20,7 @@ limitations under the License.
 package duck
 
 import (
+	"context"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,14 +43,14 @@ const (
 // every interval until isResourceReady returns `true` indicating
 // it is done, returns an error or timeout.
 func WaitForResourceReady(dynamicClient dynamic.Interface, obj *resources.MetaResource) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		return checkResourceReady(dynamicClient, obj)
 	})
 }
 
 // WaitForResourcesReady waits until all the specified resources in the given namespace are ready.
 func WaitForResourcesReady(dynamicClient dynamic.Interface, objList *resources.MetaResourceList) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		return checkResourcesReady(dynamicClient, objList)
 
 	})

--- a/test/lib/duck/serving_checks.go
+++ b/test/lib/duck/serving_checks.go
@@ -50,7 +50,7 @@ func WaitForKServiceScales(ctx context.Context, client resources.ServingClient, 
 
 func waitForKServiceDeploymentName(client resources.ServingClient, name, namespace string) (string, error) {
 	var deploymentName string
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 		dn, found, err := resources.KServiceDeploymentName(client, name, namespace)
 		if found {
 			deploymentName = dn

--- a/test/lib/recordevents/event_info_store.go
+++ b/test/lib/recordevents/event_info_store.go
@@ -222,7 +222,7 @@ func (ei *EventInfoStore) waitAtLeastNMatch(f EventInfoMatcher, min int) ([]Even
 	var matchRet []EventInfo
 	var internalErr error
 
-	wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), retryInterval, retryTimeout, true, func(ctx context.Context) (bool, error) {
 		allMatch, sInfo, matchErrs, err := ei.Find(f)
 		if err != nil {
 			internalErr = fmt.Errorf("FAIL MATCHING: unexpected error during find: %v", err)

--- a/test/lib/test_runner.go
+++ b/test/lib/test_runner.go
@@ -353,7 +353,7 @@ func SetupPullSecret(t *testing.T, client *Client) {
 
 // waitForServiceAccountExists waits until the ServiceAccount exists.
 func waitForServiceAccountExists(client *Client, name, namespace string) error {
-	return wait.PollImmediate(1*time.Second, 2*time.Minute, func() (bool, error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		sas := client.Kube.CoreV1().ServiceAccounts(namespace)
 		if _, err := sas.Get(context.Background(), name, metav1.GetOptions{}); err == nil {
 			return true, nil

--- a/test/lib/tracker.go
+++ b/test/lib/tracker.go
@@ -137,7 +137,7 @@ func (t *Tracker) Clean(awaitDeletion bool) error {
 			logf("Failed to clean the resource %q : %v", deleter.Name, err)
 		} else if awaitDeletion {
 			logf("Waiting for %s to be deleted", deleter.Name)
-			if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 				if _, err := deleter.Resource.Get(context.Background(), deleter.Name, metav1.GetOptions{}); err != nil {
 					return true, nil
 				}

--- a/test/rekt/features/broker/control_plane.go
+++ b/test/rekt/features/broker/control_plane.go
@@ -384,7 +384,7 @@ func addControlPlaneDelivery(fs *feature.FeatureSet, brokerOpts ...manifest.CfgF
 
 		f.Requirement("wait until done", func(ctx context.Context, t feature.T) {
 			interval, timeout := environment.PollTimingsFromContext(ctx)
-			err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 				gtg := true
 				for prefix, want := range expectedEvents {
 					events := prober.ReceivedOrRejectedBy(ctx, prefix)
@@ -530,7 +530,7 @@ func addControlPlaneEventRouting(fs *feature.FeatureSet, brokerOpts ...manifest.
 
 		f.Requirement("wait until done", func(ctx context.Context, t feature.T) {
 			interval, timeout := environment.PollTimingsFromContext(ctx)
-			err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 				gtg := true
 				for prefix, want := range expectedEvents {
 					events := prober.ReceivedOrRejectedBy(ctx, prefix)

--- a/test/rekt/features/channel/control_plane.go
+++ b/test/rekt/features/channel/control_plane.go
@@ -167,7 +167,7 @@ func channelAllowsSubscribersAndStatus(subscriptionURI string) feature.StepFn {
 		var channelable *duckv1.Channelable
 		interval, timeout := environment.PollTimingsFromContext(ctx)
 		var want *duckv1.SubscriberSpec
-		err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 			channelable = getChannelable(ctx, t)
 			if channelable == nil {
 				t.Fatalf("channelable is nil")
@@ -234,7 +234,7 @@ func readyChannelIsAddressable(ctx context.Context, t feature.T) {
 
 	// Poll for a ready channel.
 	interval, timeout := environment.PollTimingsFromContext(ctx)
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		ch = getChannelable(ctx, t)
 		if c := ch.Status.GetCondition(apis.ConditionReady); c.IsTrue() {
 			return true, nil

--- a/test/rekt/features/channel/data_plane.go
+++ b/test/rekt/features/channel/data_plane.go
@@ -270,7 +270,7 @@ func addControlPlaneDelivery(fs *feature.FeatureSet) {
 
 		f.Requirement("wait until done", func(ctx context.Context, t feature.T) {
 			interval, timeout := environment.PollTimingsFromContext(ctx)
-			err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+			err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 				gtg := true
 				for prefix, want := range expected {
 					events := prober.ReceivedOrRejectedBy(ctx, prefix)

--- a/test/rekt/features/knconf/control_plane.go
+++ b/test/rekt/features/knconf/control_plane.go
@@ -64,7 +64,7 @@ func KResourceHasObservedGeneration(gvr schema.GroupVersionResource, name string
 		var err error
 
 		interval, timeout := environment.PollTimingsFromContext(ctx)
-		err = wait.PollImmediate(interval, timeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 			kr, err = get()
 			if err != nil {
 				// break out if not a "not found" error.
@@ -106,7 +106,7 @@ func KResourceHasReadyInConditions(gvr schema.GroupVersionResource, name string)
 		var err error
 
 		interval, timeout := environment.PollTimingsFromContext(ctx)
-		err = wait.PollImmediate(interval, timeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 			kr, err = get()
 			if err != nil {
 				// break out if not a "not found" error.

--- a/test/rekt/resources/addressable/addressable.go
+++ b/test/rekt/resources/addressable/addressable.go
@@ -35,7 +35,7 @@ type ValidateAddressFn func(addressable *duckv1.Addressable) error
 func Address(ctx context.Context, gvr schema.GroupVersionResource, name string, timings ...time.Duration) (*duckv1.Addressable, error) {
 	interval, timeout := k8s.PollTimings(ctx, timings)
 	var addr *duckv1.Addressable
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		var err error
 		addr, err = k8s.Address(ctx, gvr, name)
 		if err == nil && addr == nil {

--- a/test/rekt/resources/broker/broker.go
+++ b/test/rekt/resources/broker/broker.go
@@ -195,7 +195,7 @@ func WaitForCondition(name string, condition Condition, timing ...time.Duration)
 		interval, timeout := k8s.PollTimings(ctx, timing)
 		var lastErr error
 		var lastBroker *eventingv1.Broker
-		err := wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (done bool, err error) {
 			br, err := eventingclient.Get(ctx).
 				EventingV1().
 				Brokers(env.Namespace()).

--- a/test/rekt/resources/eventtype/eventtype.go
+++ b/test/rekt/resources/eventtype/eventtype.go
@@ -59,7 +59,7 @@ func WaitForEventType(eventtypes ...EventType) feature.StepFn {
 		for _, et := range eventtypes[1:] {
 			eventType = eventType.And(et)
 		}
-		err := wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (done bool, err error) {
 			etl, err := eventingclient.Get(ctx).
 				EventingV1beta2().
 				EventTypes(env.Namespace()).

--- a/test/upgrade/prober/sender.go
+++ b/test/upgrade/prober/sender.go
@@ -16,6 +16,7 @@
 package prober
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -107,7 +108,7 @@ func (p *prober) removeSender() {
 	p.ensureNoError(err)
 
 	var d *appsv1.Deployment
-	pollErr := wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+	pollErr := wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		// Save err and deployment for error reporting.
 		d, err = p.client.Kube.AppsV1().
 			Deployments(p.client.Namespace).

--- a/test/upgrade/prober/verify.go
+++ b/test/upgrade/prober/verify.go
@@ -62,7 +62,7 @@ func (p *prober) Verify() (eventErrs []error, eventsSent int) {
 	}
 	p.log.Info("Waiting for complete report from receiver...")
 	start := time.Now()
-	if err := wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), jobWaitInterval, jobWaitTimeout, true, func(ctx context.Context) (bool, error) {
 		var err error
 		report, err = p.fetchReport()
 		if err != nil {
@@ -326,7 +326,7 @@ func waitForJobToComplete(ctx context.Context, client kubernetes.Interface, jobN
 	span := logging.GetEmitableSpan(ctx, fmt.Sprint("waitForJobToComplete/", jobName))
 	defer span.End()
 
-	return wait.PollImmediate(jobWaitInterval, jobWaitTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, jobWaitInterval, jobWaitTimeout, true, func(ctx context.Context) (bool, error) {
 		j, err := jobs.Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return true, err

--- a/test/upgrade/prober/wathola/receiver/services_test.go
+++ b/test/upgrade/prober/wathola/receiver/services_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 }
 
 func waitUntilFinished(r *receiver) error {
-	return wait.PollImmediate(5*time.Millisecond, 30*time.Second, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		state := r.finished.State()
 		return state != event.Active, nil
 	})

--- a/test/upgrade/prober/wathola/sender/services_test.go
+++ b/test/upgrade/prober/wathola/sender/services_test.go
@@ -140,7 +140,7 @@ func TestUnsupportedEventSender(t *testing.T) {
 }
 
 func waitForPort(t *testing.T, port int) {
-	if err := wait.PollImmediate(time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		conn, conErr := net.Dial("tcp", fmt.Sprintf(":%d", port))
 		defer func() {
 			if conn != nil {


### PR DESCRIPTION
…ilContextTimeout

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7730

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
NONE
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

