### PR TITLE
Set APIVersion and Kind of EventPolicy manually in OwnerReference of backing channels policy

### DIFF
--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 
+	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
+
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -361,7 +363,9 @@ func TestReconcile(t *testing.T) {
 						Kind:       "InMemoryChannel",
 						Name:       channelName,
 					}, {
-						Name: readyEventPolicyName,
+						APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "EventPolicy",
+						Name:       readyEventPolicyName,
 					},
 				}...),
 				WithEventPolicyLabels(map[string]string{
@@ -411,7 +415,9 @@ func TestReconcile(t *testing.T) {
 						Kind:       "InMemoryChannel",
 						Name:       channelName,
 					}, {
-						Name: unreadyEventPolicyName,
+						APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "EventPolicy",
+						Name:       unreadyEventPolicyName,
 					},
 				}...),
 				WithEventPolicyLabels(map[string]string{
@@ -464,7 +470,9 @@ func TestReconcile(t *testing.T) {
 						Kind:       "InMemoryChannel",
 						Name:       channelName,
 					}, {
-						Name: readyEventPolicyName,
+						APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "EventPolicy",
+						Name:       readyEventPolicyName,
 					},
 				}...),
 				WithEventPolicyLabels(map[string]string{
@@ -482,7 +490,9 @@ func TestReconcile(t *testing.T) {
 						Kind:       "InMemoryChannel",
 						Name:       channelName,
 					}, {
-						Name: unreadyEventPolicyName,
+						APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "EventPolicy",
+						Name:       unreadyEventPolicyName,
 					},
 				}...),
 				WithEventPolicyLabels(map[string]string{
@@ -547,7 +557,9 @@ func TestReconcile(t *testing.T) {
 						Kind:       "InMemoryChannel",
 						Name:       channelName,
 					}, {
-						Name: readyEventPolicyName,
+						APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "EventPolicy",
+						Name:       readyEventPolicyName,
 					},
 				}...),
 				WithEventPolicyLabels(map[string]string{

--- a/pkg/reconciler/channel/resources/eventpolicy.go
+++ b/pkg/reconciler/channel/resources/eventpolicy.go
@@ -43,8 +43,8 @@ func MakeEventPolicyForBackingChannel(backingChannel *eventingduckv1.Channelable
 					Name:       backingChannel.Name,
 					UID:        backingChannel.UID,
 				}, {
-					APIVersion: parentPolicy.APIVersion,
-					Kind:       parentPolicy.Kind,
+					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
+					Kind:       "EventPolicy",
 					Name:       parentPolicy.Name,
 					UID:        parentPolicy.UID,
 				},

--- a/pkg/reconciler/channel/resources/eventpolicy.go
+++ b/pkg/reconciler/channel/resources/eventpolicy.go
@@ -43,8 +43,8 @@ func MakeEventPolicyForBackingChannel(backingChannel *eventingduckv1.Channelable
 					Name:       backingChannel.Name,
 					UID:        backingChannel.UID,
 				}, {
-					APIVersion: eventingv1alpha1.SchemeGroupVersion.String(),
-					Kind:       "EventPolicy",
+					APIVersion: parentPolicy.GetGroupVersionKind().GroupVersion().String(),
+					Kind:       parentPolicy.GetGroupVersionKind().Kind,
 					Name:       parentPolicy.Name,
 					UID:        parentPolicy.UID,
 				},


### PR DESCRIPTION
We see sometimes the following error in the eventing-controller:

```
{"level":"info","ts":"2024-06-25T10:56:58.973Z","logger":"controller.event-broadcaster","caller":"record/event.go:364","msg":"Event(v1.ObjectReference{Kind:\"Channel\", Namespace:\"channel-ns\", Name:\"my-channel\", UID:\"41401bb0-d09f-45ca-b1cf-9ded4ea2bf78\", APIVersion:\"messaging.knative.dev/v1\", ResourceVersion:\"13158\", FieldPath:\"\"}): type: 'Warning' reason: 'InternalError' could not reconcile backing channels (channel-ns/my-channel) event policies: could not reconcile EventPolicy channel-ns/event-policy for backing channel channel-ns/my-channel: could not create EventPolicy channel-ns/event-policy-my-channel: EventPolicy.eventing.knative.dev \"event-policy-my-channel\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]","commit":"5297b9f-dirty","knative.dev/pod":"eventing-controller-6876c8fbd7-pmb9f"}
```
In particular: `metadata.ownerReferences.apiVersion: Invalid value: "": version must not be empty, metadata.ownerReferences.kind: Invalid value: "": kind must not be empty`

This can happen, when the EventPolicy lister did not update the TypeMeta of the policy in time.
This PR addresses it, and sets the ApiVersion and Kind in the OwnerRef manually, when we create the EventPolicy "template"
