### PR TITLE
Prevent knative-nightly integrations image references from being released

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,9 +17,50 @@
 # Documentation about this script and how to use it can be found
 # at https://github.com/knative/test-infra/tree/main/ci
 
-source $(dirname $0)/../vendor/knative.dev/hack/release.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../vendor/knative.dev/hack/release.sh"
+
+KNATIVE_EVENTING_INTEGRATIONS_IMAGES_RELEASE="$(get_latest_knative_yaml_source "eventing-integrations" "eventing-integrations-images")"
+readonly KNATIVE_EVENTING_INTEGRATIONS_IMAGES_RELEASE
+KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_RELEASE="$(get_latest_knative_yaml_source "eventing-integrations" "eventing-transformations-images")"
+readonly KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_RELEASE
+
+readonly KNATIVE_EVENTING_INTEGRATIONS_IMAGES_CM="${REPO_ROOT_DIR}/third_party/eventing-integrations-latest/eventing-integrations-images.yaml"
+readonly KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_CM="${REPO_ROOT_DIR}/third_party/eventing-integrations-latest/eventing-transformations-images.yaml"
+
+function update_eventing_integrations_release_cms() {
+   curl "${KNATIVE_EVENTING_INTEGRATIONS_IMAGES_RELEASE}" --create-dirs -o "${KNATIVE_EVENTING_INTEGRATIONS_IMAGES_CM}" || return $?
+   curl "${KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_RELEASE}" --create-dirs -o "${KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_CM}" || return $?
+}
+
+function check_knative_nightly() {
+    local files=(
+       "${KNATIVE_EVENTING_INTEGRATIONS_IMAGES_CM}"
+       "${KNATIVE_EVENTING_TRANSFORMATIONS_IMAGES_CM}"
+       "${REPO_ROOT_DIR}/config/core/configmaps/eventing-integrations-images.yaml"
+       "${REPO_ROOT_DIR}/config/core/configmaps/eventing-transformations-images.yaml"
+       "${REPO_ROOT_DIR}/config/400-config-eventing-integrations-images.yaml"
+       "${REPO_ROOT_DIR}/config/400-config-eventing-transformations-images.yaml"
+    )
+
+    for file in "${files[@]}"; do
+        if grep -q "knative-nightly" "$file"; then
+            echo "Error: Found 'knative-nightly' in $file, is eventing-integrations for this major and minor '${TAG}' version already released? https://github.com/knative-extensions/eventing-integrations/releases"
+            cat "${file}"
+            return 1
+        fi
+    done
+
+    echo "No 'knative-nightly' occurrences found."
+}
 
 function build_release() {
+  if (( PUBLISH_TO_GITHUB )); then
+    # For official releases, update eventing-integrations ConfigMaps and stop the release if a nightly image is found
+    # in the ConfigMaps.
+    update_eventing_integrations_release_cms || return $?
+    check_knative_nightly || return $?
+  fi
+
   # Run `generate-yamls.sh`, which should be versioned with the
   # branch since the detail of building may change over time.
   local YAML_LIST="$(mktemp)"


### PR DESCRIPTION
This prevents releasing `knative-nightly` references for transformations and integrations images.

This means that eventing-integrations needs to be released before eventing