### PR TITLE
fix(test): the attribute filter transform test correctly compares slices now

### DIFF
--- a/pkg/graph/transforms_test.go
+++ b/pkg/graph/transforms_test.go
@@ -186,7 +186,11 @@ func TestAttributeFilterTransform(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			transform := AttributesFilterTransform{Filter: &eventingv1.TriggerFilter{Attributes: test.filterAttributes}}
 			out, _ := transform.Apply(test.input, TransformFunctionContext{})
-			assert.Equal(t, test.expected, out)
+			if test.expected == nil {
+				assert.Nil(t, out)
+			} else {
+				assert.ElementsMatch(t, test.expected.Spec.Attributes, out.Spec.Attributes)
+			}
 		})
 	}
 }


### PR DESCRIPTION

Fixes #7929 

The test flake described in #7929 occurs because the attribute filter transform function doesn't make any guarantees on the order of elements in the final eventtype attributes array, but the test was checking if the eventtypes were equal. Instead, we only actually care if the elements in the two attributes slices match

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Only compare the elements in the attributes slices, rather than the order
