### PR TITLE
chore: refactor cross namespace test to make it reusable

### DIFF
--- a/test/rekt/crossnamespace_test.go
+++ b/test/rekt/crossnamespace_test.go
@@ -24,10 +24,12 @@ import (
 
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
 	"knative.dev/eventing/test/rekt/features/trigger"
+	"knative.dev/eventing/test/rekt/resources/broker"
 )
 
 func TestBrokerTriggerCrossNamespaceReference(t *testing.T) {
@@ -50,5 +52,7 @@ func TestBrokerTriggerCrossNamespaceReference(t *testing.T) {
 	)
 
 	// brokerEnv.Test(brokerEnvCtx, t, broker.GoesReady(brokerName))
-	triggerEnv.Test(triggerEnvCtx, t, trigger.CrossNamespaceEventLinks(brokerEnvCtx))
+	triggerEnv.Test(triggerEnvCtx, t, trigger.CrossNamespaceEventLinks(brokerEnvCtx, func(name, namespace string) feature.StepFn {
+		return broker.Install(name, broker.WithNamespace(namespace))
+	}))
 }

--- a/test/rekt/features/trigger/crossnamespace.go
+++ b/test/rekt/features/trigger/crossnamespace.go
@@ -34,7 +34,9 @@ import (
 	"knative.dev/reconciler-test/pkg/resources/service"
 )
 
-func CrossNamespaceEventLinks(brokerEnvCtx context.Context) *feature.Feature {
+type InstallBrokerStep func(brokerName, brokerNamespace string) feature.StepFn
+
+func CrossNamespaceEventLinks(brokerEnvCtx context.Context, installBroker InstallBrokerStep) *feature.Feature {
 	f := feature.NewFeature()
 
 	f.Prerequisite("Cross Namespace Event Links is enabled", featureflags.CrossEventLinksEnabled())
@@ -60,7 +62,7 @@ func CrossNamespaceEventLinks(brokerEnvCtx context.Context) *feature.Feature {
 		trigger.WithBrokerRef(brokerRef),
 	}
 
-	f.Setup("install broker", broker.Install(brokerName, broker.WithNamespace(brokerNamespace)))
+	f.Setup("install broker", installBroker(brokerName, brokerNamespace))
 	f.Setup("install trigger", trigger.Install(triggerName, triggerCfg...))
 
 	f.Setup("install subscriber", eventshub.Install(subscriberName, eventshub.StartReceiver))


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This refactors the cross namespace test to make the installation of the broker pluggable, enabling the test to be reused in EKB.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- make the installation of the broker pluggable

