### PR TITLE
hack: remove deprecated export GO111MODULE=on

### DIFF
--- a/hack/e2e-debug.sh
+++ b/hack/e2e-debug.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GO111MODULE=on
-
 source $(dirname "$0")/../test/e2e-common.sh
 
 test_name="$1"

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO111MODULE=on
-
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
 readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,8 +18,6 @@
 
 # shellcheck disable=SC1090
 
-export GO111MODULE=on
-
 source "$(dirname "${BASH_SOURCE[0]}")/../vendor/knative.dev/hack/e2e-tests.sh"
 
 # If gcloud is not available make it a no-op, not an error.


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/8995

## Summary

- Remove `export GO111MODULE=on` from `hack/verify-codegen.sh`, `hack/e2e-debug.sh`, and `test/e2e-common.sh`

`GO111MODULE=on` is ignored on Go 1.21+ and this repo declares `go 1.25.0` in `go.mod`.