### PR TITLE
Return assigned port for HTTPEventReceiver

### DIFF
--- a/pkg/adapter/mtping/runner_test.go
+++ b/pkg/adapter/mtping/runner_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -213,8 +214,8 @@ func TestSendEventsTLS(t *testing.T) {
 	eventsChan := make(chan cloudevents.Event, 10)
 	handler := eventingtlstesting.EventChannelHandler(eventsChan)
 	events := make([]cloudevents.Event, 0, 8)
-	ca := eventingtlstesting.StartServer(ctx, t, 8500, handler)
-	hostString := "localhost:8500"
+	ca, port := eventingtlstesting.StartServer(ctx, t, 0, handler)
+	hostString := fmt.Sprintf("localhost:%d", port)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/adapter/v2/cloudevents_test.go
+++ b/pkg/adapter/v2/cloudevents_test.go
@@ -18,6 +18,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 	nethttp "net/http"
 	"os"
 	"strconv"
@@ -309,7 +310,7 @@ func TestTLS(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	ca := eventingtlstesting.StartServer(ctx, t, 8333, nethttp.HandlerFunc(func(writer nethttp.ResponseWriter, request *nethttp.Request) {
+	ca, port := eventingtlstesting.StartServer(ctx, t, 0, nethttp.HandlerFunc(func(writer nethttp.ResponseWriter, request *nethttp.Request) {
 		if request.TLS == nil {
 			// It's not on TLS, fail request
 			writer.WriteHeader(nethttp.StatusInternalServerError)
@@ -328,17 +329,17 @@ func TestTLS(t *testing.T) {
 	}{
 		{
 			name:    "https sink URL, no CA certs fail",
-			sink:    "https://localhost:8333",
+			sink:    fmt.Sprintf("https://localhost:%d", port),
 			wantErr: true,
 		},
 		{
 			name:    "https sink URL with ca certs",
-			sink:    "https://localhost:8333",
+			sink:    fmt.Sprintf("https://localhost:%d", port),
 			caCerts: pointer.String(ca),
 		},
 		{
 			name:    "http sink URL with ca certs",
-			sink:    "http://localhost:8333",
+			sink:    fmt.Sprintf("http://localhost:%d", port),
 			caCerts: pointer.String(ca),
 			wantErr: true,
 		},

--- a/pkg/eventingtls/eventingtlstesting/eventingtlstesting.go
+++ b/pkg/eventingtls/eventingtlstesting/eventingtlstesting.go
@@ -47,7 +47,7 @@ func init() {
 	CA, Key, Crt = loadCerts()
 }
 
-func StartServer(ctx context.Context, t *testing.T, port int, handler http.Handler, receiverOptions ...kncloudevents.HTTPEventReceiverOption) string {
+func StartServer(ctx context.Context, t *testing.T, port int, handler http.Handler, receiverOptions ...kncloudevents.HTTPEventReceiverOption) (string, int) {
 	secret := types.NamespacedName{
 		Namespace: "knative-tests",
 		Name:      "tls-secret",
@@ -83,7 +83,7 @@ func StartServer(ctx context.Context, t *testing.T, port int, handler http.Handl
 		}
 	}()
 
-	return string(CA)
+	return string(CA), receiver.GetPort()
 }
 
 func loadCerts() ([]byte, []byte, []byte) {

--- a/pkg/kncloudevents/event_dispatcher_test.go
+++ b/pkg/kncloudevents/event_dispatcher_test.go
@@ -973,9 +973,9 @@ func testEventFormat(t *testing.T, format v1.FormatType, expectedEncoding bindin
 		w.WriteHeader(http.StatusOK)
 	})
 
-	destinationCA := eventingtlstesting.StartServer(ctx, t, port, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	destinationCA, finalPort := eventingtlstesting.StartServer(ctx, t, port, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	destination := duckv1.Addressable{
-		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", port)),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", finalPort)),
 		CACerts: &destinationCA,
 	}
 
@@ -1030,9 +1030,9 @@ func TestDispatchMessageToTLSEndpoint(t *testing.T) {
 	destinationEventsChan := make(chan cloudevents.Event, 10)
 	destinationReceivedEvents := make([]cloudevents.Event, 0, 10)
 	destinationHandler := eventingtlstesting.EventChannelHandler(destinationEventsChan)
-	destinationCA := eventingtlstesting.StartServer(ctx, t, 8334, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	destinationCA, port := eventingtlstesting.StartServer(ctx, t, 0, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	destination := duckv1.Addressable{
-		URL:     apis.HTTPS("localhost:8334"),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", port)),
 		CACerts: &destinationCA,
 	}
 
@@ -1085,9 +1085,9 @@ func TestDispatchMessageToTLSEndpointWithReply(t *testing.T) {
 		w.Write(eventToReply.Data())
 	})
 
-	destinationCA := eventingtlstesting.StartServer(ctxDestination, t, 8335, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	destinationCA, destinationPort := eventingtlstesting.StartServer(ctxDestination, t, 0, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	destination := duckv1.Addressable{
-		URL:     apis.HTTPS("localhost:8335"),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", destinationPort)),
 		CACerts: &destinationCA,
 	}
 
@@ -1095,9 +1095,9 @@ func TestDispatchMessageToTLSEndpointWithReply(t *testing.T) {
 	replyEventChan := make(chan cloudevents.Event, 10)
 	replyHandler := eventingtlstesting.EventChannelHandler(replyEventChan)
 	replyReceivedEvents := make([]cloudevents.Event, 0, 10)
-	replyCA := eventingtlstesting.StartServer(ctxReply, t, 8336, replyHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	replyCA, replyPort := eventingtlstesting.StartServer(ctxReply, t, 0, replyHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	reply := duckv1.Addressable{
-		URL:     apis.HTTPS("localhost:8336"),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", replyPort)),
 		CACerts: &replyCA,
 	}
 
@@ -1145,9 +1145,9 @@ func TestDispatchMessageToTLSEndpointWithDeadLetterSink(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	destinationCA := eventingtlstesting.StartServer(ctxDestination, t, 8337, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	destinationCA, destinationPort := eventingtlstesting.StartServer(ctxDestination, t, 0, destinationHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	destination := duckv1.Addressable{
-		URL:     apis.HTTPS("localhost:8337"),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", destinationPort)),
 		CACerts: &destinationCA,
 	}
 
@@ -1155,9 +1155,9 @@ func TestDispatchMessageToTLSEndpointWithDeadLetterSink(t *testing.T) {
 	dlsEventChan := make(chan cloudevents.Event, 10)
 	dlsHandler := eventingtlstesting.EventChannelHandler(dlsEventChan)
 	dlsReceivedEvents := make([]cloudevents.Event, 0, 10)
-	dlsCA := eventingtlstesting.StartServer(ctxDls, t, 8338, dlsHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
+	dlsCA, dlsPort := eventingtlstesting.StartServer(ctxDls, t, 0, dlsHandler, kncloudevents.WithDrainQuietPeriod(time.Millisecond))
 	dls := duckv1.Addressable{
-		URL:     apis.HTTPS("localhost:8338"),
+		URL:     apis.HTTPS(fmt.Sprintf("localhost:%d", dlsPort)),
 		CACerts: &dlsCA,
 	}
 


### PR DESCRIPTION
This allows to pass 0 as the port and thus let the OS chose a free port for the server. This helps to fix flaky tests which can occur, when we use the same port number in different tests which might run in parallel.

Fixes #7393 
Fixes #8408