### PR TITLE
Move GetLoggingConfig from cmd/broker to pkg/utils

### DIFF
--- a/cmd/auth_proxy/main.go
+++ b/cmd/auth_proxy/main.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
-	cmdbroker "knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
 	eventingclient "knative.dev/eventing/pkg/client/clientset/versioned"
@@ -51,6 +50,7 @@ import (
 	eventingv1alpha1listers "knative.dev/eventing/pkg/client/listers/eventing/v1alpha1"
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	filteredFactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
@@ -189,7 +189,7 @@ func setupInformers(ctx context.Context) (context.Context, []controller.Informer
 
 // setupLogging initializes logging configuration and returns the logger
 func setupLogging(ctx context.Context, cmw *configmap.InformedWatcher) *zap.SugaredLogger {
-	loggingConfig, err := cmdbroker.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
+	loggingConfig, err := utils.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
 	if err != nil {
 		log.Fatal("Error loading/parsing logging configuration:", err)
 	}

--- a/cmd/broker/filter/main.go
+++ b/cmd/broker/filter/main.go
@@ -38,7 +38,6 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 
-	"knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
 	"knative.dev/eventing/pkg/broker/filter"
@@ -50,6 +49,7 @@ import (
 	"knative.dev/eventing/pkg/eventingtls"
 	"knative.dev/eventing/pkg/eventtype"
 	o11yconfigmap "knative.dev/eventing/pkg/observability/configmap"
+	"knative.dev/eventing/pkg/utils"
 )
 
 const (
@@ -90,7 +90,7 @@ func main() {
 	ctx = injection.WithConfig(ctx, cfg)
 	kubeClient := kubeclient.Get(ctx)
 
-	loggingConfig, err := broker.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
+	loggingConfig, err := utils.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
 	if err != nil {
 		log.Fatal("Error loading/parsing logging configuration:", err)
 	}

--- a/cmd/broker/ingress/main.go
+++ b/cmd/broker/ingress/main.go
@@ -38,7 +38,6 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 
-	cmdbroker "knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/auth"
 	"knative.dev/eventing/pkg/broker"
@@ -51,6 +50,7 @@ import (
 	"knative.dev/eventing/pkg/eventtype"
 	o11yconfigmap "knative.dev/eventing/pkg/observability/configmap"
 	"knative.dev/eventing/pkg/observability/otel"
+	"knative.dev/eventing/pkg/utils"
 )
 
 // TODO make these constants configurable (either as env variables, config map, or part of broker spec).
@@ -104,7 +104,7 @@ func main() {
 
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 	ctx = injection.WithConfig(ctx, cfg)
-	loggingConfig, err := cmdbroker.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
+	loggingConfig, err := utils.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
 	if err != nil {
 		log.Fatal("Error loading/parsing logging configuration:", err)
 	}

--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -54,7 +54,6 @@ import (
 
 	"knative.dev/pkg/signals"
 
-	cmdbroker "knative.dev/eventing/cmd/broker"
 	"knative.dev/eventing/pkg/apis/feature"
 	"knative.dev/eventing/pkg/apis/sinks"
 	sinksv "knative.dev/eventing/pkg/apis/sinks/v1alpha1"
@@ -93,7 +92,7 @@ func main() {
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 	ctx = injection.WithConfig(ctx, cfg)
 
-	loggingConfig, err := cmdbroker.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
+	loggingConfig, err := utils.GetLoggingConfig(ctx, system.Namespace(), logging.ConfigMapName())
 	if err != nil {
 		log.Fatal("Error loading/parsing logging configuration:", err)
 	}

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package broker
+package utils
 
 import (
 	"context"
@@ -26,7 +26,9 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// GetLoggingConfig will get config from a specific namespace
+// GetLoggingConfig fetches the logging ConfigMap from the given namespace and
+// parses it into a *logging.Config. If the ConfigMap is not found, it returns
+// the default logging config.
 func GetLoggingConfig(ctx context.Context, namespace, loggingConfigMapName string) (*logging.Config, error) {
 	loggingConfigMap, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(namespace).Get(ctx, loggingConfigMapName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Summary

- Move `GetLoggingConfig` out of package `broker` (`cmd/broker/config.go`) and into `pkg/utils` (`pkg/utils/logging.go`), where the other small cross-cutting helpers already live.
- Update the four call sites (`cmd/broker/filter`, `cmd/broker/ingress`, `cmd/jobsink`, `cmd/auth_proxy`) to import `pkg/utils` instead of `cmd/broker`. `cmd/jobsink` and `cmd/auth_proxy` were importing `cmd/broker` solely for this helper.
- Delete the now-empty `cmd/broker` package.

No behavior change — this is a pure code-organization refactor.

Fixes #8712

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./pkg/utils/...`
- [x] `go test ./cmd/... ./pkg/utils/...`
- [x] `grep` confirms no remaining references to `cmdbroker` or `knative.dev/eventing/cmd/broker"` anywhere in the repo