### PR TITLE
Fix: propagate EventPolicy filter to underlying Channels EventPolicy

### DIFF
--- a/pkg/reconciler/channel/channel_test.go
+++ b/pkg/reconciler/channel/channel_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/apis/feature"
 
@@ -554,6 +556,9 @@ func TestReconcile(t *testing.T) {
 			NewEventPolicy(readyEventPolicyName, testNS,
 				WithReadyEventPolicyCondition,
 				WithEventPolicyToRef(channelV1GVK, channelName),
+				WithEventPolicyFilter(eventingv1.SubscriptionsAPIFilter{
+					CESQL: "true",
+				}),
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -586,6 +591,9 @@ func TestReconcile(t *testing.T) {
 					"messaging.knative.dev/channel-version": v1.SchemeGroupVersion.Version,
 					"messaging.knative.dev/channel-kind":    "InMemoryChannel",
 					"messaging.knative.dev/channel-name":    channelName,
+				}),
+				WithEventPolicyFilter(eventingv1.SubscriptionsAPIFilter{
+					CESQL: "true",
 				}),
 			),
 		},

--- a/pkg/reconciler/channel/resources/eventpolicy.go
+++ b/pkg/reconciler/channel/resources/eventpolicy.go
@@ -61,7 +61,8 @@ func MakeEventPolicyForBackingChannel(backingChannel *eventingduckv1.Channelable
 					},
 				},
 			},
-			From: parentPolicy.Spec.From,
+			From:    parentPolicy.Spec.From,
+			Filters: parentPolicy.Spec.Filters,
 		},
 	}
 }

--- a/pkg/reconciler/parallel/resources/eventpolicy.go
+++ b/pkg/reconciler/parallel/resources/eventpolicy.go
@@ -112,7 +112,8 @@ func MakeEventPolicyForParallelIngressChannel(p *flowsv1.Parallel, ingressChanne
 					},
 				},
 			},
-			From: parallelPolicy.Spec.From,
+			From:    parallelPolicy.Spec.From,
+			Filters: parallelPolicy.Spec.Filters,
 		},
 	}
 }

--- a/pkg/reconciler/sequence/resources/eventpolicy.go
+++ b/pkg/reconciler/sequence/resources/eventpolicy.go
@@ -112,7 +112,8 @@ func MakeEventPolicyForSequenceInputChannel(s *flowsv1.Sequence, inputChannel *e
 					},
 				},
 			},
-			From: sequencePolicy.Spec.From,
+			From:    sequencePolicy.Spec.From,
+			Filters: sequencePolicy.Spec.Filters,
 		},
 	}
 }

--- a/pkg/reconciler/testing/v1/eventpolicy.go
+++ b/pkg/reconciler/testing/v1/eventpolicy.go
@@ -19,6 +19,8 @@ package testing
 import (
 	"context"
 
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/apis/eventing/v1alpha1"
@@ -143,6 +145,12 @@ func WithEventPolicyFromSub(sub string) EventPolicyOption {
 		ep.Spec.From = append(ep.Spec.From, v1alpha1.EventPolicySpecFrom{
 			Sub: &sub,
 		})
+	}
+}
+
+func WithEventPolicyFilter(filter eventingv1.SubscriptionsAPIFilter) EventPolicyOption {
+	return func(ep *v1alpha1.EventPolicy) {
+		ep.Spec.Filters = append(ep.Spec.Filters, filter)
 	}
 }
 


### PR DESCRIPTION
The filters of the parent policy of Channels/Parallels & Sequences are not propagated to the underlying channels EventPolicies.
This PR fixes it.

Found on adding e2e tests in #8162