### PR TITLE
Fix MT Channel based broker when OIDC is enabled

### DIFF
--- a/pkg/channel/event_receiver.go
+++ b/pkg/channel/event_receiver.go
@@ -306,7 +306,7 @@ func (r *EventReceiver) ServeHTTP(response nethttp.ResponseWriter, request *neth
 		return
 	}
 
-	/// Here we do the OIDC audience verification
+	// Here we do the OIDC audience verification
 	features := feature.FromContext(ctx)
 	if features.IsOIDCAuthentication() {
 		r.logger.Debug("OIDC authentication is enabled")

--- a/pkg/channel/references.go
+++ b/pkg/channel/references.go
@@ -21,6 +21,11 @@ import (
 	"strings"
 )
 
+const (
+	// K8ServiceNameSuffix is added to the k8 service name which is owned by the channel
+	K8ServiceNameSuffix = "-kn-channel"
+)
+
 // ChannelReference references a Channel within the cluster by name and
 // namespace.
 type ChannelReference struct {
@@ -38,6 +43,11 @@ func ParseChannelFromHost(host string) (ChannelReference, error) {
 	if len(chunks) < 2 {
 		return ChannelReference{}, BadRequestError(fmt.Sprintf("bad host format %q", host))
 	}
+
+	if channelName, found := strings.CutSuffix(chunks[0], K8ServiceNameSuffix); found {
+		chunks[0] = channelName
+	}
+
 	return ChannelReference{
 		Name:      chunks[0],
 		Namespace: chunks[1],

--- a/pkg/channel/references_test.go
+++ b/pkg/channel/references_test.go
@@ -46,16 +46,24 @@ func TestParseChannelFromHost(t *testing.T) {
 		wantErr            bool
 		expectedChannelRef ChannelReference
 	}{
-		"host based": {
-			host:    "test-channel.test-namespace.svc.cluster.local",
+		"host based with channel k8 service suffix": {
+			host:    fmt.Sprintf("%s%s.%s.svc.cluster.local", referencesTestChannelName, K8ServiceNameSuffix, referencesTestNamespace),
 			wantErr: false,
 			expectedChannelRef: ChannelReference{
-				Namespace: "test-namespace",
-				Name:      "test-channel",
+				Namespace: referencesTestNamespace,
+				Name:      referencesTestChannelName,
+			},
+		},
+		"host based": {
+			host:    fmt.Sprintf("%s.%s.svc.cluster.local", referencesTestChannelName, referencesTestNamespace),
+			wantErr: false,
+			expectedChannelRef: ChannelReference{
+				Namespace: referencesTestNamespace,
+				Name:      referencesTestChannelName,
 			},
 		},
 		"bad host format should return error": {
-			host:    "test-channel",
+			host:    referencesTestChannelName,
 			wantErr: true,
 		},
 	}
@@ -91,11 +99,11 @@ func TestParseChannelFromPath(t *testing.T) {
 		expectedChannelRef ChannelReference
 	}{
 		"path based": {
-			path:    "/new-namespace/new-channel/",
+			path:    fmt.Sprintf("/%s/%s/", referencesTestNamespace, referencesTestChannelName),
 			wantErr: false,
 			expectedChannelRef: ChannelReference{
-				Namespace: "new-namespace",
-				Name:      "new-channel",
+				Namespace: referencesTestNamespace,
+				Name:      referencesTestChannelName,
 			},
 		},
 

--- a/pkg/reconciler/inmemorychannel/controller/resources/service.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
 )
@@ -35,7 +36,7 @@ const (
 type K8sServiceOption func(*corev1.Service) error
 
 func CreateChannelServiceName(name string) string {
-	return kmeta.ChildName(name, "-kn-channel")
+	return kmeta.ChildName(name, channel.K8ServiceNameSuffix)
 }
 
 // ExternalService is a functional option for CreateK8sService to create a K8s service of type ExternalName

--- a/pkg/reconciler/inmemorychannel/controller/resources/service_test.go
+++ b/pkg/reconciler/inmemorychannel/controller/resources/service_test.go
@@ -18,13 +18,13 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
 )
@@ -32,6 +32,7 @@ import (
 const (
 	serviceName    = "my-test-service"
 	imcName        = "my-test-imc"
+	imcSvcName     = imcName + channel.K8ServiceNameSuffix
 	testNS         = "my-test-ns"
 	dispatcherNS   = "dispatcher-namespace"
 	dispatcherName = "dispatcher-name"
@@ -44,7 +45,7 @@ func TestCreateExternalServiceAddress(t *testing.T) {
 }
 
 func TestCreateChannelServiceAddress(t *testing.T) {
-	if want, got := "my-test-imc-kn-channel", CreateChannelServiceName(imcName); want != got {
+	if want, got := imcSvcName, CreateChannelServiceName(imcName); want != got {
 		t.Errorf("Want: %q got %q", want, got)
 	}
 }
@@ -62,7 +63,7 @@ func TestNewK8sService(t *testing.T) {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-kn-channel", imcName),
+			Name:      CreateChannelServiceName(imcName),
 			Namespace: testNS,
 			Labels: map[string]string{
 				MessagingRoleLabel: MessagingRole,
@@ -105,7 +106,7 @@ func TestNewK8sServiceWithExternal(t *testing.T) {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-kn-channel", imcName),
+			Name:      CreateChannelServiceName(imcName),
 			Namespace: testNS,
 			Labels: map[string]string{
 				MessagingRoleLabel: MessagingRole,

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -18,6 +18,7 @@ package dispatcher
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -48,6 +49,7 @@ import (
 	"knative.dev/eventing/pkg/apis/feature"
 	v1 "knative.dev/eventing/pkg/apis/messaging/v1"
 	"knative.dev/eventing/pkg/auth"
+	"knative.dev/eventing/pkg/channel"
 	"knative.dev/eventing/pkg/channel/fanout"
 	fakeeventingclient "knative.dev/eventing/pkg/client/injection/client/fake"
 	"knative.dev/eventing/pkg/client/injection/reconciler/messaging/v1/inmemorychannel"
@@ -68,7 +70,7 @@ const (
 
 var (
 	channelServiceAddress = duckv1.Addressable{
-		URL: apis.HTTP("test-imc-kn-channel.test-namespace.svc.cluster.local"),
+		URL: apis.HTTP(fmt.Sprintf("%s%s.%s.svc.cluster.local", imcName, channel.K8ServiceNameSuffix, testNS)),
 	}
 
 	linear      = eventingduckv1.BackoffPolicyLinear

--- a/test/conformance/helpers/channel_tracing_test_helper.go
+++ b/test/conformance/helpers/channel_tracing_test_helper.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openzipkin/zipkin-go/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ch "knative.dev/eventing/pkg/channel"
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
@@ -143,7 +144,7 @@ func setupChannelTracingWithReply(
 		Span: tracinghelper.MatchHTTPSpanNoReply(
 			model.Server,
 			tracinghelper.WithHTTPHostAndPath(
-				fmt.Sprintf("%s-kn-channel.%s.svc", channelName, client.Namespace),
+				fmt.Sprintf("%s%s.%s.svc", channelName, ch.K8ServiceNameSuffix, client.Namespace),
 				"/",
 			),
 		),
@@ -177,14 +178,14 @@ func setupChannelTracingWithReply(
 					},
 					{
 						// 6. Channel Dispatcher span
-						Span: channelSpan(eventID, fmt.Sprintf("%s-kn-channel.%s.svc", replyChannelName, client.Namespace), ""),
+						Span: channelSpan(eventID, fmt.Sprintf("%s%s.%s.svc", replyChannelName, ch.K8ServiceNameSuffix, client.Namespace), ""),
 						Children: []tracinghelper.TestSpanTree{
 							{
 								// 7. Channel sends reply from Mutator Pod to the reply Channel.
 								Span: tracinghelper.MatchHTTPSpanNoReply(
 									model.Client,
 									tracinghelper.WithHTTPURL(
-										fmt.Sprintf("%s-kn-channel.%s.svc", replyChannelName, client.Namespace),
+										fmt.Sprintf("%s%s.%s.svc", replyChannelName, ch.K8ServiceNameSuffix, client.Namespace),
 										"",
 									),
 								),
@@ -194,7 +195,7 @@ func setupChannelTracingWithReply(
 										Span: tracinghelper.MatchHTTPSpanNoReply(
 											model.Server,
 											tracinghelper.WithHTTPHostAndPath(
-												fmt.Sprintf("%s-kn-channel.%s.svc", replyChannelName, client.Namespace),
+												fmt.Sprintf("%s%s.%s.svc", replyChannelName, ch.K8ServiceNameSuffix, client.Namespace),
 												"/",
 											),
 										),
@@ -245,7 +246,7 @@ func setupChannelTracingWithReply(
 			Span: tracinghelper.MatchHTTPSpanNoReply(
 				model.Client,
 				tracinghelper.WithHTTPURL(
-					fmt.Sprintf("%s-kn-channel.%s.svc", channelName, client.Namespace),
+					fmt.Sprintf("%s%s.%s.svc", channelName, ch.K8ServiceNameSuffix, client.Namespace),
 					"",
 				),
 				tracinghelper.WithLocalEndpointServiceName("sender"),


### PR DESCRIPTION
When OIDC is enabled and https is disabled (i.e. http requests are used) the event receiver is using the host name to determine the name of the channel and fails to do so. An example host name is `broker-kne-trigger-kn-channel.namespace-1.svc.cluster.local`. The channel name here is `broker-kne-trigger` without the suffix
`-kn-channel` which was hardcoded in the logic which was creating the channel owned k8 service.

The constant `-kn-channel` is now extracted into a common constant in the `channel` package. A conditional check in `ParseChannelFromHost` now checks for the suffix in the host name and removes it if needed. 

An additional test case was added and existing tests were updated.

 :bug: Fixes #8705.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :broom: Extract channel owned k8 service suffix into constant.
- :test_tube: Add unit tests and update existing.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Fixes broken MT channel based broker when TLS is disabled and OIDC enabled
```


**Docs**

Now the authorization example in the docs is actually working with TLS disabled and OIDC enabled: https://knative.dev/docs/eventing/features/authorization/#example

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

