### PR TITLE
fix: use system.Namespace() instead of hardcoded namespace in broker TLS config

### DIFF
--- a/pkg/broker/filter/server_manager.go
+++ b/pkg/broker/filter/server_manager.go
@@ -32,6 +32,7 @@ import (
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/system"
 )
 
 func NewServerManager(
@@ -58,7 +59,7 @@ func NewServerManager(
 
 func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 	secret := types.NamespacedName{
-		Namespace: "knative-eventing",
+		Namespace: system.Namespace(),
 		Name:      eventingtls.BrokerFilterServerTLSSecretName,
 	}
 

--- a/pkg/broker/ingress/server_manager.go
+++ b/pkg/broker/ingress/server_manager.go
@@ -32,6 +32,7 @@ import (
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+	"knative.dev/pkg/system"
 )
 
 func NewServerManager(
@@ -56,7 +57,7 @@ func NewServerManager(
 
 func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 	secret := types.NamespacedName{
-		Namespace: "knative-eventing",
+		Namespace: system.Namespace(),
 		Name:      eventingtls.BrokerIngressServerTLSSecretName,
 	}
 


### PR DESCRIPTION
The broker filter and ingress server managers hardcoded "knative-eventing" when looking up TLS secrets. This breaks deployments that install eventing into a custom namespace. Use system.Namespace() to read SYSTEM_NAMESPACE at runtime, consistent with the other data planes (IMC dispatcher, job sink, request-reply).

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix bug

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Broker filter and ingress TLS secret lookups now respect the configured system namespace instead of assuming "knative-eventing".
```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

