### PR TITLE
Update eventtype CRD to include `.spec.reference.address`

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -52,6 +52,9 @@ spec:
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is an optional field, it gets defaulted to the object holding it if left out.'
                     type: string
+                  address:
+                    description: 'Address points to a specific Address Name'
+                    type: string
               description:
                 description: 'Description is an optional field used to describe the
                     EventType, in any meaningful way.'
@@ -179,6 +182,9 @@ spec:
                     type: string
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is an optional field, it gets defaulted to the object holding it if left out.'
+                    type: string
+                  address:
+                    description: 'Address points to a specific Address Name'
                     type: string
               description:
                 description: 'Description is an optional field used to describe the
@@ -310,6 +316,9 @@ spec:
                     type: string
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is an optional field, it gets defaulted to the object holding it if left out.'
+                    type: string
+                  address:
+                    description: 'Address points to a specific Address Name'
                     type: string
               description:
                 description: 'Description is an optional field used to describe the


### PR DESCRIPTION
Currently we see on some eventtype tests the following warnings in the dispatcher:

```
{"level":"warn","ts":"2024-05-22T17:19:09.574Z","logger":"inmemorychannel-dispatcher","caller":"logging/warning_handler.go:32","msg":"API Warning: unknown field \"spec.reference.address\"","commit":"0e14da4-dirty","knative.dev/pod":"imc-dispatcher-59cb79846b-vbsgx"}
```

This PR addresses it and adds the `address` field to the CRD, as described in https://github.com/knative/pkg/blob/99e1685a799787390ad8cb32bce249173cfda7a6/apis/duck/v1/knative_reference.go#L29-L56