### PR TITLE
Remove sinkbindings OIDC token secret when not needed and fix status setting

### DIFF
--- a/pkg/reconciler/sinkbinding/sinkbinding.go
+++ b/pkg/reconciler/sinkbinding/sinkbinding.go
@@ -168,6 +168,8 @@ func (s *SinkBindingSubResourcesReconciler) reconcileOIDCTokenSecret(ctx context
 		logger.Debugf("OIDC token secret for %s/%s sinkbinding still valid for > %s (expires %s). Will not update secret", sb.Name, sb.Namespace, resyncAndBufferDuration, expiry)
 		// token is still valid for resync period + buffer --> we're fine
 
+		sb.Status.OIDCTokenSecretName = &secretName
+
 		return nil
 	}
 

--- a/pkg/reconciler/sinkbinding/sinkbinding.go
+++ b/pkg/reconciler/sinkbinding/sinkbinding.go
@@ -114,6 +114,10 @@ func (s *SinkBindingSubResourcesReconciler) Reconcile(ctx context.Context, b psb
 			// sink has no audience set -> don't create token secret
 			sb.Status.MarkOIDCIdentityCreatedSucceededWithReason("Sink has no audience defined", "")
 			sb.Status.MarkOIDCTokenSecretCreatedSuccceededWithReason("Sink has no audience defined", "")
+
+			if err := s.removeOIDCTokenSecretEventually(ctx, sb); err != nil {
+				return err
+			}
 			sb.Status.OIDCTokenSecretName = nil
 		}
 	} else {


### PR DESCRIPTION
## Proposed Changes

- :bug: Remove sinkbindings OIDC token secret when not needed
- :bug: Set Sinkbindings .status.oidcTokenSecretName always (prevent empty oidcTokenSecretName field in case we had a reconcile issue before)