### PR TITLE
refactor: Replace Telepresence with ko --debug

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -334,7 +334,7 @@ Wireshark:
 kubectl sniff <POD_NAME> -n knative-eventing
 ```
 
-## Debugging Knative controllers and webhooks
+## Debugging Knative controllers and friends locally
 
 `ko` has built-in support for remote debugging Go applications using
 [Delve](https://github.com/go-delve/delve). This is the recommended approach for
@@ -401,13 +401,8 @@ _Keep this terminal running while you debug._
       "request": "attach",
       "mode": "remote",
       "port": 40000,
-      "host": "127.0.0.1",
-      "substitutePath": [
-        {
-          "from": "${workspaceFolder}",
-          "to": "/go/src/knative.dev/eventing"
-        }
-      ]
+      "host": "0.0.0.0",
+      "cwd": "${workspaceFolder}"
     }
   ]
 }
@@ -415,10 +410,6 @@ _Keep this terminal running while you debug._
 
 2. Start the debug configuration in VSCode. Your breakpoints will now be active
    in the remote process.
-
-> :information_source: The `substitutePath` mapping is required so that VSCode
-> can correctly map source files between your local workspace and the paths
-> inside the container.
 
 ### Debug with IntelliJ IDEA / GoLand
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #7099
## Proposed Changes
- :broom: Replace Telepresence debugging documentation with `ko --debug` approach
- :broom: Add instructions for VSCode and IntelliJ/GoLand remote debugging via Delve
- :broom: Add troubleshooting section for common debugging issues

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact; docs update itself (DEVELOPMENT.md)
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
updated `DEVELOPMENT.md` to use ko’s built-in `--debug` flag for remote debugging instead of telepresence. this simplifies the debugging workflow by using delve directly and avoids introducing extra dependencies.
```


**Docs**
this pr updates the developer documentation (`DEVELOPMENT.md`) in this repository. no external documentation changes are needed since this only affects the development workflow and not any user-facing features.

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

