### PR TITLE
feat: use centralized TLS configuration from knative/pkg/tls

### DIFF
--- a/cmd/requestreply/main.go
+++ b/cmd/requestreply/main.go
@@ -18,12 +18,14 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/kncloudevents"
@@ -34,6 +36,7 @@ import (
 	configmap "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
@@ -109,9 +112,15 @@ func main() {
 		env.PodIdx,
 	)
 
+	tlsConfig, err := getServerTLSConfig(ctx)
+	if err != nil {
+		logger.Fatal("failed to get TLS server config", zap.Error(err))
+	}
+
 	sm, err := eventingtls.NewServerManager(ctx,
 		kncloudevents.NewHTTPEventReceiver(env.HttpPort),
-		kncloudevents.NewHTTPEventReceiver(env.HttpsPort), // TODO: add tls config when we have it
+		kncloudevents.NewHTTPEventReceiver(env.HttpsPort,
+			kncloudevents.WithTLSConfig(tlsConfig)),
 		handler,
 		configMapWatcher,
 	)
@@ -133,6 +142,17 @@ func main() {
 
 func flush(sl *zap.SugaredLogger) {
 	_ = sl.Sync()
+}
+
+func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
+	secret := types.NamespacedName{
+		Namespace: system.Namespace(),
+		Name:      eventingtls.RequestReplyServerTLSSecretName,
+	}
+
+	serverTLSConfig := eventingtls.NewDefaultServerConfig()
+	serverTLSConfig.GetCertificate = eventingtls.GetCertificateFromSecret(ctx, secretinformer.Get(ctx), kubeclient.Get(ctx), secret)
+	return eventingtls.GetTLSServerConfig(serverTLSConfig)
 }
 
 func getLoggingConfig(ctx context.Context, namespace, loggingConfigMapName string) (*logging.Config, error) {

--- a/cmd/requestreply/main_test.go
+++ b/cmd/requestreply/main_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+
+	reconcilertesting "knative.dev/pkg/reconciler/testing"
+
+	// Fake injection informers and clients
+	_ "knative.dev/pkg/client/injection/kube/client/fake"
+	_ "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret/fake"
+)
+
+func TestGetServerTLSConfig(t *testing.T) {
+	t.Setenv("SYSTEM_NAMESPACE", "knative-eventing")
+
+	ctx, _ := reconcilertesting.SetupFakeContext(t)
+
+	tlsConfig, err := getServerTLSConfig(ctx)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	if tlsConfig == nil {
+		t.Fatal("expected non-nil TLS config")
+	}
+
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, tlsConfig.MinVersion)
+	}
+
+	if tlsConfig.GetCertificate == nil {
+		t.Fatal("expected GetCertificate to be set")
+	}
+}

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -39,6 +39,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	pkgtls "knative.dev/pkg/tls"
 )
 
 const (
@@ -58,6 +59,8 @@ const (
 	BrokerFilterServerTLSSecretName = "mt-broker-filter-server-tls" //nolint:gosec // This is not a hardcoded credential
 	// BrokerIngressServerTLSSecretName is the name of the tls secret for the broker ingress server
 	BrokerIngressServerTLSSecretName = "mt-broker-ingress-server-tls" //nolint:gosec // This is not a hardcoded credential
+	// RequestReplyServerTLSSecretName is the name of the tls secret for the request reply server
+	RequestReplyServerTLSSecretName = "request-reply-server-tls" //nolint:gosec // This is not a hardcoded credential
 )
 
 type ClientConfig struct {
@@ -170,10 +173,13 @@ func GetTLSClientConfig(config ClientConfig) (*tls.Config, error) {
 		return nil, err
 	}
 
-	return &tls.Config{
-		RootCAs:    pool,
-		MinVersion: DefaultMinTLSVersion,
-	}, nil
+	cfg, err := defaultTLSConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.RootCAs = pool
+	return cfg, nil
 }
 
 func NewDefaultServerConfig() ServerConfig {
@@ -181,10 +187,31 @@ func NewDefaultServerConfig() ServerConfig {
 }
 
 func GetTLSServerConfig(config ServerConfig) (*tls.Config, error) {
-	return &tls.Config{
-		MinVersion:     DefaultMinTLSVersion,
-		GetCertificate: config.GetCertificate,
-	}, nil
+	cfg, err := defaultTLSConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.GetCertificate = config.GetCertificate
+	return cfg, nil
+}
+
+// defaultTLSConfigFromEnv loads TLS configuration from environment variables
+// using the shared knative/pkg/tls utility. DefaultConfigFromEnv defaults to
+// TLS 1.3, but eventing historically defaults to TLS 1.2, so we fall back to
+// 1.2 unless TLS_MIN_VERSION is explicitly set.
+// TODO: switch to TLS 1.3 to align with the rest of the system.
+func defaultTLSConfigFromEnv() (*tls.Config, error) {
+	cfg, err := pkgtls.DefaultConfigFromEnv("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load TLS config from env: %w", err)
+	}
+
+	if os.Getenv(pkgtls.MinVersionEnvKey) == "" {
+		cfg.MinVersion = DefaultMinTLSVersion
+	}
+
+	return cfg, nil
 }
 
 // IsHttpsSink returns true if the sink has scheme equal to https.

--- a/pkg/eventingtls/eventingtls_test.go
+++ b/pkg/eventingtls/eventingtls_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/utils/pointer"
+	pkgtls "knative.dev/pkg/tls"
 )
 
 func TestGetClientConfig(t *testing.T) {
@@ -128,4 +129,185 @@ func WithCerts(pool *x509.CertPool, caCerts string) *x509.CertPool {
 		panic("Failed to append CA certs from PEM:\n" + caCerts)
 	}
 	return pool
+}
+
+func TestGetTLSClientConfigEnv(t *testing.T) {
+	t.Run("defaults to TLS 1.2 when env not set", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "")
+
+		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
+		}
+	})
+
+	t.Run("uses TLS 1.3 when explicitly set via env", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "1.3")
+
+		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("want MinVersion TLS 1.3 (%d), got %d", tls.VersionTLS13, cfg.MinVersion)
+		}
+	})
+
+	t.Run("reads MaxVersion from env", func(t *testing.T) {
+		t.Setenv(pkgtls.MaxVersionEnvKey, "1.3")
+
+		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MaxVersion != tls.VersionTLS13 {
+			t.Fatalf("want MaxVersion TLS 1.3 (%d), got %d", tls.VersionTLS13, cfg.MaxVersion)
+		}
+	})
+
+	t.Run("reads CipherSuites from env", func(t *testing.T) {
+		t.Setenv(pkgtls.CipherSuitesEnvKey, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+
+		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(cfg.CipherSuites) != 1 || cfg.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Fatalf("want CipherSuites [%d], got %v", tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cfg.CipherSuites)
+		}
+	})
+
+	t.Run("reads CurvePreferences from env", func(t *testing.T) {
+		t.Setenv(pkgtls.CurvePreferencesEnvKey, "X25519,CurveP256")
+
+		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(cfg.CurvePreferences) != 2 {
+			t.Fatalf("want 2 CurvePreferences, got %d", len(cfg.CurvePreferences))
+		}
+		if cfg.CurvePreferences[0] != tls.X25519 || cfg.CurvePreferences[1] != tls.CurveP256 {
+			t.Fatalf("want CurvePreferences [X25519, CurveP256], got %v", cfg.CurvePreferences)
+		}
+	})
+
+	t.Run("returns error on invalid env value", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "invalid")
+
+		_, err := GetTLSClientConfig(NewDefaultClientConfig())
+		if err == nil {
+			t.Fatal("expected error for invalid TLS_MIN_VERSION, got nil")
+		}
+	})
+}
+
+func TestGetTLSServerConfig(t *testing.T) {
+	t.Run("defaults to TLS 1.2 when env not set", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
+		}
+	})
+
+	t.Run("uses TLS 1.3 when explicitly set via env", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "1.3")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("want MinVersion TLS 1.3 (%d), got %d", tls.VersionTLS13, cfg.MinVersion)
+		}
+	})
+
+	t.Run("uses TLS 1.2 when explicitly set via env", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "1.2")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
+		}
+	})
+
+	t.Run("reads MaxVersion from env", func(t *testing.T) {
+		t.Setenv(pkgtls.MaxVersionEnvKey, "1.3")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.MaxVersion != tls.VersionTLS13 {
+			t.Fatalf("want MaxVersion TLS 1.3 (%d), got %d", tls.VersionTLS13, cfg.MaxVersion)
+		}
+	})
+
+	t.Run("reads CipherSuites from env", func(t *testing.T) {
+		t.Setenv(pkgtls.CipherSuitesEnvKey, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(cfg.CipherSuites) != 1 || cfg.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Fatalf("want CipherSuites [%d], got %v", tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, cfg.CipherSuites)
+		}
+	})
+
+	t.Run("reads CurvePreferences from env", func(t *testing.T) {
+		t.Setenv(pkgtls.CurvePreferencesEnvKey, "X25519,CurveP256")
+
+		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(cfg.CurvePreferences) != 2 {
+			t.Fatalf("want 2 CurvePreferences, got %d", len(cfg.CurvePreferences))
+		}
+		if cfg.CurvePreferences[0] != tls.X25519 || cfg.CurvePreferences[1] != tls.CurveP256 {
+			t.Fatalf("want CurvePreferences [X25519, CurveP256], got %v", cfg.CurvePreferences)
+		}
+	})
+
+	t.Run("returns error on invalid env value", func(t *testing.T) {
+		t.Setenv(pkgtls.MinVersionEnvKey, "invalid")
+
+		_, err := GetTLSServerConfig(NewDefaultServerConfig())
+		if err == nil {
+			t.Fatal("expected error for invalid TLS_MIN_VERSION, got nil")
+		}
+	})
+
+	t.Run("preserves GetCertificate callback", func(t *testing.T) {
+		called := false
+		sc := ServerConfig{
+			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				called = true
+				return nil, nil
+			},
+		}
+		cfg, err := GetTLSServerConfig(sc)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if cfg.GetCertificate == nil {
+			t.Fatal("GetCertificate should not be nil")
+		}
+		_, _ = cfg.GetCertificate(nil)
+		if !called {
+			t.Fatal("GetCertificate callback was not invoked")
+		}
+	})
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Bump knative.dev/pkg to pick up the new knative.dev/pkg/tls package and replace the hardcoded TLS server config in eventingtls with the shared DefaultConfigFromEnv utility. This enables environment-based control of MinVersion, MaxVersion, CipherSuites, and CurvePreferences for all eventing TLS servers (broker filter/ingress, IMC dispatcher, job sink, auth proxy, request-reply).
Since DefaultConfigFromEnv defaults to TLS 1.3 but eventing historically defaults to TLS 1.2, GetTLSServerConfig falls back to 1.2 unless TLS_MIN_VERSION is explicitly set.
Also wires up TLS for the RequestReply data plane, which previously had a TODO placeholder.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
All eventing TLS servers now support configurable TLS settings (min/max version, cipher suites, curve preferences) via environment variables TLS_MIN_VERSION, TLS_MAX_VERSION, TLS_CIPHER_SUITES, and TLS_CURVE_PREFERENCES. The webhook reads WEBHOOK_TLS_* variants automatically. The default minimum TLS version remains 1.2.
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

