### PR TITLE
fix: install script picks up on platform architecture by default

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -20,11 +20,10 @@ set -e
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
 
 export SCALE_CHAOSDUCK_TO_ZERO=1
 export REPLICAS=1
-export KO_FLAGS=${KO_FLAGS:-"--platform="""} # Default to current OS and arch
+export KO_FLAGS=${KO_FLAGS:-"--platform=\"linux/$(uname -m)\""}
 
 source "$(dirname "$0")/../test/e2e-common.sh"
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7820

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Automatically detect platform in install script
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec


