### PR TITLE
update trust-manager to version 0.12.0

### DIFF
--- a/hack/update-cert-manager.sh
+++ b/hack/update-cert-manager.sh
@@ -21,7 +21,7 @@ metadata:
 EOF
 
   helm template -n cert-manager cert-manager jetstack/cert-manager --create-namespace --version "${cert_manager_version}" --set installCRDs=true > third_party/cert-manager/01-cert-manager.yaml
-  helm template -n cert-manager cert-manager jetstack/trust-manager --create-namespace --version "${trust_manager_version}" --set installCRDs=true > third_party/cert-manager/02-trust-manager.yaml
+  helm template -n cert-manager cert-manager jetstack/trust-manager --create-namespace --version "${trust_manager_version}" --set crds.enabled=true > third_party/cert-manager/02-trust-manager.yaml
 }
 
-update_cert_manager "v1.13.3" "v0.7.1"
+update_cert_manager "v1.13.3" "v0.12.0"

--- a/third_party/cert-manager/02-trust-manager.yaml
+++ b/third_party/cert-manager/02-trust-manager.yaml
@@ -7,18 +7,24 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: trust-manager/templates/trust.cert-manager.io_bundles.yaml
+# Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: "bundles.trust.cert-manager.io"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
-  name: bundles.trust.cert-manager.io
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: trust-manager
+    helm.sh/chart: trust-manager-v0.12.0
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/version: "v0.12.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   group: trust.cert-manager.io
   names:
@@ -29,9 +35,13 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - description: Bundle Target Key
-          jsonPath: .status.target.configMap.key
-          name: Target
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
           type: string
         - description: Bundle has been synced
           jsonPath: .status.conditions[?(@.type == "Synced")].status
@@ -48,210 +58,331 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          type: object
-          required:
-            - spec
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
               description: Desired state of the Bundle resource.
-              type: object
-              required:
-                - sources
-                - target
               properties:
                 sources:
                   description: Sources is a set of references to data whose data will sync to the target.
-                  type: array
                   items:
-                    description: BundleSource is the set of sources whose data will be appended and synced to the BundleTarget in all Namespaces.
-                    type: object
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
                     properties:
                       configMap:
-                        description: ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
-                        type: object
-                        required:
-                          - key
-                          - name
+                        description: |-
+                          ConfigMap is a reference (by name) to a ConfigMap's `data` key, or to a
+                          list of ConfigMap's `data` key using label selector, in the trust Namespace.
                         properties:
                           key:
                             description: Key is the key of the entry in the object's `data` field to be used.
                             type: string
                           name:
-                            description: Name is the name of the source object in the trust Namespace.
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
                             type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - key
+                        type: object
                       inLine:
                         description: InLine is a simple string to append as the source data.
                         type: string
                       secret:
-                        description: Secret is a reference to a Secrets's `data` key, in the trust Namespace.
-                        type: object
-                        required:
-                          - key
-                          - name
+                        description: |-
+                          Secret is a reference (by name) to a Secret's `data` key, or to a
+                          list of Secret's `data` key using label selector, in the trust Namespace.
                         properties:
                           key:
                             description: Key is the key of the entry in the object's `data` field to be used.
                             type: string
                           name:
-                            description: Name is the name of the source object in the trust Namespace.
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
                             type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - key
+                        type: object
                       useDefaultCAs:
-                        description: UseDefaultCAs, when true, requests the default CA bundle to be used as a source. Default CAs are available if trust-manager was installed via Helm or was otherwise set up to include a package-injecting init container by using the "--default-package-location" flag when starting the trust-manager controller. If default CAs were not configured at start-up, any request to use the default CAs will fail. The version of the default CA package which is used for a Bundle is stored in the defaultCAPackageVersion field of the Bundle's status field.
+                        description: |-
+                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                          Default CAs are available if trust-manager was installed via Helm
+                          or was otherwise set up to include a package-injecting init container by using the
+                          "--default-package-location" flag when starting the trust-manager controller.
+                          If default CAs were not configured at start-up, any request to use the default
+                          CAs will fail.
+                          The version of the default CA package which is used for a Bundle is stored in the
+                          defaultCAPackageVersion field of the Bundle's status field.
                         type: boolean
+                    type: object
+                  type: array
                 target:
                   description: Target is the target location in all namespaces to sync source data to.
-                  type: object
                   properties:
                     additionalFormats:
                       description: AdditionalFormats specifies any additional formats to write to the target
-                      type: object
                       properties:
                         jks:
-                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
-                          type: object
-                          required:
-                            - key
+                          description: |-
+                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                           properties:
                             key:
                               description: Key is the key of the entry in the object's `data` field to be used.
                               type: string
+                            password:
+                              default: changeit
+                              description: Password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
                         pkcs12:
-                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
-                          type: object
-                          required:
-                            - key
+                          description: |-
+                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+                            The bundle is by default created without a password.
                           properties:
                             key:
                               description: Key is the key of the entry in the object's `data` field to be used.
                               type: string
-                    configMap:
-                      description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+                            password:
+                              default: ""
+                              description: Password for PKCS12 trust store
+                              maxLength: 128
+                              type: string
+                          required:
+                            - key
+                          type: object
                       type: object
-                      required:
-                        - key
+                    configMap:
+                      description: |-
+                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
                       properties:
                         key:
                           description: Key is the key of the entry in the object's `data` field to be used.
                           type: string
-                    namespaceSelector:
-                      description: NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
+                      required:
+                        - key
                       type: object
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
                       properties:
                         matchLabels:
-                          description: MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.
-                          type: object
                           additionalProperties:
                             type: string
-                    secret:
-                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                          description: |-
+                            MatchLabels matches on the set of labels that must be present on a
+                            Namespace for the Bundle target to be synced there.
+                          type: object
                       type: object
-                      required:
-                        - key
+                    secret:
+                      description: |-
+                        Secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
                       properties:
                         key:
                           description: Key is the key of the entry in the object's `data` field to be used.
                           type: string
+                      required:
+                        - key
+                      type: object
+                  type: object
+              required:
+                - sources
+                - target
+              type: object
             status:
               description: Status of the Bundle. This is set and managed automatically.
-              type: object
               properties:
                 conditions:
-                  description: List of status conditions to indicate the status of the Bundle. Known condition types are `Bundle`.
-                  type: array
+                  description: |-
+                    List of status conditions to indicate the status of the Bundle.
+                    Known condition types are `Bundle`.
                   items:
                     description: BundleCondition contains condition information for a Bundle.
-                    type: object
-                    required:
-                      - status
-                      - type
                     properties:
                       lastTransitionTime:
-                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
-                        type: string
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
                         format: date-time
+                        type: string
                       message:
-                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        description: |-
+                          Message is a human-readable description of the details of the last
+                          transition, complementing reason.
+                        maxLength: 32768
                         type: string
                       observedGeneration:
-                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Bundle.
-                        type: integer
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Bundle.
                         format: int64
+                        minimum: 0
+                        type: integer
                       reason:
-                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        description: |-
+                          Reason is a brief machine-readable explanation for the condition's last
+                          transition.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
                         type: string
                       type:
                         description: Type of the condition, known values are (`Synced`).
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
                 defaultCAVersion:
-                  description: DefaultCAPackageVersion, if set and non-empty, indicates the version information which was retrieved when the set of default CAs was requested in the bundle source. This should only be set if useDefaultCAs was set to "true" on a source, and will be the same for the same version of a bundle with identical certificates.
+                  description: |-
+                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                    which was retrieved when the set of default CAs was requested in the bundle
+                    source. This should only be set if useDefaultCAs was set to "true" on a source,
+                    and will be the same for the same version of a bundle with identical certificates.
                   type: string
-                target:
-                  description: Target is the current Target that the Bundle is attempting or has completed syncing the source data to.
-                  type: object
-                  properties:
-                    additionalFormats:
-                      description: AdditionalFormats specifies any additional formats to write to the target
-                      type: object
-                      properties:
-                        jks:
-                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
-                          type: object
-                          required:
-                            - key
-                          properties:
-                            key:
-                              description: Key is the key of the entry in the object's `data` field to be used.
-                              type: string
-                        pkcs12:
-                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
-                          type: object
-                          required:
-                            - key
-                          properties:
-                            key:
-                              description: Key is the key of the entry in the object's `data` field to be used.
-                              type: string
-                    configMap:
-                      description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
-                      type: object
-                      required:
-                        - key
-                      properties:
-                        key:
-                          description: Key is the key of the entry in the object's `data` field to be used.
-                          type: string
-                    namespaceSelector:
-                      description: NamespaceSelector will, if set, only sync the target resource in Namespaces which match the selector.
-                      type: object
-                      properties:
-                        matchLabels:
-                          description: MatchLabels matches on the set of labels that must be present on a Namespace for the Bundle target to be synced there.
-                          type: object
-                          additionalProperties:
-                            type: string
-                    secret:
-                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
-                      type: object
-                      required:
-                        - key
-                      properties:
-                        key:
-                          description: Key is the key of the entry in the object's `data` field to be used.
-                          type: string
+              type: object
+          required:
+            - spec
+          type: object
       served: true
       storage: true
       subresources:
@@ -263,9 +394,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
   name: trust-manager
 rules:
@@ -273,7 +404,8 @@ rules:
   - "trust.cert-manager.io"
   resources:
   - "bundles"
-  verbs: ["get", "list", "watch"]
+  # We also need patch here so we can perform migrations from old CSA to SSA.
+  verbs: ["get", "list", "watch", "patch"]
 
 # Permissions to update finalizers are required for trust-manager to work correctly
 # on OpenShift, even though we don't directly use finalizers at the time of writing
@@ -290,18 +422,10 @@ rules:
   verbs: ["patch"]
 
 - apiGroups:
-  - "trust.cert-manager.io"
-  resources:
-  - "bundles"
-  # We also need update here so we can perform migrations from old CSA to SSA.
-  verbs: ["update"]
-
-- apiGroups:
   - ""
   resources:
   - "configmaps"
-  # We also need update here so we can perform migrations from old CSA to SSA.
-  verbs: ["get", "list", "create", "update", "patch", "watch", "delete"]
+  verbs: ["get", "list", "create", "patch", "watch", "delete"]
 - apiGroups:
   - ""
   resources:
@@ -320,9 +444,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
   name: trust-manager
 roleRef:
@@ -342,9 +466,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -364,9 +488,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -388,9 +512,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -409,9 +533,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -431,9 +555,9 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -454,9 +578,9 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -476,9 +600,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -489,6 +613,11 @@ spec:
     metadata:
       labels:
         app: trust-manager
+        app.kubernetes.io/name: trust-manager
+        helm.sh/chart: trust-manager-v0.12.0
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/version: "v0.12.0"
+        app.kubernetes.io/managed-by: Helm
     spec:
       serviceAccountName: trust-manager
       initContainers:
@@ -514,7 +643,7 @@ spec:
             type: RuntimeDefault
       containers:
       - name: trust-manager
-        image: "quay.io/jetstack/trust-manager:v0.7.1"
+        image: "quay.io/jetstack/trust-manager:v0.12.0"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6443
@@ -525,12 +654,14 @@ spec:
             path: /readyz
           initialDelaySeconds: 3
           periodSeconds: 7
-        command: ["trust-manager"]
         args:
+          - "--log-format=text"
           - "--log-level=1"
           - "--metrics-port=9402"
           - "--readiness-probe-port=6060"
           - "--readiness-probe-path=/readyz"
+          - "--leader-election-lease-duration=15s"
+          - "--leader-election-renew-deadline=10s"
             # trust
           - "--trust-namespace=cert-manager"
             # webhook
@@ -560,7 +691,8 @@ spec:
         kubernetes.io/os: linux
       volumes:
       - name: packages
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 50M
       - name: tls
         secret:
           defaultMode: 420
@@ -574,9 +706,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   commonName: "trust-manager.cert-manager.svc"
@@ -597,9 +729,9 @@ metadata:
   namespace: cert-manager
   labels:
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selfSigned: {}
@@ -612,12 +744,14 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/name: trust-manager
-    helm.sh/chart: trust-manager-v0.7.1
+    helm.sh/chart: trust-manager-v0.12.0
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/version: "v0.7.1"
+    app.kubernetes.io/version: "v0.12.0"
     app.kubernetes.io/managed-by: Helm
+
   annotations:
     cert-manager.io/inject-ca-from: "cert-manager/trust-manager"
+
 
 webhooks:
   - name: trust.cert-manager.io
@@ -636,6 +770,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
+
       service:
         name: trust-manager
         namespace: cert-manager


### PR DESCRIPTION
The support for trust manger s390x images are available from version 0.12.0 of trust manager. Hence upgrading the trust manager to 0.12.0.