### PR TITLE
Fix JobSink to have ObservedGeneration in status

### DIFF
--- a/config/core/resources/jobsink.yaml
+++ b/config/core/resources/jobsink.yaml
@@ -121,6 +121,10 @@ spec:
                       type:
                         description: 'Type of condition.'
                         type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: URL
           type: string

--- a/test/rekt/features/jobsink/jobsink.go
+++ b/test/rekt/features/jobsink/jobsink.go
@@ -58,7 +58,7 @@ func Success() *feature.Feature {
 	f.Setup("install job sink", jobsink.Install(jobSink, jobsink.WithForwarderJob(sinkURL.String())))
 
 	f.Setup("jobsink is addressable", jobsink.IsAddressable(jobSink))
-	f.Setup("jobsink is ready", jobsink.IsAddressable(jobSink))
+	f.Setup("jobsink is ready", jobsink.IsReady(jobSink))
 
 	f.Requirement("install source", eventshub.Install(source,
 		eventshub.StartSenderToResource(jobsink.GVR(), jobSink),
@@ -97,7 +97,7 @@ func SuccessTLS() *feature.Feature {
 	f.Setup("install job sink", jobsink.Install(jobSink, jobsink.WithForwarderJob(sinkURL.String())))
 
 	f.Setup("jobsink is addressable", jobsink.IsAddressable(jobSink))
-	f.Setup("jobsink is ready", jobsink.IsAddressable(jobSink))
+	f.Setup("jobsink is ready", jobsink.IsReady(jobSink))
 
 	f.Requirement("install source", eventshub.Install(source,
 		eventshub.StartSenderToResourceTLS(jobsink.GVR(), jobSink, nil),
@@ -142,7 +142,7 @@ func OIDC() *feature.Feature {
 	f.Setup("install job sink", jobsink.Install(jobSink, jobsink.WithForwarderJob(sinkURL.String())))
 
 	f.Setup("jobsink is addressable", jobsink.IsAddressable(jobSink))
-	f.Setup("jobsink is ready", jobsink.IsAddressable(jobSink))
+	f.Setup("jobsink is ready", jobsink.IsReady(jobSink))
 
 	f.Requirement("install source", eventshub.Install(source,
 		eventshub.StartSenderToResource(jobsink.GVR(), jobSink),


### PR DESCRIPTION
Currently the JobSinks CRD does not have a field for the ObservedGeneration in its status, while having the duck.status:

https://github.com/knative/eventing/blob/bf945f909e685d4e26c83afe5a32f00fabccb3e8/pkg/apis/sinks/v1alpha1/job_sink_types.go#L63

which has this field:
https://github.com/knative/pkg/blob/89743d9bbf7cc691f156b945bb29f96989da4e03/apis/duck/v1/status_types.go#L42

This leads to the rekt jobsinks.IsReady() check to not succeed.

This PR addresses it and adds the field in the CRD.