### PR TITLE
fix: imc dispatcher doesn't have duplicate reporting of metrics

### DIFF
--- a/pkg/channel/fanout/fanout_event_handler.go
+++ b/pkg/channel/fanout/fanout_event_handler.go
@@ -247,14 +247,14 @@ func createEventReceiverFunction(f *FanoutEventHandler) func(context.Context, ch
 				h.Set(apis.KnNamespaceHeader, ref.Namespace)
 				// Any returned error is already logged in f.dispatch().
 				dispatchResultForFanout := f.dispatch(ctx, subs, e, h)
-				_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
+
 				// If there are both http and https subscribers, we need to report the metrics for both of the type
 				if hasHttpSubs {
-					reportArgs.EventScheme = "http"
+					args.EventScheme = "http"
 					_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
 				}
 				if hasHttpsSubs {
-					reportArgs.EventScheme = "https"
+					args.EventScheme = "https"
 					_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
 				}
 			}(evnt, additionalHeaders, parentSpan, &f.reporter, &reportArgs)
@@ -278,9 +278,9 @@ func createEventReceiverFunction(f *FanoutEventHandler) func(context.Context, ch
 
 		additionalHeaders.Set(apis.KnNamespaceHeader, ref.Namespace)
 		dispatchResultForFanout := f.dispatch(ctx, subs, event, additionalHeaders)
-		err := ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
 		// If there are both http and https subscribers, we need to report the metrics for both of the type
 		// In this case we report http metrics because above we checked first for https and reported it so the left over metric to report is for http
+		var err error
 		if hasHttpSubs {
 			reportArgs.EventScheme = "http"
 			err = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7869

We were always recording the metrics once, and then if there was http or https we were recording the metric a second time. This fixes that to only do the recording of metrics once with the scheme set.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove the extra call to record the metrics


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
:bug: The IMC dispatcher metrics now correctly record the metrics once per event when there is only one request scheme, instead of twice
```
