### PR TITLE
fix(adapter): start pprof server when profiling is enabled

### DIFF
--- a/pkg/adapter/v2/main.go
+++ b/pkg/adapter/v2/main.go
@@ -18,6 +18,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -284,11 +285,20 @@ func MainWithInformers(ctx context.Context, component string, env EnvConfigAcces
 		}()
 	}
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := pprof.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Warnw("Profiling server shut down", zap.Error(err))
+		}
+	}()
+
 	// Finally start the adapter (blocking)
 	if err := adapter.Start(ctx); err != nil {
 		logger.Fatalw("Start returned an error", zap.Error(err))
 	}
 
+	_ = pprof.Shutdown(context.Background())
 	wg.Wait()
 }
 


### PR DESCRIPTION
Fixes #9007

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
The eventing adapter framework creates and configures a ProfilingServer but never calls ListenAndServe, so the profiling port is never bound even when runtime-profiling is set to enabled in the observability ConfigMap. Start the server conditionally based on the initial config, consistent with the adapter's static observability config model.


### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature
- [ ] **Conformance test** for any change to the spec

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Profiling via the observability ConfigMap (`runtime-profiling: enabled`) now works correctly for components using the eventing adapter framework. Previously the profiling server was never started and port 8008 was never bound, making pprof endpoints unreachable.

```


**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->


**Testing**
My testing might have been limited to the use-case I was trying when I first ran into the original issue.
Covered three test scenarios:
1. Nothing happens when config-observability has profiling disabled
2. Enable profiling in the cm - able to access the profiling endpoints on port 8008.
3. Enable profiling in the cm and explicitly set env on my deployment `PROFILING_PORT=8090` - able to access the profiling endpoints on port 8090.