### PR TITLE
feat: reconcile eventtype v1beta3 resources

### DIFF
--- a/config/core/resources/eventtype.yaml
+++ b/config/core/resources/eventtype.yaml
@@ -23,7 +23,7 @@ spec:
   group: eventing.knative.dev
   versions:
   - name: v1beta3
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}

--- a/pkg/apis/eventing/v1beta3/eventtype_lifecycle.go
+++ b/pkg/apis/eventing/v1beta3/eventtype_lifecycle.go
@@ -60,6 +60,10 @@ func (et *EventTypeStatus) MarkReferenceDoesNotExist() {
 	eventTypeCondSet.Manage(et).MarkFalse(EventTypeConditionReferenceExists, "ResourceDoesNotExist", "Resource in spec.reference does not exist")
 }
 
+func (et *EventTypeStatus) MarkReferenceNotSet() {
+	eventTypeCondSet.Manage(et).MarkTrueWithReason(EventTypeConditionReferenceExists, "ReferenceNotSet", "spec.reference is not set")
+}
+
 func (et *EventTypeStatus) MarkReferenceExistsUnknown(reason, messageFormat string, messageA ...interface{}) {
 	eventTypeCondSet.Manage(et).MarkUnknown(EventTypeConditionReferenceExists, reason, messageFormat, messageA...)
 }

--- a/pkg/reconciler/eventtype/controller.go
+++ b/pkg/reconciler/eventtype/controller.go
@@ -23,8 +23,8 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
-	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
-	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
+	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta3/eventtype"
+	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta3/eventtype"
 )
 
 // NewController initializes the controller and is called by the generated code

--- a/pkg/reconciler/eventtype/controller_test.go
+++ b/pkg/reconciler/eventtype/controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	// Fake injection informers
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
-	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype/fake"
+	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta3/eventtype/fake"
 )
 
 func TestNew(t *testing.T) {

--- a/pkg/reconciler/eventtype/eventtype.go
+++ b/pkg/reconciler/eventtype/eventtype.go
@@ -24,8 +24,9 @@ import (
 	"go.uber.org/zap"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 
-	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
-	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta3"
+	eventtypereconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta3/eventtype"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 )
@@ -38,8 +39,15 @@ type Reconciler struct {
 var _ eventtypereconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
-// 1. Verify the Reference exists.
-func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta2.EventType) pkgreconciler.Event {
+//  1. Check if there is a reference
+//     a) if not, reconcile to true
+//     b) if yes, continue reconciling
+//  2. Verify the Reference exist
+func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta3.EventType) pkgreconciler.Event {
+	if et.Spec.Reference == nil || isEmptyReference(et.Spec.Reference) {
+		et.Status.MarkReferenceNotSet()
+		return nil
+	}
 
 	_, err := r.kReferenceResolver.Resolve(ctx, et.Spec.Reference, et)
 	if err != nil {
@@ -54,4 +62,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, et *v1beta2.EventType) p
 	}
 	et.Status.MarkReferenceExists()
 	return nil
+}
+
+func isEmptyReference(ref *duckv1.KReference) bool {
+	return ref.Kind == "" && ref.Group == "" && ref.Name == "" && ref.APIVersion == "" && ref.Namespace == "" && (ref.Address == nil || *ref.Address == "")
 }

--- a/pkg/reconciler/eventtype/eventtype_test.go
+++ b/pkg/reconciler/eventtype/eventtype_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta2/eventtype"
+	"knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1beta3/eventtype"
 	. "knative.dev/eventing/pkg/reconciler/testing/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
@@ -87,6 +87,8 @@ func TestReconcile(t *testing.T) {
 			NewEventType(eventTypeName, testNS,
 				WithEventTypeType(eventTypeType),
 				WithEventTypeSource(eventTypeSource),
+				WithEventTypeSpecV1(),
+				WithEventTypeEmptyID(),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 			),
 		},
@@ -94,6 +96,8 @@ func TestReconcile(t *testing.T) {
 			Object: NewEventType(eventTypeName, testNS,
 				WithEventTypeType(eventTypeType),
 				WithEventTypeSource(eventTypeSource),
+				WithEventTypeSpecV1(),
+				WithEventTypeEmptyID(),
 				WithEventTypeReference(brokerReference(eventTypeBroker)),
 				WithInitEventTypeConditions,
 				WithEventTypeResourceDoesNotExist,
@@ -112,6 +116,8 @@ func TestReconcile(t *testing.T) {
 				NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithEventTypeReference(channelReference(eventTypeChannel)),
 				),
 			},
@@ -119,6 +125,8 @@ func TestReconcile(t *testing.T) {
 				Object: NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithInitEventTypeConditions,
 					WithEventTypeReference(channelReference(eventTypeChannel)),
 					WithEventTypeResourceDoesNotExist,
@@ -136,6 +144,8 @@ func TestReconcile(t *testing.T) {
 				NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithEventTypeReference(brokerReference(eventTypeBroker)),
 				),
 				resources.MakeBroker(testNS, eventTypeBroker),
@@ -144,6 +154,8 @@ func TestReconcile(t *testing.T) {
 				Object: NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithInitEventTypeConditions,
 					WithEventTypeReference(brokerReference(eventTypeBroker)),
 					WithEventTypeResourceExists,
@@ -158,6 +170,8 @@ func TestReconcile(t *testing.T) {
 				NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithEventTypeReference(channelReference(eventTypeChannel)),
 				),
 				NewInMemoryChannel(eventTypeChannel, testNS),
@@ -166,14 +180,36 @@ func TestReconcile(t *testing.T) {
 				Object: NewEventType(eventTypeName, testNS,
 					WithEventTypeType(eventTypeType),
 					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
 					WithInitEventTypeConditions,
 					WithEventTypeReference(channelReference(eventTypeChannel)),
 					WithEventTypeResourceExists,
 				),
 			}},
 			WantErr: false,
-		},
-	}
+		}, {
+			Name: "No reference set",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewEventType(eventTypeName, testNS,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
+				),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: NewEventType(eventTypeName, testNS,
+					WithInitEventTypeConditions,
+					WithEventTypeType(eventTypeType),
+					WithEventTypeSource(eventTypeSource),
+					WithEventTypeSpecV1(),
+					WithEventTypeEmptyID(),
+					WithEventTypeReferenceNotSet),
+			}},
+			WantErr: false,
+		}}
 
 	logger := logtesting.TestLogger(t)
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {

--- a/pkg/reconciler/testing/v1/eventtype.go
+++ b/pkg/reconciler/testing/v1/eventtype.go
@@ -23,16 +23,16 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	"knative.dev/eventing/pkg/apis/eventing/v1beta3"
 	"knative.dev/pkg/apis"
 )
 
 // EventTypeOption enables further configuration of an EventType.
-type EventTypeOption func(*v1beta2.EventType)
+type EventTypeOption func(*v1beta3.EventType)
 
 // NewEventType creates a EventType with EventTypeOptions.
-func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta2.EventType {
-	et := &v1beta2.EventType{
+func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta3.EventType {
+	et := &v1beta3.EventType{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -46,59 +46,106 @@ func NewEventType(name, namespace string, o ...EventTypeOption) *v1beta2.EventTy
 }
 
 // WithInitEventTypeConditions initializes the EventType's conditions.
-func WithInitEventTypeConditions(et *v1beta2.EventType) {
+func WithInitEventTypeConditions(et *v1beta3.EventType) {
 	et.Status.InitializeConditions()
 }
 
 func WithEventTypeSource(source *apis.URL) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Spec.Source = source
+	return func(et *v1beta3.EventType) {
+		if et.Spec.Attributes == nil {
+			et.Spec.Attributes = make([]v1beta3.EventAttributeDefinition, 0)
+		}
+
+		et.Spec.Attributes = append(et.Spec.Attributes, v1beta3.EventAttributeDefinition{
+			Name:     "source",
+			Required: true,
+			Value:    source.String(),
+		})
 	}
 }
 
 func WithEventTypeType(t string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
-		et.Spec.Type = t
+	return func(et *v1beta3.EventType) {
+		if et.Spec.Attributes == nil {
+			et.Spec.Attributes = make([]v1beta3.EventAttributeDefinition, 0)
+		}
+
+		et.Spec.Attributes = append(et.Spec.Attributes, v1beta3.EventAttributeDefinition{
+			Name:     "type",
+			Required: true,
+			Value:    t,
+		})
+	}
+}
+
+func WithEventTypeSpecV1() EventTypeOption {
+	return func(et *v1beta3.EventType) {
+		if et.Spec.Attributes == nil {
+			et.Spec.Attributes = make([]v1beta3.EventAttributeDefinition, 0)
+		}
+
+		et.Spec.Attributes = append(et.Spec.Attributes, v1beta3.EventAttributeDefinition{
+			Name:     "specversion",
+			Required: true,
+			Value:    "V1",
+		})
+	}
+}
+
+func WithEventTypeEmptyID() EventTypeOption {
+	return func(et *v1beta3.EventType) {
+		if et.Spec.Attributes == nil {
+			et.Spec.Attributes = make([]v1beta3.EventAttributeDefinition, 0)
+		}
+
+		et.Spec.Attributes = append(et.Spec.Attributes, v1beta3.EventAttributeDefinition{
+			Name:     "id",
+			Required: true,
+		})
 	}
 }
 
 func WithEventTypeReference(ref *duckv1.KReference) EventTypeOption {
-	return func(et *v1beta2.EventType) {
+	return func(et *v1beta3.EventType) {
 		et.Spec.Reference = ref
 	}
 }
 
 func WithEventTypeDescription(description string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
+	return func(et *v1beta3.EventType) {
 		et.Spec.Description = description
 	}
 }
 
 func WithEventTypeLabels(labels map[string]string) EventTypeOption {
-	return func(et *v1beta2.EventType) {
+	return func(et *v1beta3.EventType) {
 		et.ObjectMeta.Labels = labels
 	}
 }
 
 func WithEventTypeOwnerReference(ownerRef metav1.OwnerReference) EventTypeOption {
-	return func(et *v1beta2.EventType) {
+	return func(et *v1beta3.EventType) {
 		et.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 			ownerRef,
 		}
 	}
 }
 
-func WithEventTypeDeletionTimestamp(et *v1beta2.EventType) {
+func WithEventTypeDeletionTimestamp(et *v1beta3.EventType) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	et.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
 // WithEventTypeResourceDoesNotExist calls .Status.MarkFilterFailed on the EventType.
-func WithEventTypeResourceDoesNotExist(et *v1beta2.EventType) {
+func WithEventTypeResourceDoesNotExist(et *v1beta3.EventType) {
 	et.Status.MarkReferenceDoesNotExist()
 }
 
 // WithEventTypeResourceExists calls .Status.MarkReferenceExists on the EventType.
-func WithEventTypeResourceExists(et *v1beta2.EventType) {
+func WithEventTypeResourceExists(et *v1beta3.EventType) {
 	et.Status.MarkReferenceExists()
+}
+
+func WithEventTypeReferenceNotSet(et *v1beta3.EventType) {
+	et.Status.MarkReferenceNotSet()
 }

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -34,7 +34,7 @@ import (
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
-	eventingv1beta2 "knative.dev/eventing/pkg/apis/eventing/v1beta2"
+	eventingv1beta3 "knative.dev/eventing/pkg/apis/eventing/v1beta3"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	sinksv1alpha1 "knative.dev/eventing/pkg/apis/sinks/v1alpha1"
@@ -42,7 +42,7 @@ import (
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 	eventingv1alpha1listers "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
-	eventingv1beta2listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta2"
+	eventingv1beta3listers "knative.dev/eventing/pkg/client/listers/eventing/v1beta3"
 	flowslisters "knative.dev/eventing/pkg/client/listers/flows/v1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	sinkslisters "knative.dev/eventing/pkg/client/listers/sinks/v1alpha1"
@@ -114,8 +114,8 @@ func (l *Listers) GetAllObjects() []runtime.Object {
 	return all
 }
 
-func (l *Listers) GetEventTypeLister() eventingv1beta2listers.EventTypeLister {
-	return eventingv1beta2listers.NewEventTypeLister(l.indexerFor(&eventingv1beta2.EventType{}))
+func (l *Listers) GetEventTypeLister() eventingv1beta3listers.EventTypeLister {
+	return eventingv1beta3listers.NewEventTypeLister(l.indexerFor(&eventingv1beta3.EventType{}))
 }
 
 func (l *Listers) GetEventPolicyLister() eventingv1alpha1listers.EventPolicyLister {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This lets us reconcile eventtype v1beta3 resources with the updated eventtype v1beta3 logic.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- If no reference is set, reconcile to ready
- Reconcile on v1beta3 struct, not v1beta2


```release-note
EventTypes no longer need a reference to be set on them
```
