### PR TITLE
Support authorization in Channel ingress

### DIFF
--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -138,6 +138,7 @@ func NewController(
 		eventDispatcher:          kncloudevents.NewDispatcher(clientConfig, oidcTokenProvider),
 		tokenVerifier:            auth.NewOIDCTokenVerifier(ctx),
 		clientConfig:             clientConfig,
+		inMemoryChannelLister:    inmemorychannelInformer.Lister(),
 	}
 
 	var globalResync func(obj interface{})

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/eventing/test/rekt/features/authz"
 	"knative.dev/reconciler-test/pkg/feature"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -39,6 +40,7 @@ import (
 	"knative.dev/eventing/test/rekt/features/channel"
 	"knative.dev/eventing/test/rekt/features/oidc"
 	ch "knative.dev/eventing/test/rekt/resources/channel"
+	channelresource "knative.dev/eventing/test/rekt/resources/channel"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/subscription"
 )
@@ -391,4 +393,40 @@ func TestChannelImplSupportsOIDC(t *testing.T) {
 	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
 
 	env.TestSet(ctx, t, oidc.AddressableOIDCConformance(channel_impl.GVR(), channel_impl.GVK().Kind, name, env.Namespace()))
+}
+
+func TestChannelImplSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	name := feature.MakeRandomK8sName("channelimpl")
+	env.Prerequisite(ctx, t, channel.ImplGoesReady(name))
+
+	env.TestSet(ctx, t, authz.AddressableAuthZConformance(channel_impl.GVR(), channel_impl.GVK().Kind, name))
+}
+
+func TestChannelSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	name := feature.MakeRandomK8sName("channel")
+	env.Prerequisite(ctx, t, channel.GoesReady(name))
+
+	env.TestSet(ctx, t, authz.AddressableAuthZConformance(channelresource.GVR(), "Channel", name))
 }


### PR DESCRIPTION
Fixes #7981

Follow up on #8123

## Proposed Changes

- :gift: Verify authorization in Channel ingress
- :gift: Add support for authorization in InMemoryChannel

**Release Note**
```release-note
InMemoryChannel ingress: Reject unauthorized requests
```

* [x] WIP as it needs #8163 