### PR TITLE
Add disableCache flag to ApiServerSource for reduced API connections

### DIFF
--- a/config/core/resources/apiserversource.yaml
+++ b/config/core/resources/apiserversource.yaml
@@ -186,7 +186,9 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-
+              disableCache:
+                description: DisableCache, when set to true, configures the adapter to disable client-side caching of Kubernetes resources. This prevents the adapter from using resourceVersion-based caching which can cause throttling when tracking many resources across namespaces.
+                type: boolean
           status:
             type: object
             properties:

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -7410,6 +7410,23 @@ evaluate to true, the event MUST be attempted to be delivered. Absence of
 a filter or empty array implies a value of true.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>disableCache</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableCache, when set to true, configures the adapter to use cluster-scoped watches
+instead of per-namespace watches. This reduces the number of API connections from N
+(namespaces) to 1 per resource type, preventing client-side throttling when tracking
+resources across many namespaces. Events from non-selected namespaces are filtered
+client-side in the adapter.
+Defaults to false (per-namespace watches for better isolation).</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -8034,6 +8051,23 @@ If any filter expression in the array evaluates to false, the event MUST
 NOT be sent to the Sink. If all the filter expressions in the array
 evaluate to true, the event MUST be attempted to be delivered. Absence of
 a filter or empty array implies a value of true.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>disableCache</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableCache, when set to true, configures the adapter to use cluster-scoped watches
+instead of per-namespace watches. This reduces the number of API connections from N
+(namespaces) to 1 per resource type, preventing client-side throttling when tracking
+resources across many namespaces. Events from non-selected namespaces are filtered
+client-side in the adapter.
+Defaults to false (per-namespace watches for better isolation).</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/adapter/apiserver/config.go
+++ b/pkg/adapter/apiserver/config.go
@@ -74,4 +74,13 @@ type Config struct {
 	// (via the features.knative.dev/apiserversource-skip-permissions-check annotation), and the ApiServerSource
 	// adapter should not keep trying to establish watches on resources that it perhaps does not have permissions for.
 	FailFast bool `json:"failFast,omitempty"`
+
+	// DisableCache when true, forces cluster-scoped watches to reduce API connections
+	// and prevent client-side throttling in high-namespace scenarios.
+	DisableCache bool `json:"disableCache,omitempty"`
+
+	// OriginalNamespaces holds the user's intended namespaces for filtering
+	// when DisableCache forces AllNamespaces mode. This allows cluster-scoped
+	// watches while still filtering events to only the desired namespaces.
+	OriginalNamespaces []string `json:"originalNamespaces,omitempty"`
 }

--- a/pkg/adapter/apiserver/namespace_filter_test.go
+++ b/pkg/adapter/apiserver/namespace_filter_test.go
@@ -1,0 +1,140 @@
+package apiserver
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	adaptertest "knative.dev/eventing/pkg/adapter/v2/test"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	"knative.dev/eventing/pkg/eventfilter/subscriptionsapi"
+)
+
+// TestNamespaceFiltering tests that events from non-allowed namespaces are dropped
+func TestNamespaceFiltering(t *testing.T) {
+	ce := adaptertest.NewTestClient()
+
+	// Create delegate with namespace filter for "allowed-ns"
+	allowedNs := map[string]struct{}{
+		"allowed-ns": {},
+	}
+
+	logger := zap.NewExample().Sugar()
+	delegate := &resourceDelegate{
+		ce:                  ce,
+		source:              "unit-test",
+		ref:                 false,
+		apiServerSourceName: "test-source",
+		logger:              logger,
+		filter:              subscriptionsapi.NewAllFilter(subscriptionsapi.MaterializeFiltersList(logger.Desugar(), []eventingv1.SubscriptionsAPIFilter{})...),
+		allowedNamespaces:   allowedNs,
+		filterByNamespace:   true,
+	}
+
+	// Test 1: Event from allowed namespace SHOULD be sent
+	allowedPod := simplePod("allowed-pod", "allowed-ns")
+	err := delegate.Add(allowedPod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ce.Sent()); got != 1 {
+		t.Errorf("Expected 1 event to be sent for allowed namespace, got: %d", got)
+	}
+
+	// Reset before next test
+	ce.Reset()
+
+	// Test 2: Event from non-allowed namespace should NOT be sent
+	deniedPod := simplePod("denied-pod", "denied-ns")
+	err = delegate.Add(deniedPod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ce.Sent()); got != 0 {
+		t.Errorf("Expected 0 events to be sent for denied namespace, got: %d", got)
+	}
+}
+
+// TestNamespaceFilteringDisabled tests that when filtering is disabled, all events are sent
+func TestNamespaceFilteringDisabled(t *testing.T) {
+	ce := adaptertest.NewTestClient()
+
+	logger := zap.NewExample().Sugar()
+	// Create delegate WITHOUT namespace filtering
+	delegate := &resourceDelegate{
+		ce:                  ce,
+		source:              "unit-test",
+		ref:                 false,
+		apiServerSourceName: "test-source",
+		logger:              logger,
+		filter:              subscriptionsapi.NewAllFilter(subscriptionsapi.MaterializeFiltersList(logger.Desugar(), []eventingv1.SubscriptionsAPIFilter{})...),
+		filterByNamespace:   false, // Filtering disabled
+	}
+
+	// Both namespaces should send events
+	pod1 := simplePod("pod-1", "ns-1")
+	err := delegate.Add(pod1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ce.Sent()); got != 1 {
+		t.Errorf("Expected 1 event after first pod, got: %d", got)
+	}
+
+	pod2 := simplePod("pod-2", "ns-2")
+	err = delegate.Add(pod2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ce.Sent()); got != 2 {
+		t.Errorf("Expected 2 events after second pod, got: %d", got)
+	}
+}
+
+// TestNamespaceFilteringMultipleAllowed tests multiple allowed namespaces
+func TestNamespaceFilteringMultipleAllowed(t *testing.T) {
+	ce := adaptertest.NewTestClient()
+
+	// Create delegate with multiple allowed namespaces
+	allowedNs := map[string]struct{}{
+		"prod-1": {},
+		"prod-2": {},
+		"prod-3": {},
+	}
+
+	logger := zap.NewExample().Sugar()
+	delegate := &resourceDelegate{
+		ce:                  ce,
+		source:              "unit-test",
+		ref:                 false,
+		apiServerSourceName: "test-source",
+		logger:              logger,
+		filter:              subscriptionsapi.NewAllFilter(subscriptionsapi.MaterializeFiltersList(logger.Desugar(), []eventingv1.SubscriptionsAPIFilter{})...),
+		allowedNamespaces:   allowedNs,
+		filterByNamespace:   true,
+	}
+
+	// Test allowed namespaces - each should add one event
+	expectedCount := 0
+	for _, ns := range []string{"prod-1", "prod-2", "prod-3"} {
+		pod := simplePod("test-pod", ns)
+		err := delegate.Add(pod)
+		if err != nil {
+			t.Fatalf("unexpected error for namespace %s: %v", ns, err)
+		}
+		expectedCount++
+		if got := len(ce.Sent()); got != expectedCount {
+			t.Errorf("Expected %d events after namespace %s, got: %d", expectedCount, ns, got)
+		}
+	}
+
+	// Test denied namespace - count should stay the same
+	deniedPod := simplePod("test-pod", "dev-1")
+	err := delegate.Add(deniedPod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(ce.Sent()); got != expectedCount {
+		t.Errorf("Expected %d events (denied namespace shouldn't add), got: %d", expectedCount, got)
+	}
+}

--- a/pkg/apis/sources/v1/apiserver_types.go
+++ b/pkg/apis/sources/v1/apiserver_types.go
@@ -96,6 +96,15 @@ type ApiServerSourceSpec struct {
 	//
 	// +optional
 	Filters []eventingv1.SubscriptionsAPIFilter `json:"filters,omitempty"`
+
+	// DisableCache, when set to true, configures the adapter to use cluster-scoped watches
+	// instead of per-namespace watches. This reduces the number of API connections from N
+	// (namespaces) to 1 per resource type, preventing client-side throttling when tracking
+	// resources across many namespaces. Events from non-selected namespaces are filtered
+	// client-side in the adapter.
+	// Defaults to false (per-namespace watches for better isolation).
+	// +optional
+	DisableCache *bool `json:"disableCache,omitempty"`
 }
 
 // ApiServerSourceStatus defines the observed state of ApiServerSource

--- a/pkg/apis/sources/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/sources/v1/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *ApiServerSourceSpec) DeepCopyInto(out *ApiServerSourceSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DisableCache != nil {
+		in, out := &in.DisableCache, &out.DisableCache
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/apiserversource/apiserversource.go
+++ b/pkg/reconciler/apiserversource/apiserversource.go
@@ -239,6 +239,11 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 
 	featureFlags := feature.FromContext(ctx)
 
+	disableCache := false
+	if src.Spec.DisableCache != nil {
+		disableCache = *src.Spec.DisableCache
+	}
+
 	adapterArgs := resources.ReceiveAdapterArgs{
 		Image:         r.receiveAdapterImage,
 		Source:        src,
@@ -251,6 +256,7 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1.ApiServer
 		AllNamespaces: allNamespaces,
 		NodeSelector:  featureFlags.NodeSelector(),
 		FailFast:      skipPermissions == "true",
+		DisableCache:  disableCache,
 	}
 
 	expected, err := resources.MakeReceiveAdapter(&adapterArgs)

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_disable_cache_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_disable_cache_test.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/eventing/pkg/adapter/apiserver"
+	v1 "knative.dev/eventing/pkg/apis/sources/v1"
+	"knative.dev/eventing/pkg/reconciler/source"
+)
+
+func TestMakeReceiveAdapterWithDisableCache(t *testing.T) {
+	name := "source-name"
+
+	testCases := []struct {
+		name         string
+		disableCache bool
+		want         bool
+	}{{
+		name:         "DisableCache true",
+		disableCache: true,
+		want:         true,
+	}, {
+		name:         "DisableCache false",
+		disableCache: false,
+		want:         false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &v1.ApiServerSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "source-namespace",
+					UID:       "1234",
+				},
+				Spec: v1.ApiServerSourceSpec{
+					Resources: []v1.APIVersionKindSelector{{
+						APIVersion: "v1",
+						Kind:       "Pod",
+					}},
+					EventMode:          "Resource",
+					ServiceAccountName: "source-svc-acct",
+				},
+			}
+
+			args := &ReceiveAdapterArgs{
+				Image:        "test-image",
+				Source:       src,
+				Labels:       Labels(src.Name),
+				SinkURI:      "http://sink.example.com",
+				Configs:      &source.EmptyVarsGenerator{},
+				Namespaces:   []string{"default"},
+				DisableCache: tc.disableCache,
+			}
+
+			deployment, err := MakeReceiveAdapter(args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Find K_SOURCE_CONFIG env var
+			var config apiserver.Config
+			for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "K_SOURCE_CONFIG" {
+					if err := json.Unmarshal([]byte(env.Value), &config); err != nil {
+						t.Fatalf("failed to unmarshal K_SOURCE_CONFIG: %v", err)
+					}
+					break
+				}
+			}
+
+			if config.DisableCache != tc.want {
+				t.Errorf("DisableCache mismatch: got %v, want %v", config.DisableCache, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -152,7 +152,7 @@ O2dgzikq8iSy1BlRsVw=
 									Value: "sink-uri",
 								}, {
 									Name:  "K_SOURCE_CONFIG",
-									Value: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource"}`,
+									Value: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}},{"gvr":{"Group":"batch","Version":"v1","Resource":"jobs"}},{"gvr":{"Group":"","Version":"","Resource":"pods"},"selector":"test-key1=test-value1"}],"owner":{"apiVersion":"custom/v1","kind":"Parent"},"mode":"Resource","originalNamespaces":["source-namespace"]}`,
 								}, {
 									Name:  "SYSTEM_NAMESPACE",
 									Value: "knative-testing",
@@ -269,12 +269,12 @@ Test certificate content here
 		{
 			name:           "FailFast true",
 			failFast:       true,
-			expectedConfig: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}}],"mode":"Resource","failFast":true}`,
+			expectedConfig: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}}],"mode":"Resource","failFast":true,"originalNamespaces":["source-namespace"]}`,
 		},
 		{
 			name:           "FailFast false",
 			failFast:       false,
-			expectedConfig: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}}],"mode":"Resource"}`,
+			expectedConfig: `{"namespaces":["source-namespace"],"allNamespaces":false,"resources":[{"gvr":{"Group":"","Version":"","Resource":"namespaces"}}],"mode":"Resource","originalNamespaces":["source-namespace"]}`,
 		},
 	}
 


### PR DESCRIPTION
This adds a DisableCache field to ApiServerSource that when enabled:
- Forces cluster-scoped watches instead of per-namespace watches
- Reduces API server connections from O(N) to O(1) for N namespaces
- Implements client-side namespace filtering via OriginalNamespaces field
- Prevents client-side throttling in high-namespace scenarios



Fixes #8642 








