### PR TITLE
fix: add symlinks to request reply config

### DIFF
--- a/config/300-requestreply.yaml
+++ b/config/300-requestreply.yaml
@@ -1,0 +1,1 @@
+core/resources/requestreply.yaml

--- a/config/500-requestreply.yaml
+++ b/config/500-requestreply.yaml
@@ -1,0 +1,1 @@
+core/deployments/request-reply.yaml


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

With #8701 merged I was trying to deploy the resource locally & realized that the symlinks for some of the request reply config files were missing

