### PR TITLE
hack: quote dirname substitution and REPO_ROOT_DIR in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -69,7 +69,7 @@ function build_release() {
   ARTIFACTS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
-    cp ${ARTIFACTS_TO_PUBLISH} "${REPO_ROOT_DIR}"
+    cp "${ARTIFACTS_TO_PUBLISH}" "${REPO_ROOT_DIR}"
   fi
 }
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -65,11 +65,11 @@ function build_release() {
   # branch since the detail of building may change over time.
   local YAML_LIST="$(mktemp)"
   export TAG
-  $(dirname $0)/generate-yamls.sh "${REPO_ROOT_DIR}" "${YAML_LIST}"
+  "$(dirname "$0")/generate-yamls.sh" "${REPO_ROOT_DIR}" "${YAML_LIST}"
   ARTIFACTS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
-    cp ${ARTIFACTS_TO_PUBLISH} ${REPO_ROOT_DIR}
+    cp ${ARTIFACTS_TO_PUBLISH} "${REPO_ROOT_DIR}"
   fi
 }
 


### PR DESCRIPTION
Fixes #8991

## Summary

- Quote `$(dirname "$0")` to handle script paths with spaces
- Quote `${REPO_ROOT_DIR}` in the `cp` destination to prevent word-splitting

Unquoted command substitutions and variable expansions break when paths contain whitespace.