### PR TITLE
Add authorization conformance tests for Sequence and Parallel

### DIFF
--- a/test/rekt/features/sequence/feature.go
+++ b/test/rekt/features/sequence/feature.go
@@ -72,6 +72,7 @@ func SequenceTest(channelTemplate channel_template.ChannelTemplate) *feature.Fea
 	// Install a Sequence with three steps
 	f.Setup("install Sequence", sequence.Install(sequenceName, cfg...))
 	f.Setup("Sequence goes ready", sequence.IsReady(sequenceName))
+	f.Setup("Sequence is addressable", sequence.IsAddressable(sequenceName))
 
 	eventBody := fmt.Sprintf("TestSequence %s", uuid.New().String())
 	// Install PingSource point to sequence Address with eventBody

--- a/test/rekt/features/sequence/oidc_feature.go
+++ b/test/rekt/features/sequence/oidc_feature.go
@@ -116,6 +116,7 @@ func SequenceSendsEventWithOIDCTokenToSteps() *feature.Feature {
 	})
 
 	f.Setup("Sequence goes ready", sequence.IsReady(sequenceName))
+	f.Setup("Sequence is addressable", sequence.IsAddressable(sequenceName))
 
 	event := test.FullEvent()
 	event.SetData("text/plain", "hello")
@@ -198,6 +199,7 @@ func SequenceSendsEventWithOIDCTokenToReply() *feature.Feature {
 		sequence.Install(sequenceName, cfg...)(ctx, t)
 	})
 	f.Setup("Sequence goes ready", sequence.IsReady(sequenceName))
+	f.Setup("Sequence is addressable", sequence.IsAddressable(sequenceName))
 
 	event := test.FullEvent()
 	event.SetData("text/plain", "hello")
@@ -264,6 +266,7 @@ func SequenceWithOIDCAudienceForSteps(name string) *feature.Feature {
 	})
 
 	f.Setup("Sequence goes ready", sequence.IsReady(name))
+	f.Setup("Sequence is addressable", sequence.IsAddressable(name))
 
 	return f
 }

--- a/test/rekt/parallel_test.go
+++ b/test/rekt/parallel_test.go
@@ -22,7 +22,6 @@ package rekt
 import (
 	"testing"
 
-	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/reconciler-test/pkg/feature"
 
 	"knative.dev/pkg/system"
@@ -31,7 +30,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
+	"knative.dev/eventing/test/rekt/features/authz"
 	"knative.dev/eventing/test/rekt/features/parallel"
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
 	"knative.dev/eventing/test/rekt/resources/channel_template"
 	parallelresources "knative.dev/eventing/test/rekt/resources/parallel"
 )
@@ -101,4 +102,25 @@ func TestParallelTwoBranchesWithOIDC(t *testing.T) {
 	)
 
 	env.Test(ctx, t, parallel.ParallelWithTwoBranchesOIDC(channel_template.ImmemoryChannelTemplate()))
+}
+
+func TestParallelSupportsAuthZ(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+		eventshub.WithTLS(t),
+	)
+
+	name := feature.MakeRandomK8sName("parallel")
+	env.Prerequisite(ctx, t, parallel.GoesReady(name, parallelresources.WithChannelTemplate(channel_template.ChannelTemplate{
+		TypeMeta: channel_impl.TypeMeta(),
+		Spec:     map[string]interface{}{},
+	})))
+
+	env.TestSet(ctx, t, authz.AddressableAuthZConformance(parallelresources.GVR(), "Parallel", name))
 }

--- a/test/rekt/parallel_test.go
+++ b/test/rekt/parallel_test.go
@@ -117,10 +117,7 @@ func TestParallelSupportsAuthZ(t *testing.T) {
 	)
 
 	name := feature.MakeRandomK8sName("parallel")
-	env.Prerequisite(ctx, t, parallel.GoesReady(name, parallelresources.WithChannelTemplate(channel_template.ChannelTemplate{
-		TypeMeta: channel_impl.TypeMeta(),
-		Spec:     map[string]interface{}{},
-	})))
+	env.Prerequisite(ctx, t, parallel.ParallelWithOIDCAudienceForSteps(name))
 
 	env.TestSet(ctx, t, authz.AddressableAuthZConformance(parallelresources.GVR(), "Parallel", name))
 }

--- a/test/rekt/sequence_test.go
+++ b/test/rekt/sequence_test.go
@@ -114,10 +114,8 @@ func TestSequenceSupportsAuthZ(t *testing.T) {
 	)
 
 	name := feature.MakeRandomK8sName("sequence")
-	env.Prerequisite(ctx, t, sequence.GoesReady(name, sequenceresources.WithChannelTemplate(channel_template.ChannelTemplate{
-		TypeMeta: channel_impl.TypeMeta(),
-		Spec:     map[string]interface{}{},
-	})))
+
+	env.Prerequisite(ctx, t, sequence.SequenceWithOIDCAudienceForSteps(name))
 
 	env.TestSet(ctx, t, authz.AddressableAuthZConformance(sequenceresources.GVR(), "Sequence", name))
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->


<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Run AuthZ conformance tests for Sequence and Parallel
- Use fully functional Sequence and Parallel as otherwise they return status code 500 when events are sent to them while EventPolicy is configured to allow the traffic through it (the happy/successful path). This is different from other resources like Broker or Channel - these return 202 even if no sink is connected to them.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

