### PR TITLE
Default EventPolicy `.spec.from[].namespace` to EventPolicies namespace

### DIFF
--- a/pkg/apis/eventing/v1alpha1/eventpolicy_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/eventpolicy_defaults.go
@@ -28,4 +28,14 @@ func (ep *EventPolicy) SetDefaults(ctx context.Context) {
 }
 
 func (ets *EventPolicySpec) SetDefaults(ctx context.Context) {
+	for i := range ets.From {
+		ets.From[i].SetDefaults(ctx)
+	}
+}
+
+func (from *EventPolicySpecFrom) SetDefaults(ctx context.Context) {
+	if from.Ref != nil && from.Ref.Namespace == "" {
+		// default to event policies namespace
+		from.Ref.Namespace = apis.ParentMeta(ctx).Namespace
+	}
 }

--- a/pkg/apis/eventing/v1alpha1/eventpolicy_defaults_test.go
+++ b/pkg/apis/eventing/v1alpha1/eventpolicy_defaults_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -31,6 +33,36 @@ func TestEventPolicyDefaults(t *testing.T) {
 		"nil spec": {
 			initial:  EventPolicy{},
 			expected: EventPolicy{},
+		},
+		"default .spec.from[].namespace": {
+			initial: EventPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+				},
+				Spec: EventPolicySpec{
+					From: []EventPolicySpecFrom{
+						{
+							Ref: &EventPolicyFromReference{
+								Namespace: "",
+							},
+						},
+					},
+				},
+			},
+			expected: EventPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-ns",
+				},
+				Spec: EventPolicySpec{
+					From: []EventPolicySpecFrom{
+						{
+							Ref: &EventPolicyFromReference{
+								Namespace: "my-ns",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for n, tc := range testCases {


### PR DESCRIPTION
Defaulting the `.spec.from[].namespace` to the event policy namespace as written in the docs

https://github.com/knative/eventing/blob/32f849105ca5c37454079607b91b11ba61e91662/pkg/apis/eventing/v1alpha1/eventpolicy_types.go#L122-L126