### PR TITLE
feat(test): create knsubscribe rolebinding to current user in e2e test setup

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -91,6 +91,8 @@ function knative_setup() {
   unleash_duck || fail_test "Could not unleash the chaos duck"
 
   install_feature_cm || fail_test "Could not install features configmap"
+
+  create_knsubscribe_rolebinding || fail_test "Could not create knsusbcribe rolebinding"
 }
 
 function scale_controlplane() {
@@ -102,6 +104,10 @@ function scale_controlplane() {
     # Scale up components for HA tests
     kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas="${REPLICAS}" || failed=1
   done
+}
+
+function create_knsubscribe_rolebinding() {
+  kubectl create clusterrolebinding knsubscribe-test-rb --user=$(kubectl auth whoami -ojson | jq .status.userInfo.username -r) --clusterrole=crossnamespace=subscriber
 }
 
 # Install Knative Monitoring in the current cluster.


### PR DESCRIPTION


<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Should fix errors seen in #7933 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Create a ClusteRoleBinding to the current user for knsubscribe in the test setup
