### PR TITLE
fix: et v1beta3 does not have broker set by default

### DIFF
--- a/pkg/apis/eventing/v1beta1/eventtype_defaults.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_defaults.go
@@ -28,9 +28,6 @@ func (et *EventType) SetDefaults(ctx context.Context) {
 }
 
 func (ets *EventTypeSpec) SetDefaults(ctx context.Context) {
-	if ets.Reference == nil && ets.Broker == "" {
-		ets.Broker = "default"
-	}
 	if ets.Reference != nil {
 		ets.Reference.SetDefaults(ctx)
 	}

--- a/pkg/apis/eventing/v1beta1/eventtype_defaults_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_defaults_test.go
@@ -35,9 +35,7 @@ func TestEventTypeDefaults(t *testing.T) {
 		"nil spec": {
 			initial: EventType{},
 			expected: EventType{
-				Spec: EventTypeSpec{
-					Broker: "default",
-				},
+				Spec: EventTypeSpec{},
 			},
 		},
 		"broker empty": {
@@ -53,7 +51,6 @@ func TestEventTypeDefaults(t *testing.T) {
 				Spec: EventTypeSpec{
 					Type:   "test-type",
 					Source: testSource,
-					Broker: "default",
 					Schema: testSchema,
 				},
 			},
@@ -70,7 +67,6 @@ func TestEventTypeDefaults(t *testing.T) {
 				Spec: EventTypeSpec{
 					Type:   "test-type",
 					Source: testSource,
-					Broker: "default",
 					Schema: testSchema,
 				},
 			},

--- a/pkg/apis/eventing/v1beta1/eventtype_defaults_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_defaults_test.go
@@ -38,7 +38,7 @@ func TestEventTypeDefaults(t *testing.T) {
 				Spec: EventTypeSpec{},
 			},
 		},
-		"broker empty": {
+		"default broker reference": {
 			initial: EventType{
 				Spec: EventTypeSpec{
 					Type:   "test-type",


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8045

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove the default broker logic from the v1beta1 defaulting logic since that is still being run for every eventtype object (even though we store v1beta2 currently)

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
:bug: EventType v1beta3 resources no longer have a default broker reference set, as they can have no reference.
```


