### PR TITLE
fix: eventing clusterrole has correct knsubscribe permissions

### DIFF
--- a/config/200-crossnamespace-clusterrole.yaml
+++ b/config/200-crossnamespace-clusterrole.yaml
@@ -1,0 +1,1 @@
+core/roles/crossnamespace-clusterrole.yaml

--- a/config/channels/in-memory-channel/roles/crossnamespace-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/crossnamespace-clusterrole.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-subscriber
+  labels:
+    duck.knative.dev/crossnamespace-subscribable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  verbs:
+  - knsubscribe

--- a/config/core/200-eventing-serviceaccount.yaml
+++ b/config/core/200-eventing-serviceaccount.yaml
@@ -110,3 +110,21 @@ roleRef:
   kind: ClusterRole
   name: channelable-manipulator
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller-crossnamespace-subscriber
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+subjects:
+  - kind: ServiceAccount
+    name: eventing-controller
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: crossnamespace-subscriber
+  apiGroup: rbac.authorization.k8s.io

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -127,6 +127,20 @@ rules:
       - "patch"
       - "watch"
 
+  # cross namespace link permissions
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "inmemorychannels"
+    verbs:
+      - "knsubscribe"
+  - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "brokers"
+    verbs:
+      - "knsubscribe"
+
   # Flow resources and statuses we care about.
   - apiGroups:
       - "flows.knative.dev"

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -127,20 +127,6 @@ rules:
       - "patch"
       - "watch"
 
-  # cross namespace link permissions
-  - apiGroups:
-      - "messaging.knative.dev"
-    resources:
-      - "inmemorychannels"
-    verbs:
-      - "knsubscribe"
-  - apiGroups:
-      - "eventing.knative.dev"
-    resources:
-      - "brokers"
-    verbs:
-      - "knsubscribe"
-
   # Flow resources and statuses we care about.
   - apiGroups:
       - "flows.knative.dev"

--- a/config/core/roles/crossnamespace-clusterrole.yaml
+++ b/config/core/roles/crossnamespace-clusterrole.yaml
@@ -23,26 +23,8 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-     duck.knative.dev/subscribable: "true"
+      duck.knative.dev/crossnamespace-subscribable: "true"
 rules: [] # rules are automatically filled in by the controller manager.
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: imc-subscriber
-  labels:
-    duck.knative.dev/subscribable: "true"
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/name: knative-eventing
-rules:
-- apiGroups:
-  - messaging.knative.dev
-  resources:
-  - inmemorychannels
-  verbs:
-  - knsubscribe
 
 ---
 
@@ -51,7 +33,7 @@ kind: ClusterRole
 metadata:
   name: channel-subscriber
   labels:
-    duck.knative.dev/subscribable: "true"
+    duck.knative.dev/crossnamespace-subscribable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:
@@ -69,7 +51,7 @@ kind: ClusterRole
 metadata:
   name: broker-subscriber
   labels:
-    duck.knative.dev/subscribable: "true"
+    duck.knative.dev/crossnamespace-subscribable: "true"
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
 rules:

--- a/config/core/roles/crossnamespace-clusterrole.yaml
+++ b/config/core/roles/crossnamespace-clusterrole.yaml
@@ -1,0 +1,81 @@
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need cluster wide crossnamespace subscribe permissions for all resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossnamespace-subscriber
+  labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+     duck.knative.dev/subscribable: "true"
+rules: [] # rules are automatically filled in by the controller manager.
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-subscriber
+  labels:
+    duck.knative.dev/subscribable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  verbs:
+  - knsubscribe
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: channel-subscriber
+  labels:
+    duck.knative.dev/subscribable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels
+  verbs:
+  - knsubscribe
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: broker-subscriber
+  labels:
+    duck.knative.dev/subscribable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+rules:
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - brokers
+  verbs:
+  - knsubscribe


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes the clusterrole for the cross namespace feature to work

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add knsubscribe for imc to eventing controller
- Add knsubscribe for broker to eventing controller
