### PR TITLE
Register eventshub image for JobSink

### DIFF
--- a/test/rekt/resources/jobsink/jobsink.go
+++ b/test/rekt/resources/jobsink/jobsink.go
@@ -73,6 +73,9 @@ func Install(name string, opts ...manifest.CfgFn) feature.StepFn {
 			fn(cfg)
 		}
 
+		if err := registerImage(ctx); err != nil {
+			t.Fatal(err)
+		}
 		if _, err := manifest.InstallYamlFS(ctx, yamlEmbed, cfg); err != nil {
 			t.Fatal(err)
 		}
@@ -222,4 +225,11 @@ func GoesReadySimple(name string) *feature.Feature {
 	f.Setup("JobSink is addressable", IsAddressable(name))
 
 	return f
+}
+
+func registerImage(ctx context.Context) error {
+	im := eventshub.ImageFromContext(ctx)
+	reg := environment.RegisterPackage(im)
+	_, err := reg(ctx, environment.FromContext(ctx))
+	return err
 }


### PR DESCRIPTION
The package must be registered so that ImageProducer can map it to the right image and replace it in the final yaml.

So far the JobSink E2E test was passing because another step (which runs in parallel) registered the eventshub package in the same context earlier. However, if the JobSink step runs first it fails to replace the image and the final Yaml includes: `"image": "ko://knative.dev/reconciler-test/cmd/eventshub"`

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

