### PR TITLE
fix(test): creating the knsubscribe clusterrolebinding does not cause install script to fail

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -92,7 +92,7 @@ function knative_setup() {
 
   install_feature_cm || fail_test "Could not install features configmap"
 
-  create_knsubscribe_rolebinding || fail_test "Could not create knsusbcribe rolebinding"
+  create_knsubscribe_rolebinding || fail_test "Could not create knsubscribe rolebinding"
 }
 
 function scale_controlplane() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -107,6 +107,7 @@ function scale_controlplane() {
 }
 
 function create_knsubscribe_rolebinding() {
+  kubectl delete clusterrolebinding knsubscribe-test-rb --ignore-not-found=true
   kubectl create clusterrolebinding knsubscribe-test-rb --user=$(kubectl auth whoami -ojson | jq .status.userInfo.username -r) --clusterrole=crossnamespace=subscriber
 }
 


### PR DESCRIPTION
Currently, re-running the `./hack/install.sh` script fails because the knsubscribe clusterrolebinding was already created.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->



<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Delete the clusterrolebinding each time the script is run, ignoring not found errors

