### PR TITLE
fix-read-timout-dispatcher

### DIFF
--- a/pkg/inmemorychannel/event_dispatcher.go
+++ b/pkg/inmemorychannel/event_dispatcher.go
@@ -71,9 +71,10 @@ func NewEventDispatcher(args *InMemoryEventDispatcherArgs) *InMemoryEventDispatc
 	bindingsReceiver := kncloudevents.NewHTTPEventReceiver(
 		args.Port,
 		append(
-			kncloudevents.WithReadTimeout(args.ReadTimeout),
-			args.HTTPEventReceiverOptions,
-		)...,
+			[]kncloudevents.HTTPEventReceiverOption{
+				kncloudevents.WithReadTimeout(args.ReadTimeout),
+			},
+			args.HTTPEventReceiverOptions...)...,
 	)
 
 	dispatcher := &InMemoryEventDispatcher{


### PR DESCRIPTION
Propagates the `ReadTimeout` option from `InMemoryEventDispatcherArgs` to
the underlying `HTTPEventReceiver`. The dispatcher previously created a
receiver without setting its ReadTimeout, despite the TODO in the code.