### PR TITLE
Increase poll timings for IntegrationSource tests

### DIFF
--- a/test/rekt/integrationsource_test.go
+++ b/test/rekt/integrationsource_test.go
@@ -41,6 +41,7 @@ func TestIntegrationSourceWithSinkRef(t *testing.T) {
 		knative.WithObservabilityConfig,
 		k8s.WithEventListener,
 		environment.Managed(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
 	t.Cleanup(env.Finish)
 
@@ -74,6 +75,7 @@ func TestIntegrationSourceSendsEventsWithOIDC(t *testing.T) {
 		k8s.WithEventListener,
 		environment.Managed(t),
 		eventshub.WithTLS(t),
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
 
 	env.Test(ctx, t, integrationsource.SendsEventsWithSinkRefOIDC())


### PR DESCRIPTION
The TestIntegrationSourceWithSinkRef and TestIntegrationSourceSendsEventsWithOIDC tests were timing out during cleanup when waiting for resources to be deleted (see [here](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/8858/reconciler-tests_eventing_main/2015789965027315712)).

Increased the poll timeout in both tests to allow more time for resource cleanup, consistent with TestIntegrationSourceWithTLS which already had these timings configured.

This prevents cleanup timeout failures:
```
"magic.go:135: failed to wait for resources to be deleted: timed out waiting for the condition"
```