### PR TITLE
Remove eventing-kafka from downstream tests as it's deprecated

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -34,8 +34,6 @@ jobs:
             org: knative-extensions
           - repo: eventing-gitlab
             org: knative-extensions
-          - repo: eventing-kafka
-            org: knative-extensions
           - repo: eventing-kafka-broker
             org: knative-extensions
           - repo: eventing-rabbitmq


### PR DESCRIPTION
Note: this is not eventing-kafka-broker