### PR TITLE
Add URI validation for EventType Source and Schema fields

### DIFF
--- a/pkg/apis/eventing/v1beta1/eventtype_validation.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_validation.go
@@ -33,8 +33,14 @@ func (ets *EventTypeSpec) Validate(ctx context.Context) *apis.FieldError {
 		fe := apis.ErrMissingField("type")
 		errs = errs.Also(fe)
 	}
-	// TODO validate Source is a valid URI.
-	// TODO validate Schema is a valid URI.
+	// Validate Source is a non-empty URI when provided
+	if ets.Source != nil && ets.Source.IsEmpty() {
+		errs = errs.Also(apis.ErrInvalidValue("", "source", "source URI cannot be empty"))
+	}
+	// Validate Schema is a non-empty URI when provided
+	if ets.Schema != nil && ets.Schema.IsEmpty() {
+		errs = errs.Also(apis.ErrInvalidValue("", "schema", "schema URI cannot be empty"))
+	}
 	// There is no validation of the SchemaData, it is application specific data.
 	return errs
 }

--- a/pkg/apis/eventing/v1beta1/eventtype_validation_test.go
+++ b/pkg/apis/eventing/v1beta1/eventtype_validation_test.go
@@ -61,6 +61,23 @@ func TestEventTypeSpecValidation(t *testing.T) {
 			Source: testSource,
 			Broker: "test-broker",
 		},
+	}, {
+		name: "invalid empty source",
+		ets: &EventTypeSpec{
+			Type:   "test-type",
+			Source: &apis.URL{},
+			Broker: "test-broker",
+		},
+		want: apis.ErrInvalidValue("", "source", "source URI cannot be empty"),
+	}, {
+		name: "invalid empty schema",
+		ets: &EventTypeSpec{
+			Type:   "test-type",
+			Source: testSource,
+			Schema: &apis.URL{},
+			Broker: "test-broker",
+		},
+		want: apis.ErrInvalidValue("", "schema", "schema URI cannot be empty"),
 	},
 	}
 


### PR DESCRIPTION
## Changes
Fixes #8836 
This PR addresses the TODO comments in [eventtype_validation.go](cci:7://file:///home/kunal/go/src/knative.dev/eventing/pkg/apis/eventing/v1beta3/eventtype_validation.go:0:0-0:0) by adding validation for the `Source` and `Schema` URI fields in [EventTypeSpec](cci:2://file:///home/kunal/go/src/knative.dev/eventing/pkg/apis/eventing/v1beta2/eventtype_types.go:63:0-89:1).
**Before:** An EventType could be created with empty Source/Schema URIs (e.g., `"source": ""`), which would parse successfully but result in a meaningless empty URI.
**After:** If `Source` or `Schema` is provided (non-nil) but empty, validation will reject it with a clear error message.
## What type of PR is this?
/kind cleanup
## What this PR does
- Adds validation in `EventTypeSpec.Validate()` to check that `Source` and `Schema` fields are not empty when provided
- Adds corresponding test cases for empty URI validation
## Which issue(s) this PR fixes
Fixes the following TODOs in the codebase:
- `// TODO validate Source is a valid URI.`
- `// TODO validate Schema is a valid URI.`
## How was this tested?
```bash
go test -v ./pkg/apis/eventing/v1beta1/... -run TestEventType