### PR TITLE
feat: add package to set and verify correlation/reply ids for RequestReply

### DIFF
--- a/pkg/requestreply/correlation_id.go
+++ b/pkg/requestreply/correlation_id.go
@@ -1,0 +1,100 @@
+package requestreply
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+/*
+ The RequestReply resource uses a correlation id set as a cloudevents extension to track which cloudevent is a reply to the initial request
+
+ This works through setting an extension attribute (by default correlationid) to contain the correlationid, and then when the final service
+ processing the request determines that their event should be treated as the "reply", the correlationid attribute is copied into a reply
+ cloudevent extension attribute (by default replyid).
+
+ The format of the correlationid/replyid attribute is: <original event id>:<base64 encoding of AES encrypted original event id>
+
+ The AES encryption of the original id is done to ensure that the correlation id was created by the RequestReply resource, rather than a
+ third party.
+*/
+
+// VerifyReplyId takes the reply id from a cloudevent and checks that it is valid for this RequestReply resource, by checking that the decrypted id matches the unencrypted id
+func VerifyReplyId(ce *cloudevents.Event, replyIdName string, aesKey []byte) (bool, error) {
+	replyId, ok := ce.Extensions()[replyIdName]
+	if !ok {
+		return false, fmt.Errorf("no %s extension set on the event", replyIdName)
+	}
+
+	parts := strings.Split(replyId.(string), ":")
+	if len(parts) != 2 {
+		return false, fmt.Errorf("expected two parts in the %s attribute, had %d", replyIdName, len(parts))
+	}
+
+	originalId := parts[0]
+	encryptedId := parts[1]
+
+	encryptedBytes, err := base64.URLEncoding.DecodeString(encryptedId)
+	if err != nil {
+		return false, fmt.Errorf("failed to decode base64 data in %s: %w", replyIdName, err)
+	}
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to create aes cipher block: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return false, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	if len(encryptedBytes) < gcm.NonceSize() {
+		return false, fmt.Errorf("the encrypted data is too short to be valid")
+	}
+
+	nonce, cipherText := encryptedBytes[:gcm.NonceSize()], encryptedBytes[gcm.NonceSize():]
+	decryptedId, err := gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to decrypt the data: %w", err)
+	}
+
+	return string(decryptedId) == originalId, nil
+}
+
+// SetCorrelationId sets the correlationid for a cloudevent by encrypting the id and setting the correlationid attribute with the original and encrypted ids
+func SetCorrelationId(ce *cloudevents.Event, correlationIdName string, aesKey []byte) error {
+	id := ce.ID()
+
+	idBytes := []byte(id)
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return fmt.Errorf("failed to create aes cipher block: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("failed to read random data for gcm nonce: %w", err)
+	}
+
+	encryptedIdBytes := gcm.Seal(nonce, nonce, idBytes, nil)
+
+	encryptedId := base64.URLEncoding.EncodeToString(encryptedIdBytes)
+
+	ce.SetExtension(correlationIdName, fmt.Sprintf("%s:%s", id, encryptedId))
+
+	return nil
+}

--- a/pkg/requestreply/correlation_id.go
+++ b/pkg/requestreply/correlation_id.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package requestreply
 
 import (

--- a/pkg/requestreply/correlation_id_test.go
+++ b/pkg/requestreply/correlation_id_test.go
@@ -1,0 +1,109 @@
+package requestreply
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	exampleKey = []byte("passphrasewhichneedstobe32bytes!")
+	otherKey   = []byte("passphrasewhichneedstobe32bytes?")
+	badKey     = []byte("passphrasewhichneedstobe32bytesbutistoolong")
+)
+
+func TestCorrelationIdVerification(t *testing.T) {
+	tests := map[string]struct {
+		replyIdName           string
+		correlationIdName     string
+		encryptionKey         []byte
+		decryptionKey         []byte
+		transformEvent        func(ce *cloudevents.Event)
+		expectEncryptionError bool
+		expectDecryptionError bool
+		expectValid           bool
+	}{
+		"matching encryption and decryption keys": {
+			encryptionKey: exampleKey,
+			decryptionKey: exampleKey,
+			transformEvent: func(ce *cloudevents.Event) {
+				ce.SetExtension("replyid", ce.Extensions()["correlationid"])
+			},
+			expectValid: true,
+		},
+		"mismatched encryption and decryption keys": {
+			encryptionKey: exampleKey,
+			decryptionKey: otherKey,
+			transformEvent: func(ce *cloudevents.Event) {
+				ce.SetExtension("replyid", ce.Extensions()["correlationid"])
+			},
+			expectDecryptionError: true,
+		},
+		"invalid encryption key": {
+			encryptionKey: badKey,
+			expectEncryptionError: true,
+		},
+		"invalid replyid": {
+			encryptionKey: exampleKey,
+			decryptionKey: exampleKey,
+			transformEvent: func(ce *cloudevents.Event) {
+				correlationId := ce.Extensions()["correlationid"]
+				parts := strings.Split(correlationId.(string), ":")
+				ce.SetExtension("replyid", fmt.Sprintf("otherid:%s", parts[1]))
+			},
+			expectValid: false,
+		},
+		"different correlationid and replyid attribute names": {
+			encryptionKey: exampleKey,
+			decryptionKey: exampleKey,
+			replyIdName: "reply",
+			correlationIdName: "correlate",
+			transformEvent: func(ce *cloudevents.Event) {
+				ce.SetExtension("reply", ce.Extensions()["correlate"])
+			},
+			expectValid: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.replyIdName == "" {
+				tc.replyIdName = "replyid"
+			}
+
+			if tc.correlationIdName == "" {
+				tc.correlationIdName = "correlationid"
+			}
+
+			ce := cloudevents.NewEvent()
+			ce.SetID("exampleid")
+
+			err := SetCorrelationId(&ce, tc.correlationIdName, tc.encryptionKey)
+			if tc.expectEncryptionError {
+				assert.Error(t, err, "setting correlationid should fail")
+				return
+			}
+
+			assert.NoError(t, err, "setting correlationid should not fail")
+
+			tc.transformEvent(&ce)
+
+			valid, err := VerifyReplyId(&ce, tc.replyIdName, tc.decryptionKey)
+			if tc.expectDecryptionError {
+				assert.Error(t, err, "verifying replyid should produce an error")
+				return
+			}
+
+			assert.NoError(t, err, "verifying replyid should not produce an error")
+			assert.Equal(t, tc.expectValid, valid)
+		})
+
+	}
+	t.Parallel()
+
+}

--- a/pkg/requestreply/correlation_id_test.go
+++ b/pkg/requestreply/correlation_id_test.go
@@ -59,7 +59,7 @@ func TestCorrelationIdVerification(t *testing.T) {
 			expectDecryptionError: true,
 		},
 		"invalid encryption key": {
-			encryptionKey: badKey,
+			encryptionKey:         badKey,
 			expectEncryptionError: true,
 		},
 		"invalid replyid": {
@@ -73,9 +73,9 @@ func TestCorrelationIdVerification(t *testing.T) {
 			expectValid: false,
 		},
 		"different correlationid and replyid attribute names": {
-			encryptionKey: exampleKey,
-			decryptionKey: exampleKey,
-			replyIdName: "reply",
+			encryptionKey:     exampleKey,
+			decryptionKey:     exampleKey,
+			replyIdName:       "reply",
 			correlationIdName: "correlate",
 			transformEvent: func(ce *cloudevents.Event) {
 				ce.SetExtension("reply", ce.Extensions()["correlate"])

--- a/pkg/requestreply/correlation_id_test.go
+++ b/pkg/requestreply/correlation_id_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package requestreply
 
 import (


### PR DESCRIPTION
For the RequestReply resource to securely figure out that a new event is a reply to an earlier event it saw, it needs to encrypt the event id and set that in a correlation id attribute. For the reply event, that correlation id attribute will have been copied into the reply id attribute.

This PR adds helper functions to set and verify these IDs, to be consumed in various places later as the RequestReply implementation continues.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add function to set correlation id
- Add function to verify that a reply id is from this RequestReply resource
