### PR TITLE
Add configurable read timeout support to InMemoryEventDispatcher

### DIFF
--- a/pkg/inmemorychannel/event_dispatcher.go
+++ b/pkg/inmemorychannel/event_dispatcher.go
@@ -69,9 +69,12 @@ func (d *InMemoryEventDispatcher) WaitReady() {
 
 func NewEventDispatcher(args *InMemoryEventDispatcherArgs) *InMemoryEventDispatcher {
 	readTimeout := args.ReadTimeout
+	const DefaultReadTimeout = 30 * time.Second
+
 	if readTimeout <= 0 {
-		readTimeout = 30 * time.Second 
+		readTimeout = DefaultReadTimeout
 	}
+
 
 	bindingsReceiver := kncloudevents.NewHTTPEventReceiver(
 		args.Port,


### PR DESCRIPTION
## Changes

- Updated `NewEventDispatcher` to append the `kncloudevents.WithReadTimeout()` option when creating the `HTTPEventReceiver`.
- Exposed `ReadTimeout` as part of `InMemoryEventDispatcherArgs` to allow configuration.