### PR TITLE
fix: no more panic in the execute request method

### DIFF
--- a/pkg/kncloudevents/event_dispatcher.go
+++ b/pkg/kncloudevents/event_dispatcher.go
@@ -289,11 +289,18 @@ func (d *Dispatcher) send(ctx context.Context, message binding.Message, destinat
 }
 
 func (d *Dispatcher) executeRequest(ctx context.Context, target duckv1.Addressable, message cloudevents.Message, additionalHeaders http.Header, retryConfig *RetryConfig, oidcServiceAccount *types.NamespacedName, transformers ...binding.Transformer) (context.Context, cloudevents.Message, *DispatchInfo, error) {
+	var scheme string
+	if target.URL != nil {
+		scheme = target.URL.Scheme
+	} else {
+		// assume that the scheme is http by default
+		scheme = "http"
+	}
 	dispatchInfo := DispatchInfo{
 		Duration:       NoDuration,
 		ResponseCode:   NoResponse,
 		ResponseHeader: make(http.Header),
-		Scheme:         target.URL.Scheme,
+		Scheme:         scheme,
 	}
 
 	ctx, span := trace.StartSpan(ctx, "knative.dev", trace.WithSpanKind(trace.SpanKindClient))


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes the panic seen in the unit tests on https://github.com/knative-extensions/eventing-natss/actions/runs/9270412120/job/25503341076?pr=565

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Check if the target URL is `nil` before accessing the scheme from the URL
- Default to `http` if it the the URL is `nil`

