### PR TITLE
Sequence reconciler reads and watch the config-features configmap

### DIFF
--- a/pkg/reconciler/sequence/sequence.go
+++ b/pkg/reconciler/sequence/sequence.go
@@ -34,6 +34,8 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 
+	"knative.dev/pkg/kmp"
+
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/flows/v1"
@@ -45,7 +47,6 @@ import (
 	listers "knative.dev/eventing/pkg/client/listers/flows/v1"
 	messaginglisters "knative.dev/eventing/pkg/client/listers/messaging/v1"
 	"knative.dev/eventing/pkg/duck"
-	"knative.dev/pkg/kmp"
 
 	"knative.dev/eventing/pkg/reconciler/sequence/resources"
 )
@@ -217,6 +218,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, step int, p *v1.
 		}
 		return newSub, nil
 	} else if equal, err := kmp.SafeEqual(sub.Spec, expected.Spec); !equal || err != nil {
+		expected.ResourceVersion = sub.ResourceVersion
 		// only the mutable fields were changed, so we can update the subscription
 		updatedSub, err := r.eventingClientSet.MessagingV1().Subscriptions(sub.Namespace).Update(ctx, expected, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
In the sequence reconciler `feature.FromContext(ctx)` always returns the default feature flags as the context is not populated with the `ConfigStore`