### PR TITLE
[chore] Do not generate SSL env vars for each struct entry, just once per containersource/image

### DIFF
--- a/pkg/reconciler/integrationsource/resources/containersource.go
+++ b/pkg/reconciler/integrationsource/resources/containersource.go
@@ -63,7 +63,7 @@ func NewContainerSource(source *v1alpha1.IntegrationSource) *sourcesv1.Container
 }
 
 func generateEnvVarsFromStruct(prefix string, s interface{}) []corev1.EnvVar {
-	var envVars = makeSSLEnvVar()
+	var envVars []corev1.EnvVar
 
 	// Use reflection to inspect the struct fields
 	v := reflect.ValueOf(s)
@@ -136,7 +136,7 @@ func generateEnvVarsFromStruct(prefix string, s interface{}) []corev1.EnvVar {
 
 // Function to create environment variables for Timer or AWS configurations dynamically
 func makeEnv(source *v1alpha1.IntegrationSource) []corev1.EnvVar {
-	var envVars []corev1.EnvVar
+	var envVars = makeSSLEnvVar()
 
 	// Timer environment variables
 	if source.Spec.Timer != nil {

--- a/pkg/reconciler/integrationsource/resources/containersource_test.go
+++ b/pkg/reconciler/integrationsource/resources/containersource_test.go
@@ -118,8 +118,6 @@ func TestGenerateEnvVarsFromStruct(t *testing.T) {
 
 	// Expected environment variables including SSL settings
 	want := []corev1.EnvVar{
-		{Name: "CAMEL_KNATIVE_CLIENT_SSL_ENABLED", Value: "true"},
-		{Name: "CAMEL_KNATIVE_CLIENT_SSL_CERT_PATH", Value: "/knative-custom-certs/knative-eventing-bundle.pem"},
 		{Name: "TEST_PREFIX_FIELD1", Value: "123"},
 		{Name: "TEST_PREFIX_FIELD2", Value: "true"},
 		{Name: "TEST_PREFIX_FIELD3", Value: "hello"},


### PR DESCRIPTION
## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- just call the generation of `SSL` env-vars once, not for each provided property

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

