### PR TITLE
List applying policies in Channel and propagate EventPolicies to underlying channel

### DIFF
--- a/config/core/resources/channel.yaml
+++ b/config/core/resources/channel.yaml
@@ -244,6 +244,18 @@ spec:
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
                     type: string
+              policies:
+                description: List of applied EventPolicies
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: The API version of the applied EventPolicy. This indicates, which version of EventPolicy is supported by the resource.
+                      type: string
+                    name:
+                      description: The name of the applied EventPolicy
+                      type: string
               conditions:
                 description: Conditions the latest available observations of a resource's current state.
                 type: array

--- a/config/core/roles/controller-clusterroles.yaml
+++ b/config/core/roles/controller-clusterroles.yaml
@@ -97,6 +97,8 @@ rules:
       - "triggers/status"
       - "eventtypes"
       - "eventtypes/status"
+      - "eventpolicies"
+      - "eventpolicies/status"
     verbs:
       - "get"
       - "list"

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -49,7 +49,7 @@ Resource Types:
 <h3 id="duck.knative.dev/v1.AppliedEventPoliciesStatus">AppliedEventPoliciesStatus
 </h3>
 <p>
-(<em>Appears on:</em><a href="#eventing.knative.dev/v1.BrokerStatus">BrokerStatus</a>, <a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>, <a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>, <a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
+(<em>Appears on:</em><a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, <a href="#eventing.knative.dev/v1.BrokerStatus">BrokerStatus</a>, <a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>, <a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>)
 </p>
 <p>
 <p>AppliedEventPoliciesStatus contains the list of policies which apply to a resource.
@@ -366,6 +366,23 @@ DeliveryStatus
 <em>(Optional)</em>
 <p>DeliveryStatus contains a resolved URL to the dead letter sink address, and any other
 resolved delivery options.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AppliedEventPoliciesStatus</code><br/>
+<em>
+<a href="#duck.knative.dev/v1.AppliedEventPoliciesStatus">
+AppliedEventPoliciesStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AppliedEventPoliciesStatus</code> are embedded into this type.)
+</p>
+<em>(Optional)</em>
+<p>AppliedEventPoliciesStatus contains the list of EventPolicies which apply to this Channel</p>
 </td>
 </tr>
 </tbody>
@@ -5457,23 +5474,6 @@ ChannelableStatus
 (Members of <code>ChannelableStatus</code> are embedded into this type.)
 </p>
 <p>Channel conforms to Duck type ChannelableStatus.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AppliedEventPoliciesStatus</code><br/>
-<em>
-<a href="#duck.knative.dev/v1.AppliedEventPoliciesStatus">
-AppliedEventPoliciesStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AppliedEventPoliciesStatus</code> are embedded into this type.)
-</p>
-<em>(Optional)</em>
-<p>AppliedEventPoliciesStatus contains the list of EventPolicies which apply to this Broker</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/duck/v1/channelable_types.go
+++ b/pkg/apis/duck/v1/channelable_types.go
@@ -67,6 +67,9 @@ type ChannelableStatus struct {
 	// resolved delivery options.
 	// +optional
 	DeliveryStatus `json:",inline"`
+	// AppliedEventPoliciesStatus contains the list of EventPolicies which apply to this Channel
+	// +optional
+	AppliedEventPoliciesStatus `json:",inline"`
 }
 
 var (

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -154,6 +154,7 @@ func (in *ChannelableStatus) DeepCopyInto(out *ChannelableStatus) {
 	in.AddressStatus.DeepCopyInto(&out.AddressStatus)
 	in.SubscribableStatus.DeepCopyInto(&out.SubscribableStatus)
 	in.DeliveryStatus.DeepCopyInto(&out.DeliveryStatus)
+	in.AppliedEventPoliciesStatus.DeepCopyInto(&out.AppliedEventPoliciesStatus)
 	return
 }
 

--- a/pkg/apis/messaging/v1/channel_lifecycle.go
+++ b/pkg/apis/messaging/v1/channel_lifecycle.go
@@ -29,6 +29,7 @@ var chCondSet = apis.NewLivingConditionSet(
 	ChannelConditionBackingChannelReady,
 	ChannelConditionAddressable,
 	ChannelConditionDeadLetterSinkResolved,
+	ChannelConditionEventPoliciesReady,
 )
 
 const (
@@ -45,6 +46,10 @@ const (
 	// ChannelConditionDeadLetterSinkResolved has status True when there is a Dead Letter Sink ref or URI
 	// defined in the Spec.Delivery, is a valid destination and its correctly resolved into a valid URI
 	ChannelConditionDeadLetterSinkResolved apis.ConditionType = "DeadLetterSinkResolved"
+
+	// ChannelConditionEventPoliciesReady has status True when all the EventPolicies which reference this
+	// Channel are Ready too.
+	ChannelConditionEventPoliciesReady apis.ConditionType = "EventPoliciesReady"
 )
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
@@ -145,4 +150,20 @@ func (cs *ChannelStatus) MarkDeadLetterSinkNotConfigured() {
 func (cs *ChannelStatus) MarkDeadLetterSinkResolvedFailed(reason, messageFormat string, messageA ...interface{}) {
 	cs.DeliveryStatus = eventingduck.DeliveryStatus{}
 	chCondSet.Manage(cs).MarkFalse(ChannelConditionDeadLetterSinkResolved, reason, messageFormat, messageA...)
+}
+
+func (cs *ChannelStatus) MarkEventPoliciesFailed(reason, messageFormat string, messageA ...interface{}) {
+	chCondSet.Manage(cs).MarkFalse(ChannelConditionEventPoliciesReady, reason, messageFormat, messageA...)
+}
+
+func (cs *ChannelStatus) MarkEventPoliciesUnknown(reason, messageFormat string, messageA ...interface{}) {
+	chCondSet.Manage(cs).MarkUnknown(ChannelConditionEventPoliciesReady, reason, messageFormat, messageA...)
+}
+
+func (cs *ChannelStatus) MarkEventPoliciesTrue() {
+	chCondSet.Manage(cs).MarkTrue(ChannelConditionEventPoliciesReady)
+}
+
+func (cs *ChannelStatus) MarkEventPoliciesTrueWithReason(reason, messageFormat string, messageA ...interface{}) {
+	chCondSet.Manage(cs).MarkTrueWithReason(ChannelConditionEventPoliciesReady, reason, messageFormat, messageA...)
 }

--- a/pkg/apis/messaging/v1/in_memory_channel_types.go
+++ b/pkg/apis/messaging/v1/in_memory_channel_types.go
@@ -73,10 +73,6 @@ type InMemoryChannelSpec struct {
 type InMemoryChannelStatus struct {
 	// Channel conforms to Duck type ChannelableStatus.
 	eventingduckv1.ChannelableStatus `json:",inline"`
-
-	// AppliedEventPoliciesStatus contains the list of EventPolicies which apply to this Broker
-	// +optional
-	eventingduckv1.AppliedEventPoliciesStatus `json:",inline"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/messaging/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/messaging/v1/zz_generated.deepcopy.go
@@ -245,7 +245,6 @@ func (in *InMemoryChannelSpec) DeepCopy() *InMemoryChannelSpec {
 func (in *InMemoryChannelStatus) DeepCopyInto(out *InMemoryChannelStatus) {
 	*out = *in
 	in.ChannelableStatus.DeepCopyInto(&out.ChannelableStatus)
-	in.AppliedEventPoliciesStatus.DeepCopyInto(&out.AppliedEventPoliciesStatus)
 	return
 }
 

--- a/pkg/auth/event_policy.go
+++ b/pkg/auth/event_policy.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"strings"
 
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/apis/feature"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
@@ -286,4 +289,53 @@ func EventPolicyEventHandler(indexer cache.Indexer, gk schema.GroupKind, enqueue
 			})
 		},
 	}
+}
+
+type EventPolicyStatusMarker interface {
+	MarkEventPoliciesFailed(reason, messageFormat string, messageA ...interface{})
+	MarkEventPoliciesUnknown(reason, messageFormat string, messageA ...interface{})
+	MarkEventPoliciesTrue()
+	MarkEventPoliciesTrueWithReason(reason, messageFormat string, messageA ...interface{})
+}
+
+func UpdateStatusWithEventPolicies(featureFlags feature.Flags, status *eventingduckv1.AppliedEventPoliciesStatus, statusMarker EventPolicyStatusMarker, eventPolicyLister listerseventingv1alpha1.EventPolicyLister, gvk schema.GroupVersionKind, objectMeta metav1.ObjectMeta) error {
+	status.Policies = nil
+
+	applyingEvenPolicies, err := GetEventPoliciesForResource(eventPolicyLister, gvk, objectMeta)
+	if err != nil {
+		statusMarker.MarkEventPoliciesFailed("EventPoliciesGetFailed", "Failed to get applying event policies")
+		return fmt.Errorf("unable to get applying event policies: %w", err)
+	}
+
+	if len(applyingEvenPolicies) > 0 {
+		unreadyEventPolicies := []string{}
+		for _, policy := range applyingEvenPolicies {
+			if !policy.Status.IsReady() {
+				unreadyEventPolicies = append(unreadyEventPolicies, policy.Name)
+			} else {
+				// only add Ready policies to the list
+				status.Policies = append(status.Policies, eventingduckv1.AppliedEventPolicyRef{
+					Name:       policy.Name,
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				})
+			}
+		}
+
+		if len(unreadyEventPolicies) == 0 {
+			statusMarker.MarkEventPoliciesTrue()
+		} else {
+			statusMarker.MarkEventPoliciesFailed("EventPoliciesNotReady", "event policies %s are not ready", strings.Join(unreadyEventPolicies, ", "))
+		}
+	} else {
+		// we have no applying event policy. So we set the EP condition to True
+		if featureFlags.IsOIDCAuthentication() {
+			// in case of OIDC auth, we also set the message with the default authorization mode
+			statusMarker.MarkEventPoliciesTrueWithReason("DefaultAuthorizationMode", "Default authz mode is %q", featureFlags[feature.AuthorizationDefaultMode])
+		} else {
+			// in case OIDC is disabled, we set EP condition to true too, but give some message that authz (EPs) require OIDC
+			statusMarker.MarkEventPoliciesTrueWithReason("OIDCDisabled", "Feature %q must be enabled to support Authorization", feature.OIDCAuthentication)
+		}
+	}
+
+	return nil
 }

--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -20,6 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"knative.dev/eventing/pkg/reconciler/channel/resources"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/labels"
+	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	eventingclientset "knative.dev/eventing/pkg/client/clientset/versioned"
+
 	"go.uber.org/zap"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -52,6 +59,8 @@ type Reconciler struct {
 	dynamicClientSet dynamic.Interface
 
 	eventPolicyLister eventingv1alpha1listers.EventPolicyLister
+
+	eventingClientSet eventingclientset.Interface
 }
 
 // Check that our Reconciler implements Interface
@@ -108,7 +117,90 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, c *v1.Channel) pkgreconc
 		return fmt.Errorf("could not update channel status with EventPolicies: %v", err)
 	}
 
+	err = r.reconcileBackingChannelEventPolicies(ctx, c, backingChannel)
+	if err != nil {
+		return fmt.Errorf("could not reconcile backing channels (%s/%s) event policies: %w", backingChannel.Namespace, backingChannel.Name, err)
+	}
+
 	return nil
+}
+
+func (r *Reconciler) reconcileBackingChannelEventPolicies(ctx context.Context, channel *v1.Channel, backingChannel *eventingduckv1.Channelable) error {
+	applyingEventPoliciesForChannel, err := auth.GetEventPoliciesForResource(r.eventPolicyLister, v1.SchemeGroupVersion.WithKind("Channel"), channel.ObjectMeta)
+	if err != nil {
+		return fmt.Errorf("could not get applying EventPolicies for for channel %s/%s: %w", channel.Namespace, channel.Name, err)
+	}
+
+	for _, policy := range applyingEventPoliciesForChannel {
+		err := r.reconcileBackingChannelEventPolicy(ctx, backingChannel, policy)
+		if err != nil {
+			return fmt.Errorf("could not reconcile EventPolicy %s/%s for backing channel %s/%s: %w", policy.Namespace, policy.Name, backingChannel.Namespace, backingChannel.Name, err)
+		}
+	}
+
+	// Check, if we have old EP for the backing channel, which are not relevant anymore
+	applyingEventPoliciesForBackingChannel, err := auth.GetEventPoliciesForResource(r.eventPolicyLister, backingChannel.GroupVersionKind(), backingChannel.ObjectMeta)
+	if err != nil {
+		return fmt.Errorf("could not get applying EventPolicies for for backing channel %s/%s: %w", channel.Namespace, channel.Name, err)
+	}
+
+	selector, err := labels.ValidatedSelectorFromSet(resources.LabelsForBackingChannelsEventPolicy(backingChannel))
+	if err != nil {
+		return fmt.Errorf("could not get valid selector for backing channels EventPolicy %s/%s: %w", backingChannel.Namespace, backingChannel.Name, err)
+	}
+
+	existingEventPoliciesForBackingChannel, err := r.eventPolicyLister.EventPolicies(backingChannel.Namespace).List(selector)
+	if err != nil {
+		return fmt.Errorf("could not get existing EventPolicies in backing channels namespace %q: %w", backingChannel.Namespace, err)
+	}
+
+	for _, policy := range existingEventPoliciesForBackingChannel {
+		if !r.containsPolicy(policy.Name, applyingEventPoliciesForBackingChannel) {
+
+			// the existing policy is not in the list of applying policies anymore --> is outdated --> delete it
+			err := r.eventingClientSet.EventingV1alpha1().EventPolicies(policy.Namespace).Delete(ctx, policy.Name, metav1.DeleteOptions{})
+			if err != nil && apierrs.IsNotFound(err) {
+				return fmt.Errorf("could not delete old EventPolicy %s/%s: %w", policy.Namespace, policy.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileBackingChannelEventPolicy(ctx context.Context, backingChannel *eventingduckv1.Channelable, eventpolicy *eventingv1alpha1.EventPolicy) error {
+	expected := resources.MakeEventPolicyForBackingChannel(backingChannel, eventpolicy)
+
+	foundEP, err := r.eventPolicyLister.EventPolicies(expected.Namespace).Get(expected.Name)
+	if apierrs.IsNotFound(err) {
+		_, err := r.eventingClientSet.EventingV1alpha1().EventPolicies(expected.Namespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("could not create EventPolicy %s/%s: %w", expected.Namespace, expected.Name, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("could not get EventPolicy %s/%s: %w", expected.Namespace, expected.Name, err)
+	} else if r.policyNeedsUpdate(foundEP, expected) {
+		expected.SetResourceVersion(foundEP.ResourceVersion)
+		_, err := r.eventingClientSet.EventingV1alpha1().EventPolicies(expected.Namespace).Update(ctx, expected, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("could not update EventPolicy %s/%s: %w", expected.Namespace, expected.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) containsPolicy(name string, policies []*eventingv1alpha1.EventPolicy) bool {
+	for _, policy := range policies {
+		if policy.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) policyNeedsUpdate(foundEP, expected *eventingv1alpha1.EventPolicy) bool {
+	return !equality.Semantic.DeepDerivative(expected, foundEP)
 }
 
 // reconcileBackingChannel reconciles Channel's 'c' underlying CRD channel.

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1addr "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
@@ -41,7 +41,6 @@ import (
 	"knative.dev/pkg/tracker"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	channelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/channel"
 	"knative.dev/eventing/pkg/duck"
@@ -72,6 +71,12 @@ var (
 		Group:   "messaging.knative.dev",
 		Version: "v1",
 		Kind:    "Channel",
+	}
+
+	imcV1GVK = metav1.GroupVersionKind{
+		Group:   "messaging.knative.dev",
+		Version: "v1",
+		Kind:    "InMemoryChannel",
 	}
 )
 
@@ -348,6 +353,24 @@ func TestReconcile(t *testing.T) {
 				WithReadyEventPolicyCondition,
 				WithEventPolicyToRef(channelV1GVK, channelName),
 			),
+			NewEventPolicy(fmt.Sprintf("%s-%s", readyEventPolicyName, channelName), testNS,
+				WithEventPolicyToRef(imcV1GVK, channelName),
+				WithEventPolicyOwnerReferences([]metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "InMemoryChannel",
+						Name:       channelName,
+					}, {
+						Name: readyEventPolicyName,
+					},
+				}...),
+				WithEventPolicyLabels(map[string]string{
+					"messaging.knative.dev/channel-group":   v1.SchemeGroupVersion.Group,
+					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
+					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
+					"messaging.knative.dev/channel-name":    channelName,
+				}),
+			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewChannel(channelName, testNS,
@@ -379,6 +402,24 @@ func TestReconcile(t *testing.T) {
 			NewEventPolicy(unreadyEventPolicyName, testNS,
 				WithUnreadyEventPolicyCondition,
 				WithEventPolicyToRef(channelV1GVK, channelName),
+			),
+			NewEventPolicy(fmt.Sprintf("%s-%s", unreadyEventPolicyName, channelName), testNS,
+				WithEventPolicyToRef(imcV1GVK, channelName),
+				WithEventPolicyOwnerReferences([]metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "InMemoryChannel",
+						Name:       channelName,
+					}, {
+						Name: unreadyEventPolicyName,
+					},
+				}...),
+				WithEventPolicyLabels(map[string]string{
+					"messaging.knative.dev/channel-group":   v1.SchemeGroupVersion.Group,
+					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
+					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
+					"messaging.knative.dev/channel-name":    channelName,
+				}),
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -415,6 +456,42 @@ func TestReconcile(t *testing.T) {
 				WithUnreadyEventPolicyCondition,
 				WithEventPolicyToRef(channelV1GVK, channelName),
 			),
+			NewEventPolicy(fmt.Sprintf("%s-%s", readyEventPolicyName, channelName), testNS,
+				WithEventPolicyToRef(imcV1GVK, channelName),
+				WithEventPolicyOwnerReferences([]metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "InMemoryChannel",
+						Name:       channelName,
+					}, {
+						Name: readyEventPolicyName,
+					},
+				}...),
+				WithEventPolicyLabels(map[string]string{
+					"messaging.knative.dev/channel-group":   v1.SchemeGroupVersion.Group,
+					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
+					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
+					"messaging.knative.dev/channel-name":    channelName,
+				}),
+			),
+			NewEventPolicy(fmt.Sprintf("%s-%s", unreadyEventPolicyName, channelName), testNS,
+				WithEventPolicyToRef(imcV1GVK, channelName),
+				WithEventPolicyOwnerReferences([]metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "InMemoryChannel",
+						Name:       channelName,
+					}, {
+						Name: unreadyEventPolicyName,
+					},
+				}...),
+				WithEventPolicyLabels(map[string]string{
+					"messaging.knative.dev/channel-group":   v1.SchemeGroupVersion.Group,
+					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
+					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
+					"messaging.knative.dev/channel-name":    channelName,
+				}),
+			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: NewChannel(channelName, testNS,
@@ -427,6 +504,60 @@ func TestReconcile(t *testing.T) {
 				WithChannelEventPoliciesNotReady("EventPoliciesNotReady", fmt.Sprintf("event policies %s are not ready", unreadyEventPolicyName)),
 				WithChannelEventPoliciesListed(readyEventPolicyName)),
 		}},
+	}, {
+		Name: "should create EventPolicies for backing channel",
+		Key:  testKey,
+		Objects: []runtime.Object{
+			NewChannel(channelName, testNS,
+				WithChannelTemplate(channelCRD()),
+				WithInitChannelConditions,
+				WithChannelEventPoliciesReady(),
+				WithChannelEventPoliciesListed(readyEventPolicyName)),
+			NewInMemoryChannel(channelName, testNS,
+				WithInitInMemoryChannelConditions,
+				WithInMemoryChannelDeploymentReady(),
+				WithInMemoryChannelServiceReady(),
+				WithInMemoryChannelEndpointsReady(),
+				WithInMemoryChannelChannelServiceReady(),
+				WithInMemoryChannelAddress(backingChannelAddressable),
+				WithInMemoryChannelDLSUnknown(),
+				WithInMemoryChannelEventPoliciesReady()),
+			NewEventPolicy(readyEventPolicyName, testNS,
+				WithReadyEventPolicyCondition,
+				WithEventPolicyToRef(channelV1GVK, channelName),
+			),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: NewChannel(channelName, testNS,
+				WithChannelTemplate(channelCRD()),
+				WithInitChannelConditions,
+				WithBackingChannelObjRef(backingChannelObjRef()),
+				WithBackingChannelReady,
+				WithChannelDLSUnknown(),
+				WithChannelAddress(&backingChannelAddressable),
+				WithChannelEventPoliciesReady(),
+				WithChannelEventPoliciesListed(readyEventPolicyName)),
+		}},
+		WantCreates: []runtime.Object{
+			NewEventPolicy(fmt.Sprintf("%s-%s", readyEventPolicyName, channelName), testNS,
+				WithEventPolicyToRef(imcV1GVK, channelName),
+				WithEventPolicyOwnerReferences([]metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "InMemoryChannel",
+						Name:       channelName,
+					}, {
+						Name: readyEventPolicyName,
+					},
+				}...),
+				WithEventPolicyLabels(map[string]string{
+					"messaging.knative.dev/channel-group":   v1.SchemeGroupVersion.Group,
+					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
+					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
+					"messaging.knative.dev/channel-name":    channelName,
+				}),
+			),
+		},
 	}}
 
 	logger := logtesting.TestLogger(t)
@@ -438,6 +569,7 @@ func TestReconcile(t *testing.T) {
 			channelLister:      listers.GetMessagingChannelLister(),
 			channelableTracker: &fakeListableTracker{duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0))},
 			eventPolicyLister:  listers.GetEventPolicyLister(),
+			eventingClientSet:  fakeeventingclient.Get(ctx),
 		}
 		return channelreconciler.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetMessagingChannelLister(),
@@ -596,41 +728,4 @@ func createChannel(namespace, name string, ready bool) *unstructured.Unstructure
 			},
 		},
 	}
-}
-
-func makeEventPolicy(eventPolicyName string) *v1alpha1.EventPolicy {
-	return &v1alpha1.EventPolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "eventing.knative.dev/v1alpha1",
-			Kind:       "EventPolicy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNS,
-			Name:      eventPolicyName,
-		},
-		Spec: v1alpha1.EventPolicySpec{
-			To: []v1alpha1.EventPolicySpecTo{
-				{
-					Ref: &v1alpha1.EventPolicyToReference{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "Channel",
-						Name:       channelName,
-					},
-				},
-			},
-		},
-		Status: v1alpha1.EventPolicyStatus{},
-	}
-}
-
-func makeReadyEventPolicy() *v1alpha1.EventPolicy {
-	policy := makeEventPolicy(readyEventPolicyName)
-	policy.Status.Conditions = []apis.Condition{{Type: v1alpha1.EventPolicyConditionReady, Status: corev1.ConditionTrue}}
-	return policy
-}
-
-func makeUnreadyEventPolicy() *v1alpha1.EventPolicy {
-	policy := makeEventPolicy(unreadyEventPolicyName)
-	policy.Status.Conditions = []apis.Condition{{Type: v1alpha1.EventPolicyConditionReady, Status: corev1.ConditionFalse}}
-	return policy
 }

--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -319,6 +319,7 @@ func TestReconcile(t *testing.T) {
 			dynamicClientSet:   fakedynamicclient.Get(ctx),
 			channelLister:      listers.GetMessagingChannelLister(),
 			channelableTracker: &fakeListableTracker{duck.NewListableTrackerFromTracker(ctx, channelable.Get, tracker.New(func(types.NamespacedName) {}, 0))},
+			eventPolicyLister:  listers.GetEventPolicyLister(),
 		}
 		return channelreconciler.NewReconciler(ctx, logger,
 			fakeeventingclient.Get(ctx), listers.GetMessagingChannelLister(),

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -42,8 +42,25 @@ func NewController(
 		channelLister:    channelInformer.Lister(),
 	}
 	impl := channelreconciler.NewImpl(ctx, r)
+	var globalResync func()
+	featureStore := feature.NewStore(logging.FromContext(ctx).Named("feature-config-store"), func(name string, value interface{}) {
+		if globalResync != nil {
+			globalResync()
+		}
+	})
+	featureStore.WatchConfigs(cmw)
+
+	impl := channelreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			ConfigStore: featureStore,
+		}
+	})
 
 	r.channelableTracker = duck.NewListableTrackerFromTracker(ctx, channelable.Get, impl.Tracker)
+
+	globalResync = func() {
+		impl.GlobalResync(channelInformer.Informer())
+	}
 
 	channelInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 

--- a/pkg/reconciler/channel/controller.go
+++ b/pkg/reconciler/channel/controller.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	"knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	channelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel"
@@ -49,6 +50,7 @@ func NewController(
 		dynamicClientSet:  dynamicclient.Get(ctx),
 		channelLister:     channelInformer.Lister(),
 		eventPolicyLister: eventPolicyInformer.Lister(),
+		eventingClientSet: eventingclient.Get(ctx),
 	}
 
 	var globalResync func()

--- a/pkg/reconciler/channel/controller_test.go
+++ b/pkg/reconciler/channel/controller_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package channel
 
 import (
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/feature"
-	"testing"
 
 	"knative.dev/pkg/configmap"
 

--- a/pkg/reconciler/channel/controller_test.go
+++ b/pkg/reconciler/channel/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/channel/fake"
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"

--- a/pkg/reconciler/channel/controller_test.go
+++ b/pkg/reconciler/channel/controller_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package channel
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/pkg/apis/feature"
 	"testing"
 
 	"knative.dev/pkg/configmap"
@@ -34,7 +37,12 @@ import (
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	c := NewController(ctx, configmap.NewStaticWatcher(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      feature.FlagsConfigName,
+			Namespace: "knative-eventing",
+		},
+	}))
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/channel/resources/eventpolicy.go
+++ b/pkg/reconciler/channel/resources/eventpolicy.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/pkg/kmeta"
+)
+
+const (
+	BackingChannelEventPolicyLabelPrefix = "messaging.knative.dev/"
+)
+
+func MakeEventPolicyForBackingChannel(backingChannel *eventingduckv1.Channelable, parentPolicy *eventingv1alpha1.EventPolicy) *eventingv1alpha1.EventPolicy {
+	parentPolicy = parentPolicy.DeepCopy()
+
+	return &eventingv1alpha1.EventPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: backingChannel.Namespace,
+			Name:      kmeta.ChildName(fmt.Sprintf("%s-", parentPolicy.Name), backingChannel.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: backingChannel.APIVersion,
+					Kind:       backingChannel.Kind,
+					Name:       backingChannel.Name,
+					UID:        backingChannel.UID,
+				}, {
+					APIVersion: parentPolicy.APIVersion,
+					Kind:       parentPolicy.Kind,
+					Name:       parentPolicy.Name,
+					UID:        parentPolicy.UID,
+				},
+			},
+			Labels: LabelsForBackingChannelsEventPolicy(backingChannel),
+		},
+		Spec: eventingv1alpha1.EventPolicySpec{
+			To: []eventingv1alpha1.EventPolicySpecTo{
+				{
+					Ref: &eventingv1alpha1.EventPolicyToReference{
+						APIVersion: backingChannel.APIVersion,
+						Kind:       backingChannel.Kind,
+						Name:       backingChannel.Name,
+					},
+				},
+			},
+			From: parentPolicy.Spec.From,
+		},
+	}
+}
+
+func LabelsForBackingChannelsEventPolicy(backingChannel *eventingduckv1.Channelable) map[string]string {
+	return map[string]string{
+		BackingChannelEventPolicyLabelPrefix + "channel-group":   backingChannel.GroupVersionKind().Group,
+		BackingChannelEventPolicyLabelPrefix + "channel-version": backingChannel.GroupVersionKind().Version,
+		BackingChannelEventPolicyLabelPrefix + "channel-kind":    backingChannel.Kind,
+		BackingChannelEventPolicyLabelPrefix + "channel-name":    backingChannel.Name,
+	}
+}

--- a/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/inmemorychannel_test.go
@@ -22,8 +22,6 @@ import (
 	"strconv"
 	"testing"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -104,6 +102,12 @@ var (
 	dlsStatus = &duckv1.Addressable{
 		URL:     dlsURI,
 		CACerts: nil,
+	}
+
+	imcV1GVK = metav1.GroupVersionKind{
+		Group:   "messaging.knative.dev",
+		Version: "v1",
+		Kind:    "InMemoryChannel",
 	}
 )
 
@@ -659,11 +663,7 @@ func TestAllCases(t *testing.T) {
 				makeChannelService(NewInMemoryChannel(imcName, testNS)),
 				NewEventPolicy(readyEventPolicyName, testNS,
 					WithReadyEventPolicyCondition,
-					WithEventPolicyToRef(v1alpha1.EventPolicyToReference{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "InMemoryChannel",
-						Name:       imcName,
-					}),
+					WithEventPolicyToRef(imcV1GVK, imcName),
 				),
 			},
 			WantErr: false,
@@ -698,11 +698,7 @@ func TestAllCases(t *testing.T) {
 				makeChannelService(NewInMemoryChannel(imcName, testNS)),
 				NewEventPolicy(unreadyEventPolicyName, testNS,
 					WithUnreadyEventPolicyCondition,
-					WithEventPolicyToRef(v1alpha1.EventPolicyToReference{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "InMemoryChannel",
-						Name:       imcName,
-					}),
+					WithEventPolicyToRef(imcV1GVK, imcName),
 				),
 			},
 			WantErr: false,
@@ -736,19 +732,11 @@ func TestAllCases(t *testing.T) {
 				makeChannelService(NewInMemoryChannel(imcName, testNS)),
 				NewEventPolicy(readyEventPolicyName, testNS,
 					WithReadyEventPolicyCondition,
-					WithEventPolicyToRef(v1alpha1.EventPolicyToReference{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "InMemoryChannel",
-						Name:       imcName,
-					}),
+					WithEventPolicyToRef(imcV1GVK, imcName),
 				),
 				NewEventPolicy(unreadyEventPolicyName, testNS,
 					WithUnreadyEventPolicyCondition,
-					WithEventPolicyToRef(v1alpha1.EventPolicyToReference{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "InMemoryChannel",
-						Name:       imcName,
-					}),
+					WithEventPolicyToRef(imcV1GVK, imcName),
 				),
 			},
 			WantErr: false,

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -1487,6 +1487,7 @@ func TestAllCases(t *testing.T) {
 					WithBackingChannelReady,
 					WithChannelAddress(sink),
 					WithChannelDLSUnknown(),
+					WithChannelEventPoliciesReady(),
 				),
 				NewInMemoryChannel(channelName, testNS,
 					WithInitInMemoryChannelConditions,

--- a/pkg/reconciler/testing/v1/channel.go
+++ b/pkg/reconciler/testing/v1/channel.go
@@ -159,6 +159,12 @@ func WithChannelDLSUnknown() ChannelOption {
 	}
 }
 
+func WithChannelEventPoliciesReady() ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkEventPoliciesTrue()
+	}
+}
+
 func WithChannelDLSResolvedFailed() ChannelOption {
 	return func(c *eventingv1.Channel) {
 		c.Status.MarkDeadLetterSinkResolvedFailed(

--- a/pkg/reconciler/testing/v1/channel.go
+++ b/pkg/reconciler/testing/v1/channel.go
@@ -16,6 +16,8 @@ package testing
 import (
 	"context"
 	"fmt"
+	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing/pkg/apis/feature"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -162,6 +164,35 @@ func WithChannelDLSUnknown() ChannelOption {
 func WithChannelEventPoliciesReady() ChannelOption {
 	return func(c *eventingv1.Channel) {
 		c.Status.MarkEventPoliciesTrue()
+	}
+}
+
+func WithChannelEventPoliciesNotReady(reason, message string) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkEventPoliciesFailed(reason, message)
+	}
+}
+
+func WithChannelEventPoliciesListed(policyNames ...string) ChannelOption {
+	return func(c *eventingv1.Channel) {
+		for _, name := range policyNames {
+			c.Status.Policies = append(c.Status.Policies, eventingduckv1.AppliedEventPolicyRef{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Name:       name,
+			})
+		}
+	}
+}
+
+func WithChannelEventPoliciesReadyBecauseOIDCDisabled() ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkEventPoliciesTrueWithReason("OIDCDisabled", "Feature %q must be enabled to support Authorization", feature.OIDCAuthentication)
+	}
+}
+
+func WithChannelEventPoliciesReadyBecauseNoPolicyAndOIDCEnabled() ChannelOption {
+	return func(c *eventingv1.Channel) {
+		c.Status.MarkEventPoliciesTrueWithReason("DefaultAuthorizationMode", "Default authz mode is %q", feature.AuthorizationAllowSameNamespace)
 	}
 }
 

--- a/pkg/reconciler/testing/v1/channel.go
+++ b/pkg/reconciler/testing/v1/channel.go
@@ -16,9 +16,10 @@ package testing
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/apis/feature"
-	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 

--- a/pkg/reconciler/testing/v1/eventpolicy.go
+++ b/pkg/reconciler/testing/v1/eventpolicy.go
@@ -66,23 +66,28 @@ func WithUnreadyEventPolicyCondition(ep *v1alpha1.EventPolicy) {
 	}
 }
 
-func WithEventPolicyTo(tos ...v1alpha1.EventPolicySpecTo) EventPolicyOption {
-	return func(ep *v1alpha1.EventPolicy) {
-		ep.Spec.To = append(ep.Spec.To, tos...)
-	}
-}
-
-func WithEventPolicyToRef(ref v1alpha1.EventPolicyToReference) EventPolicyOption {
+func WithEventPolicyToRef(gvk metav1.GroupVersionKind, name string) EventPolicyOption {
 	return func(ep *v1alpha1.EventPolicy) {
 		ep.Spec.To = append(ep.Spec.To, v1alpha1.EventPolicySpecTo{
-			Ref: &ref,
+			Ref: &v1alpha1.EventPolicyToReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+			},
 		})
 	}
 }
 
-func WithEventPolicyFrom(froms ...v1alpha1.EventPolicySpecFrom) EventPolicyOption {
+func WithEventPolicyFrom(gvk metav1.GroupVersionKind, name, namespace string) EventPolicyOption {
 	return func(ep *v1alpha1.EventPolicy) {
-		ep.Spec.From = append(ep.Spec.From, froms...)
+		ep.Spec.From = append(ep.Spec.From, v1alpha1.EventPolicySpecFrom{
+			Ref: &v1alpha1.EventPolicyFromReference{
+				APIVersion: apiVersion(gvk),
+				Kind:       gvk.Kind,
+				Name:       name,
+				Namespace:  namespace,
+			},
+		})
 	}
 }
 

--- a/pkg/reconciler/testing/v1/eventpolicy.go
+++ b/pkg/reconciler/testing/v1/eventpolicy.go
@@ -97,10 +97,8 @@ func WithEventPolicyLabels(labels map[string]string) EventPolicyOption {
 	}
 }
 
-func WithEventPolicyOwnerReference(ownerRef metav1.OwnerReference) EventPolicyOption {
+func WithEventPolicyOwnerReferences(ownerRefs ...metav1.OwnerReference) EventPolicyOption {
 	return func(ep *v1alpha1.EventPolicy) {
-		ep.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			ownerRef,
-		}
+		ep.ObjectMeta.OwnerReferences = append(ep.ObjectMeta.OwnerReferences, ownerRefs...)
 	}
 }


### PR DESCRIPTION
Fixes #8013

## Proposed Changes

- :gift: List `EventPolicies` in the channels `.status.policies`, which apply for it
- :gift: Add the `EventPoliciesReady` condition to indicate, if the referenced policies are Ready
- :gift: Create a copy of the EventPolicies applying for the Channel, to target the backing channel

**Release Note**

```release-note
List applying EventPolicies in Channels status and propagate EventPolicies to backing channel
```
