### PR TITLE
Add ability to override jwks_url

### DIFF
--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -71,6 +71,9 @@ const (
 	// DefaultRequestReplyTimeout is a value for RequestReplyDefaultTimeout that indicates to timeout
 	// a RequestReply resource after 30 seconds by default.
 	DefaultRequestReplyTimeout Flag = "30s"
+
+	// DefaultJWKSURI is the default JWKS URI used in most Kubernetes clusters.
+	DefaultJWKSURI Flag = ""
 )
 
 // Flags is a map containing all the enabled/disabled flags for the experimental features.
@@ -90,6 +93,7 @@ func newDefaults() Flags {
 		AuthorizationDefaultMode:   AuthorizationAllowSameNamespace,
 		OIDCDiscoveryBaseURL:       DefaultOIDCDiscoveryBaseURL,
 		RequestReplyDefaultTimeout: DefaultRequestReplyTimeout,
+		JWKSURI:                    DefaultJWKSURI,
 	}
 }
 
@@ -169,6 +173,19 @@ func (e Flags) RequestReplyDefaultTimeout() string {
 	return string(timeout)
 }
 
+func (e Flags) JWKSURI() string {
+	if e == nil {
+		return string(DefaultJWKSURI)
+	}
+
+	jwksURI, ok := e[JWKSURI]
+	if !ok {
+		return string(DefaultJWKSURI)
+	}
+
+	return string(jwksURI)
+}
+
 func (e Flags) String() string {
 	return fmt.Sprintf("%+v", map[string]Flag(e))
 }
@@ -219,6 +236,8 @@ func NewFlagsConfigFromMap(data map[string]string) (Flags, error) {
 		} else if sanitizedKey == AuthorizationDefaultMode && strings.EqualFold(v, string(AuthorizationAllowSameNamespace)) {
 			flags[sanitizedKey] = AuthorizationAllowSameNamespace
 		} else if strings.Contains(k, NodeSelectorLabel) || sanitizedKey == OIDCDiscoveryBaseURL {
+			flags[sanitizedKey] = Flag(v)
+		} else if sanitizedKey == JWKSURI {
 			flags[sanitizedKey] = Flag(v)
 		} else {
 			flags[k] = Flag(v)

--- a/pkg/apis/feature/features_test.go
+++ b/pkg/apis/feature/features_test.go
@@ -63,6 +63,8 @@ func TestGetFlags(t *testing.T) {
 	require.Equal(t, expectedNodeSelector, nodeSelector)
 
 	require.Equal(t, flags.OIDCDiscoveryBaseURL(), "https://oidc.eks.eu-west-1.amazonaws.com/id/1")
+	
+	require.Equal(t, flags.JWKSURI(), "https://oidc.eks.eu-west-1.amazonaws.com/id/1/jwk")
 }
 
 func TestShouldNotOverrideDefaults(t *testing.T) {

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -30,4 +30,5 @@ const (
 	AuthorizationDefaultMode   = "default-authorization-mode"
 	OIDCDiscoveryBaseURL       = "oidc-discovery-base-url"
 	RequestReplyDefaultTimeout = "requestreply-default-timeout"
+	JWKSURI					   = "oidc-jwks-uri"
 )

--- a/pkg/apis/feature/testdata/config-features.yaml
+++ b/pkg/apis/feature/testdata/config-features.yaml
@@ -30,3 +30,4 @@ data:
     apiserversources-nodeselector-testkey1: testvalue1
     apiserversources-nodeselector-testkey2: testvalue2
     oidc-discovery-base-url: "https://oidc.eks.eu-west-1.amazonaws.com/id/1"
+    oidc-jwks-uri: "https://oidc.eks.eu-west-1.amazonaws.com/id/1/jwk"

--- a/pkg/auth/verifier.go
+++ b/pkg/auth/verifier.go
@@ -283,7 +283,7 @@ func (v *Verifier) getHTTPClientForKubeAPIServer() (*http.Client, error) {
 }
 
 func (v *Verifier) getHTTPClient(features feature.Flags) (*http.Client, error) {
-	if features.OIDCDiscoveryBaseURL() == "https://kubernetes.default.svc" {
+	if features.OIDCDiscoveryBaseURL() == "https://kubernetes.default.svc" && features.JWKSURI() == "" {
 		return v.getHTTPClientForKubeAPIServer()
 	}
 
@@ -327,6 +327,11 @@ func (v *Verifier) getKubernetesOIDCDiscovery(features feature.Flags, client *ht
 	openIdConfig := &openIDMetadata{}
 	if err := json.Unmarshal(body, openIdConfig); err != nil {
 		return nil, fmt.Errorf("could not unmarshall openid config: %w", err)
+	}
+
+	// overwrite jwk uri if it is set in the feature flags
+	if features.JWKSURI() != "" {
+		openIdConfig.JWKSURI = features.JWKSURI()
 	}
 
 	return openIdConfig, nil


### PR DESCRIPTION
Fixes #8348

## Proposed Changes

- Make `jwks-uri` configurable, allowing the default value to be overwritten by passing a value in `JWKSURI` in the feature config.
- Default to an empty string (`""`), and use the JWKS URI provided by `oidc-discovery-base-url` if no `jwks-uri` is specified.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

