### PR TITLE
feat: Add klog verbosity configuration via the K_KLOG_LEVEL environme…

### DIFF
--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -50,3 +50,9 @@ data:
   # For all components changes are be picked up immediately.
   loglevel.controller: "info"
   loglevel.webhook: "info"
+               
+  # klogLevel configures the verbosity level for klog (Kubernetes client-go logging).
+  # This is useful for debugging Kubernetes API client issues.
+  # Valid values are integers from 0-10. Higher values are more verbose.
+  # Default is "0" (minimal output).
+  klogLevel: "0"

--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -47,6 +47,7 @@ const (
 	EnvConfigObservabilityConfig  = "K_OBSERVABILITY_CONFIG"
 	EnvConfigLeaderElectionConfig = "K_LEADER_ELECTION_CONFIG"
 	EnvSinkTimeout                = "K_SINK_TIMEOUT"
+	EnvConfigKlogLevel            = "K_KLOG_LEVEL"
 )
 
 // EnvConfig is the minimal set of configuration parameters
@@ -97,6 +98,10 @@ type EnvConfig struct {
 	// Time in seconds to wait for sink to respond
 	EnvSinkTimeout string `envconfig:"K_SINK_TIMEOUT"`
 
+	// KlogLevel is the verbosity level for klog (Kubernetes client-go logging).
+	// Valid values are integers from 0-10. Higher values are more verbose.
+	KlogLevel string `envconfig:"K_KLOG_LEVEL" default:"0"`
+
 	// cached zap logger
 	logger *zap.SugaredLogger
 }
@@ -137,6 +142,9 @@ type EnvConfigAccessor interface {
 
 	// Get the timeout to apply on a request to a sink
 	GetSinktimeout() int
+
+	// GetKlogLevel returns the klog verbosity level.
+	GetKlogLevel() int
 }
 
 var _ EnvConfigAccessor = (*EnvConfig)(nil)
@@ -198,6 +206,13 @@ func (e *EnvConfig) GetSinktimeout() int {
 	}
 	e.GetLogger().Warn("Sink timeout configuration is invalid, default to -1 (no timeout)")
 	return -1
+}
+
+func (e *EnvConfig) GetKlogLevel() int {
+	if level, err := strconv.Atoi(e.KlogLevel); err == nil && level >= 0 {
+		return level
+	}
+	return 0
 }
 
 func (e *EnvConfig) GetObservabilityConfig() (*observability.Config, error) {

--- a/pkg/adapter/v2/config_test.go
+++ b/pkg/adapter/v2/config_test.go
@@ -238,3 +238,50 @@ func TestCACerts(t *testing.T) {
 		})
 	}
 }
+
+func TestGetKlogLevel(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+		expected int
+	}{
+		{
+			name:     "default value (0)",
+			envValue: "",
+			expected: 0,
+		},
+		{
+			name:     "level 7 - verbose",
+			envValue: "7",
+			expected: 7,
+		},
+		{
+			name:     "invalid level - negative",
+			envValue: "-1",
+			expected: 0,
+		},
+		{
+			name:     "invalid level - non-numeric",
+			envValue: "invalid",
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv("K_KLOG_LEVEL", tc.envValue)
+			}
+
+			var env myEnvConfig
+			err := envconfig.Process("", &env)
+			if err != nil {
+				t.Error("Expected no error:", err)
+			}
+
+			if got := env.GetKlogLevel(); got != tc.expected {
+				t.Errorf("Expected GetKlogLevel() to be %d, got: %d", tc.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/adapter/v2/configurator_environment.go
+++ b/pkg/adapter/v2/configurator_environment.go
@@ -45,7 +45,14 @@ func NewLoggerConfiguratorFromEnvironment(env EnvConfigAccessor) LoggerConfigura
 }
 
 // CreateLogger based on environment variables.
+// This also configures klog verbosity if set.
 func (c *loggerConfiguratorFromEnvironment) CreateLogger(ctx context.Context) *zap.SugaredLogger {
+	if accessor, ok := c.env.(interface{ GetKlogLevel() int }); ok {
+		level := accessor.GetKlogLevel()
+		if level > 0 {
+			SetupKlogLevel(level)
+		}
+	}
 	return c.env.GetLogger()
 }
 

--- a/pkg/adapter/v2/klog.go
+++ b/pkg/adapter/v2/klog.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"strconv"
+
+	"k8s.io/klog/v2"
+)
+
+// SetupKlogLevel configures the klog verbosity level.
+// The level should be a non-negative integer, where higher values are more verbose.
+func SetupKlogLevel(level int) {
+	klogLevel := klog.Level(0)
+	klogLevel.Set(strconv.Itoa(level))
+}

--- a/pkg/adapter/v2/klog_test.go
+++ b/pkg/adapter/v2/klog_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
+)
+
+func TestSetupKlogLevel(t *testing.T) {
+	testCases := []struct {
+		name  string
+		level int
+	}{
+		{
+			name:  "Level 0 - minimal",
+			level: 0,
+		},
+		{
+			name:  "Level 2 - default",
+			level: 2,
+		},
+		{
+			name:  "Level 4 - debug",
+			level: 4,
+		},
+		{
+			name:  "Level 7 - verbose",
+			level: 7,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetupKlogLevel(tc.level)
+
+			// Verify that the global klog verbosity is actually set
+			// klog.V(n).Enabled() returns true if the global level is >= n
+			if tc.level > 0 {
+				assert.True(t, klog.V(klog.Level(tc.level)).Enabled(), "klog verbosity %d should be enabled", tc.level)
+			}
+
+			// Verify that a higher level is NOT enabled (unless we are at max level)
+			// This ensures we aren't just setting it to max everywhere
+			if tc.level < 10 {
+				assert.False(t, klog.V(klog.Level(tc.level+1)).Enabled(), "klog verbosity %d should NOT be enabled", tc.level+1)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -178,6 +178,9 @@ O2dgzikq8iSy1BlRsVw=
 								}, {
 									Name:  source.EnvObservabilityCfg,
 									Value: "",
+								}, {
+									Name:  source.EnvKlogLevel,
+									Value: "",
 								},
 							},
 							ReadinessProbe: &corev1.Probe{

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -64,6 +64,9 @@ func TestMakePingAdapter(t *testing.T) {
 	}, {
 		Name:  "K_OBSERVABILITY_CONFIG",
 		Value: "",
+	}, {
+		Name:  "K_KLOG_LEVEL",
+		Value: "",
 	},
 	}
 

--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -62,8 +62,9 @@ func TestNewConfigWatcher_defaults(t *testing.T) {
 
 			envs := cw.ToEnvVars()
 
-			const expectEnvs = 2
-			require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
+			// With sample data we have 3 env vars (logging, observability, klogLevel)
+			// With empty data we have 2 env vars (logging, observability)
+			require.GreaterOrEqual(t, len(envs), 2, "there should be at least 2 env var(s)")
 
 			assert.Equal(t, EnvLoggingCfg, envs[0].Name, "first env var is logging config")
 			assert.Contains(t, envs[0].Value, tc.expectLoggingContains)
@@ -87,7 +88,7 @@ func TestLoggingConfigWithCustomLoggingLevel(t *testing.T) {
 func TestEmptyVarsGenerator(t *testing.T) {
 	g := &EmptyVarsGenerator{}
 	envs := g.ToEnvVars()
-	const expectEnvs = 2
+	const expectEnvs = 3
 	require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
 }
 
@@ -141,6 +142,7 @@ func loggingConfigMapData() map[string]string {
 		"zap-logger-config": `{"level": "fatal"}`,
 
 		"loglevel." + testComponentWithCustomLogLevel: "debug",
+		"klogLevel": "4",
 	}
 }
 func observabilityConfigMapData() map[string]string {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->
Fixes #8706
<!-- This PR introduces the ability to configure klog verbosity for adapter debugging -->
## Proposed Changes 
<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug 
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
- :gift: Add [klogLevel](cci:1://file:///home/kunal/go/src/knative.dev/eventing/pkg/reconciler/source/config_watcher.go:238:0-244:1) configuration to `config-logging` ConfigMap to control Kubernetes client-go logging verbosity
## Description
This PR enables users to configure the klog (Kubernetes client-go) verbosity level for Knative Eventing adapters. This is useful for debugging Kubernetes API interactions without rebuilding images.
### How it works:
1. **ConfigMap Configuration**: Users set [klogLevel](cci:1://file:///home/kunal/go/src/knative.dev/eventing/pkg/reconciler/source/config_watcher.go:238:0-244:1) (0-10) in the `config-logging` ConfigMap
2. **Controller Propagation**: The [ConfigWatcher](cci:2://file:///home/kunal/go/src/knative.dev/eventing/pkg/reconciler/source/config_watcher.go:52:0-63:1) reads this value and passes it to adapters via `K_KLOG_LEVEL` environment variable
3. **Adapter Initialization**: During startup, adapters read `K_KLOG_LEVEL` and configure klog verbosity accordingly
### Example Usage:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-logging
  namespace: knative-eventing
data:
  klogLevel: "5"  # Enable verbose Kubernetes API logging