### PR TITLE
feat: enable KN_VERIFY_CORRELATION_ID in cesql runtimes

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -23,6 +23,7 @@ import (
 
 	eventpolicyinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventpolicy"
 	"knative.dev/eventing/pkg/observability/otel"
+	"knative.dev/eventing/pkg/requestreply"
 
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
@@ -190,6 +191,10 @@ func main() {
 	logger.Info("Starting informers.")
 	if err := controller.StartInformers(ctx.Done(), informers...); err != nil {
 		logger.Fatal("Failed to start informers", zap.Error(err))
+	}
+
+	if err := requestreply.RegisterCESQLVerifyCorrelationIdFilter(ctx); err != nil {
+		logger.Fatal("failed to register KN_VERIFY_CORRELATION_ID to CESQL runtime", zap.Error(err))
 	}
 
 	// Start the servers


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This enables the custom CESQL function in the webhook and trigger filter runtimes so that the request reply feature works there.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Enable CESQL function in webhook for trigger validation
- Enable CESQL function in filter for actual running of the filters

```release-note
Eventing Core triggers now support the KN_VERIFY_CORRELATION_ID CESQL function
```


