### PR TITLE
feat: add request reply cesql function

### DIFF
--- a/pkg/requestreply/cesql.go
+++ b/pkg/requestreply/cesql.go
@@ -15,6 +15,8 @@ import (
 
 var once = sync.Once{}
 
+// RegisterCESQLVerifyCorrelationIdFilter registers a new function with the CESQL runtime to verify correlation ids
+// The function signature is KN_VERIFY_CORRELATION_ID(correlation_id, namespace, secret_names...)
 func RegisterCESQLVerifyCorrelationIdFilter(ctx context.Context) error {
 	secretInformer := secretinformer.Get(ctx)
 	logger := logging.FromContext(ctx)
@@ -41,7 +43,7 @@ func RegisterCESQLVerifyCorrelationIdFilter(ctx context.Context) error {
 					continue
 				}
 
-				validId, err := VerifyReplyId(replyId, aesKey) // TODO: rethink API here - maybe pass the id directly, instead of event + id name?
+				validId, err := VerifyReplyId(replyId, aesKey)
 				if err != nil {
 					logger.Warnf("failed to verify replyid for event: %s", err)
 				}

--- a/pkg/requestreply/cesql.go
+++ b/pkg/requestreply/cesql.go
@@ -25,7 +25,7 @@ func RegisterCESQLVerifyCorrelationIdFilter(ctx context.Context) error {
 		cesql.TypePtr(cesql.StringType),
 		cesql.BooleanType,
 		func(e cloudevents.Event, args []interface{}) (interface{}, error) {
-			correlationIdName, namespace := args[0].(string), args[1].(string)
+			replyId, namespace := args[0].(string), args[1].(string)
 			secretNames := args[2:]
 
 			for _, secretName := range secretNames {
@@ -41,7 +41,7 @@ func RegisterCESQLVerifyCorrelationIdFilter(ctx context.Context) error {
 					continue
 				}
 
-				validId, err := VerifyReplyId(&e, correlationIdName, aesKey) // TODO: rethink API here - maybe pass the id directly, instead of event + id name?
+				validId, err := VerifyReplyId(replyId, aesKey) // TODO: rethink API here - maybe pass the id directly, instead of event + id name?
 				if err != nil {
 					logger.Warnf("failed to verify replyid for event: %s", err)
 				}

--- a/pkg/requestreply/cesql.go
+++ b/pkg/requestreply/cesql.go
@@ -1,0 +1,65 @@
+package requestreply
+
+import (
+	"context"
+	"sync"
+
+	cesql "github.com/cloudevents/sdk-go/sql/v2"
+	cefn "github.com/cloudevents/sdk-go/sql/v2/function"
+	ceruntime "github.com/cloudevents/sdk-go/sql/v2/runtime"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/logging"
+)
+
+var once = sync.Once{}
+
+func RegisterCESQLVerifyCorrelationIdFilter(ctx context.Context) error {
+	secretInformer := secretinformer.Get(ctx)
+	logger := logging.FromContext(ctx)
+
+	var verifyCorrelationId = cefn.NewFunction(
+		"KN_VERIFY_CORRELATION_ID",
+		[]cesql.Type{cesql.StringType, cesql.StringType},
+		cesql.TypePtr(cesql.StringType),
+		cesql.BooleanType,
+		func(e cloudevents.Event, args []interface{}) (interface{}, error) {
+			correlationIdName, namespace := args[0].(string), args[1].(string)
+			secretNames := args[2:]
+
+			for _, secretName := range secretNames {
+				secret, err := secretInformer.Lister().Secrets(namespace).Get(secretName.(string))
+				if err != nil {
+					logger.Warnf("failed to get secret %s in namespace %s: %s", secretName.(string), namespace, err.Error())
+					continue
+				}
+
+				aesKey, ok := secret.Data["key"]
+				if !ok {
+					logger.Warnf("no key in secret %s in namespace %s", secretName.(string), namespace)
+					continue
+				}
+
+				validId, err := VerifyReplyId(&e, correlationIdName, aesKey) // TODO: rethink API here - maybe pass the id directly, instead of event + id name?
+				if err != nil {
+					logger.Warnf("failed to verify replyid for event: %s", err)
+				}
+
+				if validId {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		},
+	)
+
+	var err error = nil
+
+	once.Do(func() {
+		err = ceruntime.AddFunction(verifyCorrelationId)
+	})
+
+	return err
+}

--- a/pkg/requestreply/cesql.go
+++ b/pkg/requestreply/cesql.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package requestreply
 
 import (

--- a/pkg/requestreply/cesql_test.go
+++ b/pkg/requestreply/cesql_test.go
@@ -1,0 +1,127 @@
+package requestreply
+
+import (
+	"fmt"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/eventing/pkg/eventfilter"
+	"knative.dev/eventing/pkg/eventfilter/subscriptionsapi"
+	reconcilertesting "knative.dev/pkg/reconciler/testing"
+
+	// Fake injection informer
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
+)
+
+const (
+	eventType   = "dev.knative.example"
+	eventSource = "knativesource"
+	eventID     = "1234567890"
+)
+
+func TestCESQLFilterWithVerifyCorrelationId(t *testing.T) {
+	tests := map[string]struct {
+		getEvent    func() *cloudevents.Event
+		want        eventfilter.FilterResult
+		replyIdName string
+		expression  string
+	}{
+		"has matching replyid": {
+			getEvent: func() *cloudevents.Event {
+				ce := makeEvent()
+				SetCorrelationId(ce, "replyid", exampleKey)
+				return ce
+			},
+			want: eventfilter.PassFilter,
+		},
+		"has matching replyid on second secret": {
+			getEvent: func() *cloudevents.Event {
+				ce := makeEvent()
+				SetCorrelationId(ce, "replyid", otherKey)
+				return ce
+			},
+			want:       eventfilter.PassFilter,
+			expression: "KN_VERIFY_CORRELATION_ID(replyid, \"default\", \"request-reply-secret-1\", \"request-reply-secret-2\")",
+		},
+		"no matching secret for replyid": {
+			getEvent: func() *cloudevents.Event {
+				ce := makeEvent()
+				SetCorrelationId(ce, "replyid", otherKey)
+				return ce
+			},
+			want: eventfilter.FailFilter,
+		},
+		"malformed replyid": {
+			getEvent: func() *cloudevents.Event {
+				ce := makeEvent()
+				ce.SetExtension("replyid", fmt.Sprintf("%s:", eventID))
+				return ce
+			},
+			want: eventfilter.FailFilter,
+		},
+		"no replyid": {
+			getEvent: makeEvent,
+			want: eventfilter.FailFilter,
+		},
+	}
+
+	ctx, _ := reconcilertesting.SetupFakeContext(t)
+
+	_ = secretinformer.Get(ctx).Informer().GetStore().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "request-reply-secret-1",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"key": exampleKey,
+		},
+	})
+
+	_ = secretinformer.Get(ctx).Informer().GetStore().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "request-reply-secret-2",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"key": otherKey,
+		},
+	})
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := RegisterCESQLVerifyCorrelationIdFilter(ctx)
+			assert.NoError(t, err, "registering the correlation id function should not fail")
+
+			if tc.replyIdName == "" {
+				tc.replyIdName = "replyid"
+			}
+
+			if tc.expression == "" {
+				tc.expression = fmt.Sprintf("KN_VERIFY_CORRELATION_ID(%s, \"default\", \"request-reply-secret-1\")", tc.replyIdName)
+			}
+
+			ce := tc.getEvent()
+
+			filter, err := subscriptionsapi.NewCESQLFilter(tc.expression)
+			assert.NoError(t, err, "parsing the CESQL filter should succeed")
+
+			result := filter.Filter(ctx, *ce)
+			assert.Equal(t, tc.want, result, "cesql result should match expected result")
+		})
+	}
+}
+
+func makeEvent() *cloudevents.Event {
+	ce := cloudevents.NewEvent()
+	ce.SetType(eventType)
+	ce.SetSource(eventSource)
+	ce.SetID(eventID)
+
+	return &ce
+}

--- a/pkg/requestreply/cesql_test.go
+++ b/pkg/requestreply/cesql_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package requestreply
 
 import (

--- a/pkg/requestreply/cesql_test.go
+++ b/pkg/requestreply/cesql_test.go
@@ -65,7 +65,7 @@ func TestCESQLFilterWithVerifyCorrelationId(t *testing.T) {
 		},
 		"no replyid": {
 			getEvent: makeEvent,
-			want: eventfilter.FailFilter,
+			want:     eventfilter.FailFilter,
 		},
 	}
 

--- a/pkg/requestreply/correlation_id.go
+++ b/pkg/requestreply/correlation_id.go
@@ -42,15 +42,10 @@ import (
 */
 
 // VerifyReplyId takes the reply id from a cloudevent and checks that it is valid for this RequestReply resource, by checking that the decrypted id matches the unencrypted id
-func VerifyReplyId(ce *cloudevents.Event, replyIdName string, aesKey []byte) (bool, error) {
-	replyId, ok := ce.Extensions()[replyIdName]
-	if !ok {
-		return false, fmt.Errorf("no %s extension set on the event", replyIdName)
-	}
-
-	parts := strings.Split(replyId.(string), ":")
+func VerifyReplyId(replyId string, aesKey []byte) (bool, error) {
+	parts := strings.Split(replyId, ":")
 	if len(parts) != 2 {
-		return false, fmt.Errorf("expected two parts in the %s attribute, had %d", replyIdName, len(parts))
+		return false, fmt.Errorf("expected two parts in the replyid attribute, had %d", len(parts))
 	}
 
 	originalId := parts[0]
@@ -58,7 +53,7 @@ func VerifyReplyId(ce *cloudevents.Event, replyIdName string, aesKey []byte) (bo
 
 	encryptedBytes, err := base64.URLEncoding.DecodeString(encryptedId)
 	if err != nil {
-		return false, fmt.Errorf("failed to decode base64 data in %s: %w", replyIdName, err)
+		return false, fmt.Errorf("failed to decode base64 data in replyid: %w", err)
 	}
 
 	block, err := aes.NewCipher(aesKey)

--- a/pkg/requestreply/correlation_id_test.go
+++ b/pkg/requestreply/correlation_id_test.go
@@ -109,7 +109,7 @@ func TestCorrelationIdVerification(t *testing.T) {
 
 			tc.transformEvent(&ce)
 
-			valid, err := VerifyReplyId(&ce, tc.replyIdName, tc.decryptionKey)
+			valid, err := VerifyReplyId(ce.Extensions()[tc.replyIdName].(string), tc.decryptionKey)
 			if tc.expectDecryptionError {
 				assert.Error(t, err, "verifying replyid should produce an error")
 				return


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8318 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add a CESQL function for verifying correlation ids
- Add unit tests for trigger filters with the CESQL function registered
- Change the VerifyCorrelationId interface to allow the CESQL function definition to be more idiomatic

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Knative now supports the KN_VERIFY_CORRELATION_ID CESQL function, allowing you to verify knative correlation ids in your trigger filters.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

