### PR TITLE
Split AuthZ e2e tests

### DIFF
--- a/test/rekt/features/authz/addressable_authz_conformance.go
+++ b/test/rekt/features/authz/addressable_authz_conformance.go
@@ -36,13 +36,29 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 )
 
+// AddressableAuthZConformance returns a feature set to test all Authorization features for an addressable.
 func AddressableAuthZConformance(gvr schema.GroupVersionResource, kind, name string) *feature.FeatureSet {
+	fs := feature.FeatureSet{
+		Name: fmt.Sprintf("%s handles authorization features correctly", kind),
+		Features: []*feature.Feature{
+			addressableRespectsEventPolicyFilters(gvr, kind, name),
+		},
+	}
+
+	fs.Features = append(fs.Features, AddressableAuthZConformanceRequestHandling(gvr, kind, name).Features...)
+
+	return &fs
+}
+
+// AddressableAuthZConformanceRequestHandling returns a FeatureSet to test the basic authorization features.
+// This basic feature set contains to allow authorized and reject unauthorized requests. In addition it also
+// tests, that the addressable becomes unready in case of a NotReady assigned EventPolicy.
+func AddressableAuthZConformanceRequestHandling(gvr schema.GroupVersionResource, kind, name string) *feature.FeatureSet {
 	fs := feature.FeatureSet{
 		Name: fmt.Sprintf("%s handles authorization in requests correctly", kind),
 		Features: []*feature.Feature{
 			addressableAllowsAuthorizedRequest(gvr, kind, name),
 			addressableRejectsUnauthorizedRequest(gvr, kind, name),
-			addressableRespectsEventPolicyFilters(gvr, kind, name),
 			addressableBecomesUnreadyOnUnreadyEventPolicy(gvr, kind, name),
 		},
 	}


### PR DESCRIPTION
Currently the authz e2e conformance tests, test all authz features. This includes also to respect the filters.
Anyhow not all AuthZ supporting implementations implement the full feature set yet. For example EKB should support basic AuthZ - but no filtering yet. Anyhow it would be great to already have the possibility to enable the AuthZ e2e tests.

This PR addresses it and splits the AuthZ e2e tests and thus allows more fine grained tests.