### PR TITLE
Don't swallow errors in Lineage package

### DIFF
--- a/pkg/graph/constructor.go
+++ b/pkg/graph/constructor.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,6 +36,15 @@ import (
 )
 
 type ConstructorConfig struct {
+	// Lenient will cause the graph building to ignore non-fatal errors that occur while listing resources.
+	//
+	// For example, if brokers cannot be listed due to a permission error, the graph will still be built with other
+	// resources.
+	//
+	// However, if the brokers cannot be listed due to a network error, the graph building will stop and return an error
+	// regardless of the Lenient setting.
+	Lenient bool
+
 	EventingClient        *eventingclient.Clientset
 	DynamicClient         *dynamic.DynamicClient
 	Namespaces            []string
@@ -97,15 +105,26 @@ func (g *Graph) fetchBrokers(ctx context.Context, config ConstructorConfig, even
 
 	for _, ns := range config.Namespaces {
 		brokers, err := eventingClient.EventingV1().Brokers(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) {
-			return err
+
+		if apierrs.IsNotFound(err) {
+			continue
 		}
 
-		if err == nil {
-			for _, broker := range brokers.Items {
-				if config.ShouldAddBroker == nil || config.ShouldAddBroker(broker) {
-					g.AddBroker(broker)
-				}
+		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+			if !config.Lenient {
+				return fmt.Errorf("failed to list brokers: %w", err)
+			}
+			logger.Warn("failed to list brokers while constructing lineage graph", zap.Error(err))
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list brokers: %w", err)
+		}
+
+		for _, broker := range brokers.Items {
+			if config.ShouldAddBroker == nil || config.ShouldAddBroker(broker) {
+				g.AddBroker(broker)
 			}
 		}
 	}
@@ -119,17 +138,27 @@ func (g *Graph) fetchChannels(ctx context.Context, config ConstructorConfig, eve
 	}
 
 	for _, ns := range config.Namespaces {
-
 		channels, err := eventingClient.MessagingV1().Channels(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) {
-			return err
+
+		if apierrs.IsNotFound(err) {
+			continue
 		}
 
-		if err == nil {
-			for _, channel := range channels.Items {
-				if config.ShouldAddChannel == nil || config.ShouldAddChannel(channel) {
-					g.AddChannel(channel)
-				}
+		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+			if !config.Lenient {
+				return fmt.Errorf("failed to list channels: %w", err)
+			}
+			logger.Warn("failed to list channels while constructing lineage graph", zap.Error(err))
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list channels: %w", err)
+		}
+
+		for _, channel := range channels.Items {
+			if config.ShouldAddChannel == nil || config.ShouldAddChannel(channel) {
+				g.AddChannel(channel)
 			}
 		}
 	}
@@ -163,17 +192,28 @@ func (g *Graph) fetchTriggers(ctx context.Context, config ConstructorConfig, eve
 
 	for _, ns := range config.Namespaces {
 		triggers, err := eventingClient.EventingV1().Triggers(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) {
-			return err
+
+		if apierrs.IsNotFound(err) {
+			continue
 		}
 
-		if err == nil {
-			for _, trigger := range triggers.Items {
-				if config.ShouldAddTrigger == nil || config.ShouldAddTrigger(trigger) {
-					err := g.AddTrigger(trigger)
-					if err != nil {
-						return err
-					}
+		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+			if !config.Lenient {
+				return fmt.Errorf("failed to list triggers: %w", err)
+			}
+			logger.Warn("failed to list triggers while constructing lineage graph", zap.Error(err))
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list triggers: %w", err)
+		}
+
+		for _, trigger := range triggers.Items {
+			if config.ShouldAddTrigger == nil || config.ShouldAddTrigger(trigger) {
+				err := g.AddTrigger(trigger)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -189,17 +229,28 @@ func (g *Graph) fetchSubscriptions(ctx context.Context, config ConstructorConfig
 
 	for _, ns := range config.Namespaces {
 		subscriptions, err := eventingClient.MessagingV1().Subscriptions(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) {
-			return err
+
+		if apierrs.IsNotFound(err) {
+			continue
 		}
 
-		if err == nil {
-			for _, subscription := range subscriptions.Items {
-				if config.ShouldAddSubscription == nil || config.ShouldAddSubscription(subscription) {
-					err := g.AddSubscription(subscription)
-					if err != nil {
-						return err
-					}
+		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+			if !config.Lenient {
+				return fmt.Errorf("failed to list subscriptions: %w", err)
+			}
+			logger.Warn("failed to list subscriptions while constructing lineage graph", zap.Error(err))
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list subscriptions: %w", err)
+		}
+
+		for _, subscription := range subscriptions.Items {
+			if config.ShouldAddSubscription == nil || config.ShouldAddSubscription(subscription) {
+				err := g.AddSubscription(subscription)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -215,17 +266,28 @@ func (g *Graph) fetchEventTypes(ctx context.Context, config ConstructorConfig, e
 
 	for _, ns := range config.Namespaces {
 		eventTypes, err := eventingClient.EventingV1beta3().EventTypes(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) {
-			return err
+
+		if apierrs.IsNotFound(err) {
+			continue
 		}
 
-		if err == nil {
-			for _, eventType := range eventTypes.Items {
-				if config.ShouldAddEventType == nil || config.ShouldAddEventType(eventType) {
-					err := g.AddEventType(eventType)
-					if err != nil {
-						return err
-					}
+		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+			if !config.Lenient {
+				return fmt.Errorf("failed to list eventtypes: %w", err)
+			}
+			logger.Warn("failed to list eventtypes while constructing lineage graph", zap.Error(err))
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to list eventtypes: %w", err)
+		}
+
+		for _, eventType := range eventTypes.Items {
+			if config.ShouldAddEventType == nil || config.ShouldAddEventType(eventType) {
+				err := g.AddEventType(eventType)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -415,12 +477,21 @@ func getSources(ctx context.Context, config ConstructorConfig, logger zap.Logger
 			Resource: "customresourcedefinitions",
 		},
 	).List(ctx, metav1.ListOptions{LabelSelector: labels.Set{"duck.knative.dev/source": "true"}.String()})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		} else {
-			return nil, fmt.Errorf("unable to list source CRDs: %w", err)
+
+	if apierrs.IsNotFound(err) {
+		return nil, nil
+	}
+
+	if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+		if !config.Lenient {
+			return nil, fmt.Errorf("failed to list source CRDs: %w", err)
 		}
+		logger.Warn("failed to list source CRDs while constructing lineage graph", zap.Error(err))
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list source CRDs: %w", err)
 	}
 
 	duckSources := []duckv1.Source{}
@@ -434,18 +505,31 @@ func getSources(ctx context.Context, config ConstructorConfig, logger zap.Logger
 
 		for _, ns := range config.Namespaces {
 			sourcesList, err := config.DynamicClient.Resource(sourceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				// just log and continue, we may succeed for other sources
-				logger.Warn("Failed to list sources", zap.Error(err))
+
+			if apierrs.IsNotFound(err) {
 				continue
+			}
+
+			if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
+				if !config.Lenient {
+					return nil, fmt.Errorf("failed to list sources: %w", err)
+				}
+				logger.Warn("failed to list sources while constructing lineage graph", zap.Error(err))
+				continue
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to list sources: %w", err)
 			}
 
 			for i := range sourcesList.Items {
 				unstructuredSource := sourcesList.Items[i]
 				duckSource, err := duckSourceFromUnstructured(&unstructuredSource)
-				if err == nil {
-					duckSources = append(duckSources, duckSource)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert unstructured source to duck source: %w", err)
 				}
+
+				duckSources = append(duckSources, duckSource)
 			}
 		}
 	}

--- a/pkg/graph/constructor.go
+++ b/pkg/graph/constructor.go
@@ -97,12 +97,8 @@ func (g *Graph) fetchBrokers(ctx context.Context, config ConstructorConfig, even
 
 	for _, ns := range config.Namespaces {
 		brokers, err := eventingClient.EventingV1().Brokers(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) && !apierrs.IsUnauthorized(err) && !apierrs.IsForbidden(err) {
+		if err != nil && !apierrs.IsNotFound(err) {
 			return err
-		}
-
-		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
-			logger.Warn("failed to list brokers while constructing lineage graph", zap.Error(err))
 		}
 
 		if err == nil {
@@ -125,12 +121,8 @@ func (g *Graph) fetchChannels(ctx context.Context, config ConstructorConfig, eve
 	for _, ns := range config.Namespaces {
 
 		channels, err := eventingClient.MessagingV1().Channels(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) && !apierrs.IsUnauthorized(err) && !apierrs.IsForbidden(err) {
+		if err != nil && !apierrs.IsNotFound(err) {
 			return err
-		}
-
-		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
-			logger.Warn("failed to list channels while constructing lineage graph", zap.Error(err))
 		}
 
 		if err == nil {
@@ -171,12 +163,8 @@ func (g *Graph) fetchTriggers(ctx context.Context, config ConstructorConfig, eve
 
 	for _, ns := range config.Namespaces {
 		triggers, err := eventingClient.EventingV1().Triggers(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) && !apierrs.IsUnauthorized(err) && !apierrs.IsForbidden(err) {
+		if err != nil && !apierrs.IsNotFound(err) {
 			return err
-		}
-
-		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
-			logger.Warn("failed to list triggers while constructing lineage graph", zap.Error(err))
 		}
 
 		if err == nil {
@@ -201,12 +189,8 @@ func (g *Graph) fetchSubscriptions(ctx context.Context, config ConstructorConfig
 
 	for _, ns := range config.Namespaces {
 		subscriptions, err := eventingClient.MessagingV1().Subscriptions(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) && !apierrs.IsUnauthorized(err) && !apierrs.IsForbidden(err) {
+		if err != nil && !apierrs.IsNotFound(err) {
 			return err
-		}
-
-		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
-			logger.Warn("failed to list subscriptions while constructing lineage graph", zap.Error(err))
 		}
 
 		if err == nil {
@@ -231,12 +215,8 @@ func (g *Graph) fetchEventTypes(ctx context.Context, config ConstructorConfig, e
 
 	for _, ns := range config.Namespaces {
 		eventTypes, err := eventingClient.EventingV1beta3().EventTypes(ns).List(ctx, metav1.ListOptions{})
-		if err != nil && !apierrs.IsNotFound(err) && !apierrs.IsUnauthorized(err) && !apierrs.IsForbidden(err) {
+		if err != nil && !apierrs.IsNotFound(err) {
 			return err
-		}
-
-		if apierrs.IsUnauthorized(err) || apierrs.IsForbidden(err) {
-			logger.Warn("failed to list eventtypes while constructing lineage graph", zap.Error(err))
 		}
 
 		if err == nil {
@@ -436,10 +416,7 @@ func getSources(ctx context.Context, config ConstructorConfig, logger zap.Logger
 		},
 	).List(ctx, metav1.ListOptions{LabelSelector: labels.Set{"duck.knative.dev/source": "true"}.String()})
 	if err != nil {
-		if errors.IsNotFound(err) || errors.IsUnauthorized(err) || errors.IsForbidden(err) {
-			logger.Warn("failed to list source CRDs", zap.Error(err))
-			// no need to keep processing here, but also this isn't an error that should stop us from
-			// continuing to build the graph
+		if errors.IsNotFound(err) {
 			return nil, nil
 		} else {
 			return nil, fmt.Errorf("unable to list source CRDs: %w", err)


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Don't swallow errors in Lineage package
- I was having hard time understanding why the Backstage backend was returning 200 with corrupt auth
- Introduced a field called `Lenient:bool` (wanted to have the default to `false`, thus, a positive field name versus `FailFast`). If this field is set to false, there will be no behavior changes, except one place (noted below).

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
:page_facing_up: The event lineage package does not swallow the 400 and 401 errors anymore. Callers should handle those errors themselves.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

