### PR TITLE
Add e2e test for Broker authorization

### DIFF
--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -50,4 +50,10 @@ kubectl apply -Rf "$(dirname "$0")/config-authentication-oidc"
 
 go_test_e2e -timeout=1h ./test/rekt -run OIDC || fail_test
 
+echo "Running E2E Authorization Reconciler Tests"
+
+kubectl apply -Rf "$(dirname "$0")/config-authentication-oidc"
+
+go_test_e2e -timeout=1h ./test/rekt -run AuthZ || fail_test
+
 success

--- a/test/e2e-rekt-tests.sh
+++ b/test/e2e-rekt-tests.sh
@@ -44,16 +44,10 @@ kubectl apply -Rf "$(dirname "$0")/config-transport-encryption"
 
 go_test_e2e -timeout=1h ./test/rekt -run TLS || fail_test
 
-echo "Running E2E OIDC Reconciler Tests"
+echo "Running E2E Auth Reconciler Tests"
 
 kubectl apply -Rf "$(dirname "$0")/config-authentication-oidc"
 
-go_test_e2e -timeout=1h ./test/rekt -run OIDC || fail_test
-
-echo "Running E2E Authorization Reconciler Tests"
-
-kubectl apply -Rf "$(dirname "$0")/config-authentication-oidc"
-
-go_test_e2e -timeout=1h ./test/rekt -run AuthZ || fail_test
+go_test_e2e -timeout=1h ./test/rekt -run "OIDC|AuthZ" || fail_test
 
 success

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -284,3 +284,18 @@ func TestBrokerSendsEventsWithOIDCSupport(t *testing.T) {
 
 	env.TestSet(ctx, t, broker.BrokerSendEventWithOIDC())
 }
+
+func TestBrokerSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	env.TestSet(ctx, t, broker.BrokerSupportsAuthZ())
+}

--- a/test/rekt/features/broker/authz_feature.go
+++ b/test/rekt/features/broker/authz_feature.go
@@ -21,12 +21,10 @@ import (
 
 	"github.com/cloudevents/sdk-go/v2/test"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
-	"knative.dev/eventing/test/rekt/resources/eventpolicy"
-	"knative.dev/eventing/test/rekt/resources/pingsource"
-	"knative.dev/reconciler-test/pkg/environment"
-
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/eventpolicy"
+	"knative.dev/eventing/test/rekt/resources/pingsource"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/reconciler-test/pkg/eventshub"
@@ -73,18 +71,16 @@ func BrokerAcceptsEventsFromAuthorizedSender() *feature.Feature {
 		trigger.WithBrokerName(brokerName),
 		trigger.WithSubscriber(service.AsKReference(sink), "")))
 
-	f.Setup("Install the EventPolicy", func(ctx context.Context, t feature.T) {
-		eventpolicy.Install(
-			eventPolicyName,
-			eventpolicy.WithToRef(
-				broker.GVR().GroupVersion().WithKind("Broker"),
-				brokerName),
-			eventpolicy.WithFromRef(
-				pingsource.Gvr().GroupVersion().WithKind("PingSource"),
-				source,
-				environment.FromContext(ctx).Namespace()),
-		)(ctx, t)
-	})
+	f.Setup("Install the EventPolicy", eventpolicy.Install(
+		eventPolicyName,
+		eventpolicy.WithToRef(
+			broker.GVR().GroupVersion().WithKind("Broker"),
+			brokerName),
+		eventpolicy.WithFromRef(
+			pingsource.Gvr().GroupVersion().WithKind("PingSource"),
+			source,
+			""),
+	))
 
 	// Install source
 	f.Requirement("Install Pingsource", func(ctx context.Context, t feature.T) {

--- a/test/rekt/features/broker/authz_feature.go
+++ b/test/rekt/features/broker/authz_feature.go
@@ -18,6 +18,7 @@ package broker
 
 import (
 	"context"
+
 	"github.com/cloudevents/sdk-go/v2/test"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	"knative.dev/eventing/test/rekt/resources/eventpolicy"
@@ -136,13 +137,13 @@ func BrokerRejectsEventsFromUnauthorizedSender() *feature.Feature {
 		trigger.WithSubscriber(service.AsKReference(sink), "")))
 	f.Setup("Trigger goes ready", trigger.IsReady(triggerName))
 
-	// Install an event policy for Broker allowing from a dummy subject, to not fall back to the default-auth-mode
+	// Install an event policy for Broker allowing from a sample subject, to not fall back to the default-auth-mode
 	f.Setup("Install an EventPolicy", eventpolicy.Install(
 		eventPolicyName,
 		eventpolicy.WithToRef(
 			broker.GVR().GroupVersion().WithKind("Broker"),
 			brokerName),
-		eventpolicy.WithFromSubject("dummy-sub")))
+		eventpolicy.WithFromSubject("sample-sub")))
 
 	// Send event
 	f.Requirement("Install Source", eventshub.Install(

--- a/test/rekt/features/broker/authz_feature.go
+++ b/test/rekt/features/broker/authz_feature.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/test"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/test/rekt/resources/eventpolicy"
+	"knative.dev/eventing/test/rekt/resources/pingsource"
+	"knative.dev/reconciler-test/pkg/environment"
+
+	"knative.dev/eventing/test/rekt/features/featureflags"
+	"knative.dev/eventing/test/rekt/resources/broker"
+	"knative.dev/eventing/test/rekt/resources/trigger"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/resources/service"
+)
+
+func BrokerSupportsAuthZ() *feature.FeatureSet {
+	return &feature.FeatureSet{
+		Name: "Broker supports authorization",
+		Features: []*feature.Feature{
+			BrokerAcceptsEventsFromAuthorizedSender(),
+			BrokerRejectsEventsFromUnauthorizedSender(),
+		},
+	}
+}
+
+func BrokerAcceptsEventsFromAuthorizedSender() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker accepts events from a authorized sender")
+
+	f.Prerequisite("OIDC Authentication is enabled", featureflags.AuthenticationOIDCEnabled())
+	f.Prerequisite("transport encryption is strict", featureflags.TransportEncryptionStrict())
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
+	source := feature.MakeRandomK8sName("source")
+	brokerName := feature.MakeRandomK8sName("broker")
+	sink := feature.MakeRandomK8sName("sink")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	eventPolicyName := feature.MakeRandomK8sName("eventpolicy")
+
+	// Install the broker
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+	f.Setup("Broker is addressable", broker.IsAddressable(brokerName))
+
+	// Install the sink
+	f.Setup("Install Sink", eventshub.Install(
+		sink,
+		eventshub.StartReceiver,
+	))
+
+	f.Setup("Install the Trigger", trigger.Install(triggerName,
+		trigger.WithBrokerName(brokerName),
+		trigger.WithSubscriber(service.AsKReference(sink), "")))
+
+	f.Setup("Install the EventPolicy", func(ctx context.Context, t feature.T) {
+		eventpolicy.Install(
+			eventPolicyName,
+			eventpolicy.WithToRef(
+				broker.GVR().GroupVersion().WithKind("Broker"),
+				brokerName),
+			eventpolicy.WithFromRef(
+				pingsource.Gvr().GroupVersion().WithKind("PingSource"),
+				source,
+				environment.FromContext(ctx).Namespace()),
+		)(ctx, t)
+	})
+
+	// Install source
+	f.Requirement("Install Pingsource", func(ctx context.Context, t feature.T) {
+		brokeruri, err := broker.Address(ctx, brokerName)
+		if err != nil {
+			t.Error("failed to get address of broker", err)
+		}
+
+		pingsource.Install(source,
+			pingsource.WithSink(&duckv1.Destination{URI: brokeruri.URL, CACerts: brokeruri.CACerts, Audience: brokeruri.Audience}),
+			pingsource.WithData("text/plain", "hello, world!"))(ctx, t)
+	})
+	f.Requirement("PingSource goes ready", pingsource.IsReady(source))
+
+	f.Alpha("Broker").
+		Must("accepts event from valid sender", assert.OnStore(sink).MatchEvent(
+			test.HasType(sourcesv1.PingSourceEventType)).AtLeast(1))
+
+	return f
+}
+
+func BrokerRejectsEventsFromUnauthorizedSender() *feature.Feature {
+	f := feature.NewFeatureNamed("Broker rejects events from an unauthorized sender")
+
+	f.Prerequisite("OIDC Authentication is enabled", featureflags.AuthenticationOIDCEnabled())
+	f.Prerequisite("transport encryption is strict", featureflags.TransportEncryptionStrict())
+	f.Prerequisite("should not run when Istio is enabled", featureflags.IstioDisabled())
+
+	source := feature.MakeRandomK8sName("source")
+	brokerName := feature.MakeRandomK8sName("broker")
+	sink := feature.MakeRandomK8sName("sink")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	eventPolicyName := feature.MakeRandomK8sName("eventpolicy")
+
+	event := test.FullEvent()
+
+	// Install the broker
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithEnvConfig()...))
+	f.Setup("Broker is ready", broker.IsReady(brokerName))
+	f.Setup("Broker is addressable", broker.IsAddressable(brokerName))
+
+	// Install the sink
+	f.Setup("Install Sink", eventshub.Install(
+		sink,
+		eventshub.StartReceiver,
+	))
+
+	f.Setup("Install the Trigger", trigger.Install(triggerName,
+		trigger.WithBrokerName(brokerName),
+		trigger.WithSubscriber(service.AsKReference(sink), "")))
+	f.Setup("Trigger goes ready", trigger.IsReady(triggerName))
+
+	// Install an event policy for Broker allowing from a dummy subject, to not fall back to the default-auth-mode
+	f.Setup("Install an EventPolicy", eventpolicy.Install(
+		eventPolicyName,
+		eventpolicy.WithToRef(
+			broker.GVR().GroupVersion().WithKind("Broker"),
+			brokerName),
+		eventpolicy.WithFromSubject("dummy-sub")))
+
+	// Send event
+	f.Requirement("Install Source", eventshub.Install(
+		source,
+		eventshub.StartSenderToResourceTLS(broker.GVR(), brokerName, nil),
+		eventshub.InputEvent(event),
+	))
+
+	f.Alpha("Broker").
+		Must("event is sent", assert.OnStore(source).MatchSentEvent(
+			test.HasId(event.ID())).Exact(1)).
+		Must("broker rejects event with a 403 response", assert.OnStore(source).Match(assert.MatchStatusCode(403)).Exact(1))
+
+	return f
+}

--- a/test/rekt/resources/eventpolicy/eventpolicy_test.go
+++ b/test/rekt/resources/eventpolicy/eventpolicy_test.go
@@ -18,8 +18,9 @@ package eventpolicy_test
 
 import (
 	"embed"
-	"knative.dev/eventing/test/rekt/resources/broker"
 	"os"
+
+	"knative.dev/eventing/test/rekt/resources/broker"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/test/rekt/resources/eventpolicy"

--- a/test/rekt/resources/eventpolicy/eventpolicy_test.go
+++ b/test/rekt/resources/eventpolicy/eventpolicy_test.go
@@ -18,13 +18,11 @@ package eventpolicy_test
 
 import (
 	"embed"
+	"knative.dev/eventing/test/rekt/resources/broker"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/test/rekt/resources/eventpolicy"
-	"knative.dev/pkg/ptr"
-
 	testlog "knative.dev/reconciler-test/pkg/logging"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
@@ -82,49 +80,30 @@ func Example_full() {
 	}
 
 	cfgFn := []manifest.CfgFn{
-		eventpolicy.WithTo([]v1alpha1.EventPolicySpecTo{
-			{
-				Ref: &v1alpha1.EventPolicyToReference{
-					Name:       "my-broker",
-					Kind:       "Broker",
-					APIVersion: "eventing.knative.dev/v1",
+		eventpolicy.WithToRef(
+			broker.GVR().GroupVersion().WithKind("Broker"),
+			"my-broker"),
+		eventpolicy.WithToSelector(
+			broker.GVR().GroupVersion().WithKind("Broker"),
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"matchlabel1": "matchlabelvalue1",
+					"matchlabel2": "matchlabelvalue2",
 				},
-			},
-			{
-				Selector: &v1alpha1.EventPolicySelector{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"matchlabel1": "matchlabelvalue1",
-							"matchlabel2": "matchlabelvalue2",
-						},
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "matchlabelselector1",
-								Values:   []string{"matchlabelselectorvalue1"},
-								Operator: metav1.LabelSelectorOpIn,
-							},
-						},
-					},
-					TypeMeta: &metav1.TypeMeta{
-						APIVersion: "eventing.knative.dev/v1",
-						Kind:       "Broker",
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "matchlabelselector1",
+						Values:   []string{"matchlabelselectorvalue1"},
+						Operator: metav1.LabelSelectorOpIn,
 					},
 				},
-			},
-		}...),
-		eventpolicy.WithFrom([]v1alpha1.EventPolicySpecFrom{
-			{
-				Ref: &v1alpha1.EventPolicyFromReference{
-					APIVersion: "eventing.knative.dev/v1",
-					Name:       "my-broker",
-					Kind:       "Broker",
-					Namespace:  "my-ns-2",
-				},
-			},
-			{
-				Sub: ptr.String("my-sub"),
-			},
-		}...),
+			}),
+		eventpolicy.WithFromRef(
+			broker.GVR().GroupVersion().WithKind("Broker"),
+			"my-broker",
+			"my-ns-2",
+		),
+		eventpolicy.WithFromSubject("my-sub"),
 	}
 
 	for _, fn := range cfgFn {


### PR DESCRIPTION
Fixes #8131

## Proposed Changes

- :gift: Run authorization tests as part of e2e test suite (test with `AuthZ` in their name)
- :gift: Add e2e tests for Broker authorization