### PR TITLE
Trigger patch release to cover latest go cve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module knative.dev/eventing
 
+// A placeholder comment to rebuild with Go 1.23.5 toolchain to cover CVEs
+
 go 1.22.7
 
 require (


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Trigger patch release to cover latest go cve

A rebuild with latest toolchain is enough to fix the CVE. 


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Fix go vulnerability CVE-2024-4533
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->


/cc @pierDipi @matzew 