### PR TITLE
Fix Broker EventPolicy status condition set

### DIFF
--- a/pkg/reconciler/broker/controller.go
+++ b/pkg/reconciler/broker/controller.go
@@ -93,6 +93,7 @@ func NewController(
 		BrokerConditionTriggerChannel,
 		BrokerConditionFilter,
 		BrokerConditionAddressable,
+		eventingv1.BrokerConditionEventPoliciesReady,
 	))
 
 	brokerFilter := pkgreconciler.AnnotationFilterFunc(brokerreconciler.ClassAnnotationKey, eventing.MTChannelBrokerClassValue, false /*allowUnset*/)


### PR DESCRIPTION
Currently we have the bug, that the Broker is still in Ready state, even when the EventPoliciesReady status condition is false:

```
  conditions:
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    status: "True"
    type: Addressable
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    message: No dead letter sink is configured.
    reason: DeadLetterSinkNotConfigured
    severity: Info
    status: "True"
    type: DeadLetterSinkResolved
  - lastTransitionTime: "2024-08-12T15:49:08Z"
    message: event policies event-policy are not ready
    reason: EventPoliciesNotReady
    severity: Info
    status: "False"
    type: EventPoliciesReady
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    status: "True"
    type: FilterReady
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    status: "True"
    type: IngressReady
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-08-12T15:48:15Z"
    status: "True"
    type: TriggerChannelReady
  observedGeneration: 1
```

This PR addresses it and fixes the issue.

A test for this is added as part of #8150 (this wasn't detected in the unit tests, as the AlternateBrokerConditionSet was registered in the controller)

**Release Note**

```release-note
Fix Broker status condition to become NotReady, when EventPoliciesReady condition is false.
```