### PR TITLE
Set UID in Brokers backing channels EventPolicies OwnerReference

### DIFF
--- a/pkg/reconciler/broker/resources/eventpolicy.go
+++ b/pkg/reconciler/broker/resources/eventpolicy.go
@@ -41,6 +41,7 @@ func MakeEventPolicyForBackingChannel(b *eventingv1.Broker, backingChannel *even
 					APIVersion: eventingv1.SchemeGroupVersion.String(),
 					Kind:       brokerKind,
 					Name:       b.Name,
+					UID:        b.UID,
 				},
 			},
 			Labels: LabelsForBackingChannelsEventPolicy(b),


### PR DESCRIPTION
Currently seeing the following error in the controller logs:

```
failed to reconcile EventPolicy for Broker broker-iinpthqx: failed to create EventPolicy for Broker broker-iinpthqx-ep-broker-iinpthqx-kne-trigger: EventPolicy.eventing.knative.dev \"broker-iinpthqx-ep-broker-iinpthqx-kne-trigger\" is invalid: metadata.ownerReferences.uid: Invalid value: \"\": uid must not be empty
```

This PR addresses it and sets the UID in the Owner reference.

## Proposed Changes

- :bug: Set UID in Brokers backing channels EventPolicies OwnerReference