### PR TITLE
RequestReply: Added feature flag for default timeout

### DIFF
--- a/pkg/apis/eventing/v1alpha1/requestreply_defaults.go
+++ b/pkg/apis/eventing/v1alpha1/requestreply_defaults.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/utils/ptr"
+	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/pkg/apis"
 )
 
@@ -30,7 +31,7 @@ func (rr *RequestReply) SetDefaults(ctx context.Context) {
 
 func (rrs *RequestReplySpec) SetDefaults(ctx context.Context) {
 	if rrs.Timeout == nil || *rrs.Timeout == "" {
-		rrs.Timeout = ptr.To("30s")
+		rrs.Timeout = ptr.To(feature.FromContextOrDefaults(ctx).RequestReplyDefaultTimeout())
 	}
 
 	if rrs.CorrelationAttribute == "" {

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -166,7 +166,7 @@ func (e Flags) RequestReplyDefaultTimeout() string {
 		return string(DefaultRequestReplyTimeout)
 	}
 
-	return string(timeout) // TODO, check this, check this whole function really
+	return string(timeout)
 }
 
 func (e Flags) String() string {

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -67,6 +67,10 @@ const (
 
 	// DefaultOIDCDiscoveryURL is the default OIDC Discovery URL used in most Kubernetes clusters.
 	DefaultOIDCDiscoveryBaseURL Flag = "https://kubernetes.default.svc"
+
+	// DefaultRequestReplyTimeout is a value for RequestReplyDefaultTimeout that indicates to timeout
+	// a RequestReply resource after 30 seconds by default.
+	DefaultRequestReplyTimeout Flag = "30s"
 )
 
 // Flags is a map containing all the enabled/disabled flags for the experimental features.
@@ -75,16 +79,17 @@ type Flags map[string]Flag
 
 func newDefaults() Flags {
 	return map[string]Flag{
-		KReferenceGroup:          Disabled,
-		DeliveryRetryAfter:       Disabled,
-		DeliveryTimeout:          Enabled,
-		KReferenceMapping:        Disabled,
-		TransportEncryption:      Disabled,
-		OIDCAuthentication:       Disabled,
-		EvenTypeAutoCreate:       Disabled,
-		NewAPIServerFilters:      Disabled,
-		AuthorizationDefaultMode: AuthorizationAllowSameNamespace,
-		OIDCDiscoveryBaseURL:     DefaultOIDCDiscoveryBaseURL,
+		KReferenceGroup:            Disabled,
+		DeliveryRetryAfter:         Disabled,
+		DeliveryTimeout:            Enabled,
+		KReferenceMapping:          Disabled,
+		TransportEncryption:        Disabled,
+		OIDCAuthentication:         Disabled,
+		EvenTypeAutoCreate:         Disabled,
+		NewAPIServerFilters:        Disabled,
+		AuthorizationDefaultMode:   AuthorizationAllowSameNamespace,
+		OIDCDiscoveryBaseURL:       DefaultOIDCDiscoveryBaseURL,
+		RequestReplyDefaultTimeout: DefaultRequestReplyTimeout,
 	}
 }
 
@@ -149,6 +154,19 @@ func (e Flags) OIDCDiscoveryBaseURL() string {
 	}
 
 	return string(discoveryUrl)
+}
+
+func (e Flags) RequestReplyDefaultTimeout() string {
+	if e == nil {
+		return string(DefaultRequestReplyTimeout)
+	}
+
+	timeout, ok := e[RequestReplyDefaultTimeout]
+	if !ok {
+		return string(DefaultRequestReplyTimeout)
+	}
+
+	return string(timeout) // TODO, check this, check this whole function really
 }
 
 func (e Flags) String() string {

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -17,16 +17,18 @@ limitations under the License.
 package feature
 
 const (
-	KReferenceGroup          = "kreference-group"
-	DeliveryRetryAfter       = "delivery-retryafter"
-	DeliveryTimeout          = "delivery-timeout"
-	KReferenceMapping        = "kreference-mapping"
-	TransportEncryption      = "transport-encryption"
-	EvenTypeAutoCreate       = "eventtype-auto-create"
-	OIDCAuthentication       = "authentication-oidc"
-	NodeSelectorLabel        = "apiserversources-nodeselector-"
-	CrossNamespaceEventLinks = "cross-namespace-event-links"
-	NewAPIServerFilters      = "new-apiserversource-filters"
-	AuthorizationDefaultMode = "default-authorization-mode"
-	OIDCDiscoveryBaseURL     = "oidc-discovery-base-url"
+	KReferenceGroup            = "kreference-group"
+	DeliveryRetryAfter         = "delivery-retryafter"
+	DeliveryTimeout            = "delivery-timeout"
+	KReferenceMapping          = "kreference-mapping"
+	TransportEncryption        = "transport-encryption"
+	EvenTypeAutoCreate         = "eventtype-auto-create"
+	OIDCAuthentication         = "authentication-oidc"
+	NodeSelectorLabel          = "apiserversources-nodeselector-"
+	CrossNamespaceEventLinks   = "cross-namespace-event-links"
+	NewAPIServerFilters        = "new-apiserversource-filters"
+	AuthorizationDefaultMode   = "default-authorization-mode"
+	OIDCDiscoveryBaseURL       = "oidc-discovery-base-url"
+	RequestReplyDefaultTimeout = "requestreply-default-timeout" // TODO check this
+
 )

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -29,6 +29,5 @@ const (
 	NewAPIServerFilters        = "new-apiserversource-filters"
 	AuthorizationDefaultMode   = "default-authorization-mode"
 	OIDCDiscoveryBaseURL       = "oidc-discovery-base-url"
-	RequestReplyDefaultTimeout = "requestreply-default-timeout" // TODO check this
-
+	RequestReplyDefaultTimeout = "requestreply-default-timeout"
 )


### PR DESCRIPTION
_<!--_ 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8338

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add feature flag for default timeout on RequestReply resources
- Use feature flag in webhook

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Made request reply timeout configurable through config-features
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

