### PR TITLE
Injected tracing headers into jobsink event file

### DIFF
--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -68,6 +68,7 @@ import (
 	"knative.dev/eventing/pkg/observability"
 	o11yconfigmap "knative.dev/eventing/pkg/observability/configmap"
 	"knative.dev/eventing/pkg/observability/otel"
+	eventingtracing "knative.dev/eventing/pkg/tracing"
 	"knative.dev/eventing/pkg/utils"
 )
 
@@ -260,7 +261,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	message := cehttp.NewMessageFromHttpRequest(r)
 	defer message.Finish(nil)
 
-	event, err := binding.ToEvent(r.Context(), message)
+	event, err := binding.ToEvent(r.Context(), message, eventingtracing.PopulateCEDistributedTracing(ctx))
 	if err != nil {
 		logger.Warn("failed to extract event from request", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/tracing/populate_ce_distributed_tracing.go
+++ b/pkg/tracing/populate_ce_distributed_tracing.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ceCarrier struct {
+	reader binding.MessageMetadataReader
+	writer binding.MessageMetadataWriter
+}
+
+func (c ceCarrier) Get(key string) string {
+	// Cloudevents may store values in non-string ways, so we will ignore non-string values
+	if val, ok := c.reader.GetExtension(key).(string); ok {
+		return val
+	}
+	return ""
+}
+
+func (c ceCarrier) Set(key, value string) {
+	c.writer.SetExtension(key, value)
+}
+func (c ceCarrier) Keys() []string {
+	// We really only care about opentelemetry headers, and there is no way to get the keys given the interface we have.
+	// So we will just return the keys we care about.
+	return (propagation.TraceContext{}).Fields()
+}
+
+func PopulateCEDistributedTracing(ctx context.Context) binding.TransformerFunc {
+	return func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		span := trace.SpanFromContext(ctx)
+		if span.IsRecording() {
+			carrier := ceCarrier{
+				reader: reader,
+				writer: writer,
+			}
+			otel.GetTextMapPropagator().Inject(ctx, carrier)
+		}
+		return nil
+	}
+}

--- a/pkg/tracing/populate_ce_distributed_tracing_test.go
+++ b/pkg/tracing/populate_ce_distributed_tracing_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	bindingtest "github.com/cloudevents/sdk-go/v2/binding/test"
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"knative.dev/pkg/observability/tracing"
+)
+
+func TestPopulateCEDistributedTracing(t *testing.T) {
+	otel.SetTextMapPropagator(tracing.DefaultTextMapPropagator())
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
+
+	origCtx := context.Background()
+
+	tracer := tp.Tracer("ce-distributed-tracing-test")
+
+	spanCtx, testSpan := tracer.Start(origCtx, "name")
+	testSpan.SetAttributes(
+		attribute.String("client", "A"),
+	)
+
+	wantEvent := event.New(event.CloudEventsVersionV1)
+	wantEvent.SetID("aaa")
+	wantEvent.SetType("hello.world")
+	wantEvent.SetSource("example.com")
+
+	bindingtest.RunTransformerTests(t, context.Background(), []bindingtest.TransformerTestArgs{
+		{
+			Name:         "Check propagation",
+			InputMessage: bindingtest.MustCreateMockBinaryMessage(wantEvent),
+			AssertFunc: func(t *testing.T, haveEvent event.Event) {
+				require.Equal(t, wantEvent.Data(), haveEvent.Data()) // Event data should be unchanged
+
+				// Check that the cloudevent propagation is identical to http propagation
+				header := http.Header{}
+				otel.GetTextMapPropagator().Inject(spanCtx, propagation.HeaderCarrier(header))
+				testSpan.End()
+				ext := haveEvent.Extensions()
+				require.Equal(t, ext["traceparent"], header.Get("traceparent"))
+			},
+			Transformers: binding.Transformers{PopulateCEDistributedTracing(spanCtx)},
+		},
+		{
+			Name:       "Check empty span",
+			InputEvent: wantEvent,
+			AssertFunc: func(t *testing.T, haveEvent event.Event) {
+				test.AssertEventEquals(t, wantEvent, haveEvent) // Event should be unchanged
+			},
+			Transformers: binding.Transformers{PopulateCEDistributedTracing(origCtx)},
+		},
+	})
+}


### PR DESCRIPTION
Fixes #8607 
Hey! I finally got around to implementing what we talked about in the issue above.

Please tell me if I should move the implementation of PopulateCEDistributedTracing. I just looked around until I found something similar enough, and put the code right next to it.

This currently only injects the headers into Jobsink events, are there any other places where events are propagated without http, and could benefit from this?
Let me know if you need any more changes 😄 

## Proposed Changes
- :gift: Inject tracing headers into cloudevent according to [the spec](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md)

### Pre-review Checklist
- [X] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior - Does this need to be done?
- [ ] **Docs PR** for any user-facing impact - Does this need to be done?
- [ ] **Spec PR** for any new API feature - Not relevant
- [ ] **Conformance test** for any change to the spec - Not relevant

**Release Note**
```release-note
Event files received by Jobsinks will now include the Distributed Tracing extension
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

