### PR TITLE
fix: remove duplicated observedGeneration from jobsinks.sinks.knative.dev

### DIFF
--- a/config/core/resources/jobsink.yaml
+++ b/config/core/resources/jobsink.yaml
@@ -94,10 +94,6 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
-                observedGeneration:
-                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
-                  type: integer
-                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array


### PR DESCRIPTION
This PR removes the duplicated observedGeneration in jobsinks.sinks.knative.dev. This was intoduced in https://github.com/knative/eventing/pull/8297

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :bug: Fix duplicated observedGeneration in jobsinks.sinks.knative.dev

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec