### PR TITLE
fix: rename `job-sink` to `job_sink`

### DIFF
--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -65,7 +65,7 @@ import (
 	"knative.dev/eventing/pkg/utils"
 )
 
-const component = "job-sink"
+const component = "job_sink"
 
 func main() {
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8296 

<!-- Please include the 'why' behind your changes if no issue exists -->


## Proposed Changes

Rename the JobSink component from 'job-sink' to `job_sink` to make the generated metrics meet the 
Prometheus naming requirement.

ref: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: 
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix bug

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
JobSink: all related metrics will start with prefix `job_sink` instead of `job-sink`
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

