### PR TITLE
fix: tracker can track resources in different ns

### DIFF
--- a/pkg/duck/listable.go
+++ b/pkg/duck/listable.go
@@ -162,7 +162,7 @@ func (t *listableTracker) TrackInNamespaceKReference(ctx context.Context, obj me
 	}
 }
 
-// TrackInNamespace satisfies the ListableTracker interface.
+// Track satisfies the ListableTracker interface.
 func (t *listableTracker) Track(ctx context.Context, obj metav1.Object, namespace string) Track {
 	return func(ref corev1.ObjectReference) error {
 		// This is often used by Trigger and Subscription, both of which pass in refs that do not
@@ -181,7 +181,7 @@ func (t *listableTracker) Track(ctx context.Context, obj metav1.Object, namespac
 	}
 }
 
-// TrackInNamespaceKReference satisfies the ListableTracker interface.
+// TrackKReference satisfies the ListableTracker interface.
 func (t *listableTracker) TrackKReference(ctx context.Context, obj metav1.Object, namespace string) TrackKReference {
 	return func(ref duckv1.KReference) error {
 		// This is often used by Trigger and Subscription, both of which pass in refs that do not

--- a/pkg/duck/listable.go
+++ b/pkg/duck/listable.go
@@ -42,6 +42,12 @@ type ListableTracker interface {
 	// TrackInNamespaceKReference returns a function that can be used to watch arbitrary apis.Listable resources
 	// in the same namespace as obj. Any change will cause a callback for obj.
 	TrackInNamespaceKReference(ctx context.Context, obj metav1.Object) TrackKReference
+	// Track returns a function that can be used to watch arbitrary apis.Listable resources in the
+	// provided namespace. Any change will cause a callback for obj.
+	Track(ctx context.Context, obj metav1.Object, namespace string) Track
+	// TrackKReference returns a function that can be used to watch arbitrary apis.Listable resources
+	// in the provided namespace. Any change will cause a callback for obj.
+	TrackKReference(ctx context.Context, obj metav1.Object, namespace string) TrackKReference
 	// ListerFor returns the lister for the object reference. It returns an error if the lister does not exist.
 	ListerFor(ref corev1.ObjectReference) (cache.GenericLister, error)
 	// InformerFor returns the informer for the object reference. It returns an error if the informer does not exist.
@@ -151,6 +157,45 @@ func (t *listableTracker) TrackInNamespaceKReference(ctx context.Context, obj me
 			APIVersion: ref.APIVersion,
 			Kind:       ref.Kind,
 			Namespace:  obj.GetNamespace(),
+			Name:       ref.Name,
+		}, obj)
+	}
+}
+
+// TrackInNamespace satisfies the ListableTracker interface.
+func (t *listableTracker) Track(ctx context.Context, obj metav1.Object, namespace string) Track {
+	return func(ref corev1.ObjectReference) error {
+		// This is often used by Trigger and Subscription, both of which pass in refs that do not
+		// specify the namespace.
+		ref.Namespace = namespace
+		if err := t.ensureTracking(ctx, ref); err != nil {
+			return err
+		}
+
+		return t.tracker.TrackReference(tracker.Reference{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+			Namespace:  namespace,
+			Name:       ref.Name,
+		}, obj)
+	}
+}
+
+// TrackInNamespaceKReference satisfies the ListableTracker interface.
+func (t *listableTracker) TrackKReference(ctx context.Context, obj metav1.Object, namespace string) TrackKReference {
+	return func(ref duckv1.KReference) error {
+		// This is often used by Trigger and Subscription, both of which pass in refs that do not
+		// specify the namespace.
+		ref.Namespace = namespace
+		coreRef := corev1.ObjectReference{APIVersion: ref.APIVersion, Kind: ref.Kind, Name: ref.Name, Namespace: ref.Namespace}
+		if err := t.ensureTracking(ctx, coreRef); err != nil {
+			return err
+		}
+
+		return t.tracker.TrackReference(tracker.Reference{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+			Namespace:  namespace,
 			Name:       ref.Name,
 		}, obj)
 	}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Helps reduce flakes in the cross namespace feature by letting the tracker track references in a different namespace than the object.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add methods that track references in a provided ns, rather than that of the object.

