### PR TITLE
Remove k8s 1.32 runs in KinD e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -19,6 +19,7 @@ jobs:
         k8s-version:
           - v1.33.x
           - v1.34.x
+          - v1.35.x
 
         test-suite:
         - ./test/e2e


### PR DESCRIPTION
Knative requires at least k8s 1.33 now. So removing 1.32 from the KinD e2e tests