### PR TITLE
feat: add github workflow to send slack reminder for office hours

### DIFF
--- a/.github/workflows/weekly-office-hours-slack-reminder.yaml
+++ b/.github/workflows/weekly-office-hours-slack-reminder.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Weekly Eventing WG Office Hours Slack Reminder"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 14 * * 4 # 1 hour before the meeting time
+
+jobs:
+  remind:
+    name: weekly-eventing-office-hours-reminder
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Post reminder to Slack
+        uses: rtCamp/action-slack-notify@v2.2.1
+        env:
+          SLACK_ICON: http://github.com/knative.png?size=48
+          SLACK_USERNAME: github-actions
+          SLACK_TITLE: Knative Eventing Office Hours Reminder
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          MSG_MINIMAL: 'true'
+          SLACK_CHANNEL: 'knative-eventing'
+          SLACK_MESSAGE: "This is a friendly reminder that the Knative Eventing Office Hours start in 1 hour. We hope to see you there! Please join the zoom meeting: https://zoom.us/j/92717482035?pwd=SnBiWnl6MXRvcUNFWHZ4Wkt5Z0FYZz09"


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This PR adds a github action that sends a reminder one hour before the weekly office hours to slack (similar to the TOC review messages and Knative UX messages)

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Send a slack message one hour before the office hours with a link to the zoom meeting
