### PR TITLE
Add e2e test to verify used sender identity is correct

### DIFF
--- a/test/rekt/features/channel/oidc_feature.go
+++ b/test/rekt/features/channel/oidc_feature.go
@@ -18,6 +18,7 @@ package channel
 
 import (
 	"context"
+
 	"github.com/cloudevents/sdk-go/v2/test"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"

--- a/test/rekt/features/pingsource/oidc_feature.go
+++ b/test/rekt/features/pingsource/oidc_feature.go
@@ -18,6 +18,7 @@ package pingsource
 
 import (
 	"context"
+
 	"github.com/cloudevents/sdk-go/v2/test"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/pingsource"

--- a/test/rekt/features/pingsource/oidc_feature.go
+++ b/test/rekt/features/pingsource/oidc_feature.go
@@ -18,7 +18,6 @@ package pingsource
 
 import (
 	"context"
-
 	"github.com/cloudevents/sdk-go/v2/test"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/pingsource"
@@ -54,7 +53,10 @@ func PingSourceSendEventOIDC() *feature.Feature {
 
 	f.Stable("pingsource as event source").
 		Must("delivers events",
-			assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.sources.ping")).AtLeast(1))
+			assert.OnStore(sink).MatchEvent(test.HasType("dev.knative.sources.ping")).AtLeast(1)).
+		Must("uses pingsources identity for OIDC", assert.OnStore(sink).MatchWithContext(
+			assert.MatchKind(eventshub.EventReceived).WithContext(),
+			assert.MatchOIDCUserFromResource(pingsource.Gvr(), source)).Exact(1))
 
 	return f
 }

--- a/test/rekt/resources/subscription/subscription.go
+++ b/test/rekt/resources/subscription/subscription.go
@@ -34,7 +34,7 @@ import (
 //go:embed *.yaml
 var yaml embed.FS
 
-func gvr() schema.GroupVersionResource {
+func GVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1", Resource: "subscriptions"}
 }
 
@@ -136,7 +136,7 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 
 // IsReady tests to see if a Subscription becomes ready within the time given.
 func IsReady(name string, timing ...time.Duration) feature.StepFn {
-	return k8s.IsReady(gvr(), name, timing...)
+	return k8s.IsReady(GVR(), name, timing...)
 }
 
 // WithSubscriberFromDestination adds the subscriber related config to a Trigger spec.


### PR DESCRIPTION
Adding some e2e tests to verify, that the senders identity from `.status.auth` was used for authenticating the request.