### PR TITLE
Fix test case in TestCreateExpectedEventPatterns

### DIFF
--- a/test/rekt/features/broker/topology_test.go
+++ b/test/rekt/features/broker/topology_test.go
@@ -175,14 +175,14 @@ func TestCreateExpectedEventPatterns(t *testing.T) {
 			DeadLetterSink: dlqSink,
 		},
 		t0FailCount: 0,
-		t1FailCount: 1,
+		t1FailCount: 2,
 		want: map[string]knconf.EventPattern{
 			"t0": {
 				Success:  []bool{true},
 				Interval: []uint{0},
 			},
 			"t1": {
-				Success:  []bool{false, true},
+				Success:  []bool{false, false},
 				Interval: []uint{0, 0},
 			},
 			"t0dlq":     noEvents,
@@ -214,7 +214,7 @@ func TestCreateExpectedEventPatterns(t *testing.T) {
 		},
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			cfg := []triggerCfg{{
 				delivery:  tt.t0DS,
 				failCount: tt.t0FailCount,


### PR DESCRIPTION
`TestCreateExpectedEventPatterns` will start to fail with go 1.22 (see https://github.com/knative/eventing/pull/8019#issuecomment-2182882142):

```
$ go test ./test/rekt/features/broker/... -run TestCreateExpectedEventPatterns
ok      knative.dev/eventing/test/rekt/features/broker  0.015s

$ GOEXPERIMENT=loopvar go test ./test/rekt/features/broker/... -run TestCreateExpectedEventPatterns
--- FAIL: TestCreateExpectedEventPatterns (0.00s)
    --- FAIL: TestCreateExpectedEventPatterns/t1,_one_retry,_one_failure,_both_t0_/_t1_get_it,_t1dlq_gets_it_too (0.00s)
        topology_test.go:227: t1, one retry, one failure, both t0 / t1 get it, t1dlq gets it too: Maps unequal: want:
            map[brokerdlq:{Success:[] Interval:[]} t0:{Success:[true] Interval:[0]} t0dlq:{Success:[] Interval:[]} t1:{Success:[false true] Interval:[0 0]} t1dlq:{Success:[true] Interval:[0]}]
            got:
            map[brokerdlq:{Success:[] Interval:[]} t0:{Success:[true] Interval:[0]} t0dlq:{Success:[] Interval:[]} t1:{Success:[false true] Interval:[0 0]} t1dlq:{Success:[] Interval:[]}]
FAIL
FAIL    knative.dev/eventing/test/rekt/features/broker  0.016s
FAIL
```

The test was actually never totally correct and only the last test case was tested. See https://go.dev/blog/loopvar-preview:

> In Go 1.21, ... passes because `t.Parallel` blocks each subtest until the entire loop has finished and then runs all the subtests in parallel.

This PR addresses it and fixes the test. Actually the tests is the same as the one for t0 which was setup correctly:

https://github.com/knative/eventing/blob/67958c6ee8da412c86c2a22b5a523e1b91c20654/test/rekt/features/broker/topology_test.go#L101-L122