### PR TITLE
test: update KAIL_VERSION from v0.16.1 to v0.17.4

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -74,7 +74,7 @@ readonly LATEST_RELEASE_VERSION=$(latest_version)
 
 readonly SKIP_UPLOAD_TEST_IMAGES="${SKIP_UPLOAD_TEST_IMAGES:-}"
 
-readonly KAIL_VERSION=v0.16.1
+readonly KAIL_VERSION=v0.17.4
 
 UNINSTALL_LIST=()
 


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/9005

## Summary

- Bump `KAIL_VERSION` in `test/e2e-common.sh` from `v0.16.1` to `v0.17.4` (latest upstream release)