### PR TITLE
Add kubebuilder marker

### DIFF
--- a/pkg/apis/sinks/v1alpha1/job_sink_types.go
+++ b/pkg/apis/sinks/v1alpha1/job_sink_types.go
@@ -71,7 +71,9 @@ type JobSinkSpec struct {
 }
 
 // JobSinkStatus defines the observed state of JobSink.
+// +kubebuilder:subresource:status
 type JobSinkStatus struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
 	duckv1.Status `json:",inline"`
 
 	// AddressStatus is the part where the JobSink fulfills the Addressable contract.


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8412 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-bug: Fix bug
-
-
Adds a kubebuilder marker to control how the CRD generator handles the embedded duckv1.Status
Should prevent the duplicate observedGeneration field in the generated CRD
Follows Knative's patterns for handling status fields
### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

