### PR TITLE
Restore component-specific default metrics ports

### DIFF
--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -102,7 +102,7 @@ func main() {
 
 	pprof := k8sruntime.NewProfilingServer(sl.Named("pprof"))
 
-	mp, tp := otel.SetupObservabilityOrDie(ctx, "broker.filter", sl, pprof)
+	mp, tp := otel.SetupObservabilityOrDie(ctx, "broker.filter", sl, pprof, otel.WithDefaultMetricsPort(defaultMetricsPort))
 
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -114,7 +114,7 @@ func main() {
 
 	pprof := k8sruntime.NewProfilingServer(sl.Named("pprof"))
 
-	mp, tp := otel.SetupObservabilityOrDie(ctx, "broker.ingress", sl, pprof)
+	mp, tp := otel.SetupObservabilityOrDie(ctx, "broker.ingress", sl, pprof, otel.WithDefaultMetricsPort(defaultMetricsPort))
 
 	defer func() {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -72,8 +72,9 @@ import (
 )
 
 const (
-	component = "job_sink"
-	ScopeName = "knative.dev/cmd/jobsink"
+	component          = "job_sink"
+	ScopeName          = "knative.dev/cmd/jobsink"
+	defaultMetricsPort = 9092
 )
 
 var (
@@ -103,7 +104,7 @@ func main() {
 
 	pprof := k8sruntime.NewProfilingServer(sl.Named("pprof"))
 
-	mp, tp := otel.SetupObservabilityOrDie(ctx, "jobsink", sl, pprof)
+	mp, tp := otel.SetupObservabilityOrDie(ctx, "jobsink", sl, pprof, otel.WithDefaultMetricsPort(defaultMetricsPort))
 
 	defer func() {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -33,7 +33,7 @@ const (
 	DefaultEnableSinkEventErrorReporting = false
 
 	// DefaultMetricsPort is the default port used for prometheus metrics if the prometheus protocol is used
-	DefaultMetricsPort = 9092
+	DefaultMetricsPort = 9090
 )
 
 type (
@@ -67,11 +67,6 @@ func NewFromMap(m map[string]string) (*Config, error) {
 		return nil, err
 	} else {
 		c.BaseConfig = *cfg
-	}
-
-	// Force the port to the default queue user metrics port if it's not overridden
-	if c.BaseConfig.Metrics.Protocol == metrics.ProtocolPrometheus && c.BaseConfig.Metrics.Endpoint == "" {
-		c.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
 	}
 
 	err := configmap.Parse(m, configmap.As(EnableSinkEventErrorReportingKey, &c.EnableSinkEventErrorReporting))


### PR DESCRIPTION
Before the OTEL migration, most components exposed metrics on port 9090, while `mt-broker-filter`, `mt-broker-ingress`, and `job-sink` used port 9092. The migration acidentially changed all components to use 9092.

This PR addresses it and:
- Sets the global default metrics port back to 9090
- Adds a functional options pattern (`WithDefaultMetricsPort`) to allow components to specify custom default ports
- Updates `broker-filter`, `broker-ingress`, and `job-sink` to explicitly request port 9092 (`job-sink`s pod template used port 9092, but didn't expose it on 9092 (still was on 9090 before). So this was kind "in-the-middle". Therefor I changed it to 9092 too.

**Links**:
* #8669

**Release Note**

```release-note
Expose metrics by default on port 9090 again (except for mt-broker-ingress, mt-broker-filter) as it was before the OTEL migration
```