### PR TITLE
hack: remove redundant 'set -e' alongside 'set -o errexit'

### DIFF
--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -16,7 +16,6 @@
 
 # This script builds and installs Knative Eventing components from source for local development.
 
-set -e
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/8993

## Summary

- Remove duplicate `set -e` from `hack/create-kind-cluster.sh` and `hack/install.sh`

`set -e` is an exact alias for `set -o errexit`. The long-form option is already present in both scripts; the short form is redundant.