### PR TITLE
Prevent AuthZ test pollution by ensuring unready test runs last

### DIFF
--- a/test/rekt/features/authz/addressable_authz_conformance.go
+++ b/test/rekt/features/authz/addressable_authz_conformance.go
@@ -63,7 +63,7 @@ func AddressableAuthZConformanceRequestHandling(gvr schema.GroupVersionResource,
 			addressableAllowsAuthorizedRequest(gvr, kind, name, cloudevents.EncodingStructured),
 			addressableRejectsUnauthorizedRequest(gvr, kind, name, cloudevents.EncodingBinary),
 			addressableRejectsUnauthorizedRequest(gvr, kind, name, cloudevents.EncodingStructured),
-			addressableBecomesUnreadyOnUnreadyEventPolicy(gvr, kind, name),
+			zAddressableBecomesUnreadyOnUnreadyEventPolicy(gvr, kind, name),
 		},
 	}
 	return &fs
@@ -214,7 +214,11 @@ func addressableRespectsEventPolicyFilters(gvr schema.GroupVersionResource, kind
 	return f
 }
 
-func addressableBecomesUnreadyOnUnreadyEventPolicy(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
+// zAddressableBecomesUnreadyOnUnreadyEventPolicy tests that an addressable becomes NotReady when an EventPolicy is NotReady.
+// The function name starts with 'z' to ensure it runs last when tests are sorted alphabetically by the test framework.
+// This test creates an EventPolicy with an invalid reference which makes the addressable NotReady, so it must run
+// after all other tests to avoid interfering with them.
+func zAddressableBecomesUnreadyOnUnreadyEventPolicy(gvr schema.GroupVersionResource, kind, name string) *feature.Feature {
 	f := feature.NewFeatureNamed(fmt.Sprintf("%s becomes NotReady when EventPolicy is NotReady", kind))
 
 	f.Prerequisite("OIDC authentication is enabled", featureflags.AuthenticationOIDCEnabled())


### PR DESCRIPTION
The addressableBecomesUnreadyOnUnreadyEventPolicy test creates an EventPolicy with an invalid "doesnt-exist" reference, which makes the shared addressable NotReady. This was causing subsequent tests to fail because the test framework sorts tests alphabetically by name before execution.

The test was running as:
1. accepts (binary/structured)
2. becomes_NotReady ← created invalid EventPolicy here
3. only_admits (filter tests) ← failed due to NotReady addressable
4. rejects (binary/structured)

Renamed the function to zAddressableBecomesUnreadyOnUnreadyEventPolicy to force it to run last alphabetically, ensuring it doesn't interfere with other tests (like [here](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/8858/reconciler-tests_eventing_main/2015749553403203584)).

Fixes test failures in TestIntegrationSinkSupportsAuthZ and other AddressableAuthZConformance test suites.