### PR TITLE
Remove conversion webhook config in EventPolicy CRD

### DIFF
--- a/config/core/resources/eventpolicy.yaml
+++ b/config/core/resources/eventpolicy.yaml
@@ -209,11 +209,3 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing


### PR DESCRIPTION
As we don't have multiple EP versions yet, we don't need the conversion webhook configuration in the EventPolicy CRD

/cherry-pick release-v1.16
/cherry-pick release-v1.15