### PR TITLE
Docs: Fix typo in development guide

### DIFF
--- a/docs/broker/filtering.md
+++ b/docs/broker/filtering.md
@@ -280,7 +280,7 @@ spec:
 Cannot be specified with the SourceAndType filter.
 
 _This example assumes the repository name is available as a CloudEvents
-extension `{"repository":proposals"}`._
+extension `{"repository":"proposals"}`._
 
 Specified with the attributes filter:
 
@@ -309,7 +309,7 @@ spec:
 Cannot be specified with the SourceAndType filter.
 
 _This example assumes the repository name is available as a CloudEvents
-extension `{"github.repository":proposals"}`._
+extension `{"github.repository":"proposals"}`._
 
 Specified with the attributes filter:
 
@@ -350,7 +350,7 @@ spec:
 Cannot be specified with the SourceAndType filter or the attributes filter.
 
 _This example assumes the event data is the parseable equivalent of
-`{"user":{"id":"abc123"}`._
+`{"user":{"id":"abc123"}}`._
 
 ```yaml
 spec:

--- a/docs/decisions/eventing-and-messaging.md
+++ b/docs/decisions/eventing-and-messaging.md
@@ -68,4 +68,5 @@ additional repos in the release process.
 ## Source documents
 
 [Proposal by Mark Fisher](https://docs.google.com/document/d/1w5Bd5kEiiMk7i7X0EUdy6PFbWUpwGTwep8I0N52esyM/edit#)
+
 [Decision by eventing approvers](https://docs.google.com/spreadsheets/d/16aOhfRnkaGcQIOR5kiumld-GmrgGBIm9fppvAXx3mgc/edit?)

--- a/docs/delivery/README.md
+++ b/docs/delivery/README.md
@@ -40,11 +40,11 @@ these situations.
 ### Dead Letter Sink
 
 Channels are responsible for forwarding received events to subscribers. When
-they fail to do so, they are responsible for sending the failing events to an
+they fail to do so, they are responsible for sending the failing events to a
 **dead letter sink**, potentially one per subscriber.
 
 Similarly Event Sources are responsible for sending events to a sink and when
-they fail to do so, they are responsible for sending the failing events to an
+they fail to do so, they are responsible for sending the failing events to a
 **dead letter sink**.
 
 The dead letter sink can be a channel but it does not have to.


### PR DESCRIPTION

Fixes # 
N/A

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

 :broom:  Fixed typos in internal documentation
- Fixed spelling errors in `docs/broker/filtering.md`
- Fixed spelling errors in `docs/decisions/eventing-and-messaging.md`
- Fixed spelling errors in `docs/delivery/README.md`


### Pre-review Checklist

(Documentation fix only - no code changes)

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

NONE



**Docs**

N/A

