### PR TITLE
Allow storage-version-migration job to successfully run when optional CRDs are not installed (inmemorychannels, etc)

### DIFF
--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -41,6 +41,9 @@ spec:
       containers:
         - name: migrate
           image: ko://knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+          env:
+            - name: IGNORE_NOT_FOUND
+              value: true
           args:
             - "apiserversources.sources.knative.dev"
             - "brokers.eventing.knative.dev"

--- a/config/post-install/storage-version-migrator.yaml
+++ b/config/post-install/storage-version-migrator.yaml
@@ -43,7 +43,7 @@ spec:
           image: ko://knative.dev/pkg/apiextensions/storageversion/cmd/migrate
           env:
             - name: IGNORE_NOT_FOUND
-              value: true
+              value: "true"
           args:
             - "apiserversources.sources.knative.dev"
             - "brokers.eventing.knative.dev"


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8415 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Set the the `IGNORE_NOT_FOUND` environment variable to true in the storage-version-migrator.yaml file

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Allow storage-version-migration job to successfully run when optional CRDs are not installed (inmemorychannels, etc).
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

