### PR TITLE
[WIP] Merge Redundant TLS & OIDC e2e Tests

### DIFF
--- a/test/rekt/parallel_test.go
+++ b/test/rekt/parallel_test.go
@@ -51,22 +51,6 @@ func TestParallel(t *testing.T) {
 	env.Test(ctx, t, parallel.ParallelWithTwoBranches(channel_template.ImmemoryChannelTemplate()))
 }
 
-func TestParallelTLS(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
-	t.Cleanup(env.Finish)
-
-	env.Test(ctx, t, parallel.ParallelWithTwoBranchesTLS(channel_template.ImmemoryChannelTemplate()))
-}
-
 func TestParallelSupportsOIDC(t *testing.T) {
 	t.Parallel()
 
@@ -88,17 +72,26 @@ func TestParallelSupportsOIDC(t *testing.T) {
 	env.Test(ctx, t, parallel.ParallelHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
 }
 
-func TestParallelTwoBranchesWithOIDC(t *testing.T) {
-	t.Parallel()
+func TestParallelTLSAndOIDC(t *testing.T) {
+    t.Parallel()
 
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
+    ctx, env := global.Environment(
+        knative.WithKnativeNamespace(system.Namespace()),
+        knative.WithLoggingConfig,
+        knative.WithTracingConfig,
+        k8s.WithEventListener,
+        environment.Managed(t),
+        eventshub.WithTLS(t),
+    )
+    t.Cleanup(env.Finish)
 
-	env.Test(ctx, t, parallel.ParallelWithTwoBranchesOIDC(channel_template.ImmemoryChannelTemplate()))
+    t.Run("TestParallelTLS", func(t *testing.T) {
+        t.Parallel()
+        env.Test(ctx, t, parallel.ParallelWithTwoBranchesTLS(channel_template.ImmemoryChannelTemplate()))
+    })
+
+    t.Run("TestParallelOIDC", func(t *testing.T) {
+        t.Parallel()
+        env.Test(ctx, t, parallel.ParallelWithTwoBranchesOIDC(channel_template.ImmemoryChannelTemplate()))
+    })
 }

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -46,23 +46,6 @@ func TestPingSourceWithSinkRef(t *testing.T) {
 	env.Test(ctx, t, pingsource.SendsEventsWithSinkRef())
 }
 
-func TestPingSourceTLS(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
-	t.Cleanup(env.Finish)
-
-	env.ParallelTest(ctx, t, pingsource.SendsEventsTLS())
-	env.ParallelTest(ctx, t, pingsource.SendsEventsTLSTrustBundle())
-}
-
 func TestPingSourceWithSinkURI(t *testing.T) {
 	t.Parallel()
 
@@ -120,17 +103,27 @@ func TestPingSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
 	env.Test(ctx, t, pingsource.SendsEventsWithBrokerAsSinkTLS())
 }
 
-func TestPingSourceSendsEventsOIDC(t *testing.T) {
-	t.Parallel()
+func TestPingSourceTLSAndOIDC(t *testing.T) {
+    t.Parallel()
 
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
+    ctx, env := global.Environment(
+        knative.WithKnativeNamespace(system.Namespace()),
+        knative.WithLoggingConfig,
+        knative.WithTracingConfig,
+        k8s.WithEventListener,
+        environment.Managed(t),
+        eventshub.WithTLS(t),
+    )
+    t.Cleanup(env.Finish)
 
-	env.Test(ctx, t, pingsource.PingSourceSendEventOIDC())
+    t.Run("SendsEventsTLS", func(t *testing.T) {
+        t.Parallel()
+        env.ParallelTest(ctx, t, pingsource.SendsEventsTLS())
+        env.ParallelTest(ctx, t, pingsource.SendsEventsTLSTrustBundle())
+    })
+
+    t.Run("SendsEventsOIDC", func(t *testing.T) {
+        t.Parallel()
+        env.Test(ctx, t, pingsource.PingSourceSendEventOIDC())
+    })
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Addresses #7638 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :broom: merged `TestParallelTLS` & `TestParallelTwoBranchesWithOIDC` into `TestParallelTLSAndOIDC`
- :broom: merged `TestPingSourceTLS` & `TestPingSourceSendsEventsOIDC` into `TestPingSourceTLSAndOIDC`
- 

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

