### PR TITLE
fix unused linter errors

### DIFF
--- a/pkg/requestreply/ingress_handler.go
+++ b/pkg/requestreply/ingress_handler.go
@@ -348,8 +348,3 @@ func (h *IngressHandler) handleReplyEvent(responseWriter http.ResponseWriter, ev
 	// send the reply event back to the original response writer
 	pr.replyEvent <- event
 }
-
-func isResponseEvent(event *cloudevents.Event, rr *v1alpha1.RequestReply) bool {
-	_, ok := event.Extensions()[rr.Spec.ReplyAttribute]
-	return ok
-}

--- a/test/conformance/helpers/tracing_test_helper.go
+++ b/test/conformance/helpers/tracing_test_helper.go
@@ -21,13 +21,10 @@ import (
 	"testing"
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	tracinghelper "knative.dev/eventing/test/conformance/helpers/tracing"
 	testlib "knative.dev/eventing/test/lib"
-	"knative.dev/eventing/test/lib/recordevents"
 )
 
 // SetupTracingTestInfrastructureFunc sets up the infrastructure for running tracing tests. It returns the
@@ -49,61 +46,8 @@ func tracingTest(
 	setupInfrastructure SetupTracingTestInfrastructureFunc,
 	channel metav1.TypeMeta,
 ) {
-	const (
-		recordEventsPodName = "recordevents"
-	)
-
 	client := testlib.Setup(t, true, setupClient)
 	defer testlib.TearDown(client)
 
-	// TODO - redo with OTel
-	// Start the event info store. Note this is done _before_ we setup the infrastructure, which
-	// sends the event.
-	// targetTracker, err := recordevents.NewEventInfoStore(client, recordEventsPodName, client.Namespace)
-	// if err != nil {
-	// 	t.Fatal("Pod tracker failed:", err)
-	// }
-
-	// Setup the test infrastructure
-	// expectedTestSpan, eventMatcher := setupInfrastructure(ctx, t, &channel, client, recordEventsPodName, true)
-
-	// Assert that the event was seen.
-	// matches := targetTracker.AssertAtLeast(1, recordevents.MatchEvent(eventMatcher))
-
-	// Match the trace
-	// traceID := getTraceIDHeader(t, matches)
-	// trace, err := zipkin.JSONTracePred(traceID, 5*time.Minute, func(trace []model.SpanModel) bool {
-	// 	tree, err := tracinghelper.GetTraceTree(trace)
-	// 	if err != nil {
-	// 		return false
-	// 	}
-	// 	// Do not pass t to prevent unnecessary log output.
-	// 	return len(expectedTestSpan.MatchesSubtree(nil, tree)) > 0
-	// })
-	// if err != nil {
-	// 	t.Logf("Unable to get trace %q: %v. Trace so far %+v", traceID, err, tracinghelper.PrettyPrintTrace(trace))
-	// 	tree, err := tracinghelper.GetTraceTree(trace)
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// 	if len(expectedTestSpan.MatchesSubtree(t, tree)) == 0 {
-	// 		t.Fatalf("No matching subtree. want: %v got: %v", expectedTestSpan, tree)
-	// 	}
-	// }
-}
-
-// getTraceIDHeader gets the TraceID from the passed in events.  It returns the header from the
-// first matching event, but registers a fatal error if more than one traceid header is seen
-// in that message.
-func getTraceIDHeader(t *testing.T, evInfos []recordevents.EventInfo) string {
-	for i := range evInfos {
-		if nil != evInfos[i].HTTPHeaders {
-			sc := trace.SpanContextFromContext(propagation.TraceContext{}.Extract(context.TODO(), propagation.HeaderCarrier(evInfos[i].HTTPHeaders)))
-			if sc.HasTraceID() {
-				return sc.TraceID().String()
-			}
-		}
-	}
-	t.Fatalf("FAIL: No traceid in %d messages: (%v)", len(evInfos), evInfos)
-	return ""
+	// TODO - redo with OTel - https://github.com/knative/eventing/issues/8853
 }


### PR DESCRIPTION
Can be seen for example in: https://github.com/knative/eventing/actions/runs/21171606060/job/60889521311

```
  Error: pkg/requestreply/ingress_handler.go:352:6: func isResponseEvent is unused (unused)
  func isResponseEvent(event *cloudevents.Event, rr *v1alpha1.RequestReply) bool {
       ^
  Error: test/conformance/helpers/tracing_test_helper.go:53:3: const recordEventsPodName is unused (unused)
  		recordEventsPodName = "recordevents"
  		^
  Error: test/conformance/helpers/tracing_test_helper.go:98:6: func getTraceIDHeader is unused (unused)
  func getTraceIDHeader(t *testing.T, evInfos []recordevents.EventInfo) string {
       ^
  3 issues:
  * unused: 3
```


/kind cleanup