### PR TITLE
fix: add comments and improve regex for attribute filter transform function

### DIFF
--- a/pkg/graph/transforms.go
+++ b/pkg/graph/transforms.go
@@ -44,6 +44,10 @@ type AttributesFilterTransform struct {
 
 var _ Transform = &AttributesFilterTransform{}
 
+// Apply will apply the transform to a given input eventtype. This will "narrow" the eventtype to represent only events which could pass the attribute filter.
+// For example, if the "type" attribute was not yet set on the eventtype, but the filter requires "type"="example.event.type", then after this filter the
+// eventtype would have the attribute definition for "type"="example.event.type". Additionally, if an eventtype can not be narrowed this returns nil. For
+// example using the filter from the earlier example, if the "type" was already set to "other.event.type" then the eventtype would not be compatible.
 func (aft *AttributesFilterTransform) Apply(et *eventingv1beta3.EventType, tfc TransformFunctionContext) (*eventingv1beta3.EventType, TransformFunctionContext) {
 	etAttributes := make(map[string]*eventingv1beta3.EventAttributeDefinition)
 	for i := range et.Spec.Attributes {
@@ -87,15 +91,27 @@ func (aft *AttributesFilterTransform) Name() string {
 	return "attributes-filter"
 }
 
+// buildRegexForAttribute build a regex which detects whether the current value for the attribute is compatible
+// with the value required by the attribute filter. Specifically, it will handle variables in the eventtype so
+// that if there are values that can be set in the variable so that it can match the attribute filter, those
+// values will be chosen.
 func buildRegexForAttribute(attribute string) (*regexp.Regexp, error) {
 	chunks := []string{"^"}
 
 	var chunk strings.Builder
 	for i := 0; i < len(attribute); {
-		if attribute[i] == '{' {
-			chunks = append(chunks, chunk.String(), "[a-zA-Z]+")
+		// handle escaped curly brackets. If not escaped, treat them like part of a variable
+		if attribute[i] == '\\' && i+1 < len(attribute) && (attribute[i+1] == '{' || attribute[i+1] == '}') {
+			chunk.WriteByte(attribute[i+1])
+			i += 2
+			continue
+		} else if attribute[i] == '{' {
+			// this regex allows any character except those disallowed by the cloudevents spec. Technically, it is slightly more permissive
+			// than the cloudevents spec, because creating a regex for code surrogates used properly in pairs is complicated
+			chunks = append(chunks, chunk.String(), "[^\\x{0000}-\\x{001f}\\x{007f}-\\x{009f}\\x{fdd0}-\\x{fdef}\\x{fffe}\\x{ffff}]+")
 			chunk.Reset()
 
+			// for variable names we only allow [a-zA-Z0-9]+, so we don't need to worry about escaped characters or brackets in the variable name
 			offset := strings.Index(attribute[i:], "}")
 			if offset == -1 {
 				return nil, fmt.Errorf("no closing bracket for variable")
@@ -103,6 +119,9 @@ func buildRegexForAttribute(attribute string) (*regexp.Regexp, error) {
 
 			i += offset + 1
 			continue
+		} else if attribute[i] == '}' {
+			// we have an unpaired bracket
+			return nil, fmt.Errorf("no opening bracket for a closing bracket. If you want to have a bracket in your value, please escape it with a \\ character")
 		}
 
 		chunk.WriteByte(attribute[i])


### PR DESCRIPTION
Follow up on review comments in #7909 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Make regex more closely match the allowed values in the cloudevents spec
- Add comments explaining the complicated parts of the code
- Handle malformed variables

