### PR TITLE
[chore] Use a generic access/secret key in the secret for AWS connections

### DIFF
--- a/pkg/reconciler/integrationsource/resources/containersource.go
+++ b/pkg/reconciler/integrationsource/resources/containersource.go
@@ -29,6 +29,11 @@ import (
 	"knative.dev/pkg/kmeta"
 )
 
+const (
+	awsAccessKey = "aws.accessKey"
+	awsSecretKey = "aws.secretKey"
+)
+
 func NewContainerSource(source *v1alpha1.IntegrationSource) *sourcesv1.ContainerSource {
 	return &sourcesv1.ContainerSource{
 		ObjectMeta: metav1.ObjectMeta{
@@ -150,8 +155,8 @@ func makeEnv(source *v1alpha1.IntegrationSource) []corev1.EnvVar {
 		envVars = append(envVars, generateEnvVarsFromStruct("CAMEL_KAMELET_AWS_S3_SOURCE", *source.Spec.Aws.S3)...)
 		if secretName != "" {
 			envVars = append(envVars, []corev1.EnvVar{
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_S3_SOURCE_ACCESSKEY", "aws.s3.accessKey", secretName),
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_S3_SOURCE_SECRETKEY", "aws.s3.secretKey", secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_S3_SOURCE_ACCESSKEY", awsAccessKey, secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_S3_SOURCE_SECRETKEY", awsSecretKey, secretName),
 			}...)
 		}
 		return envVars
@@ -162,8 +167,8 @@ func makeEnv(source *v1alpha1.IntegrationSource) []corev1.EnvVar {
 		envVars = append(envVars, generateEnvVarsFromStruct("CAMEL_KAMELET_AWS_SQS_SOURCE", *source.Spec.Aws.SQS)...)
 		if secretName != "" {
 			envVars = append(envVars, []corev1.EnvVar{
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_SQS_SOURCE_ACCESSKEY", "aws.s3.accessKey", secretName),
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_SQS_SOURCE_SECRETKEY", "aws.s3.secretKey", secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_SQS_SOURCE_ACCESSKEY", awsAccessKey, secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_SQS_SOURCE_SECRETKEY", awsSecretKey, secretName),
 			}...)
 		}
 		return envVars
@@ -174,8 +179,8 @@ func makeEnv(source *v1alpha1.IntegrationSource) []corev1.EnvVar {
 		envVars = append(envVars, generateEnvVarsFromStruct("CAMEL_KAMELET_AWS_DDB_STREAMS_SOURCE", *source.Spec.Aws.DDBStreams)...)
 		if secretName != "" {
 			envVars = append(envVars, []corev1.EnvVar{
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_DDB_STREAMS_SOURCE_ACCESSKEY", "aws.s3.accessKey", secretName),
-				makeSecretEnvVar("CAMEL_KAMELET_AWS_DDB_STREAMS_SOURCE_SECRETKEY", "aws.s3.secretKey", secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_DDB_STREAMS_SOURCE_ACCESSKEY", awsAccessKey, secretName),
+				makeSecretEnvVar("CAMEL_KAMELET_AWS_DDB_STREAMS_SOURCE_SECRETKEY", awsSecretKey, secretName),
 			}...)
 		}
 		return envVars


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Update the access/secret key on the K8S secret to be not tied to AWS S3, but be more generic

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

