### PR TITLE
[release-1.18] Use release version of eventing-integrations

### DIFF
--- a/third_party/eventing-integrations-latest/eventing-integrations-images.yaml
+++ b/third_party/eventing-integrations-latest/eventing-integrations-images.yaml
@@ -4,13 +4,13 @@ metadata:
   name: eventing-integrations-images
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "v20250417-9bbd02b"
+    app.kubernetes.io/version: "v1.18.0"
 data:
-  aws-ddb-streams-source: gcr.io/knative-nightly/aws-ddb-streams-source@sha256:a38e0a812a5072a51a8264eb0c6ff58f36e5261c5c5aef7b928659875a33b3cc
-  timer-source: gcr.io/knative-nightly/timer-source@sha256:bc8bdff1bb4314d23729813feb6cfafced6edc749c0ae1a47ed2d920f0f0840c
-  log-sink: gcr.io/knative-nightly/log-sink@sha256:cd5150e44b11187012bf115224d89dae52666bf2bc505cd0dc307d66c0b2a0f0
-  aws-sqs-source: gcr.io/knative-nightly/aws-sqs-source@sha256:fbad19762b713737adb87082eb1853f64eae4b86a009845aca781d483c79ac09
-  aws-sns-sink: gcr.io/knative-nightly/aws-sns-sink@sha256:9a11f52fb37fcae280f2712249da30349dbfc016c9782420aab92bba42c38cd0
-  aws-s3-sink: gcr.io/knative-nightly/aws-s3-sink@sha256:518003922a4fb8f45e9af046e3f5e11dbb9f0b65472a914bb86f951b4cb06c29
-  aws-s3-source: gcr.io/knative-nightly/aws-s3-source@sha256:7e95fc5f67129da6e5137d8b84ac48b79fc2e129381d597d39cd9bd8ffadcb68
-  aws-sqs-sink: gcr.io/knative-nightly/aws-sqs-sink@sha256:53bc6c564c0671482a00cd092f1e69b63e3fe2b86fd3a32f05fcf32cc006982f
+  aws-ddb-streams-source: gcr.io/knative-releases/aws-ddb-streams-source@sha256:f3a1b04ea62ab0aafd9675d82dbd09186b154349a287e33581bd7435fa9b96b2
+  timer-source: gcr.io/knative-releases/timer-source@sha256:ffa7dde82d5d30a3fd411ca7fda01e5a77157116c97cc17da0f7ac0b07032e93
+  log-sink: gcr.io/knative-releases/log-sink@sha256:87da054374112c0e78c5a0bbcda09205c030507bde2d6629e5a32d593ff587ca
+  aws-sqs-source: gcr.io/knative-releases/aws-sqs-source@sha256:87a49ca30eceedcde2458ef48517c5d24669f904c9d88a80aa5de196115bacef
+  aws-sns-sink: gcr.io/knative-releases/aws-sns-sink@sha256:c997f8a226a6a89e29c98136ac47b81d6b9b673bc40cdb4a392d3df5f00969f2
+  aws-s3-sink: gcr.io/knative-releases/aws-s3-sink@sha256:6998f21cb3fbf33980ee6814d7dab9c45543c39472afaab3f573dd53f8448d6d
+  aws-s3-source: gcr.io/knative-releases/aws-s3-source@sha256:87480e82fd46d1884c588c4ef05e2dfcf866a5a3ae5a3952bd60c7c51bc1919f
+  aws-sqs-sink: gcr.io/knative-releases/aws-sqs-sink@sha256:278f14bfcff3de55f7c93deb4c3001a19b58f86de00033235f0fb29baa3c0e0b

--- a/third_party/eventing-integrations-latest/eventing-transformations-images.yaml
+++ b/third_party/eventing-integrations-latest/eventing-transformations-images.yaml
@@ -4,6 +4,6 @@ metadata:
   name: eventing-transformations-images
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "v20250417-9bbd02b"
+    app.kubernetes.io/version: "v1.18.0"
 data:
-  transform-jsonata: gcr.io/knative-nightly/transform-jsonata:9bbd02b9edfe4d2381838aef8ab1a09023afa346@sha256:865a05ab73ffa6ac5bb2eb6d300ef388dbcbef4819a414955523ede3514e408d
+  transform-jsonata: gcr.io/knative-releases/transform-jsonata:v1.18.0@sha256:fd60d124074e146289f78a1c17d19ba338cc95c268c390741e22c05483a716d3


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- [release-1.18] Use release version of eventing-integrations

After the release I'll figure out how to update CMs with released version during release steps. 

/cc @matzew @creydr 