### PR TITLE
hack: quote YAML_OUTPUT_DIR in rm command to prevent word-splitting

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -45,7 +45,7 @@ readonly YAML_LIST_FILE=${2:?"Second argument must be the output file"}
 if [[ -z "${YAML_OUTPUT_DIR:-}" ]]; then
   readonly YAML_OUTPUT_DIR="$(mktemp -d)"
 fi
-rm -fr ${YAML_OUTPUT_DIR}/*.yaml
+rm -fr "${YAML_OUTPUT_DIR}"/*.yaml
 
 # Generated Knative component YAML files
 readonly EVENTING_CORE_YAML=${YAML_OUTPUT_DIR}/"eventing-core.yaml"


### PR DESCRIPTION
Fixes #8989

## Summary

- Quote `${YAML_OUTPUT_DIR}` in the `rm -fr` call in `hack/generate-yamls.sh`

Without quotes, a path containing spaces causes word-splitting and may silently delete files in the wrong location.