### PR TITLE
Support arbitrary data for rekt configmap package

### DIFF
--- a/test/rekt/resources/configmap/config-features.yaml
+++ b/test/rekt/resources/configmap/config-features.yaml
@@ -3,10 +3,23 @@ kind: ConfigMap
 metadata:
   name: {{ .name }}
   namespace: {{ .namespace }}
+  {{ if .labels }}
+  labels:
+    {{ range $key, $value := .labels }}
+    {{ $key }}: "{{ $value }}"
+    {{ end }}
+  {{ else }}
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
+  {{ end }}
 data:
+  {{ if .data }}
+  {{ range $key, $value := .data }}
+  {{ $key }}: |-
+    {{ $value }}
+  {{ end }}
+  {{ else }}
   _example: |
     my-enabled-flag: "enabled"
     my-disabled-flag: "disabled"
@@ -14,4 +27,4 @@ data:
     apiserversources-nodeselector-testkey: testvalue
     apiserversources-nodeselector-testkey1: testvalue1
     apiserversources-nodeselector-testkey2: testvalue2
-
+  {{ end }}

--- a/test/rekt/resources/configmap/configmap.go
+++ b/test/rekt/resources/configmap/configmap.go
@@ -19,6 +19,7 @@ package configmap
 import (
 	"context"
 	"embed"
+	"strings"
 
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -42,5 +43,17 @@ func Install(name string, ns string, opts ...manifest.CfgFn) feature.StepFn {
 		if _, err := manifest.InstallYamlFS(ctx, yaml, cfg); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+var WithLabels = manifest.WithLabels
+
+func WithData(key, value string) manifest.CfgFn {
+	return func(m map[string]interface{}) {
+		if _, ok := m["data"]; !ok {
+			m["data"] = map[string]string{}
+		}
+		value = strings.ReplaceAll(value, "\n", "\n    ")
+		m["data"].(map[string]string)[key] = value
 	}
 }

--- a/test/rekt/resources/configmap/configmap_test.go
+++ b/test/rekt/resources/configmap/configmap_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	"os"
+
+	testlog "knative.dev/reconciler-test/pkg/logging"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+func Example_withData() {
+	ctx := testlog.NewContext()
+	images := map[string]string{}
+	cfg := map[string]interface{}{
+		"name":      "foo",
+		"namespace": "bar",
+	}
+
+	WithData("ca.crt", "x\nx")(cfg)
+	WithLabels(map[string]string{"a": "b"})(cfg)
+
+	files, err := manifest.ExecuteYAML(ctx, yaml, images, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	manifest.OutputYAML(os.Stdout, files)
+	// Output:
+	// apiVersion: v1
+	// kind: ConfigMap
+	// metadata:
+	//   name: foo
+	//   namespace: bar
+	//   labels:
+	//     a: "b"
+	// data:
+	//   ca.crt: |-
+	//     x
+	//     x
+}


### PR DESCRIPTION
This will help with testing the CA trust bundle rotation.

