### PR TITLE
Add jobsinks-addressable-resolver cluster role

### DIFF
--- a/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
+++ b/config/channels/in-memory-channel/roles/controller-clusterrole.yaml
@@ -54,15 +54,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - sinks.knative.dev
-    resources:
-      - jobsinks
-      - jobsinks/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
       - services

--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -144,3 +144,25 @@ rules:
   - get
   - list
   - watch
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jobsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+    - sinks.knative.dev
+  resources:
+    - jobsinks
+    - jobsinks/status
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
This will ensure that all ServiceAccounts that are bound to "addressable-resolver" ClusterRole can read JobSinks.

This replaces https://github.com/knative/eventing/commit/2e4d353d579cfafad62d42b585b9a4b96b194ffb because it's more general. The fix was suggested in [PR for Eventing Kafka Broker](https://github.com/knative-extensions/eventing-kafka-broker/pull/4155#issuecomment-2453971704)

Fixes also issues like this for SinkBindings:
```
{"level":"error","ts":"2024-11-04T08:06:16.160Z","logger":"eventing-webhook","caller":"sinkbinding/sinkbinding.go:87",
"msg":"Failed to get Addressable from Destination:
%!w(*fmt.wrapError=&{failed to get lister for
sinks.knative.dev/v1alpha1,
Resource=jobsinks: jobsinks.sinks.knative.dev is forbidden:
User \"system:serviceaccount:knative-eventing:eventing-webhook\"
cannot list resource \"jobsinks\" in API group \"sinks.knative.dev\"
```

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

