### PR TITLE
fix: remove ingress option from delivery format

### DIFF
--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -508,7 +508,9 @@ For more details: <a href="https://github.com/knative/eventing/issues/5811">http
 <td>
 <code>format</code><br/>
 <em>
-string
+<a href="#duck.knative.dev/v1.FormatType">
+FormatType
+</a>
 </em>
 </td>
 <td>
@@ -517,8 +519,7 @@ string
 It can be one of the following values:
 - nil: default value, no specific format required.
 - &ldquo;JSON&rdquo;: indicates the event should be in structured mode.
-- &ldquo;binary&rdquo;: indicates the event should be in binary mode.
-- &ldquo;ingress&rdquo;: indicates the event should be in ingress mode.</p>
+- &ldquo;binary&rdquo;: indicates the event should be in binary mode.</p>
 </td>
 </tr>
 </tbody>
@@ -580,6 +581,27 @@ string
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="duck.knative.dev/v1.FormatType">FormatType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em><a href="#duck.knative.dev/v1.DeliverySpec">DeliverySpec</a>)
+</p>
+<p>
+<p>FormatType is the type for delivery format</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;binary&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;json&#34;</p></td>
+<td></td>
+</tr></tbody>
 </table>
 <h3 id="duck.knative.dev/v1.Subscribable">Subscribable
 </h3>

--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"context"
-	"strings"
 
 	"github.com/rickb777/date/period"
 	"knative.dev/pkg/apis"
@@ -88,9 +87,8 @@ type DeliverySpec struct {
 	// - nil: default value, no specific format required.
 	// - "JSON": indicates the event should be in structured mode.
 	// - "binary": indicates the event should be in binary mode.
-	// - "ingress": indicates the event should be in ingress mode.
 	//+optional
-	Format *string `json:"format,omitempty"`
+	Format *FormatType `json:"format,omitempty"`
 }
 
 func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
@@ -134,12 +132,10 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if ds.Format != nil {
-		validFormats := map[string]bool{
-			"json":    true,
-			"binary":  true,
-			"ingress": true,
-		}
-		if _, ok := validFormats[strings.ToLower(*ds.Format)]; !ok {
+		switch *ds.Format {
+		case DeliveryFormatBinary, DeliveryFormatJson:
+			// nothing
+		default:
 			errs = errs.Also(apis.ErrInvalidValue(*ds.Format, "format"))
 		}
 	}
@@ -167,6 +163,14 @@ const (
 
 	// Exponential backoff policy
 	BackoffPolicyExponential BackoffPolicyType = "exponential"
+)
+
+// FormatType is the type for delivery format
+type FormatType string
+
+const (
+	DeliveryFormatJson   FormatType = "json"
+	DeliveryFormatBinary FormatType = "binary"
 )
 
 // DeliveryStatus contains the Status of an object supporting delivery options. This type is intended to be embedded into a status struct.

--- a/pkg/apis/duck/v1/delivery_types_test.go
+++ b/pkg/apis/duck/v1/delivery_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -144,20 +145,16 @@ func TestDeliverySpecValidation(t *testing.T) {
 	},
 		{
 			name: "valid format JSON",
-			spec: &DeliverySpec{Format: pointer.String("json")},
+			spec: &DeliverySpec{Format: ptr.To(DeliveryFormatJson)},
 			want: nil,
 		},
 		{
 			name: "vaalid format binary",
-			spec: &DeliverySpec{Format: pointer.String("binary")},
-			want: nil,
-		}, {
-			name: "valid format ingress",
-			spec: &DeliverySpec{Format: pointer.String("ingress")},
+			spec: &DeliverySpec{Format: ptr.To(DeliveryFormatBinary)},
 			want: nil,
 		}, {
 			name: "invalid format",
-			spec: &DeliverySpec{Format: pointer.String("invalid")},
+			spec: &DeliverySpec{Format: ptr.To(FormatType("invalid"))},
 			want: func() *apis.FieldError {
 				return apis.ErrInvalidValue("invalid", "format")
 			}(),

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -203,7 +203,7 @@ func (in *DeliverySpec) DeepCopyInto(out *DeliverySpec) {
 	}
 	if in.Format != nil {
 		in, out := &in.Format, &out.Format
-		*out = new(string)
+		*out = new(FormatType)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Removes the delivery format option we had before, and aligns the code with the approach used for other similar fields in the delivery spec.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- remove the ingress option from the format type
- create a type alias and some constants for the format type options
