### PR TITLE
fix: evictor checks if pod is nil before evicting

### DIFF
--- a/pkg/scheduler/statefulset/autoscaler.go
+++ b/pkg/scheduler/statefulset/autoscaler.go
@@ -332,11 +332,11 @@ func (a *autoscaler) compact(s *st.State, scaleUpFactor int32) error {
 					})
 
 					if err != nil {
-						return err
+						return fmt.Errorf("failed to get pod %q to evict resources: %w", placements[i].PodName, err)
 					}
 
 					if pod == nil {
-						return fmt.Errorf("no pod found to evict")
+						return fmt.Errorf("pod %q not found to evict resources", placements[i].PodName)
 					}
 
 					err = a.evictor(pod, vpod, &placements[i])


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes bug where the kafka controller panics when trying to call the evictor. The logs look like:
```
E0406 06:11:46.692883       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 125 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f099e0?, 0x398e990})
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc005248c10?})
	/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x1f099e0?, 0x398e990?})
	/usr/lib/golang/src/runtime/panic.go:914 +0x21f
knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup.(*evictor).evict(0xc0004bd400, 0x0, {0x25f9c38?, 0xc00087dc00?}, 0xc000b5fd40)
	/go/src/github.com/openshift/origin/control-plane/pkg/reconciler/consumergroup/evictor.go:68 +0x17e
knative.dev/eventing/pkg/scheduler/statefulset.(*autoscaler).compact(0xc00073f4a0, 0xc002be1a40, 0x1)
	/go/src/github.com/openshift/origin/vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go:333 +0x229
knative.dev/eventing/pkg/scheduler/statefulset.(*autoscaler).mayCompact(0xc00073f4a0, 0xc002be1a40, 0x1)
```

The relevant line here is:
```
knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup.(*evictor).evict(0xc0004bd400, 0x0, {0x25f9c38?, 0xc00087dc00?}, 0xc000b5fd40)
```

The signature for evict is `func (e *evictor) evict(pod *corev1.Pod, vpod scheduler.VPod, from *eventingduckv1alpha1.Placement)`. From this, and knowing that go internally handles methods on structs as `func (e *evictor, pod *corev1.Pod, vpod scheduler.VPod, from *eventingduckv1alpha1.Placement)`, it's clear that the issue is in the pod value being nil.

There is only one place where the evictor function is actually called, and only one place in that function where the pod value is written, so with the added error/nil checks in this PR we can be confident that the problem is resolved.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Check for errors/nil when getting the pod in the statefulset autoscaler evictor before evicting