### PR TITLE
make sinkbinding oidc-token volume mount readOnly

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle.go
@@ -262,12 +262,14 @@ func (sb *SinkBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 			ps.Spec.Template.Spec.Containers[i].VolumeMounts = append(ps.Spec.Template.Spec.Containers[i].VolumeMounts, corev1.VolumeMount{
 				Name:      oidcTokenVolumeName,
 				MountPath: "/oidc",
+				ReadOnly:  true,
 			})
 		}
 		for i := range ps.Spec.Template.Spec.InitContainers {
 			ps.Spec.Template.Spec.InitContainers[i].VolumeMounts = append(ps.Spec.Template.Spec.InitContainers[i].VolumeMounts, corev1.VolumeMount{
 				Name:      oidcTokenVolumeName,
 				MountPath: "/oidc",
+				ReadOnly:  true,
 			})
 		}
 	}

--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -874,6 +874,7 @@ func TestSinkBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      oidcTokenVolumeName,
 								MountPath: "/oidc",
+								ReadOnly:  true,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -892,6 +893,7 @@ func TestSinkBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      oidcTokenVolumeName,
 								MountPath: "/oidc",
+								ReadOnly:  true,
 							}},
 						}},
 						Volumes: []corev1.Volume{{


### PR DESCRIPTION
Fixes #8893

## Proposed Changes

- :bug: Make the sinkbinding oidc-token volume mount readOnly


### Pre-review Checklist

- [X] **At least 80% unit test coverage**
