### PR TITLE
fix: workflow syntax for weekly reminder

### DIFF
--- a/.github/workflows/weekly-office-hours-slack-reminder.yaml
+++ b/.github/workflows/weekly-office-hours-slack-reminder.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Weekly Eventing WG Office Hours Slack Reminder"
+name: 'Weekly Eventing WG Office Hours Slack Reminder'
 
 on:
   workflow_dispatch:
@@ -23,7 +23,6 @@ jobs:
   remind:
     name: weekly-eventing-office-hours-reminder
     runs-on: 'ubuntu-latest'
-
     steps:
       - name: Post reminder to Slack
         uses: rtCamp/action-slack-notify@v2.2.1


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes the syntax error in the weekly reminder workflow