### PR TITLE
ci: upgrade actions/checkout from v2 to v6 in knative-downstream workflow

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -49,11 +49,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -49,11 +49,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}


### PR DESCRIPTION
Fixes #8987

## Summary

- Replace `actions/checkout@v2` with `actions/checkout@v4` on both checkout steps in `.github/workflows/knative-downstream.yaml`

`actions/checkout@v2` is deprecated and no longer receives security patches. v4 is the current stable release.

## Test plan
- [ ] Workflow syntax is valid YAML
- [ ] Downstream CI jobs run successfully with updated action