### PR TITLE
Disable controller default health probes in the IMC dispatcher

### DIFF
--- a/cmd/in_memory/channel_dispatcher/main.go
+++ b/cmd/in_memory/channel_dispatcher/main.go
@@ -44,6 +44,8 @@ func main() {
 		eventingtls.TrustBundleLabelSelector,
 	)
 
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
+
 	sharedmain.MainWithContext(ctx, "inmemorychannel-dispatcher",
 		inmemorychannel.NewController,
 	)


### PR DESCRIPTION
The IMC dispatcher is using the same server receiving events for k8s readiness and liveness probes, so we don't need the controller internal health server to be running.

The controller internal health server is using the same port which leads to this error:

```
2024-07-31T15:58:53.582Z	error	inmemorychannel-dispatcher	sharedmain/main.go:334	Error while running server	{"commit": "b7bfc92", "knative.dev/pod": "imc-dispatcher-696d94588d-j7fr5", "error": "listen tcp :8080: bind: address already in use"}
knative.dev/pkg/injection/sharedmain.MainWithConfig
	knative.dev/pkg@v0.0.0-20240716082220-4355f0c73608/injection/sharedmain/main.go:334
knative.dev/pkg/injection/sharedmain.MainWithContext
	knative.dev/pkg@v0.0.0-20240716082220-4355f0c73608/injection/sharedmain/main.go:209
main.main
	knative.dev/eventing/cmd/in_memory/channel_dispatcher/main.go:47
runtime.main
	runtime/proc.go:271
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

