### PR TITLE
:bug: Codecov reject any coverage drop

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,8 +4,9 @@ coverage:
   status:
     project:
       default:
-        target: 80
-        threshold: 1%
+        # Reject the coverage drop
+        target: auto
+        threshold: 0%
     patch:
       # Disable the coverage threshold of the patch, so that PRs are
       # only failing because of overall project coverage threshold.


### PR DESCRIPTION
Instead of failing every PR, check for coverage drop. In this way, the coverage can only raise naturally.

## Proposed Changes

- :bug: Codecov reject any coverage drop

/kind bug