### PR TITLE
fix: metrics with prometheus default to same port as before

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -69,7 +69,7 @@ func NewFromMap(m map[string]string) (*Config, error) {
 		c.BaseConfig = *cfg
 	}
 
-	// Force the port to the default queue user metrics port if it's not overriden
+	// Force the port to the default queue user metrics port if it's not overridden
 	if c.BaseConfig.Metrics.Protocol == metrics.ProtocolPrometheus && c.BaseConfig.Metrics.Endpoint == "" {
 		c.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
 	}
@@ -108,7 +108,7 @@ func MergeWithDefaults(cfg *Config) *Config {
 		cfg.Metrics = d.Metrics
 	}
 
-	// Force the port to the default queue user metrics port if it's not overriden
+	// Force the port to the default queue user metrics port if it's not overridden
 	if cfg.BaseConfig.Metrics.Protocol == metrics.ProtocolPrometheus && cfg.BaseConfig.Metrics.Endpoint == "" {
 		cfg.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
 	}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes accidental change in default prometheus metrics port introduced when switching to OTel.

In https://github.com/knative/eventing/blob/d952cdf73bb59f1fb561da7bfe25ce292b314fef/cmd/broker/filter/main.go#L113C19-L113C37 you can see that before this port was by default 9092 (and this is what our deployment/svc resources use unless changed by users). 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- If no endpoint is set when using prometheus metrics protocol, default to `:9092`

```release-note
fix: metrics with prometheus use the same default port as before, 9092
```

