### PR TITLE
List applying EventPolicies in Brokers status

### DIFF
--- a/pkg/apis/eventing/v1/broker_lifecycle.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle.go
@@ -32,6 +32,7 @@ const (
 	BrokerConditionFilter                 apis.ConditionType = "FilterReady"
 	BrokerConditionAddressable            apis.ConditionType = "Addressable"
 	BrokerConditionDeadLetterSinkResolved apis.ConditionType = "DeadLetterSinkResolved"
+	BrokerConditionEventPoliciesReady     apis.ConditionType = "EventPoliciesReady"
 )
 
 var brokerCondSet = apis.NewLivingConditionSet(
@@ -40,6 +41,7 @@ var brokerCondSet = apis.NewLivingConditionSet(
 	BrokerConditionFilter,
 	BrokerConditionAddressable,
 	BrokerConditionDeadLetterSinkResolved,
+	BrokerConditionEventPoliciesReady,
 )
 var brokerCondSetLock = sync.RWMutex{}
 
@@ -117,4 +119,20 @@ func (bs *BrokerStatus) MarkDeadLetterSinkNotConfigured() {
 func (bs *BrokerStatus) MarkDeadLetterSinkResolvedFailed(reason, messageFormat string, messageA ...interface{}) {
 	bs.DeliveryStatus = eventingduck.DeliveryStatus{}
 	bs.GetConditionSet().Manage(bs).MarkFalse(BrokerConditionDeadLetterSinkResolved, reason, messageFormat, messageA...)
+}
+
+func (bs *BrokerStatus) MarkEventPoliciesTrue() {
+	bs.GetConditionSet().Manage(bs).MarkTrue(BrokerConditionEventPoliciesReady)
+}
+
+func (bs *BrokerStatus) MarkEventPoliciesTrueWithReason(reason, messageFormat string, messageA ...interface{}) {
+	bs.GetConditionSet().Manage(bs).MarkTrueWithReason(BrokerConditionEventPoliciesReady, reason, messageFormat, messageA...)
+}
+
+func (bs *BrokerStatus) MarkEventPoliciesFailed(reason, messageFormat string, messageA ...interface{}) {
+	bs.GetConditionSet().Manage(bs).MarkFalse(BrokerConditionEventPoliciesReady, reason, messageFormat, messageA...)
+}
+
+func (bs *BrokerStatus) MarkEventPoliciesUnknown(reason, messageFormat string, messageA ...interface{}) {
+	bs.GetConditionSet().Manage(bs).MarkUnknown(BrokerConditionEventPoliciesReady, reason, messageFormat, messageA...)
 }

--- a/pkg/apis/eventing/v1/broker_lifecycle_test.go
+++ b/pkg/apis/eventing/v1/broker_lifecycle_test.go
@@ -194,6 +194,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Type:   BrokerConditionDeadLetterSinkResolved,
 					Status: corev1.ConditionUnknown,
 				}, {
+					Type:   BrokerConditionEventPoliciesReady,
+					Status: corev1.ConditionUnknown,
+				}, {
 					Type:   BrokerConditionFilter,
 					Status: corev1.ConditionUnknown,
 				}, {
@@ -225,6 +228,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   BrokerConditionDeadLetterSinkResolved,
+					Status: corev1.ConditionUnknown,
+				}, {
+					Type:   BrokerConditionEventPoliciesReady,
 					Status: corev1.ConditionUnknown,
 				}, {
 					Type:   BrokerConditionFilter,
@@ -260,6 +266,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Type:   BrokerConditionDeadLetterSinkResolved,
 					Status: corev1.ConditionUnknown,
 				}, {
+					Type:   BrokerConditionEventPoliciesReady,
+					Status: corev1.ConditionUnknown,
+				}, {
 					Type:   BrokerConditionFilter,
 					Status: corev1.ConditionTrue,
 				}, {
@@ -286,6 +295,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}, {
 					Type:   BrokerConditionDeadLetterSinkResolved,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   BrokerConditionEventPoliciesReady,
 					Status: corev1.ConditionTrue,
 				}, {
 					Type:   BrokerConditionFilter,
@@ -315,6 +327,9 @@ func TestBrokerInitializeConditions(t *testing.T) {
 					Status: corev1.ConditionTrue,
 				}, {
 					Type:   BrokerConditionDeadLetterSinkResolved,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   BrokerConditionEventPoliciesReady,
 					Status: corev1.ConditionTrue,
 				}, {
 					Type:   BrokerConditionFilter,
@@ -350,6 +365,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady      *bool
 		markFilterReady              *bool
 		markDLSResolved              *bool
+		markEventPolicyReady         *bool
 		markAddressable              *bool
 		address                      *apis.URL
 		markIngressSubscriptionOwned bool
@@ -361,6 +377,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -371,6 +388,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -381,6 +399,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -391,6 +410,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &falseVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -401,6 +421,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &falseVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -411,6 +432,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      nil,
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -421,6 +443,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &trueVal,
 		markAddressable:              nil,
 		address:                      nil,
 		markIngressSubscriptionOwned: true,
@@ -432,6 +455,7 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              &falseVal,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
@@ -442,16 +466,29 @@ func TestBrokerIsReady(t *testing.T) {
 		markTriggerChannelReady:      &trueVal,
 		markFilterReady:              &trueVal,
 		markDLSResolved:              nil,
+		markEventPolicyReady:         &trueVal,
 		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &trueVal,
 		wantReady:                    true,
+	}, {
+		name:                         "eventpolicy sad",
+		markIngressReady:             &trueVal,
+		markTriggerChannelReady:      &trueVal,
+		markFilterReady:              &trueVal,
+		markDLSResolved:              &trueVal,
+		markEventPolicyReady:         &falseVal,
+		address:                      &apis.URL{Scheme: "http", Host: "hostname"},
+		markIngressSubscriptionOwned: true,
+		markIngressSubscriptionReady: &trueVal,
+		wantReady:                    false,
 	}, {
 		name:                         "all sad",
 		markIngressReady:             &falseVal,
 		markTriggerChannelReady:      &falseVal,
 		markFilterReady:              &falseVal,
 		markDLSResolved:              &falseVal,
+		markEventPolicyReady:         &falseVal,
 		address:                      nil,
 		markIngressSubscriptionOwned: true,
 		markIngressSubscriptionReady: &falseVal,
@@ -486,6 +523,14 @@ func TestBrokerIsReady(t *testing.T) {
 				bs.MarkDeadLetterSinkResolvedFailed("Unable to get the dead letter sink's URI", "DLS reference not found")
 			} else {
 				bs.MarkDeadLetterSinkNotConfigured()
+			}
+
+			if test.markEventPolicyReady == &trueVal {
+				bs.MarkEventPoliciesTrue()
+			} else if test.markEventPolicyReady == &falseVal {
+				bs.MarkEventPoliciesFailed("", "")
+			} else {
+				bs.MarkEventPoliciesUnknown("", "")
 			}
 
 			if test.markFilterReady != nil {

--- a/pkg/apis/eventing/v1/test_helper.go
+++ b/pkg/apis/eventing/v1/test_helper.go
@@ -66,6 +66,7 @@ func (t testHelper) ReadyBrokerStatus() *BrokerStatus {
 		URL: apis.HTTP("example.com"),
 	})
 	bs.MarkDeadLetterSinkResolvedSucceeded(eventingduckv1.DeliveryStatus{})
+	bs.MarkEventPoliciesTrue()
 	return bs
 }
 
@@ -77,6 +78,7 @@ func (t testHelper) ReadyBrokerStatusWithoutDLS() *BrokerStatus {
 	bs.SetAddress(&duckv1.Addressable{
 		URL: apis.HTTP("example.com"),
 	})
+	bs.MarkEventPoliciesTrue()
 	bs.MarkDeadLetterSinkNotConfigured()
 	return bs
 }

--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -19,6 +19,8 @@ package broker
 import (
 	"context"
 
+	"knative.dev/eventing/pkg/auth"
+
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/apis"
@@ -41,6 +43,7 @@ import (
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	"knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	subscriptioninformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription"
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	"knative.dev/eventing/pkg/duck"
@@ -69,6 +72,7 @@ func NewController(
 	endpointsInformer := endpointsinformer.Get(ctx)
 	configmapInformer := configmapinformer.Get(ctx)
 	secretInformer := secretinformer.Get(ctx)
+	eventPolicyInformer := eventpolicyinformer.Get(ctx)
 
 	var globalResync func(obj interface{})
 
@@ -101,6 +105,7 @@ func NewController(
 		brokerClass:        eventing.MTChannelBrokerClassValue,
 		configmapLister:    configmapInformer.Lister(),
 		secretLister:       secretInformer.Lister(),
+		eventPolicyLister:  eventPolicyInformer.Lister(),
 	}
 	impl := brokerreconciler.NewImpl(ctx, r, eventing.MTChannelBrokerClassValue, func(impl *controller.Impl) controller.Options {
 		return controller.Options{
@@ -144,6 +149,12 @@ func NewController(
 		FilterFunc: controller.FilterWithName(ingressServerTLSSecretName),
 		Handler:    controller.HandleAll(globalResync),
 	})
+
+	brokerGK := eventingv1.SchemeGroupVersion.WithKind("Broker").GroupKind()
+
+	// Enqueue the Broker, if we have an EventPolicy which was referencing
+	// or got updated and now is referencing the Broker
+	eventPolicyInformer.Informer().AddEventHandler(auth.EventPolicyEventHandler(brokerInformer.Informer().GetIndexer(), brokerGK, impl.EnqueueKey))
 
 	return impl
 }

--- a/pkg/reconciler/broker/controller_test.go
+++ b/pkg/reconciler/broker/controller_test.go
@@ -29,6 +29,7 @@ import (
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/ducks/duck/v1/channelable/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/conditions/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"


### PR DESCRIPTION
Fixes #7976 

## Proposed Changes

- :gift: List `EventPolicies` in the Brokers `.status.policies`, which apply for it
- :gift: Add the `EventPoliciesReady` condition to indicate, if the referenced policies are Ready

**Release Note**

```release-note
List applying EventPolicies in Brokers status
```