### PR TITLE
Add JobSink to storage version migration

### DIFF
--- a/config/post-install/clusterrole.yaml
+++ b/config/post-install/clusterrole.yaml
@@ -110,6 +110,19 @@ rules:
       - "patch"
       - "watch"
   - apiGroups:
+      - "sinks.knative.dev"
+    resources:
+      - "jobsinks"
+      - "jobsinks/finalizers"
+      - "jobsinks/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
       - ""
     resources:
       - "namespaces"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -53,6 +53,7 @@ spec:
             - "sinkbindings.sources.knative.dev"
             - "subscriptions.messaging.knative.dev"
             - "triggers.eventing.knative.dev"
+            - "jobsinks.sinks.knative.dev"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
This is not necessary as we only have one version but it's better to have it from the start