### PR TITLE
fix: sequence updates subscription where possible, instead of recreating it

### DIFF
--- a/pkg/reconciler/sequence/sequence_test.go
+++ b/pkg/reconciler/sequence/sequence_test.go
@@ -887,18 +887,15 @@ func TestAllCases(t *testing.T) {
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(0)}}))),
 		},
 		WantErr: false,
-		WantDeletes: []clientgotesting.DeleteActionImpl{{
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{
 				Namespace: testNS,
 				Resource:  v1.SchemeGroupVersion.WithResource("subscriptions"),
 			},
-			Name: resources.SequenceChannelName(sequenceName, 0),
-		}},
-		WantCreates: []runtime.Object{
-			resources.NewSubscription(0, NewSequence(sequenceName, testNS,
+			Object: resources.NewSubscription(0, NewSequence(sequenceName, testNS,
 				WithSequenceChannelTemplateSpec(imc),
 				WithSequenceSteps([]v1.SequenceStep{{Destination: createDestination(1)}}))),
-		},
+		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewSequence(sequenceName, testNS,
 				WithInitSequenceConditions,
@@ -991,6 +988,18 @@ func TestAllCases(t *testing.T) {
 				Name: resources.SequenceChannelName(sequenceName, 2),
 			},
 		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Resource:  v1.SchemeGroupVersion.WithResource("subscriptions"),
+			},
+			Object: resources.NewSubscription(1, NewSequence(sequenceName, testNS,
+				WithSequenceChannelTemplateSpec(imc),
+				WithSequenceSteps([]v1.SequenceStep{
+					{Destination: createDestination(0)},
+					{Destination: createDestination(1)}},
+				))),
+		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewSequence(sequenceName, testNS,
 				WithInitSequenceConditions,
@@ -1120,6 +1129,18 @@ func TestAllCases(t *testing.T) {
 				Name: resources.SequenceChannelName(sequenceName, 2),
 			},
 		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Resource:  v1.SchemeGroupVersion.WithResource("subscriptions"),
+			},
+			Object: resources.NewSubscription(1, NewSequence(sequenceName, testNS,
+				WithSequenceChannelTemplateSpec(imc),
+				WithSequenceSteps([]v1.SequenceStep{
+					{Destination: createDestination(0)},
+					{Destination: createDestination(1)}},
+				))),
+		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewSequence(sequenceName, testNS,
 				WithInitSequenceConditions,
@@ -1233,6 +1254,18 @@ func TestAllCases(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for delete inmemorychannels"),
 		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: testNS,
+				Resource:  v1.SchemeGroupVersion.WithResource("subscriptions"),
+			},
+			Object: resources.NewSubscription(1, NewSequence(sequenceName, testNS,
+				WithSequenceChannelTemplateSpec(imc),
+				WithSequenceSteps([]v1.SequenceStep{
+					{Destination: createDestination(0)},
+					{Destination: createDestination(1)}},
+				))),
+		}},
 
 		WantDeletes: []clientgotesting.DeleteActionImpl{
 			{


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7939

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Check if the changed fields in a subscription are mutable or immutable, and update or recreate accordingly
- Update unit tests to watch for updates where appropriate


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
sequences now update subscriptions instead of recreating them, where possible
```



