### PR TITLE
Assert EventTypes references for IMC test

### DIFF
--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -102,17 +102,3 @@ func TestPingSourceEventTypeMatch(t *testing.T) {
 
 	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypeEventsFromPingSource())
 }
-
-func TestContainerSourceEventTypeAutoCreate(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	env.Test(ctx, t, eventtype_autocreate.AutoCreateEventTypesOnContainerSource())
-}

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -245,7 +245,7 @@ func AutoCreateEventTypesOnContainerSource() *feature.Feature {
 	expectedTypes := sets.New(event.Type())
 
 	f.Stable("containersource").
-		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
+		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasType(event.Type())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
 			eventtype.AssertExactPresent(expectedTypes),

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -227,8 +227,7 @@ func AutoCreateEventTypeEventsFromPingSource() *feature.Feature {
 func AutoCreateEventTypesOnContainerSource() *feature.Feature {
 	f := feature.NewFeature()
 
-	event := cetest.FullEvent()
-	event.SetType("test.containersource.custom.event.type")
+	csEventType := "dev.knative.eventing.samples.heartbeat"
 
 	sourceName := feature.MakeRandomK8sName("containersource")
 	sink := feature.MakeRandomK8sName("sink")
@@ -242,10 +241,10 @@ func AutoCreateEventTypesOnContainerSource() *feature.Feature {
 
 	f.Setup("containersource is ready", containersource.IsReady(sourceName))
 
-	expectedTypes := sets.New(event.Type())
+	expectedTypes := sets.New(csEventType)
 
 	f.Stable("containersource").
-		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasType(event.Type())).AtLeast(1)).
+		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasType(csEventType)).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
 			eventtype.AssertExactPresent(expectedTypes),

--- a/test/experimental/features/eventtype_autocreate/features.go
+++ b/test/experimental/features/eventtype_autocreate/features.go
@@ -68,7 +68,8 @@ func AutoCreateEventTypesOnIMC() *feature.Feature {
 		Must("deliver events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
-			eventtype.AssertPresent(expectedTypes)))
+			eventtype.AssertPresent(expectedTypes),
+			eventtype.AssertReferencePresent(channel_impl.AsRef(channelName))))
 
 	return f
 }
@@ -247,7 +248,8 @@ func AutoCreateEventTypesOnContainerSource() *feature.Feature {
 		Must("delivers events to subscriber", assert.OnStore(sink).MatchEvent(cetest.HasId(event.ID())).AtLeast(1)).
 		Must("create event type", eventtype.WaitForEventType(
 			eventtype.AssertReady(expectedTypes),
-			eventtype.AssertExactPresent(expectedTypes)))
+			eventtype.AssertExactPresent(expectedTypes),
+			eventtype.AssertReferencePresent(service.AsKReference(sink))))
 
 	return f
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This is a follow-up to https://github.com/knative/eventing/pull/7888
All of the tests should be asserting the eventtype's reference.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Assert eventtype reference for InMemoryChannel
- Remove TestContainerSourceEventTypeAutoCreate as automatic EventType creation for ContainerSource is not supported

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

