### PR TITLE
Update TokenVerifier to verify AuthZ too

### DIFF
--- a/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/filter-clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
       - brokers/status
       - triggers
       - triggers/status
+      - eventpolicies
     verbs:
       - get
       - list

--- a/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
+++ b/config/brokers/mt-channel-broker/roles/ingress-clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
       - eventing.knative.dev
     resources:
       - brokers
+      - eventpolicies
     verbs:
       - get
       - list

--- a/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/dispatcher-clusterrole.yaml
@@ -76,8 +76,14 @@ rules:
       - eventing.knative.dev
     resources:
       - eventtypes
+      - eventpolicies
     verbs:
-      - create
       - get
       - list
       - watch
+  - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - eventtypes
+    verbs:
+      - create

--- a/config/core/roles/job-sink-clusterrole.yaml
+++ b/config/core/roles/job-sink-clusterrole.yaml
@@ -82,4 +82,11 @@ rules:
       - create
       - update
       - patch
-
+  - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - eventpolicies
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/core/roles/webhook-clusterrole.yaml
+++ b/config/core/roles/webhook-clusterrole.yaml
@@ -128,6 +128,15 @@ rules:
       - "create"
       - "patch"
 
+  - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - eventpolicies
+    verbs:
+      - get
+      - list
+      - watch
+
   # For the SinkBinding reconciler adding the OIDC identity service accounts
   - apiGroups:
       - ""

--- a/pkg/auth/event_policy.go
+++ b/pkg/auth/event_policy.go
@@ -35,6 +35,10 @@ import (
 	"knative.dev/pkg/resolver"
 )
 
+const (
+	kubernetesServiceAccountPrefix = "system:serviceaccount"
+)
+
 // GetEventPoliciesForResource returns the applying EventPolicies for a given resource
 func GetEventPoliciesForResource(lister listerseventingv1alpha1.EventPolicyLister, resourceGVK schema.GroupVersionKind, resourceObjectMeta metav1.ObjectMeta) ([]*v1alpha1.EventPolicy, error) {
 	policies, err := lister.EventPolicies(resourceObjectMeta.GetNamespace()).List(labels.Everything())
@@ -194,7 +198,7 @@ func resolveSubjectsFromReference(resolver *resolver.AuthenticatableResolver, re
 
 	objFullSANames := make([]string, 0, len(objSAs))
 	for _, sa := range objSAs {
-		objFullSANames = append(objFullSANames, fmt.Sprintf("system:serviceaccount:%s:%s", reference.Namespace, sa))
+		objFullSANames = append(objFullSANames, fmt.Sprintf("%s:%s:%s", kubernetesServiceAccountPrefix, reference.Namespace, sa))
 	}
 
 	return objFullSANames, nil

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -53,6 +53,7 @@ import (
 	triggerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 
 	// Fake injection client
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
 )
 

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -46,6 +46,7 @@ import (
 	brokerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 
 	// Fake injection client
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	_ "knative.dev/pkg/client/injection/kube/client/fake"
 )
 

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller_test.go
@@ -40,6 +40,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/factory/filtered/fake"
 	_ "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
 
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel/fake"
 )


### PR DESCRIPTION
Updates the TokenVerifier to verify AuthZ too

* providing `VerifyRequest()` which bundles AuthN and AuthZ checks
* deprecating `VerifyJWTFromRequest()` which only checks AuthN (switch to `VerifyRequest()` will be done in #7980 and #7981)