### PR TITLE
Allow imc-controller to list JobSinks

### DIFF
--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -54,6 +54,15 @@ rules:
       - list
       - watch
   - apiGroups:
+      - sinks.knative.dev
+    resources:
+      - jobsinks
+      - jobsinks/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - services


### PR DESCRIPTION
This is required otherwise MTChannelBasedBroker backed by IMC channel can't forward events to JobSink. The error on ImMemoryChannel is following:
```
failed to get lister for sinks.knative.dev/v1alpha1, Resource=jobsinks:
jobsinks.sinks.knative.dev is forbidden:
User "system:serviceaccount:knative-eventing:imc-controller" cannot list
resource "jobsinks" in API group "sinks.knative.dev" at the cluster
scope
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

