### PR TITLE
hack: remove redundant exit-code check after go run in install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -22,10 +22,6 @@ set -o nounset
 set -o pipefail
 
 go run "$(dirname "$0")/../test/version_check/check_k8s_version.go"
-if [[ $? -ne 0 ]]; then
-    echo "Kubernetes version check failed. Exiting."
-    exit 1
-fi
 
 export SCALE_CHAOSDUCK_TO_ZERO=1
 export REPLICAS=1


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/9001

## Summary

- Remove the `if [[ $? -ne 0 ]]` block after `go run` in `hack/install.sh`

`set -o errexit` is already active; the manual check is dead code.