### PR TITLE
hack: replace fragile awk pipeline with 'go env GOARCH' in install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -30,7 +30,7 @@ fi
 export SCALE_CHAOSDUCK_TO_ZERO=1
 export REPLICAS=1
 
-KO_ARCH=$(go env | grep GOARCH | awk -F\' '{print $2}')
+KO_ARCH=$(go env GOARCH)
 
 export KO_FLAGS=${KO_FLAGS:-"--platform=linux/$KO_ARCH"}
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/8999

## Summary

- Replace `go env | grep GOARCH | awk -F\'' '{print $2}'` with `$(go env GOARCH)` in `hack/install.sh`

`go env GOARCH` is the canonical, documented way to read a single Go environment variable.