### PR TITLE
EventType tests verify the type under spec.reference 

### DIFF
--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -217,7 +217,8 @@ func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
 			cetest.HasType(sourcesv1.PingSourceEventType)).AtLeast(1)).
 		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedCeTypes),
-			eventtype.AssertPresent(expectedCeTypes)))
+			eventtype.AssertPresent(expectedCeTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -136,7 +136,9 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
-			eventtype.AssertExactPresent(expectedTypes)))
+			eventtype.AssertExactPresent(expectedTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))),
+	)
 
 	return f
 }

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -138,7 +138,7 @@ func AutoCreateEventTypesOnBroker(brokerName string) *feature.Feature {
 			eventtype.AssertReady(expectedTypes),
 			eventtype.AssertExactPresent(expectedTypes),
 			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))),
-	)
+		)
 
 	return f
 }

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -318,7 +318,8 @@ func SendsEventsWithEventTypes() *feature.Feature {
 		Must("ApiServerSource test eventtypes match",
 			eventtype.WaitForEventType(
 				eventtype.AssertReady(expectedCeTypes),
-				eventtype.AssertPresent(expectedCeTypes)))
+				eventtype.AssertPresent(expectedCeTypes),
+				eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -318,7 +318,7 @@ func SendsEventsWithEventTypes() *feature.Feature {
 		Must("ApiServerSource test eventtypes match",
 			eventtype.WaitForEventType(
 				eventtype.AssertReady(expectedCeTypes),
-				eventtype.AssertPresent(expectedCeTypes),
+				eventtype.AssertPresent(expectedCeTypes)))
 
 	return f
 }

--- a/test/rekt/features/apiserversource/data_plane.go
+++ b/test/rekt/features/apiserversource/data_plane.go
@@ -319,7 +319,6 @@ func SendsEventsWithEventTypes() *feature.Feature {
 			eventtype.WaitForEventType(
 				eventtype.AssertReady(expectedCeTypes),
 				eventtype.AssertPresent(expectedCeTypes),
-				eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }

--- a/test/rekt/features/pingsource/features.go
+++ b/test/rekt/features/pingsource/features.go
@@ -227,7 +227,8 @@ func SendsEventsWithEventTypes() *feature.Feature {
 			test.HasType("dev.knative.sources.ping")).AtLeast(1)).
 		Must("PingSource test eventtypes match", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedCeTypes),
-			eventtype.AssertPresent(expectedCeTypes)))
+			eventtype.AssertPresent(expectedCeTypes),
+			eventtype.AssertReferencePresent(broker.AsKReference(brokerName))))
 
 	return f
 }


### PR DESCRIPTION
Fixes #7629 

## Proposed Changes

Add check for EventType Reference in tests
