### PR TITLE
Update Github actions automatically

### DIFF
--- a/.github/.dependabot.yaml
+++ b/.github/.dependabot.yaml
@@ -1,0 +1,8 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
As per title

(The [update-actions](https://github.com/knative-extensions/knobots/actions/runs/9278824473/job/25530427713) job seems to do this only for some specific worklows)