### PR TITLE
Migrate rekt tests to use new observability config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	knative.dev/hack v0.0.0-20250708013849-70d4b00da6ba
 	knative.dev/hack/schema v0.0.0-20250708013849-70d4b00da6ba
 	knative.dev/pkg v0.0.0-20250804212045-2a0abb7b5eb3
-	knative.dev/reconciler-test v0.0.0-20250729152438-4f40f6229058
+	knative.dev/reconciler-test v0.0.0-20250805151946-e7475cab4beb
 	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -120,7 +120,6 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
-	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1133,8 +1133,8 @@ knative.dev/hack/schema v0.0.0-20250708013849-70d4b00da6ba h1:62Pntgfj10nhIt7ZlC
 knative.dev/hack/schema v0.0.0-20250708013849-70d4b00da6ba/go.mod h1:KkibP1IazICP5ClxwN5D26LDSygsqbYnVGuGFTsHNOQ=
 knative.dev/pkg v0.0.0-20250804212045-2a0abb7b5eb3 h1:5IWHlFvSTR/gZY+bShXCAHFFZ6rQqhYvx1KxVwlsnKw=
 knative.dev/pkg v0.0.0-20250804212045-2a0abb7b5eb3/go.mod h1:qpyBu3z/r1fRfyLo/Zdpis1mmtixdXmsCPmJMz/BsLc=
-knative.dev/reconciler-test v0.0.0-20250729152438-4f40f6229058 h1:nNGCDaiSSwBkUpuF0ojmZ44PmoMj5Sh3WXCj4v79a7M=
-knative.dev/reconciler-test v0.0.0-20250729152438-4f40f6229058/go.mod h1:sYsIKzfL4m1fA3FOgeNtWIcydP9+8aLcZXsUfsD9+uw=
+knative.dev/reconciler-test v0.0.0-20250805151946-e7475cab4beb h1:n11e7PDru+6wQp+dUUbSkoY9jAcdgwFAytLVRKAqGG4=
+knative.dev/reconciler-test v0.0.0-20250805151946-e7475cab4beb/go.mod h1:Yrp3+hda56ss8D3lG42NTMSaeJ/cI2WkuhotcSpGKmg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/test/experimental/eventtype_autocreate_test.go
+++ b/test/experimental/eventtype_autocreate_test.go
@@ -35,7 +35,7 @@ func TestIMCEventTypeAutoCreate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -49,7 +49,7 @@ func TestSubscriptionEventTypeAutoCreate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -63,7 +63,7 @@ func TestBrokerEventTypeAutoCreate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -79,7 +79,7 @@ func TestTriggerEventTypeAutoCreate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -95,7 +95,7 @@ func TestPingSourceEventTypeMatch(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/experimental/kreference_group_test.go
+++ b/test/experimental/kreference_group_test.go
@@ -35,7 +35,7 @@ func TestChannelToChannel(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/experimental/retry_after_test.go
+++ b/test/experimental/retry_after_test.go
@@ -41,7 +41,7 @@ func TestRetryAfter(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/apiserversource_test.go
+++ b/test/rekt/apiserversource_test.go
@@ -55,7 +55,7 @@ func TestApiServerSourceValidationWebhookConfigurationOnUpdate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -72,7 +72,7 @@ func TestApiServerSourceDataPlane_SinkTypes(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 2*time.Minute),
@@ -87,7 +87,7 @@ func TestApiServerSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -103,7 +103,7 @@ func TestApiServerSourceDataPlaneTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -120,7 +120,7 @@ func TestApiServerSourceDataPlane_EventModes(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -134,7 +134,7 @@ func TestApiServerSourceDataPlane_ResourceMatching(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -148,7 +148,7 @@ func TestApiServerSourceDataPlane_EventsRetries(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -162,7 +162,7 @@ func TestApiServerSourceDataPlane_MultipleNamespaces(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -176,7 +176,7 @@ func TestApiServerSourceDataPlane_MultipleNamespacesEmptySelector(t *testing.T) 
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -190,7 +190,7 @@ func TestApiserversourceSendEventWithJWTOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -205,7 +205,7 @@ func TestApiServerSourceDeployment(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 2*time.Minute),
@@ -220,7 +220,7 @@ func TestApiServerSourceNewFiltersFeature(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -234,7 +234,7 @@ func TestApiServerSourceSkipPermissionsFeature(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/broker_test.go
+++ b/test/rekt/broker_test.go
@@ -46,7 +46,7 @@ func TestBrokerWithManyTriggers(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		tracing.WithGatherer(t),
@@ -64,7 +64,7 @@ func TestBrokerWorkFlowWithTransformation(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -79,7 +79,7 @@ func TestBrokerAsMiddleware(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
@@ -97,7 +97,7 @@ func TestBrokerWithDLQ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -117,7 +117,7 @@ func TestBrokerWithFlakyDLQ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -135,7 +135,7 @@ func TestBrokerConformance(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -151,7 +151,7 @@ func TestBrokerDefaultDelivery(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -166,7 +166,7 @@ func TestBrokerPreferHeaderCheck(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -183,7 +183,7 @@ func TestBrokerRedelivery(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -199,7 +199,7 @@ func TestBrokerPropagatesMetadata(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -214,7 +214,7 @@ func TestBrokerDeadLetterSinkExtensions(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -229,7 +229,7 @@ func TestBrokerDeliverLongMessage(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -244,7 +244,7 @@ func TestBrokerDeliverLongResponseMessage(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -259,7 +259,7 @@ func TestMTChannelBrokerRotateTLSCertificates(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -275,7 +275,7 @@ func TestBrokerSupportsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(4*time.Second, 12*time.Minute),
@@ -294,7 +294,7 @@ func TestBrokerSendsEventsWithOIDCSupport(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -309,7 +309,7 @@ func TestBrokerSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/channel_test.go
+++ b/test/rekt/channel_test.go
@@ -51,7 +51,7 @@ func TestChannelConformance(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
@@ -172,7 +172,7 @@ func TestChannelChain(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -195,7 +195,7 @@ func TestChannelDeadLetterSink(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -215,7 +215,7 @@ func TestChannelAsyncHandler(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -235,7 +235,7 @@ func TestGenericChannelDeadLetterSink(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -266,7 +266,7 @@ func TestEventTransformationForSubscriptionV1(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -285,7 +285,7 @@ func TestBinaryEventForChannel(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -304,7 +304,7 @@ func TestStructuredEventForChannel(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -320,7 +320,7 @@ func TestChannelPreferHeaderCheck(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -338,7 +338,7 @@ func TestChannelDeadLetterSinkExtensions(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		tracing.WithGatherer(t),
 		environment.Managed(t),
@@ -357,7 +357,7 @@ func TestInMemoryChannelRotateIngressTLSCertificate(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -373,7 +373,7 @@ func TestInMemoryChannelTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -391,7 +391,7 @@ func TestChannelImplDispatcherAuthenticatesWithOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -406,7 +406,7 @@ func TestChannelImplSupportsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		environment.WithPollTimings(4*time.Second, 12*time.Minute),
@@ -424,7 +424,7 @@ func TestChannelImplSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -442,7 +442,7 @@ func TestChannelSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/container_source_test.go
+++ b/test/rekt/container_source_test.go
@@ -37,7 +37,7 @@ func TestContainerSourceWithSinkRef(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestContainerSourceWithSinkURI(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -66,7 +66,7 @@ func TestContainerSourceWithCloudEventOverrides(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -80,7 +80,7 @@ func TestContainerSourceWithArgs(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -94,7 +94,7 @@ func TestContainerSourceWithTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -110,7 +110,7 @@ func TestContainerSourceSendsEventsWithOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/crossnamespace_test.go
+++ b/test/rekt/crossnamespace_test.go
@@ -36,7 +36,7 @@ func TestBrokerTriggerCrossNamespaceReference(t *testing.T) {
 	brokerEnvCtx, _ := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -44,7 +44,7 @@ func TestBrokerTriggerCrossNamespaceReference(t *testing.T) {
 	triggerEnvCtx, triggerEnv := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/delivery_timeout_test.go
+++ b/test/rekt/delivery_timeout_test.go
@@ -40,7 +40,7 @@ func TestDeliveryTimeout(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestBrokerTriggerWithDeliveryTimeout(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/eventtransform_test.go
+++ b/test/rekt/eventtransform_test.go
@@ -38,7 +38,7 @@ func TestEventTransformJsonataDirect(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestEventTransformJsonataDirectTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -67,7 +67,7 @@ func TestEventTransformJsonataWithSink(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -81,7 +81,7 @@ func TestEventTransformJsonataWithSinkTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -96,7 +96,7 @@ func TestEventTransformJsonataWithSinkReplyTransform(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/integration_sink_test.go
+++ b/test/rekt/integration_sink_test.go
@@ -36,7 +36,7 @@ func TestIntegrationSinkSuccess(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -50,7 +50,7 @@ func TestIntegrationSinkSuccessTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		eventshub.WithTLS(t),
 		environment.Managed(t),

--- a/test/rekt/integrationsource_test.go
+++ b/test/rekt/integrationsource_test.go
@@ -37,7 +37,7 @@ func TestIntegrationSourceWithSinkRef(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestIntegrationSourceWithTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -68,7 +68,7 @@ func TestIntegrationSourceSendsEventsWithOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/job_sink_test.go
+++ b/test/rekt/job_sink_test.go
@@ -41,7 +41,7 @@ func TestJobSinkSuccess(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -55,7 +55,7 @@ func TestJobSinkDeleteJobCascadeSecretDeletion(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -71,7 +71,7 @@ func TestJobSinkSuccessTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		eventshub.WithTLS(t),
 		environment.Managed(t),
@@ -86,7 +86,7 @@ func TestJobSinkOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		eventshub.WithTLS(t),
 		environment.Managed(t),
@@ -101,7 +101,7 @@ func TestJobSinkSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		eventshub.WithTLS(t),
 		environment.Managed(t),

--- a/test/rekt/new_trigger_filters_test.go
+++ b/test/rekt/new_trigger_filters_test.go
@@ -37,7 +37,7 @@ func TestMTChannelBrokerNewTriggerFilters(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/parallel_test.go
+++ b/test/rekt/parallel_test.go
@@ -43,7 +43,7 @@ func TestParallel(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -58,7 +58,7 @@ func TestParallelTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -74,7 +74,7 @@ func TestParallelSupportsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -95,7 +95,7 @@ func TestParallelTwoBranchesWithOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -110,7 +110,7 @@ func TestParallelSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -37,7 +37,7 @@ func TestPingSourceWithSinkRef(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestPingSourceTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -70,7 +70,7 @@ func TestPingSourceWithSinkURI(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -84,7 +84,7 @@ func TestPingSourceWithCloudEventData(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -98,7 +98,7 @@ func TestPingSourceWithSecondsInSchedule(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -112,7 +112,7 @@ func TestPingSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -127,7 +127,7 @@ func TestPingSourceSendsEventsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/sequence_test.go
+++ b/test/rekt/sequence_test.go
@@ -42,7 +42,7 @@ func TestSequence(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -57,7 +57,7 @@ func TestSequenceTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -72,7 +72,7 @@ func TestSequenceSupportsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -92,7 +92,7 @@ func TestSequenceSendsEventsOIDC(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -107,7 +107,7 @@ func TestSequenceSupportsAuthZ(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/rekt/sink_binding_test.go
+++ b/test/rekt/sink_binding_test.go
@@ -37,7 +37,7 @@ func TestSinkBindingV1Deployment(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -52,7 +52,7 @@ func TestSinkBindingV1DeploymentTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -68,7 +68,7 @@ func TestSinkBindingV1Deployment_BrokerAsSinkTLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
@@ -83,7 +83,7 @@ func TestSinkBindingV1Job(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)

--- a/test/rekt/trigger_test.go
+++ b/test/rekt/trigger_test.go
@@ -46,7 +46,7 @@ func TestTriggerWithDLS(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -59,7 +59,7 @@ func TestMultiTriggerTopology(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -72,7 +72,7 @@ func TestTriggerDependencyAnnotation(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -85,7 +85,7 @@ func TestTriggerDeliveryFormat(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 	)
@@ -99,7 +99,7 @@ func TestTriggerTLSSubscriber(t *testing.T) {
 	ctx, env := global.Environment(
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -46,7 +46,7 @@ var (
 	opts             = []environment.EnvOpts{
 		knative.WithKnativeNamespace(system.Namespace()),
 		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
+		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 	}
 )

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
@@ -73,7 +73,7 @@ const (
 //	ctx, env := global.Environment(
 //	  knative.WithKnativeNamespace("knative-namespace"),
 //	  knative.WithLoggingConfig,
-//	  knative.WithTracingConfig,
+//	  knative.WithObservabilityConfig,
 //	  k8s.WithEventListener,
 //	)
 func Install(name string, options ...EventsHubOption) feature.StepFn {
@@ -91,9 +91,9 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			log.Fatalf("Error while computing environment variables for eventshub: %s", err)
 		}
 
-		// eventshub needs tracing and logging config
+		// eventshub needs observability and logging config
 		envs[ConfigLoggingEnv] = knative.LoggingConfigFromContext(ctx)
-		envs[ConfigTracingEnv] = knative.TracingConfigFromContext(ctx)
+		envs[ConfigObservabilityEnv] = knative.ObservabilityConfigFromContext(ctx)
 
 		// Register the event info store to assert later the events published by the eventshub
 		eventListener := k8s.EventListenerFromContext(ctx)
@@ -116,7 +116,7 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
 			serviceName = feature.MakeRandomK8sName(name)
 		}
 
-		cfg := map[string]interface{}{
+		cfg := map[string]any{
 			"name":           name,
 			"serviceName":    serviceName,
 			"envs":           envs,

--- a/vendor/knative.dev/reconciler-test/pkg/knative/observability_config.go
+++ b/vendor/knative.dev/reconciler-test/pkg/knative/observability_config.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knative
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	o11yconfigmap "knative.dev/pkg/observability/configmap"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+type observabilityCfgEnvKey struct{}
+
+func WithObservabilityConfig(ctx context.Context, env environment.Environment) (context.Context, error) {
+	knativeNamespace := KnativeNamespaceFromContext(ctx)
+	cm, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(knativeNamespace).Get(context.Background(), o11yconfigmap.Name(), metav1.GetOptions{})
+	if err != nil {
+		return ctx, fmt.Errorf("error while retrieving the %s config map in namespace %s: %+v", o11yconfigmap.Name(), knativeNamespace, errors.WithStack(err))
+	}
+
+	config, err := o11yconfigmap.Parse(cm)
+	if err != nil {
+		return ctx, fmt.Errorf("error while parsing the %s config map in namespace %s: %+v", o11yconfigmap.Name(), knativeNamespace, errors.WithStack(err))
+	}
+
+	configSerialized, err := json.Marshal(config)
+	if err != nil {
+		return ctx, fmt.Errorf("error while serializing the %s config map in namespace %s: %+v", o11yconfigmap.Name(), knativeNamespace, errors.WithStack(err))
+	}
+
+	return context.WithValue(ctx, observabilityCfgEnvKey{}, string(configSerialized)), nil
+}
+
+var _ environment.EnvOpts = WithTracingConfig
+
+func ObservabilityConfigFromContext(ctx context.Context) string {
+	if e, ok := ctx.Value(observabilityCfgEnvKey{}).(string); ok {
+		return e
+	}
+	panic("no observability config found in the context, make sure you properly configured the env opts using WithObservabilityConfig")
+}

--- a/vendor/knative.dev/reconciler-test/pkg/knative/tracing_config.go
+++ b/vendor/knative.dev/reconciler-test/pkg/knative/tracing_config.go
@@ -30,6 +30,7 @@ import (
 
 type tracingConfigEnvKey struct{}
 
+// Deprecated: use WithObservabilityConfig instead
 func WithTracingConfig(ctx context.Context, env environment.Environment) (context.Context, error) {
 	knativeNamespace := KnativeNamespaceFromContext(ctx)
 	cm, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(knativeNamespace).Get(context.Background(), configtracing.ConfigName, metav1.GetOptions{})
@@ -52,6 +53,7 @@ func WithTracingConfig(ctx context.Context, env environment.Environment) (contex
 
 var _ environment.EnvOpts = WithTracingConfig
 
+// Deprecated: use ObservabilityConfigFromContext instead
 func TracingConfigFromContext(ctx context.Context) string {
 	if e, ok := ctx.Value(tracingConfigEnvKey{}).(string); ok {
 		return e

--- a/vendor/knative.dev/reconciler-test/pkg/milestone/emitter_tracing.go
+++ b/vendor/knative.dev/reconciler-test/pkg/milestone/emitter_tracing.go
@@ -18,38 +18,17 @@ package milestone
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-
-	"github.com/openzipkin/zipkin-go/model"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"knative.dev/pkg/logging"
-	"knative.dev/pkg/test/helpers"
-	"knative.dev/pkg/test/zipkin"
 
 	"knative.dev/reconciler-test/pkg/feature"
 )
 
-const defaultTracesEndpoint = "http://localhost:9411/api/v2/traces"
-
 type tracingEmitter struct {
-	ctx       context.Context
-	namespace string
-	t         feature.T
 }
 
 // NewTracingGatherer implements Emitter and gathers traces for events from the tracing entpoint.
+// TODO(Cali0707): get this to work with the new OTel changes
 func NewTracingGatherer(ctx context.Context, namespace string, zipkinNamespace string, t feature.T) (Emitter, error) {
-	err := zipkin.SetupZipkinTracingFromConfigTracing(ctx,
-		kubeclient.Get(ctx),
-		logging.FromContext(ctx).Infof,
-		zipkinNamespace)
-	return &tracingEmitter{ctx: ctx, namespace: namespace, t: t}, err
+	return &tracingEmitter{}, nil
 }
 
 func (e tracingEmitter) Environment(env map[string]string) {
@@ -83,111 +62,7 @@ func (e tracingEmitter) TestSetFinished(featureSet string, t feature.T) {
 }
 
 func (e tracingEmitter) Finished(result Result) {
-	if !result.Failed() {
-		// Don't export traces on successful runs.
-		return
-	}
-	log := logging.FromContext(e.ctx)
-	trace, err := e.getTracesForNamespace(e.namespace)
-	if err != nil {
-		log.Warnf("Unable to fetch traces for namespace %s: %v", e.namespace, err)
-	}
-	if err := e.exportTrace(trace, fmt.Sprintf("%s.json", e.namespace)); err != nil {
-		log.Warnf("Failed to export traces for namespace %s: %v", e.namespace, err)
-	}
 }
 
 func (e tracingEmitter) Exception(reason, messageFormat string, messageA ...interface{}) {
-}
-
-func (e tracingEmitter) getTracesForNamespace(ns string) ([]byte, error) {
-	logging.FromContext(e.ctx).Infof("Fetching traces for namespace %s", ns)
-	query := fmt.Sprintf("namespace=%s", ns)
-	trace, err := e.findTrace(query)
-	if err != nil {
-		return nil, err
-	}
-	return trace, nil
-}
-
-func (e tracingEmitter) exportTrace(trace []byte, fileName string) error {
-	tracesDir := filepath.Join(getLocalArtifactsDir(), "traces")
-	if err := helpers.CreateDir(tracesDir); err != nil {
-		return fmt.Errorf("error creating directory %q: %w", tracesDir, err)
-	}
-	fp := filepath.Join(tracesDir, fileName)
-	logging.FromContext(e.ctx).Infof("Exporting trace into %s", fp)
-	f, err := os.Create(fp)
-	if err != nil {
-		return fmt.Errorf("error creating file %q: %w", fp, err)
-	}
-	defer f.Close()
-	_, err = f.Write(trace)
-	if err != nil {
-		return fmt.Errorf("error writing trace into file %q: %w", fp, err)
-	}
-	return nil
-}
-
-// getLocalArtifactsDir gets the artifacts directory where prow looks for artifacts.
-// By default, it will look at the env var ARTIFACTS.
-func getLocalArtifactsDir() string {
-	dir := os.Getenv("ARTIFACTS")
-	if dir == "" {
-		dir = "artifacts"
-		log.Printf("Env variable ARTIFACTS not set. Using %s instead.", dir)
-	}
-	return dir
-}
-
-// findTrace fetches tracing endpoint and retrieves Zipkin traces matching the annotation query.
-func (e tracingEmitter) findTrace(annotationQuery string) ([]byte, error) {
-	trace := []byte("{}")
-	spanModelsAll, err := e.sendTraceQuery(defaultTracesEndpoint, annotationQuery)
-	if err != nil {
-		return trace, fmt.Errorf("failed to send trace query %q: %w", annotationQuery, err)
-	}
-	if len(spanModelsAll) == 0 {
-		return trace, fmt.Errorf("no traces found for query %q", annotationQuery)
-	}
-	var models []model.SpanModel
-	for _, m := range spanModelsAll {
-		models = append(models, m...)
-	}
-	b, err := json.MarshalIndent(models, "", "  ")
-	if err != nil {
-		return trace, fmt.Errorf("failed to marshall span models: %w", err)
-	}
-	return b, nil
-}
-
-// sendTraceQuery sends the query to the tracing endpoint and returns all spans matching the query.
-func (e tracingEmitter) sendTraceQuery(endpoint string, annotationQuery string) ([][]model.SpanModel, error) {
-	var empty [][]model.SpanModel
-	req, err := http.NewRequest("GET", endpoint, nil)
-	if err != nil {
-		return empty, err
-	}
-	q := req.URL.Query()
-	q.Add("annotationQuery", annotationQuery)
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return empty, err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return empty, err
-	}
-
-	var models [][]model.SpanModel
-	err = json.Unmarshal(body, &models)
-	if err != nil {
-		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %w", body, err)
-	}
-
-	return models, nil
 }

--- a/vendor/knative.dev/reconciler-test/pkg/tracing/tracing.go
+++ b/vendor/knative.dev/reconciler-test/pkg/tracing/tracing.go
@@ -18,11 +18,9 @@ package tracing
 
 import (
 	"context"
-	"log"
 
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/test/zipkin"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/knative"
@@ -31,6 +29,7 @@ import (
 
 // WithGatherer registers the trace gatherer with the environment and will be
 // receiving milestone events.
+// TODO(Cali0707): make this work with the OTel tracing
 func WithGatherer(t feature.T) environment.EnvOpts {
 	return func(ctx context.Context, env environment.Environment) (context.Context, error) {
 		gatherer, err := milestone.NewTracingGatherer(ctx, env.Namespace(),
@@ -45,6 +44,4 @@ func WithGatherer(t feature.T) environment.EnvOpts {
 	}
 }
 
-func Cleanup() {
-	zipkin.CleanupZipkinTracingSetup(log.Printf)
-}
+func Cleanup() {}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -528,8 +528,6 @@ golang.org/x/tools/internal/stdlib
 golang.org/x/tools/internal/typeparams
 golang.org/x/tools/internal/typesinternal
 golang.org/x/tools/internal/versions
-# golang.org/x/tools/go/expect v0.1.1-deprecated
-## explicit; go 1.23.0
 # gomodules.xyz/jsonpatch/v2 v2.5.0
 ## explicit; go 1.20
 gomodules.xyz/jsonpatch/v2
@@ -1401,7 +1399,7 @@ knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20250729152438-4f40f6229058
+# knative.dev/reconciler-test v0.0.0-20250805151946-e7475cab4beb
 ## explicit; go 1.24.0
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Update reconciler-test
- Migrate all e2e tests that used `knative.WithTracingConfig` to use `knative.WithObservabilityConfig`


