### PR TITLE
fix: EventTransform not updating when expression changes

### DIFF
--- a/pkg/reconciler/eventtransform/eventtransform_test.go
+++ b/pkg/reconciler/eventtransform/eventtransform_test.go
@@ -1339,7 +1339,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})
 
-					d.Annotations[JsonataCertificateRevisionKey] = "1"
+					d.Spec.Template.Annotations[JsonataCertificateRevisionKey] = "1"
 				}),
 				&corev1.Endpoints{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1552,7 +1552,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})
 
-					d.Annotations[JsonataCertificateRevisionKey] = "1"
+					d.Spec.Template.Annotations[JsonataCertificateRevisionKey] = "1"
 				}),
 				&corev1.Endpoints{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1942,7 +1942,7 @@ func TestReconcile(t *testing.T) {
 						},
 					})
 
-					d.Annotations[JsonataCertificateRevisionKey] = "1"
+					d.Spec.Template.Annotations[JsonataCertificateRevisionKey] = "1"
 				}),
 				&corev1.Endpoints{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #8845

## Proposed Changes

- :bug: Update EventTransform deployment correctly, when expression changes

In Kubernetes, changes to a deployments metadata do not trigger pod restarts. Only changes to spec.template trigger rolling updates
