### PR TITLE
Docs: fix cert-manager manual deploy guide in `DEVELOPMENT.md`.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -185,11 +185,20 @@ Depending on your needs you might want to install other
 
 ## Install Cert-Manager
 
-Install the Cert-manager operator to run e2e tests for TLS
+Install the Cert-manager operator to run e2e tests for TLS. You need to install the Cert-manager components in two steps. First deploy the namespace and the Cert-manager and wait until three pods are running and one is completed.
 
 ```shell
-kubectl apply -f third_party/cert-manager
+kubectl apply -f third_party/cert-manager/00-namespace.yaml && \
+kubectl apply -f third_party/cert-manager/01-cert-manager.yaml
 ```
+
+Then deploy the Trust-manager and you're done.
+
+```shell
+kubectl apply -f third_party/cert-manager/02-trust-manager.yaml
+```
+
+To give you an idea how the Cert-manager is deployed in the `./hack/run.sh install` script take a look at the [`install_cert_manager`](https://github.com/knative/eventing/blob/bfd6957835e486c582a25bb2683bf83f681b15c3/test/e2e-common.sh#L431) function in [`e2e-common.sh`](https://github.com/knative/eventing/blob/main/test/e2e-common.sh).
 
 Depending on your needs you might want to install other
 [Broker implementations](https://github.com/knative/eventing/tree/main/docs/broker).


### PR DESCRIPTION
Also add a reference to the function in the `e2e-common.sh` which shows how the Cert-manager is deployed by the `run.sh` script.

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #8740

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :book: Update `DEVELOPMENT.md` [_Install Cert-manager_](https://github.com/knative/eventing/blob/main/DEVELOPMENT.md#install-cert-manager) section.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Correct guide on how to install Cert-manager manually in DEVELOPMENT.md
```
