### PR TITLE
workaround DeepDerivative CreationTimestamp comparison

### DIFF
--- a/pkg/auth/serviceaccount.go
+++ b/pkg/auth/serviceaccount.go
@@ -109,6 +109,9 @@ func EnsureOIDCServiceAccountExistsForResource(ctx context.Context, serviceAccou
 		return fmt.Errorf("service account %s not owned by %s %s", sa.Name, gvk.Kind, objectMeta.Name)
 	}
 
+	// DeepDerivative does not understand default metav1.Time{} as an empty value
+	expected.CreationTimestamp = sa.CreationTimestamp
+
 	if !equality.Semantic.DeepDerivative(expected, sa) {
 		expected.ResourceVersion = sa.ResourceVersion
 


### PR DESCRIPTION
The DeepDerivative does not treat the default value of CreationTimestamp (metav1.Time{}) as a "null" value, so it will always compare to actual CreationTimestamp of the existing ServiceAccount.

The proposed changes to the serviceaccount_test.go were originally written by @pierDipi 

## Proposed Changes

- :broom: Fix unnecessary updates of auth ServiceAccounts

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec