### PR TITLE
fix: remove duplicate configMaps

### DIFF
--- a/config/channels/in-memory-channel/configmaps/observability.yaml
+++ b/config/channels/in-memory-channel/configmaps/observability.yaml
@@ -1,1 +1,0 @@
-../../../core/configmaps/observability.yaml

--- a/config/channels/in-memory-channel/configmaps/tracing.yaml
+++ b/config/channels/in-memory-channel/configmaps/tracing.yaml
@@ -1,1 +1,0 @@
-../../../core/configmaps/tracing.yaml


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes https://github.com/knative/eventing/issues/7809

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: remove redundant `config-observability` and `config-tracing` config maps for `in-memory-channel`.

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

No


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

No documentation changes required I think.

