### PR TITLE
JobSink: Delete secrets associated with jobs when jobs are deleted

### DIFF
--- a/cmd/jobsink/main_test.go
+++ b/cmd/jobsink/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/jobsink/main_test.go
+++ b/cmd/jobsink/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+
+	"knative.dev/eventing/pkg/utils"
+)
+
+type testCase struct {
+	JobSinkName string
+	Source      string
+	Id          string
+}
+
+func TestToJobName(t *testing.T) {
+	testcases := []testCase{
+		{
+			JobSinkName: "job-sink-success",
+			Source:      "mysource3/myservice",
+			Id:          "2234-5678",
+		},
+		{
+			JobSinkName: "a",
+			Source:      "0",
+			Id:          "0",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.JobSinkName+"_"+tc.Source+"_"+tc.Id, func(t *testing.T) {
+			if errs := validation.NameIsDNS1035Label(tc.JobSinkName, false); len(errs) != 0 {
+				t.Errorf("Invalid JobSinkName: %v", errs)
+			}
+
+			name := toJobName(tc.JobSinkName, tc.Source, tc.Id)
+			doubleName := toJobName(tc.JobSinkName, tc.Source, tc.Id)
+			if name != doubleName {
+				t.Errorf("Before: %q, after: %q", name, doubleName)
+			}
+
+			if got := utils.ToDNS1123Subdomain(name); got != name {
+				t.Errorf("ToDNS1123Subdomain(Want) returns a different result, Want: %q, Got: %q", name, got)
+			}
+
+			if errs := validation.NameIsDNS1035Label(name, false); len(errs) != 0 {
+				t.Errorf("toJobName produced invalid name %q given %q, %q, %q: errors: %#v", name, tc.JobSinkName, tc.Source, tc.Id, errs)
+			}
+		})
+	}
+}
+
+func FuzzToJobName(f *testing.F) {
+	testcases := []testCase{
+		{
+			JobSinkName: "job-sink-success",
+			Source:      "mysource3/myservice",
+			Id:          "2234-5678",
+		},
+		{
+			JobSinkName: "a",
+			Source:      "0",
+			Id:          "0",
+		},
+	}
+
+	for _, tc := range testcases {
+		f.Add(tc.JobSinkName, tc.Source, tc.Id) // Use f.Add to provide a seed corpus
+	}
+	f.Fuzz(func(t *testing.T, js, source, id string) {
+		if errs := validation.NameIsDNSLabel(js, false); len(errs) != 0 {
+			t.Skip("Prerequisite: invalid jobsink name")
+		}
+
+		name := toJobName(js, source, id)
+		doubleName := toJobName(js, source, id)
+		if name != doubleName {
+			t.Errorf("Before: %q, after: %q", name, doubleName)
+		}
+
+		if got := utils.ToDNS1123Subdomain(name); got != name {
+			t.Errorf("ToDNS1123Subdomain(Want) returns a different result, Want: %q, Got: %q", name, got)
+		}
+
+		if errs := validation.NameIsDNSLabel(name, false); len(errs) != 0 {
+			t.Errorf("toJobName produced invalid name %q given %q, %q, %q: errors: %#v", name, js, source, id, errs)
+		}
+	})
+}

--- a/hack/e2e-debug.sh
+++ b/hack/e2e-debug.sh
@@ -35,4 +35,4 @@ wait_until_pods_running knative-eventing || fail_test "Pods in knative-eventing 
 
 header "Running tests"
 
-go test -tags=e2e -v -timeout=30m -run="${test_name}" "${test_dir}" || fail_test "Test(s) failed"
+go test -tags=e2e -v -timeout=30m -parallel=12 -run="${test_name}" "${test_dir}" || fail_test "Test(s) failed"

--- a/test/rekt/features/jobsink/jobsink.go
+++ b/test/rekt/features/jobsink/jobsink.go
@@ -24,6 +24,7 @@ import (
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/google/uuid"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -43,11 +44,14 @@ import (
 	"knative.dev/eventing/test/rekt/resources/jobsink"
 )
 
-func Success() *feature.Feature {
+func Success(jobSinkName string) *feature.Feature {
 	f := feature.NewFeature()
 
 	sink := feature.MakeRandomK8sName("sink")
 	jobSink := feature.MakeRandomK8sName("jobsink")
+	if jobSinkName != "" {
+		jobSink = jobSinkName
+	}
 	source := feature.MakeRandomK8sName("source")
 
 	event := cetest.FullEvent()
@@ -79,6 +83,31 @@ func Success() *feature.Feature {
 		AtLeast(1),
 	)
 	f.Assert("At least one Job is complete", AtLeastOneJobIsComplete(jobSink))
+
+	return f
+}
+
+func DeleteJobsCascadeSecretsDeletion(jobSink string) *feature.Feature {
+	f := feature.NewFeature()
+
+	f.Setup("Prerequisite: At least one secret for jobsink present", verifySecretsForJobSink(jobSink, func(secrets *corev1.SecretList) bool {
+		return len(secrets.Items) > 0
+	}))
+
+	f.Requirement("delete jobs for jobsink", func(ctx context.Context, t feature.T) {
+		err := kubeclient.Get(ctx).BatchV1().
+			Jobs(environment.FromContext(ctx).Namespace()).
+			DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", sinks.JobSinkNameLabel, jobSink),
+			})
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	f.Assert("No secrets for jobsink are present", verifySecretsForJobSink(jobSink, func(secrets *corev1.SecretList) bool {
+		return len(secrets.Items) == 0
+	}))
 
 	return f
 }
@@ -237,5 +266,29 @@ func AtLeastOneJobIsComplete(jobSinkName string) feature.StepFn {
 
 		bytes, _ := json.MarshalIndent(jobs.Items, "", "  ")
 		t.Errorf("No job is complete:\n%v", string(bytes))
+	}
+}
+
+func verifySecretsForJobSink(jobSink string, verify func(secrets *corev1.SecretList) bool) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+
+		interval, timeout := environment.PollTimingsFromContext(ctx)
+		lastSecretList := &corev1.SecretList{}
+		err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+			var err error
+			lastSecretList, err = kubeclient.Get(ctx).CoreV1().
+				Secrets(environment.FromContext(ctx).Namespace()).
+				List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", sinks.JobSinkNameLabel, jobSink),
+				})
+			if err != nil {
+				return false, fmt.Errorf("failed to list secrets: %w", err)
+			}
+			return verify(lastSecretList), nil
+		})
+		if err != nil {
+			bytes, _ := json.Marshal(lastSecretList)
+			t.Errorf("failed to wait for no secrets: %v\nSecret list:\n%s", err, string(bytes))
+		}
 	}
 }

--- a/test/rekt/features/jobsink/jobsink.go
+++ b/test/rekt/features/jobsink/jobsink.go
@@ -95,9 +95,10 @@ func DeleteJobsCascadeSecretsDeletion(jobSink string) *feature.Feature {
 	}))
 
 	f.Requirement("delete jobs for jobsink", func(ctx context.Context, t feature.T) {
+		policy := metav1.DeletePropagationBackground
 		err := kubeclient.Get(ctx).BatchV1().
 			Jobs(environment.FromContext(ctx).Namespace()).
-			DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			DeleteCollection(ctx, metav1.DeleteOptions{PropagationPolicy: &policy}, metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", sinks.JobSinkNameLabel, jobSink),
 			})
 		if err != nil {

--- a/test/rekt/job_sink_test.go
+++ b/test/rekt/job_sink_test.go
@@ -46,7 +46,23 @@ func TestJobSinkSuccess(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Test(ctx, t, jobsink.Success())
+	env.Test(ctx, t, jobsink.Success(""))
+}
+
+func TestJobSinkDeleteJobCascadeSecretDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	jobSinkName := feature.MakeRandomK8sName("jobsink")
+	env.Test(ctx, t, jobsink.Success(jobSinkName))
+	env.Test(ctx, t, jobsink.DeleteJobsCascadeSecretsDeletion(jobSinkName))
 }
 
 func TestJobSinkSuccessTLS(t *testing.T) {


### PR DESCRIPTION
As reported in https://github.com/knative/eventing/issues/8323 old
JobSink secrets lead to processing old events again while new events
are lost, even though this _should_ not happen because distinct events
must have different id or source, it's a valid issue as it leaves orphan
secrets.

Using OwnerReference and k8s garbage collection, now a secret created
for a given event is bound to a given Job lifecycle, so that when a job is
deleted, the associated secret will be deleted.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes https://github.com/knative/eventing/issues/8323

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- JobSink: Delete secrets associated with jobs when jobs are deleted
- Create Job before Secret to bind the secret to the Job lifecycle via owner reference
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
JobSink: bind secrets lifecycle to associated jobs lifecycle. Using OwnerReference and k8s garbage collection, now a secret created for a given event is bound to a given Job lifecycle, so that when a job is deleted, the associated secret will be deleted.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

