### PR TITLE
fix: eventtype conversion sets all required attributes for new version

### DIFF
--- a/pkg/apis/eventing/v1beta2/eventtype_conversion.go
+++ b/pkg/apis/eventing/v1beta2/eventtype_conversion.go
@@ -45,19 +45,27 @@ func (source *EventType) ConvertTo(ctx context.Context, to apis.Convertible) err
 			}
 		}
 
-		sink.Spec.Attributes = []v1beta3.EventAttributeDefinition{}
+		sink.Spec.Attributes = []v1beta3.EventAttributeDefinition{
+			{
+				Name:     "specversion",
+				Required: true,
+			},
+			{
+				Name:     "id",
+				Required: true,
+			},
+		}
+		// set all required attributes for the v1beta3 resource. if there is no value that makes sense, leave that empty
 		if source.Spec.Type != "" {
 			sink.Spec.Attributes = append(sink.Spec.Attributes, v1beta3.EventAttributeDefinition{
 				Name:     "type",
 				Required: true,
 				Value:    source.Spec.Type,
 			})
-		}
-		if source.Spec.Schema != nil {
+		} else {
 			sink.Spec.Attributes = append(sink.Spec.Attributes, v1beta3.EventAttributeDefinition{
-				Name:     "schemadata",
-				Required: false,
-				Value:    source.Spec.Schema.String(),
+				Name:     "type",
+				Required: true,
 			})
 		}
 		if source.Spec.Source != nil {
@@ -65,6 +73,20 @@ func (source *EventType) ConvertTo(ctx context.Context, to apis.Convertible) err
 				Name:     "source",
 				Required: true,
 				Value:    source.Spec.Source.String(),
+			})
+		} else {
+			sink.Spec.Attributes = append(sink.Spec.Attributes, v1beta3.EventAttributeDefinition{
+				Name:     "source",
+				Required: true,
+			})
+		}
+
+		// convert the schema so that we don't lose it in the conversion.
+		if source.Spec.Schema != nil {
+			sink.Spec.Attributes = append(sink.Spec.Attributes, v1beta3.EventAttributeDefinition{
+				Name:     "schemadata",
+				Required: false,
+				Value:    source.Spec.Schema.String(),
 			})
 		}
 		return nil

--- a/pkg/apis/eventing/v1beta2/eventtype_conversion_test.go
+++ b/pkg/apis/eventing/v1beta2/eventtype_conversion_test.go
@@ -79,19 +79,27 @@ func TestEventTypeConversionV1Beta3(t *testing.T) {
 			Description: in.Spec.Description,
 			Attributes: []v1beta3.EventAttributeDefinition{
 				{
+					Name:     "specversion",
+					Required: true,
+				},
+				{
+					Name:     "id",
+					Required: true,
+				},
+				{
 					Name:     "type",
 					Required: true,
 					Value:    in.Spec.Type,
 				},
 				{
-					Name:     "schemadata",
-					Required: false,
-					Value:    in.Spec.Schema.String(),
-				},
-				{
 					Name:     "source",
 					Required: true,
 					Value:    in.Spec.Source.String(),
+				},
+				{
+					Name:     "schemadata",
+					Required: false,
+					Value:    in.Spec.Schema.String(),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes a problem where any v1beta2 eventtype converted to a v1beta3 eventtype would have some attributes missing that would make it an invalid v1beta3 eventtype.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Always set all 4 required attributes
- Omit the value for the required attribute if it can't be determined from the v1beta2 resource

