### PR TITLE
Adding symbolic link for event policy type. 

### DIFF
--- a/config/300-eventpolicy.yaml
+++ b/config/300-eventpolicy.yaml
@@ -1,0 +1,1 @@
+core/resources/eventpolicy.yaml


### PR DESCRIPTION
Should we add this symbolic link, for consistency?

/cc @pierDipi 