### PR TITLE
[release-1.19] adjust test to allow operator upgrade [skip-dot-release]

### DIFF
--- a/test/upgrade/prober/wathola/config/reader.go
+++ b/test/upgrade/prober/wathola/config/reader.go
@@ -52,7 +52,6 @@ func Read(configFile string) error {
 		return err
 	}
 	d := toml.NewDecoder(r)
-	d.DisallowUnknownFields()
 	err = d.Decode(Instance)
 	return err
 }


### PR DESCRIPTION
Unblocks - https://github.com/knative/operator/pull/2120

The test is running eventing code from `main` which is deploying a config file that doesn't work with eventing v1.19

This adjust eventing 1.19 to allow ignored fields to unblock the upgrade