### PR TITLE
hack: quote REPO_ROOT_DIR inside mktemp call in verify-codegen.sh

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -22,7 +22,7 @@ export GO111MODULE=on
 
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
-readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+readonly TMP_DIFFROOT="$(mktemp -d "${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX")"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/9003

## Summary

- Add quotes around `${REPO_ROOT_DIR}` in the `mktemp` call in `hack/verify-codegen.sh` to handle repo paths containing spaces.