### PR TITLE
fix: et autocreate makes eventtype id required

### DIFF
--- a/pkg/eventtype/eventtypes.go
+++ b/pkg/eventtype/eventtypes.go
@@ -99,7 +99,7 @@ func (h *EventTypeAutoHandler) AutoCreateEventType(ctx context.Context, event *e
 					{Name: "source", Value: source.String(), Required: true},
 					{Name: "schemadata", Value: schema.String(), Required: true},
 					{Name: "specversion", Value: event.SpecVersion(), Required: true},
-					{Name: "id", Required: false},
+					{Name: "id", Required: true},
 				},
 				Reference:   addressable,
 				Description: "Event Type auto-created by controller",


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Follow up on https://github.com/knative/eventing/pull/8276#discussion_r1816527630

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- EventTypes autocreated have the `id` attribute required