### PR TITLE
Add observedGeneration in JobSink OpenAPI schema

### DIFF
--- a/config/core/resources/jobsink.yaml
+++ b/config/core/resources/jobsink.yaml
@@ -94,6 +94,10 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array

--- a/pkg/reconciler/jobsink/jobsink_test.go
+++ b/pkg/reconciler/jobsink/jobsink_test.go
@@ -28,10 +28,6 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
-	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
-	jobsinkreconciler "knative.dev/eventing/pkg/client/injection/reconciler/sinks/v1alpha1/jobsink"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1"
-	. "knative.dev/eventing/pkg/reconciler/testing/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	v1 "knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
@@ -40,6 +36,12 @@ import (
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/network"
 	. "knative.dev/pkg/reconciler/testing"
+
+	"knative.dev/eventing/pkg/apis/sinks/v1alpha1"
+	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
+	jobsinkreconciler "knative.dev/eventing/pkg/client/injection/reconciler/sinks/v1alpha1/jobsink"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1"
+	. "knative.dev/eventing/pkg/reconciler/testing/v1alpha1"
 )
 
 const (
@@ -195,6 +197,36 @@ func TestReconcile(t *testing.T) {
 						WithJobSinkEventPoliciesNotReady("EventPoliciesNotReady", fmt.Sprintf("event policies %s are not ready", unreadyEventPolicyName)),
 						WithJobSinkEventPoliciesListed(readyEventPolicyName),
 					),
+				},
+			},
+		},
+		{
+			Name: "Successful reconciliation, observed generation",
+			Key:  testKey,
+			Objects: []runtime.Object{
+				NewJobSink(jobSinkName, testNamespace,
+					func(sink *v1alpha1.JobSink) {
+						sink.Generation = 4242
+					},
+					WithJobSinkJob(testJob("")),
+					WithInitJobSinkConditions),
+			},
+			WantErr: false,
+			WantCreates: []runtime.Object{
+				testJob("test-jobSinkml6mm"),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewJobSink(jobSinkName, testNamespace,
+						WithJobSinkJob(testJob("")),
+						WithJobSinkAddressableReady(),
+						WithJobSinkJobStatusSelector(),
+						WithJobSinkAddress(&jobSinkAddressable),
+						func(sink *v1alpha1.JobSink) {
+							sink.Generation = 4242
+							sink.Status.ObservedGeneration = 4242
+						},
+						WithJobSinkEventPoliciesReadyBecauseOIDCDisabled()),
 				},
 			},
 		},


### PR DESCRIPTION
Spotted via warning `{"level":"warn","ts":"2024-11-04T08:27:58.926Z","logger":"controller","caller":"logging/warning_handler.go:32","msg":"API Warning: unknown field \"status.observedGeneration\"","commit":"19e4c4b-dirty","knative.dev/pod":"eventing-controller-66689fc58-n9fdh"}
`

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8295

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add observedGeneration in JobSink OpenAPI schema

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Add observedGeneration in JobSink OpenAPI schema
```


/kind bug

