### PR TITLE
Add broker transformation test to upgrade tests

### DIFF
--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -23,7 +23,10 @@ import (
 	"sync"
 	"testing"
 
+	"knative.dev/eventing/pkg/apis/eventing"
+	brokerfeatures "knative.dev/eventing/test/rekt/features/broker"
 	"knative.dev/eventing/test/rekt/features/channel"
+	brokerresources "knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/subscription"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -37,7 +40,16 @@ import (
 	"knative.dev/reconciler-test/pkg/manifest"
 )
 
-var channelConfigMux = &sync.Mutex{}
+var (
+	channelConfigMux = &sync.Mutex{}
+	brokerConfigMux  = &sync.Mutex{}
+	opts             = []environment.EnvOpts{
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+	}
+)
 
 // RunMainTest expects flags to be already initialized.
 // This function needs to be exposed, so that test cases in other repositories can call the upgrade
@@ -63,7 +75,7 @@ type DurableFeature struct {
 	EnvOpts  []environment.EnvOpts
 	setupEnv environment.Environment
 	setupCtx context.Context
-	VerifyF  *feature.Feature
+	VerifyF  func() *feature.Feature
 	Global   environment.GlobalEnvironment
 }
 
@@ -83,14 +95,14 @@ func (fe *DurableFeature) Setup(label string) pkgupgrade.Operation {
 func (fe *DurableFeature) Verify(label string) pkgupgrade.Operation {
 	return pkgupgrade.NewOperation(label, func(c pkgupgrade.Context) {
 		c.T.Parallel()
-		fe.setupEnv.Test(fe.setupCtx, c.T, fe.VerifyF)
+		fe.setupEnv.Test(fe.setupCtx, c.T, fe.VerifyF())
 	})
 }
 
 func (fe *DurableFeature) VerifyAndTeardown(label string) pkgupgrade.Operation {
 	return pkgupgrade.NewOperation(label, func(c pkgupgrade.Context) {
 		c.T.Parallel()
-		fe.setupEnv.Test(fe.setupCtx, c.T, fe.VerifyF)
+		fe.setupEnv.Test(fe.setupCtx, c.T, fe.VerifyF())
 		// Ensures teardown of resources/namespace.
 		fe.setupEnv.Finish()
 	})
@@ -103,7 +115,7 @@ func (fe *DurableFeature) SetupVerifyAndTeardown(label string) pkgupgrade.Operat
 			append(fe.EnvOpts, environment.Managed(c.T))...,
 		)
 		env.Test(ctx, c.T, fe.SetupF)
-		env.Test(ctx, c.T, fe.VerifyF)
+		env.Test(ctx, c.T, fe.VerifyF())
 	})
 }
 
@@ -290,14 +302,29 @@ func InMemoryChannelFeature(glob environment.GlobalEnvironment) *DurableFeature 
 	setupF := feature.NewFeature()
 	sink, ch := channel.ChannelChainSetup(setupF, 1, createSubscriberFn)
 
-	verifyF := feature.NewFeature()
-	channel.ChannelChainAssert(verifyF, sink, ch)
+	verifyF := func() *feature.Feature {
+		f := feature.NewFeature()
+		channel.ChannelChainAssert(f, sink, ch)
+		return f
+	}
 
-	opts := []environment.EnvOpts{
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
+	return &DurableFeature{SetupF: setupF, VerifyF: verifyF, Global: glob, EnvOpts: opts}
+}
+
+func BrokerEventTransformationForTrigger(glob environment.GlobalEnvironment,
+) *DurableFeature {
+	// Prevent race conditions on EnvCfg.BrokerClass when running tests in parallel.
+	brokerConfigMux.Lock()
+	defer brokerConfigMux.Unlock()
+	brokerresources.EnvCfg.BrokerClass = eventing.MTChannelBrokerClassValue
+
+	setupF := feature.NewFeature()
+	cfg := brokerfeatures.BrokerEventTransformationForTriggerSetup(setupF)
+
+	verifyF := func() *feature.Feature {
+		f := feature.NewFeature()
+		brokerfeatures.BrokerEventTransformationForTriggerAssert(f, cfg)
+		return f
 	}
 
 	return &DurableFeature{SetupF: setupF, VerifyF: verifyF, Global: glob, EnvOpts: opts}

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -303,7 +303,7 @@ func InMemoryChannelFeature(glob environment.GlobalEnvironment) *DurableFeature 
 	sink, ch := channel.ChannelChainSetup(setupF, 1, createSubscriberFn)
 
 	verifyF := func() *feature.Feature {
-		f := feature.NewFeature()
+		f := feature.NewFeatureNamed(setupF.Name)
 		channel.ChannelChainAssert(f, sink, ch)
 		return f
 	}
@@ -322,7 +322,7 @@ func BrokerEventTransformationForTrigger(glob environment.GlobalEnvironment,
 	cfg := brokerfeatures.BrokerEventTransformationForTriggerSetup(setupF)
 
 	verifyF := func() *feature.Feature {
-		f := feature.NewFeature()
+		f := feature.NewFeatureNamed(setupF.Name)
 		brokerfeatures.BrokerEventTransformationForTriggerAssert(f, cfg)
 		return f
 	}

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -52,12 +52,16 @@ func TestEventingUpgrades(t *testing.T) {
 	g := FeatureGroupWithUpgradeTests{
 		// A feature that will run the same test post-upgrade and post-downgrade.
 		NewFeatureSmoke(InMemoryChannelFeature(global)),
+		NewFeatureSmoke(BrokerEventTransformationForTrigger(global)),
 		// A feature that will be created pre-upgrade and verified/removed post-upgrade.
 		NewFeatureOnlyUpgrade(InMemoryChannelFeature(global)),
+		NewFeatureOnlyUpgrade(BrokerEventTransformationForTrigger(global)),
 		// A feature that will be created pre-upgrade, verified post-upgrade, verified and removed post-downgrade.
 		NewFeatureUpgradeDowngrade(InMemoryChannelFeature(global)),
+		NewFeatureUpgradeDowngrade(BrokerEventTransformationForTrigger(global)),
 		// A feature that will be created post-upgrade, verified and removed post-downgrade.
 		NewFeatureOnlyDowngrade(InMemoryChannelFeature(global)),
+		NewFeatureOnlyDowngrade(BrokerEventTransformationForTrigger(global)),
 	}
 
 	suite := pkgupgrade.Suite{


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Refactor broker transformation test so that it can be used in upgrade tests (this will also be reused in knative-extensions/eventing-kafka-broker, see [WIP pull request](https://github.com/knative-extensions/eventing-kafka-broker/pull/4095) )
- Include Broker transformation test in upgrade test suite
- Fix `DurableFeature`. The `FeatureF` must be a function that can be called multiple times on demand, and it will create a new feature every time - with different resources to prevent clash with existing resources.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

