### PR TITLE
Make auth package indepent from eventpolicy informer

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"context"
 	"fmt"
-	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	"log"
+
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"

--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -153,9 +153,9 @@ func main() {
 	oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
+	authVerifier := auth.NewVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector).Lister().ConfigMaps(system.Namespace())
-	handler, err = filter.NewHandler(logger, oidcTokenVerifier, oidcTokenProvider, triggerinformer.Get(ctx), brokerinformer.Get(ctx), subscriptioninformer.Get(ctx), reporter, trustBundleConfigMapInformer, ctxFunc)
+	handler, err = filter.NewHandler(logger, authVerifier, oidcTokenProvider, triggerinformer.Get(ctx), brokerinformer.Get(ctx), subscriptioninformer.Get(ctx), reporter, trustBundleConfigMapInformer, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	"log"
 
 	"github.com/google/uuid"
@@ -152,7 +153,7 @@ func main() {
 	oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
 	// We are running both the receiver (takes messages in from the Broker) and the dispatcher (send
 	// the messages to the triggers' subscribers) in this binary.
-	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx)
+	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector).Lister().ConfigMaps(system.Namespace())
 	handler, err = filter.NewHandler(logger, oidcTokenVerifier, oidcTokenProvider, triggerinformer.Get(ctx), brokerinformer.Get(ctx), subscriptioninformer.Get(ctx), reporter, trustBundleConfigMapInformer, ctxFunc)
 	if err != nil {

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -168,9 +168,9 @@ func main() {
 	reporter := ingress.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 
 	oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
+	authVerifier := auth.NewVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector).Lister().ConfigMaps(system.Namespace())
-	handler, err = ingress.NewHandler(logger, reporter, broker.TTLDefaulter(logger, int32(env.MaxTTL)), brokerInformer, oidcTokenVerifier, oidcTokenProvider, trustBundleConfigMapInformer, ctxFunc)
+	handler, err = ingress.NewHandler(logger, reporter, broker.TTLDefaulter(logger, int32(env.MaxTTL)), brokerInformer, authVerifier, oidcTokenProvider, trustBundleConfigMapInformer, ctxFunc)
 	if err != nil {
 		logger.Fatal("Error creating Handler", zap.Error(err))
 	}

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -49,6 +49,7 @@ import (
 	"knative.dev/eventing/pkg/broker/ingress"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
 	brokerinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker"
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/eventtype"
@@ -167,7 +168,7 @@ func main() {
 	reporter := ingress.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))
 
 	oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx)
+	oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister())
 	trustBundleConfigMapInformer := configmapinformer.Get(ctx, eventingtls.TrustBundleLabelSelector).Lister().ConfigMaps(system.Namespace())
 	handler, err = ingress.NewHandler(logger, reporter, broker.TTLDefaulter(logger, int32(env.MaxTTL)), brokerInformer, oidcTokenVerifier, oidcTokenProvider, trustBundleConfigMapInformer, ctxFunc)
 	if err != nil {

--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -115,10 +115,10 @@ func main() {
 	}
 
 	h := &Handler{
-		k8s:               kubeclient.Get(ctx),
-		lister:            jobsink.Get(ctx).Lister(),
-		withContext:       ctxFunc,
-		oidcTokenVerifier: auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
+		k8s:          kubeclient.Get(ctx),
+		lister:       jobsink.Get(ctx).Lister(),
+		withContext:  ctxFunc,
+		authVerifier: auth.NewVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
 	}
 
 	tlsConfig, err := getServerTLSConfig(ctx)
@@ -159,10 +159,10 @@ func main() {
 }
 
 type Handler struct {
-	k8s               kubernetes.Interface
-	lister            sinkslister.JobSinkLister
-	withContext       func(ctx context.Context) context.Context
-	oidcTokenVerifier *auth.OIDCTokenVerifier
+	k8s          kubernetes.Interface
+	lister       sinkslister.JobSinkLister
+	withContext  func(ctx context.Context) context.Context
+	authVerifier *auth.Verifier
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -201,7 +201,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	logger.Debug("Handling POST request", zap.String("URI", r.RequestURI))
 
-	err = h.oidcTokenVerifier.VerifyRequest(ctx, feature.FromContext(ctx), js.Status.Address.Audience, js.Namespace, js.Status.Policies, r, w)
+	err = h.authVerifier.VerifyRequest(ctx, feature.FromContext(ctx), js.Status.Address.Audience, js.Namespace, js.Status.Policies, r, w)
 	if err != nil {
 		logger.Warn("Failed to verify AuthN and AuthZ.", zap.Error(err))
 		return
@@ -374,7 +374,7 @@ func (h *Handler) handleGet(ctx context.Context, w http.ResponseWriter, r *http.
 
 	logger.Debug("Handling GET request", zap.String("URI", r.RequestURI))
 
-	err = h.oidcTokenVerifier.VerifyRequest(ctx, feature.FromContext(ctx), js.Status.Address.Audience, js.Namespace, js.Status.Policies, r, w)
+	err = h.authVerifier.VerifyRequest(ctx, feature.FromContext(ctx), js.Status.Address.Audience, js.Namespace, js.Status.Policies, r, w)
 	if err != nil {
 		logger.Warn("Failed to verify AuthN and AuthZ.", zap.Error(err))
 		return

--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -54,6 +54,7 @@ import (
 	"knative.dev/eventing/pkg/apis/sinks"
 	sinksv "knative.dev/eventing/pkg/apis/sinks/v1alpha1"
 	"knative.dev/eventing/pkg/auth"
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	"knative.dev/eventing/pkg/client/injection/informers/sinks/v1alpha1/jobsink"
 	sinkslister "knative.dev/eventing/pkg/client/listers/sinks/v1alpha1"
 	"knative.dev/eventing/pkg/eventingtls"
@@ -117,7 +118,7 @@ func main() {
 		k8s:               kubeclient.Get(ctx),
 		lister:            jobsink.Get(ctx).Lister(),
 		withContext:       ctxFunc,
-		oidcTokenVerifier: auth.NewOIDCTokenVerifier(ctx),
+		oidcTokenVerifier: auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
 	}
 
 	tlsConfig, err := getServerTLSConfig(ctx)

--- a/pkg/auth/token_verifier.go
+++ b/pkg/auth/token_verifier.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	duckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	"knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/apis/feature"
+	listerseventingv1alpha1 "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/logging"
 )
@@ -61,11 +61,11 @@ type IDToken struct {
 	AccessTokenHash string
 }
 
-func NewOIDCTokenVerifier(ctx context.Context) *OIDCTokenVerifier {
+func NewOIDCTokenVerifier(ctx context.Context, eventPolicyLister listerseventingv1alpha1.EventPolicyLister) *OIDCTokenVerifier {
 	tokenHandler := &OIDCTokenVerifier{
 		logger:            logging.FromContext(ctx).With("component", "oidc-token-handler"),
 		restConfig:        injection.GetConfig(ctx),
-		eventPolicyLister: eventpolicyinformer.Get(ctx).Lister(),
+		eventPolicyLister: eventPolicyLister,
 	}
 
 	if err := tokenHandler.initOIDCProvider(ctx); err != nil {

--- a/pkg/broker/filter/filter_handler.go
+++ b/pkg/broker/filter/filter_handler.go
@@ -90,12 +90,12 @@ type Handler struct {
 	logger             *zap.Logger
 	withContext        func(ctx context.Context) context.Context
 	filtersMap         *subscriptionsapi.FiltersMap
-	tokenVerifier      *auth.OIDCTokenVerifier
+	tokenVerifier      *auth.Verifier
 	EventTypeCreator   *eventtype.EventTypeAutoHandler
 }
 
 // NewHandler creates a new Handler and its associated EventReceiver.
-func NewHandler(logger *zap.Logger, tokenVerifier *auth.OIDCTokenVerifier, oidcTokenProvider *auth.OIDCTokenProvider, triggerInformer v1.TriggerInformer, brokerInformer v1.BrokerInformer, subscriptionInformer messaginginformers.SubscriptionInformer, reporter StatsReporter, trustBundleConfigMapLister corev1listers.ConfigMapNamespaceLister, wc func(ctx context.Context) context.Context) (*Handler, error) {
+func NewHandler(logger *zap.Logger, tokenVerifier *auth.Verifier, oidcTokenProvider *auth.OIDCTokenProvider, triggerInformer v1.TriggerInformer, brokerInformer v1.BrokerInformer, subscriptionInformer messaginginformers.SubscriptionInformer, reporter StatsReporter, trustBundleConfigMapLister corev1listers.ConfigMapNamespaceLister, wc func(ctx context.Context) context.Context) (*Handler, error) {
 	kncloudevents.ConfigureConnectionArgs(&kncloudevents.ConnectionArgs{
 		MaxIdleConns:        defaultMaxIdleConnections,
 		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -54,6 +54,7 @@ import (
 
 	brokerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	triggerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
+	eventpolicyinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 	subscriptioninformerfake "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 
 	// Fake injection client
@@ -443,7 +444,7 @@ func TestReceiver(t *testing.T) {
 
 			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 			oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx)
+			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			for _, trig := range tc.triggers {
 				// Replace the SubscriberURI to point at our fake server.
@@ -652,7 +653,7 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 
 			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 			oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx)
+			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			// Replace the SubscriberURI to point at our fake server.
 			for _, trig := range tc.triggers {

--- a/pkg/broker/filter/filter_handler_test.go
+++ b/pkg/broker/filter/filter_handler_test.go
@@ -444,7 +444,7 @@ func TestReceiver(t *testing.T) {
 
 			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 			oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
+			authVerifier := auth.NewVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			for _, trig := range tc.triggers {
 				// Replace the SubscriberURI to point at our fake server.
@@ -480,7 +480,7 @@ func TestReceiver(t *testing.T) {
 			reporter := &mockReporter{}
 			r, err := NewHandler(
 				logger,
-				oidcTokenVerifier,
+				authVerifier,
 				oidcTokenProvider,
 				triggerinformerfake.Get(ctx),
 				brokerinformerfake.Get(ctx),
@@ -653,7 +653,7 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 
 			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 			oidcTokenProvider := auth.NewOIDCTokenProvider(ctx)
-			oidcTokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
+			authVerifier := auth.NewVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			// Replace the SubscriberURI to point at our fake server.
 			for _, trig := range tc.triggers {
@@ -689,7 +689,7 @@ func TestReceiver_WithSubscriptionsAPI(t *testing.T) {
 			reporter := &mockReporter{}
 			r, err := NewHandler(
 				logger,
-				oidcTokenVerifier,
+				authVerifier,
 				oidcTokenProvider,
 				triggerinformerfake.Get(ctx),
 				brokerinformerfake.Get(ctx),

--- a/pkg/broker/ingress/ingress_handler.go
+++ b/pkg/broker/ingress/ingress_handler.go
@@ -73,12 +73,12 @@ type Handler struct {
 
 	eventDispatcher *kncloudevents.Dispatcher
 
-	tokenVerifier *auth.OIDCTokenVerifier
+	tokenVerifier *auth.Verifier
 
 	withContext func(ctx context.Context) context.Context
 }
 
-func NewHandler(logger *zap.Logger, reporter StatsReporter, defaulter client.EventDefaulter, brokerInformer v1.BrokerInformer, tokenVerifier *auth.OIDCTokenVerifier, oidcTokenProvider *auth.OIDCTokenProvider, trustBundleConfigMapLister corev1listers.ConfigMapNamespaceLister, withContext func(ctx context.Context) context.Context) (*Handler, error) {
+func NewHandler(logger *zap.Logger, reporter StatsReporter, defaulter client.EventDefaulter, brokerInformer v1.BrokerInformer, tokenVerifier *auth.Verifier, oidcTokenProvider *auth.OIDCTokenProvider, trustBundleConfigMapLister corev1listers.ConfigMapNamespaceLister, withContext func(ctx context.Context) context.Context) (*Handler, error) {
 	connectionArgs := kncloudevents.ConnectionArgs{
 		MaxIdleConns:        defaultMaxIdleConnections,
 		MaxIdleConnsPerHost: defaultMaxIdleConnectionsPerHost,

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -291,13 +291,13 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			}
 
 			tokenProvider := auth.NewOIDCTokenProvider(ctx)
-			tokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
+			authVerifier := auth.NewVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			h, err := NewHandler(logger,
 				&mockReporter{},
 				tc.defaulter,
 				brokerinformerfake.Get(ctx),
-				tokenVerifier,
+				authVerifier,
 				tokenProvider,
 				configmapinformer.Get(ctx).Lister().ConfigMaps("ns"),
 				func(ctx context.Context) context.Context {

--- a/pkg/broker/ingress/ingress_handler_test.go
+++ b/pkg/broker/ingress/ingress_handler_test.go
@@ -44,6 +44,7 @@ import (
 	"knative.dev/eventing/pkg/broker"
 
 	brokerinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
+	eventpolicyinformerfake "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
 
 	// Fake injection client
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy/fake"
@@ -290,7 +291,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			}
 
 			tokenProvider := auth.NewOIDCTokenProvider(ctx)
-			tokenVerifier := auth.NewOIDCTokenVerifier(ctx)
+			tokenVerifier := auth.NewOIDCTokenVerifier(ctx, eventpolicyinformerfake.Get(ctx).Lister())
 
 			h, err := NewHandler(logger,
 				&mockReporter{},

--- a/pkg/channel/event_receiver.go
+++ b/pkg/channel/event_receiver.go
@@ -71,7 +71,7 @@ type EventReceiver struct {
 	hostToChannelFunc    ResolveChannelFromHostFunc
 	pathToChannelFunc    ResolveChannelFromPathFunc
 	reporter             StatsReporter
-	tokenVerifier        *auth.OIDCTokenVerifier
+	tokenVerifier        *auth.Verifier
 	audience             string
 	getPoliciesForFunc   GetPoliciesForFunc
 	withContext          func(context.Context) context.Context
@@ -120,7 +120,7 @@ func ReceiverWithGetPoliciesForFunc(fn GetPoliciesForFunc) EventReceiverOptions 
 	}
 }
 
-func OIDCTokenVerification(tokenVerifier *auth.OIDCTokenVerifier, audience string) EventReceiverOptions {
+func OIDCTokenVerification(tokenVerifier *auth.Verifier, audience string) EventReceiverOptions {
 	return func(r *EventReceiver) error {
 		r.tokenVerifier = tokenVerifier
 		r.audience = audience

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -137,7 +137,7 @@ func NewController(
 		eventingClient:           eventingclient.Get(ctx).EventingV1beta2(),
 		eventTypeLister:          eventtypeinformer.Get(ctx).Lister(),
 		eventDispatcher:          kncloudevents.NewDispatcher(clientConfig, oidcTokenProvider),
-		tokenVerifier:            auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
+		authVerifier:             auth.NewVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
 		clientConfig:             clientConfig,
 		inMemoryChannelLister:    inmemorychannelInformer.Lister(),
 	}

--- a/pkg/reconciler/inmemorychannel/dispatcher/controller.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/controller.go
@@ -54,6 +54,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/channel"
 	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1beta2/eventtype"
 	inmemorychannelinformer "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/inmemorychannel"
 	inmemorychannelreconciler "knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
@@ -136,7 +137,7 @@ func NewController(
 		eventingClient:           eventingclient.Get(ctx).EventingV1beta2(),
 		eventTypeLister:          eventtypeinformer.Get(ctx).Lister(),
 		eventDispatcher:          kncloudevents.NewDispatcher(clientConfig, oidcTokenProvider),
-		tokenVerifier:            auth.NewOIDCTokenVerifier(ctx),
+		tokenVerifier:            auth.NewOIDCTokenVerifier(ctx, eventpolicyinformer.Get(ctx).Lister()),
 		clientConfig:             clientConfig,
 		inMemoryChannelLister:    inmemorychannelInformer.Lister(),
 	}

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel.go
@@ -62,8 +62,8 @@ type Reconciler struct {
 	featureStore             *feature.Store
 	eventDispatcher          *kncloudevents.Dispatcher
 
-	tokenVerifier *auth.OIDCTokenVerifier
-	clientConfig  eventingtls.ClientConfig
+	authVerifier *auth.Verifier
+	clientConfig eventingtls.ClientConfig
 }
 
 // Check the interfaces Reconciler should implement
@@ -134,7 +134,7 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			channelRef,
 			UID,
 			r.eventDispatcher,
-			channel.OIDCTokenVerification(r.tokenVerifier, audience(imc)),
+			channel.OIDCTokenVerification(r.authVerifier, audience(imc)),
 			channel.ReceiverWithContextFunc(wc),
 			channel.ReceiverWithGetPoliciesForFunc(r.getAppliedEventPolicyRef),
 		)
@@ -167,7 +167,7 @@ func (r *Reconciler) reconcile(ctx context.Context, imc *v1.InMemoryChannel) rec
 			UID,
 			r.eventDispatcher,
 			channel.ResolveChannelFromPath(channel.ParseChannelFromPath),
-			channel.OIDCTokenVerification(r.tokenVerifier, audience(imc)),
+			channel.OIDCTokenVerification(r.authVerifier, audience(imc)),
 			channel.ReceiverWithContextFunc(wc),
 			channel.ReceiverWithGetPoliciesForFunc(r.getAppliedEventPolicyRef),
 		)


### PR DESCRIPTION
Currently the pkg/auth package depends on the eventpolicy informer (through the tokenverifier), requiring everything what imports `knative.dev/eventing/pkg/auth` to have permissions to read&list EventPolicies.
This leads to the following issues e.g. for PingSource (which does not need the TokenVerifier):

```
W0916 14:29:26.690900       1 reflector.go:547] k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232: failed to list *v1alpha1.EventPolicy: eventpolicies.eventing.knative.dev is forbidden: User "system:serviceaccount:knative-eventing:pingsource-mt-adapter" cannot list resource "eventpolicies" in API group "eventing.knative.dev" at the cluster scope
E0916 14:29:26.690991       1 reflector.go:150] k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232: Failed to watch *v1alpha1.EventPolicy: failed to list *v1alpha1.EventPolicy: eventpolicies.eventing.knative.dev is forbidden: User "system:serviceaccount:knative-eventing:pingsource-mt-adapter" cannot list resource "eventpolicies" in API group "eventing.knative.dev" at the cluster scope
```

This PR addresses it and removes the dependency in the TokenVerifier to the EventPolicy informer. In addition it renames the `auth.OIDCTokenVerifier` to `auth.Verifier` as this includes AuthN and AuthZ.