### PR TITLE
fix: Wait for full deployment rollout before marking IntegrationSink Ready

### DIFF
--- a/pkg/reconciler/integration/sink/integrationsink.go
+++ b/pkg/reconciler/integration/sink/integrationsink.go
@@ -177,7 +177,7 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, sink *sinks.Integr
 		logging.FromContext(ctx).Debugw("Reusing existing Deployment", zap.Any("Deployment", deployment))
 	}
 
-	sink.Status.PropagateDeploymentStatus(&deployment.Status)
+	sink.Status.PropagateDeploymentStatus(deployment)
 	return deployment, nil
 }
 

--- a/pkg/reconciler/integration/sink/resources/container_image.go
+++ b/pkg/reconciler/integration/sink/resources/container_image.go
@@ -62,6 +62,7 @@ func MakeDeploymentSpec(sink *v1alpha1.IntegrationSink, authProxyImage string, f
 			Labels: integration.Labels(sink.Name),
 		},
 		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: integration.Labels(sink.Name),
 			},

--- a/pkg/reconciler/integration/sink/resources/container_image_test.go
+++ b/pkg/reconciler/integration/sink/resources/container_image_test.go
@@ -88,6 +88,7 @@ func TestNewSQSContainerSink(t *testing.T) {
 			Labels: integration.Labels(testName),
 		},
 		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: integration.Labels(testName),
 			},

--- a/pkg/reconciler/testing/v1alpha1/integrationsink.go
+++ b/pkg/reconciler/testing/v1alpha1/integrationsink.go
@@ -57,9 +57,9 @@ func WithInitIntegrationSinkConditions(s *v1alpha1.IntegrationSink) {
 	s.Status.InitializeConditions()
 }
 
-func WithIntegrationSinkPropagateDeploymenteStatus(status *appsv1.DeploymentStatus) IntegrationSinkOption {
+func WithIntegrationSinkPropagateDeploymenteStatus(deployment *appsv1.Deployment) IntegrationSinkOption {
 	return func(s *v1alpha1.IntegrationSink) {
-		s.Status.PropagateDeploymentStatus(status)
+		s.Status.PropagateDeploymentStatus(deployment)
 	}
 }
 


### PR DESCRIPTION
Previously, IntegrationSink would mark `DeploymentReady=True` when any replica was available, even if old pods with stale `AUTH_POLICIES` were still running during a rollout. This caused race conditions where:

1. Tests would send requests hitting old pods with outdated policies, resulting in 403 errors and CI flakes (like [here](https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing_main_periodic/2015351308772446208))
2. Production clients could see `Ready=True` but hit pods without the latest EventPolicy changes

Now PropagateDeploymentStatus checks that:
- ObservedGeneration == Generation (controller processed latest spec)
- UpdatedReplicas == Replicas (all pods updated to new template)
- AvailableReplicas == Replicas (all updated pods are ready)

This ensures IntegrationSink only becomes Ready when all pods have the current `AUTH_POLICIES` configuration, fixing both test flakes and the production correctness issue.