### PR TITLE
ci: standardize rtCamp/action-slack-notify to v2.2.1 across workflows

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -139,7 +139,7 @@ jobs:
         fi
 
     - name: Post failure notice to Slack
-      uses: rtCamp/action-slack-notify@v2.2.1
+      uses: rtCamp/action-slack-notify@v2.3.3
       if: ${{ failure() && github.event_name != 'pull_request' }}
       env:
         SLACK_ICON: http://github.com/knative.png?size=48

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -139,7 +139,7 @@ jobs:
         fi
 
     - name: Post failure notice to Slack
-      uses: rtCamp/action-slack-notify@v2.1.0
+      uses: rtCamp/action-slack-notify@v2.2.1
       if: ${{ failure() && github.event_name != 'pull_request' }}
       env:
         SLACK_ICON: http://github.com/knative.png?size=48

--- a/.github/workflows/weekly-office-hours-slack-reminder.yaml
+++ b/.github/workflows/weekly-office-hours-slack-reminder.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
       - name: Post reminder to Slack
         if: steps.check-week.outputs.should_run == 'true'
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.3
         env:
           SLACK_ICON: http://github.com/knative.png?size=48
           SLACK_USERNAME: github-actions


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/8997

## Summary

- Update `rtCamp/action-slack-notify` in `kind-e2e.yaml` from `v2.1.0` to `v2.2.1` to match the version already used in `weekly-office-hours-slack-reminder.yaml`