### PR TITLE
feat: reduced unnecessary creation of filters

### DIFF
--- a/pkg/eventfilter/subscriptionsapi/all_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/all_filter.go
@@ -42,6 +42,11 @@ type allFilter struct {
 
 // NewAllFilter returns an event filter which passes if all the contained filters pass
 func NewAllFilter(filters ...eventfilter.Filter) eventfilter.Filter {
+	// just one filter, no need to create a new AllFilter
+	if len(filters) == 1 {
+		return filters[0]
+	}
+
 	filterCounts := make([]filterCount, len(filters))
 	for i, filter := range filters {
 		filterCounts[i] = filterCount{

--- a/pkg/eventfilter/subscriptionsapi/any_filter.go
+++ b/pkg/eventfilter/subscriptionsapi/any_filter.go
@@ -37,6 +37,11 @@ type anyFilter struct {
 
 // NewAnyFilter returns an event filter which passes if any of the contained filters passes.
 func NewAnyFilter(filters ...eventfilter.Filter) eventfilter.Filter {
+	// just one filter, no need to create a new AnyFilter
+	if len(filters) == 1 {
+		return filters[0]
+	}
+
 	filterCounts := make([]filterCount, len(filters))
 	for i, filter := range filters {
 		filterCounts[i] = filterCount{


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

The filters field is implicitly an `AllFilter`, which means that even if a user only creates a single filter two filters will get created. Similarly, if for some reason a user creates an all filter or any filter with only a single subfilter, we should not create the extra "wrapper" filter.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Only create an all or any filter if the filters list is > 1

