### PR TITLE
Fix EventTransform with TLS Sink test

### DIFF
--- a/pkg/reconciler/eventtransform/resources_jsonata.go
+++ b/pkg/reconciler/eventtransform/resources_jsonata.go
@@ -298,7 +298,6 @@ func jsonataDeployment(ctx context.Context, withCombinedTrustBundle bool, cw *re
 				Name: "NODE_EXTRA_CA_CERTS",
 				Value: filepath.Join(
 					eventingtls.TrustBundleMountPath,
-					eventingtls.TrustBundleCombined,
 					eventingtls.TrustBundleCombinedPemFile,
 				),
 			},


### PR DESCRIPTION
The test wasn't actually running do to OIDC prerequisite (which is not needed / or enabled in test/config-transport-encryption)