### PR TITLE
[release-1.17] Migrate golanglint-ci config to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,16 +1,11 @@
+version: "2"
 run:
-  timeout: 10m
-
   build-tags:
     - e2e
     - probe
     - preupgrade
     - postupgrade
     - postdowngrade
-
-  skip-dirs:
-    - pkg/client
-
 linters:
   enable:
     - asciicheck
@@ -20,10 +15,28 @@ linters:
     - unparam
   disable:
     - errcheck
-
-issues:
-  exclude-rules:
-    - path: test # Excludes /test, *_test.go etc.
-      linters:
-        - gosec
-        - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+          - unparam
+        path: test
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - pkg/client
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - pkg/client


### PR DESCRIPTION
Manual backport of #8557