### PR TITLE
Update default minimum TLS version to 1.3

### DIFF
--- a/cmd/requestreply/main_test.go
+++ b/cmd/requestreply/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"crypto/tls"
 	"testing"
 
 	reconcilertesting "knative.dev/pkg/reconciler/testing"
@@ -39,10 +38,6 @@ func TestGetServerTLSConfig(t *testing.T) {
 
 	if tlsConfig == nil {
 		t.Fatal("expected non-nil TLS config")
-	}
-
-	if tlsConfig.MinVersion != tls.VersionTLS12 {
-		t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, tlsConfig.MinVersion)
 	}
 
 	if tlsConfig.GetCertificate == nil {

--- a/pkg/eventingtls/eventingtls.go
+++ b/pkg/eventingtls/eventingtls.go
@@ -47,8 +47,6 @@ const (
 	TLSKey = "tls.key"
 	// TLSCrt is the key in the TLS secret for the public key of TLS servers
 	TLSCrt = "tls.crt"
-	// DefaultMinTLSVersion is the default minimum TLS version for servers and clients.
-	DefaultMinTLSVersion = tls.VersionTLS12
 	// SecretCACrt is the name of the CA Cert in the secret
 	SecretCACert = "ca.crt"
 	// IMCDispatcherServerTLSSecretName is the name of the tls secret for the imc dispatcher server
@@ -198,17 +196,11 @@ func GetTLSServerConfig(config ServerConfig) (*tls.Config, error) {
 
 // defaultTLSConfigFromEnv loads TLS configuration from environment variables
 // using the shared knative/pkg/tls utility. DefaultConfigFromEnv defaults to
-// TLS 1.3, but eventing historically defaults to TLS 1.2, so we fall back to
-// 1.2 unless TLS_MIN_VERSION is explicitly set.
-// TODO: switch to TLS 1.3 to align with the rest of the system.
+// TLS 1.3.
 func defaultTLSConfigFromEnv() (*tls.Config, error) {
 	cfg, err := pkgtls.DefaultConfigFromEnv("")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config from env: %w", err)
-	}
-
-	if os.Getenv(pkgtls.MinVersionEnvKey) == "" {
-		cfg.MinVersion = DefaultMinTLSVersion
 	}
 
 	return cfg, nil

--- a/pkg/eventingtls/eventingtls_test.go
+++ b/pkg/eventingtls/eventingtls_test.go
@@ -67,16 +67,14 @@ wSdZWoEx7ye2kUHEyRKdRGbHyJtY9YYvaROznzxqVpIqHxnRQnE/If7kcN4t/7vi
 				CACerts: pointer.String(""),
 			},
 			expected: tls.Config{
-				MinVersion: tls.VersionTLS12,
-				RootCAs:    sysCertPool,
+				RootCAs: sysCertPool,
 			},
 		},
 		{
 			name: "nil CA certs",
 			cfg:  ClientConfig{},
 			expected: tls.Config{
-				MinVersion: tls.VersionTLS12,
-				RootCAs:    sysCertPool,
+				RootCAs: sysCertPool,
 			},
 		},
 		{
@@ -85,8 +83,7 @@ wSdZWoEx7ye2kUHEyRKdRGbHyJtY9YYvaROznzxqVpIqHxnRQnE/If7kcN4t/7vi
 				CACerts: pointer.String(pemCaCert),
 			},
 			expected: tls.Config{
-				MinVersion: tls.VersionTLS12,
-				RootCAs:    WithCerts(sysCertPool, pemCaCert),
+				RootCAs: WithCerts(sysCertPool, pemCaCert),
 			},
 		},
 		{
@@ -94,10 +91,8 @@ wSdZWoEx7ye2kUHEyRKdRGbHyJtY9YYvaROznzxqVpIqHxnRQnE/If7kcN4t/7vi
 			cfg: ClientConfig{
 				CACerts: pointer.String(pemCaCert[:len(pemCaCert)-30]),
 			},
-			expected: tls.Config{
-				MinVersion: tls.VersionTLS12,
-			},
-			wantErr: true,
+			expected: tls.Config{},
+			wantErr:  true,
 		},
 	}
 
@@ -115,10 +110,6 @@ wSdZWoEx7ye2kUHEyRKdRGbHyJtY9YYvaROznzxqVpIqHxnRQnE/If7kcN4t/7vi
 			if !got.RootCAs.Equal(tc.expected.RootCAs) {
 				t.Fatalf("Got RootCAs are not equal to expected RootCAs")
 			}
-
-			if got.MinVersion != tc.expected.MinVersion {
-				t.Fatalf("want MinVersion %v, got %v", tc.expected.MinVersion, got.MinVersion)
-			}
 		})
 	}
 }
@@ -132,18 +123,6 @@ func WithCerts(pool *x509.CertPool, caCerts string) *x509.CertPool {
 }
 
 func TestGetTLSClientConfigEnv(t *testing.T) {
-	t.Run("defaults to TLS 1.2 when env not set", func(t *testing.T) {
-		t.Setenv(pkgtls.MinVersionEnvKey, "")
-
-		cfg, err := GetTLSClientConfig(NewDefaultClientConfig())
-		if err != nil {
-			t.Fatal("unexpected error:", err)
-		}
-		if cfg.MinVersion != tls.VersionTLS12 {
-			t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
-		}
-	})
-
 	t.Run("uses TLS 1.3 when explicitly set via env", func(t *testing.T) {
 		t.Setenv(pkgtls.MinVersionEnvKey, "1.3")
 
@@ -206,18 +185,6 @@ func TestGetTLSClientConfigEnv(t *testing.T) {
 }
 
 func TestGetTLSServerConfig(t *testing.T) {
-	t.Run("defaults to TLS 1.2 when env not set", func(t *testing.T) {
-		t.Setenv(pkgtls.MinVersionEnvKey, "")
-
-		cfg, err := GetTLSServerConfig(NewDefaultServerConfig())
-		if err != nil {
-			t.Fatal("unexpected error:", err)
-		}
-		if cfg.MinVersion != tls.VersionTLS12 {
-			t.Fatalf("want MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
-		}
-	})
-
 	t.Run("uses TLS 1.3 when explicitly set via env", func(t *testing.T) {
 		t.Setenv(pkgtls.MinVersionEnvKey, "1.3")
 


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

This updates the eventingtls package to use TLS 1.3 as the default minimum version, aligning with the default behavior of `knative.dev/pkg/network/tls`. The fallback to TLS 1.2 and the associated TODO have been removed.

Additionally, tests asserting the default MinVersion have been removed from `pkg/eventingtls` and `cmd/requestreply`, as this configuration is now handled entirely by the underlying `knative.dev/pkg/network/tls` utility.
:broom:

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [x] **Spec PR** for any new API feature
- [x] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

