### PR TITLE
[test] don't pass the t's logger to the adapter

### DIFF
--- a/pkg/adapter/apiserver/adapter_test.go
+++ b/pkg/adapter/apiserver/adapter_test.go
@@ -350,7 +350,7 @@ func TestAdapter_FailFast(t *testing.T) {
 			}
 
 			ctx, _ := pkgtesting.SetupFakeContext(t)
-			logger := logging.FromContext(ctx).Named("adapter-test")
+			logger := zap.NewNop().Sugar()
 
 			a := &apiServerAdapter{
 				ce:     ce,


### PR DESCRIPTION
fixing a data race, as seen e.g. in https://prow.knative.dev/view/gcs/knative-prow/logs/continuous_eventing_main_periodic/2042044786172497920

don't tie the test context's logger to the adapter. The failFast adapter `Start` by design terminates as soon as the first watch failure occurs, so it doesn't wait for the other watches to stop. The `a.logger.Error("reflector exited: %v", err)` may then be invoked on the test logger _after_ the test has already finished, thus causing a "data race"