### PR TITLE
fix: verify trigger is not ready before pingsource dependency exists

### DIFF
--- a/test/rekt/features/trigger/feature.go
+++ b/test/rekt/features/trigger/feature.go
@@ -28,14 +28,12 @@ import (
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/eventshub"
 	"knative.dev/reconciler-test/pkg/feature"
-	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
 	"knative.dev/reconciler-test/pkg/resources/service"
 
 	"knative.dev/reconciler-test/pkg/eventshub/assert"
 
 	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/eventing/pkg/eventingtls/eventingtlstesting"
 	"knative.dev/eventing/test/rekt/features/featureflags"
 	"knative.dev/eventing/test/rekt/resources/broker"
@@ -73,26 +71,10 @@ func TriggerDependencyAnnotation() *feature.Feature {
 	f.Setup("install trigger", trigger.Install(triggerName, cfg...))
 
 	// trigger is not ready since the pingsource dependency is not installed yet
-	f.Setup("trigger is not ready before pingsource dependency exists", func(ctx context.Context, t feature.T) {
-		trigger.IsNotReady(triggerName)(ctx, t)
+	f.Setup("trigger is not ready before pingsource dependency exists", trigger.IsNotReady(triggerName))
 
-		// verify that trigger's pingsource DependencyDoesNotExist condition is met
-		err := k8s.WaitForResourceCondition(ctx, t, environment.FromContext(ctx).Namespace(), triggerName, trigger.GVR(),
-			func(obj duckv1.KResource) bool {
-				expectedReason := "DependencyDoesNotExist"
-				expectedMessage := fmt.Sprintf(`Dependency does not exist: pingsources.sources.knative.dev "%s" not found`, psourcename)
-
-				condition := obj.Status.GetCondition(eventingv1.TriggerConditionDependency)
-				if condition != nil && condition.Reason == expectedReason && condition.Message == expectedMessage {
-					return true
-				}
-				return false
-			})
-
-		if err != nil {
-			t.Error("trigger's pingsource DependencyDoesNotExist condition not met", err)
-		}
-	})
+	// verify that the trigger has the DependencyDoesNotExist condition
+	f.Setup("trigger has DependencyDoesNotExist condition", trigger.DependencyDoesNotExist(triggerName))
 
 	// trigger won't go ready until after the pingsource exists, because of the dependency annotation
 	f.Requirement("trigger goes ready", trigger.IsReady(triggerName))

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/manifest"
@@ -222,6 +223,24 @@ func IsReady(name string, timing ...time.Duration) feature.StepFn {
 // IsNotReady tests to see if a Trigger is not ready within the time given.
 func IsNotReady(name string, timing ...time.Duration) feature.StepFn {
 	return k8s.IsNotReady(GVR(), name, timing...)
+}
+
+// DependencyDoesNotExist tests to see if a Trigger meets the DependencyDoesNotExist condition within the time given.
+func DependencyDoesNotExist(name string, timing ...time.Duration) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		err := k8s.WaitForResourceCondition(ctx, t, environment.FromContext(ctx).Namespace(), name, GVR(),
+			func(obj duckv1.KResource) bool {
+				condition := obj.Status.GetCondition(eventingv1.TriggerConditionDependency)
+				if condition != nil && condition.Reason == "DependencyDoesNotExist" {
+					return true
+				}
+				return false
+			}, timing...)
+
+		if err != nil {
+			t.Error("trigger did not meet DependencyDoesNotExist condition", err)
+		}
+	}
 }
 
 func WithNewFilters(filters []eventingv1.SubscriptionsAPIFilter) manifest.CfgFn {

--- a/test/rekt/resources/trigger/trigger.go
+++ b/test/rekt/resources/trigger/trigger.go
@@ -219,6 +219,11 @@ func IsReady(name string, timing ...time.Duration) feature.StepFn {
 	return k8s.IsReady(GVR(), name, timing...)
 }
 
+// IsNotReady tests to see if a Trigger is not ready within the time given.
+func IsNotReady(name string, timing ...time.Duration) feature.StepFn {
+	return k8s.IsNotReady(GVR(), name, timing...)
+}
+
 func WithNewFilters(filters []eventingv1.SubscriptionsAPIFilter) manifest.CfgFn {
 	jsonBytes, err := json.Marshal(filters)
 	if err != nil {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7896

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- :broom: add step function in setup phase to verify that the trigger is not ready because the pingsource dependency doesn't exist yet
