### PR TITLE
Fix IMC metrics for transport encryption

### DIFF
--- a/pkg/channel/fanout/fanout_event_handler.go
+++ b/pkg/channel/fanout/fanout_event_handler.go
@@ -197,16 +197,11 @@ func (f *FanoutEventHandler) SetSubscriptions(ctx context.Context, subs []Subscr
 }
 
 func (f *FanoutEventHandler) GetSubscriptions(ctx context.Context) []Subscription {
-	ret, _, _ := f.getSubscriptionsWithScheme()
-	return ret
-}
-
-func (f *FanoutEventHandler) getSubscriptionsWithScheme() (ret []Subscription, hasHttpSubs bool, hasHttpsSubs bool) {
 	f.subscriptionsMutex.RLock()
 	defer f.subscriptionsMutex.RUnlock()
-	ret = make([]Subscription, len(f.subscriptions))
+	ret := make([]Subscription, len(f.subscriptions))
 	copy(ret, f.subscriptions)
-	return ret, f.hasHttpSubs, f.hasHttpsSubs
+	return ret
 }
 
 func (f *FanoutEventHandler) autoCreateEventType(ctx context.Context, evnt event.Event) {
@@ -229,35 +224,21 @@ func createEventReceiverFunction(f *FanoutEventHandler) func(context.Context, ch
 				f.autoCreateEventType(ctx, evnt)
 			}
 
-			subs, hasHttpSubs, hasHttpsSubs := f.getSubscriptionsWithScheme()
-
+			subs := f.GetSubscriptions(ctx)
 			if len(subs) == 0 {
 				// Nothing to do here
 				return nil
 			}
 
 			parentSpan := trace.FromContext(ctx)
-			reportArgs := channel.ReportArgs{}
-			reportArgs.EventType = evnt.Type()
-			reportArgs.Ns = ref.Namespace
 
-			go func(e event.Event, h nethttp.Header, s *trace.Span, r *channel.StatsReporter, args *channel.ReportArgs) {
+			go func(e event.Event, h nethttp.Header, s *trace.Span) {
 				// Run async dispatch with background context.
 				ctx = trace.NewContext(context.Background(), s)
-				h.Set(apis.KnNamespaceHeader, ref.Namespace)
 				// Any returned error is already logged in f.dispatch().
-				dispatchResultForFanout := f.dispatch(ctx, subs, e, h)
+				_ = f.dispatch(ctx, subs, e, h)
 
-				// If there are both http and https subscribers, we need to report the metrics for both of the type
-				if hasHttpSubs {
-					args.EventScheme = "http"
-					_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
-				}
-				if hasHttpsSubs {
-					args.EventScheme = "https"
-					_ = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, *r, *args)
-				}
-			}(evnt, additionalHeaders, parentSpan, &f.reporter, &reportArgs)
+			}(evnt, additionalHeaders, parentSpan)
 			return nil
 		}
 	}
@@ -266,30 +247,15 @@ func createEventReceiverFunction(f *FanoutEventHandler) func(context.Context, ch
 			f.autoCreateEventType(ctx, event)
 		}
 
-		subs, hasHttpSubs, hasHttpsSubs := f.getSubscriptionsWithScheme()
+		subs := f.GetSubscriptions(ctx)
 		if len(subs) == 0 {
 			// Nothing to do here
 			return nil
 		}
 
-		reportArgs := channel.ReportArgs{}
-		reportArgs.EventType = event.Type()
-		reportArgs.Ns = ref.Namespace
-
-		additionalHeaders.Set(apis.KnNamespaceHeader, ref.Namespace)
+		// Any returned error is already logged in f.dispatch().
 		dispatchResultForFanout := f.dispatch(ctx, subs, event, additionalHeaders)
-		// If there are both http and https subscribers, we need to report the metrics for both of the type
-		// In this case we report http metrics because above we checked first for https and reported it so the left over metric to report is for http
-		var err error
-		if hasHttpSubs {
-			reportArgs.EventScheme = "http"
-			err = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
-		}
-		if hasHttpsSubs {
-			reportArgs.EventScheme = "https"
-			err = ParseDispatchResultAndReportMetrics(dispatchResultForFanout, f.reporter, reportArgs)
-		}
-		return err
+		return dispatchResultForFanout.err
 	}
 }
 
@@ -297,7 +263,7 @@ func (f *FanoutEventHandler) ServeHTTP(response nethttp.ResponseWriter, request 
 	f.receiver.ServeHTTP(response, request)
 }
 
-// ParseDispatchResultAndReportMetric processes the dispatch result and records the related channel metrics with the appropriate context
+// ParseDispatchResultAndReportMetrics processes the dispatch result and records the related channel metrics with the appropriate context
 func ParseDispatchResultAndReportMetrics(result DispatchResult, reporter channel.StatsReporter, reportArgs channel.ReportArgs) error {
 	if result.info != nil && result.info.Duration > kncloudevents.NoDuration {
 		if result.info.ResponseCode > kncloudevents.NoResponse {
@@ -318,11 +284,22 @@ func ParseDispatchResultAndReportMetrics(result DispatchResult, reporter channel
 // dispatch takes the event, fans it out to each subscription in subs. If all the fanned out
 // events return successfully, then return nil. Else, return an error.
 func (f *FanoutEventHandler) dispatch(ctx context.Context, subs []Subscription, event event.Event, additionalHeaders nethttp.Header) DispatchResult {
-	errorCh := make(chan DispatchResult, len(subs))
+	results := make(chan DispatchResult, len(subs))
 	for _, sub := range subs {
 		go func(s Subscription) {
-			dispatchedResultPerSub, err := f.makeFanoutRequest(ctx, event, additionalHeaders, s)
-			errorCh <- DispatchResult{err: err, info: dispatchedResultPerSub}
+			h := additionalHeaders.Clone()
+			h.Set(apis.KnNamespaceHeader, s.Namespace)
+
+			dispatchedResultPerSub, err := f.makeFanoutRequest(ctx, event, h, s)
+			r := DispatchResult{err: err, info: dispatchedResultPerSub}
+			results <- r
+
+			args := channel.ReportArgs{
+				Ns:          s.Namespace,
+				EventType:   event.Type(),
+				EventScheme: r.info.Scheme,
+			}
+			_ = ParseDispatchResultAndReportMetrics(r, f.reporter, args)
 		}(sub)
 	}
 
@@ -335,7 +312,7 @@ func (f *FanoutEventHandler) dispatch(ctx context.Context, subs []Subscription, 
 	}
 	for range subs {
 		select {
-		case dispatchResult := <-errorCh:
+		case dispatchResult := <-results:
 			if dispatchResult.info != nil {
 				if dispatchResult.info.Duration > kncloudevents.NoDuration {
 					if totalDispatchTimeForFanout > kncloudevents.NoDuration {

--- a/pkg/kncloudevents/event_dispatcher.go
+++ b/pkg/kncloudevents/event_dispatcher.go
@@ -62,6 +62,7 @@ type DispatchInfo struct {
 	ResponseCode   int
 	ResponseHeader http.Header
 	ResponseBody   []byte
+	Scheme         string
 }
 
 type SendOption func(*senderConfig) error
@@ -287,6 +288,7 @@ func (d *Dispatcher) executeRequest(ctx context.Context, target duckv1.Addressab
 		Duration:       NoDuration,
 		ResponseCode:   NoResponse,
 		ResponseHeader: make(http.Header),
+		Scheme:         target.URL.Scheme,
 	}
 
 	ctx, span := trace.StartSpan(ctx, "knative.dev", trace.WithSpanKind(trace.SpanKindClient))


### PR DESCRIPTION
Rather than reporting metrics (and scheme tag) as an aggregate for all subscriptions, we will report them for each individual subscription with the correct subscriber's scheme.

