### PR TITLE
Add integrationsinks-addressable-resolver cluster role

### DIFF
--- a/config/core/roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/roles/addressable-resolvers-clusterrole.yaml
@@ -166,3 +166,25 @@ rules:
     - get
     - list
     - watch
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integrationsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+    - sinks.knative.dev
+  resources:
+    - integrationsinks
+    - integrationsinks/status
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
This will ensure that all ServiceAccounts that are bound to "addressable-resolver" ClusterRole can read IntegrationSinks.


relates to thir pr: https://github.com/knative/eventing/pull/8298
