### PR TITLE
JobSink: add webhook validation for spec.job

### DIFF
--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -175,3 +175,7 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]

--- a/docs/sink/jobsink-invalid.yaml
+++ b/docs/sink/jobsink-invalid.yaml
@@ -1,0 +1,21 @@
+apiVersion: sinks.knative.dev/v1alpha1
+kind: JobSink
+metadata:
+  name: job-sink-invalid
+spec:
+  job:
+    apiVersion: batch/v1
+    kind: Job
+    spec:
+      completions: 12
+      parallelism: 3
+      template:
+        spec:
+          # restartPolicy: Never -> missing field
+          containers:
+            - name: main
+              image: docker.io/library/bash:5
+              command: [ "bash" ]        # example command simulating a bug which triggers the FailJob action
+              args:
+                - -c
+                - echo "Hello world!" && sleep 5

--- a/pkg/apis/sinks/register.go
+++ b/pkg/apis/sinks/register.go
@@ -17,7 +17,10 @@ limitations under the License.
 package sinks
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -31,3 +34,21 @@ var (
 		Resource: "jobsinks",
 	}
 )
+
+type Config struct {
+	KubeClient kubernetes.Interface
+}
+
+type configKey struct{}
+
+func WithConfig(ctx context.Context, cfg *Config) context.Context {
+	return context.WithValue(ctx, configKey{}, cfg)
+}
+
+func GetConfig(ctx context.Context) *Config {
+	v := ctx.Value(configKey{})
+	if v == nil {
+		panic("Missing value for config")
+	}
+	return v.(*Config)
+}

--- a/pkg/apis/sinks/v1alpha1/job_sink_validation.go
+++ b/pkg/apis/sinks/v1alpha1/job_sink_validation.go
@@ -19,10 +19,14 @@ package v1alpha1
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+
+	"knative.dev/eventing/pkg/apis/sinks"
 )
 
 func (sink *JobSink) Validate(ctx context.Context) *apis.FieldError {
+	ctx = apis.WithinParent(ctx, sink.ObjectMeta)
 	return sink.Spec.Validate(ctx).ViaField("spec")
 }
 
@@ -31,6 +35,21 @@ func (sink *JobSinkSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	if sink.Job == nil {
 		return errs.Also(apis.ErrMissingOneOf("job"))
+	}
+
+	if sink.Job != nil {
+		job := sink.Job.DeepCopy()
+		job.Name = "temporary-job-name"
+		_, err := sinks.GetConfig(ctx).KubeClient.
+			BatchV1().
+			Jobs(apis.ParentMeta(ctx).Namespace).
+			Create(ctx, job, metav1.CreateOptions{
+				DryRun:          []string{metav1.DryRunAll},
+				FieldValidation: metav1.FieldValidationStrict,
+			})
+		if err != nil {
+			return apis.ErrGeneric(err.Error(), "job")
+		}
 	}
 
 	return errs

--- a/pkg/apis/sinks/v1alpha1/job_sink_validation.go
+++ b/pkg/apis/sinks/v1alpha1/job_sink_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
 	"knative.dev/pkg/apis"
 
 	"knative.dev/eventing/pkg/apis/sinks"
@@ -39,7 +40,7 @@ func (sink *JobSinkSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	if sink.Job != nil {
 		job := sink.Job.DeepCopy()
-		job.Name = "temporary-job-name"
+		job.Name = names.SimpleNameGenerator.GenerateName(apis.ParentMeta(ctx).Name)
 		_, err := sinks.GetConfig(ctx).KubeClient.
 			BatchV1().
 			Jobs(apis.ParentMeta(ctx).Namespace).


### PR DESCRIPTION
Validate `spec.job` using a dry-run create of the given job.