### PR TITLE
JobSink: Inject a `KNATIVE_EXECUTION_MODE` environment variable with value `batch`

### DIFF
--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -257,6 +257,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	js = js.DeepCopy() // Do not modify informer copy.
+	js.SetDefaults(ctx)
+
 	job := js.Spec.Job.DeepCopy()
 	job.Name = jobName
 	if job.Labels == nil {

--- a/pkg/apis/sinks/v1alpha1/job_sink_types.go
+++ b/pkg/apis/sinks/v1alpha1/job_sink_types.go
@@ -22,9 +22,20 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+)
+
+const (
+	ExecutionModeEnvVar = "KNATIVE_EXECUTION_MODE"
+)
+
+type ExecutionMode string
+
+const (
+	ExecutionModeBatch ExecutionMode = "batch"
 )
 
 // +genclient

--- a/pkg/reconciler/jobsink/jobsink_test.go
+++ b/pkg/reconciler/jobsink/jobsink_test.go
@@ -263,6 +263,9 @@ func testJob(name string) *batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name: "test-container",
+							Env: []corev1.EnvVar{
+								{Name: "KNATIVE_EXECUTION_MODE", Value: "batch"},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
To support long running functions in Knative Functions, we will inject a `KNATIVE_EXECUTION_MODE` environment variable with value `batch` so that function can change it's runtime behavior to read the event file rather than starting a long-running server.

Part of: https://github.com/knative/func/issues/2586

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- inject a `KNATIVE_EXECUTION_MODE` environment variable with value `batch` to Jobs for JobSink

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
JobSink: Inject a `KNATIVE_EXECUTION_MODE` environment variable with value `batch`
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

