### PR TITLE
SubjectAccessReviews resources correction

### DIFF
--- a/pkg/crossnamespace/validation.go
+++ b/pkg/crossnamespace/validation.go
@@ -49,6 +49,9 @@ func CheckNamespace(ctx context.Context, r ResourceInfo) *apis.FieldError {
 		return nil
 	}
 
+	// convert the kind (Broker or Channel) into a resource (brokers or channels)
+	targetResource := strings.ToLower(targetKind) + "s"
+
 	// GetUserInfo accesses the UserInfo attached to the webhook context.
 	userInfo := apis.GetUserInfo(ctx)
 	if userInfo == nil {
@@ -66,7 +69,7 @@ func CheckNamespace(ctx context.Context, r ResourceInfo) *apis.FieldError {
 		Namespace: targetNamespace,
 		Verb:      "knsubscribe",
 		Group:     targetGroup,
-		Resource:  targetKind,
+		Resource:  targetResource,
 	}
 
 	// Create the SubjectAccessReview

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -474,7 +474,7 @@ func TestAllCases(t *testing.T) {
 					WithRoleRules(
 						WithPolicyRule(
 							WithAPIGroups([]string{"messaging.knative.dev"}),
-							WithResources("InMemoryChannel"),
+							WithResources("InMemoryChannels"),
 							WithVerbs("knsubscribe")))),
 				// Rolebinding
 				CreateRoleBinding("test-role", channelNS,
@@ -507,7 +507,7 @@ func TestAllCases(t *testing.T) {
 				),
 			}},
 			WantCreates: []runtime.Object{
-				makeSubjectAccessReview("test-user", makeResourceAttributes(channelNS, channelName, "knsubscribe", "messaging.knative.dev", "InMemoryChannel")),
+				makeSubjectAccessReview("test-user", makeResourceAttributes(channelNS, channelName, "knsubscribe", "messaging.knative.dev", "inmemorychannels")),
 			},
 		}, {
 			Name: "subscription goes ready without api version",

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"slices"
+	"strings"
 	"testing"
 
 	authv1 "k8s.io/api/authorization/v1"
@@ -136,8 +137,12 @@ func MakeFactory(ctor Ctor, unstructured bool, logger *zap.SugaredLogger) Factor
 							continue
 						}
 						for _, rule := range role.Rules {
+							resources := make([]string, 0, len(rule.Resources))
+							for _, resource := range rule.Resources {
+								resources = append(resources, strings.ToLower(resource))
+							}
 							if slices.Contains(rule.APIGroups, sar.Spec.ResourceAttributes.Group) &&
-								(slices.Contains(rule.Resources, "*") || slices.Contains(rule.Resources, sar.Spec.ResourceAttributes.Resource)) &&
+								(slices.Contains(rule.Resources, "*") || slices.Contains(resources, strings.ToLower(sar.Spec.ResourceAttributes.Resource))) &&
 								slices.Contains(rule.Verbs, sar.Spec.ResourceAttributes.Verb) {
 								res := sar.DeepCopy()
 								res.Status.Allowed = true


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes how we create the Resources field in a SubjectAccessReview. The SAR expects this in a form like `brokers`, but we currently pass it `Broker`. This leads to it not working.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Update the crossnamespace validation code to create a RBAC resources field from an object Kind
- Update the test factory to validate that the resources field is correct

