### PR TITLE
Remove Kubernetes 1.33 from KinD e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.33.x
           - v1.34.x
           - v1.35.x
 


### PR DESCRIPTION
Kubernetes 1.33 is not supported with the next knative release anymore