### PR TITLE
Remove rekt test from GH actions e2e test run

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,7 +21,6 @@ jobs:
         - v1.29.0
 
         test-suite:
-        - ./test/rekt/...
         - ./test/e2e
         - ./test/conformance
         - ./test/experimental


### PR DESCRIPTION
Removing the rekt tests from the Github actions KinD e2e tests, as they are pretty unstable in our tier and we run them in Prow anyhow as a required job.

/cc @pierDipi 