### PR TITLE
hack: fix unquoted variables in hack scripts to prevent word-splitting

### DIFF
--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -49,11 +49,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@v6
+      uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@v6
+      uses: actions/checkout@v2
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -49,11 +49,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -45,7 +45,7 @@ readonly YAML_LIST_FILE=${2:?"Second argument must be the output file"}
 if [[ -z "${YAML_OUTPUT_DIR:-}" ]]; then
   readonly YAML_OUTPUT_DIR="$(mktemp -d)"
 fi
-rm -fr ${YAML_OUTPUT_DIR}/*.yaml
+rm -fr "${YAML_OUTPUT_DIR}"/*.yaml
 
 # Generated Knative component YAML files
 readonly EVENTING_CORE_YAML=${YAML_OUTPUT_DIR}/"eventing-core.yaml"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -66,10 +66,11 @@ function build_release() {
   local YAML_LIST="$(mktemp)"
   export TAG
   "$(dirname "$0")/generate-yamls.sh" "${REPO_ROOT_DIR}" "${YAML_LIST}"
-  ARTIFACTS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
+  mapfile -t artifacts < "${YAML_LIST}"
+  ARTIFACTS_TO_PUBLISH="${artifacts[*]}"
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
-    cp "${ARTIFACTS_TO_PUBLISH}" "${REPO_ROOT_DIR}"
+    cp "${artifacts[@]}" "${REPO_ROOT_DIR}"
   fi
 }
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -65,12 +65,12 @@ function build_release() {
   # branch since the detail of building may change over time.
   local YAML_LIST="$(mktemp)"
   export TAG
-  $(dirname $0)/generate-yamls.sh "${REPO_ROOT_DIR}" "${YAML_LIST}"
+  "$(dirname "$0")/generate-yamls.sh" "${REPO_ROOT_DIR}" "${YAML_LIST}"
   ARTIFACTS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
-    cp ${ARTIFACTS_TO_PUBLISH} ${REPO_ROOT_DIR}
+    cp "${ARTIFACTS_TO_PUBLISH}" "${REPO_ROOT_DIR}"
   fi
 }
 
-main $@
+main "$@"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -67,7 +67,6 @@ function build_release() {
   export TAG
   "$(dirname "$0")/generate-yamls.sh" "${REPO_ROOT_DIR}" "${YAML_LIST}"
   mapfile -t artifacts < "${YAML_LIST}"
-  ARTIFACTS_TO_PUBLISH="${artifacts[*]}"
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
     cp "${artifacts[@]}" "${REPO_ROOT_DIR}"

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -22,7 +22,7 @@ export GO111MODULE=on
 
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
-readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+readonly TMP_DIFFROOT="$(mktemp -d "${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX")"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"


### PR DESCRIPTION
Combines #8990, #8992, and #9004 into a single PR as requested by @creydr.

Also fixes `main $@` → `main "$@"` in `release.sh` spotted during review.

## Changes

- **`generate-yamls.sh`**: Quote `${YAML_OUTPUT_DIR}` in `rm` command
- **`release.sh`**: Quote `$(dirname $0)` invocation, `${REPO_ROOT_DIR}` in `cp`, and `$@` in `main` call
- **`verify-codegen.sh`**: Quote `${REPO_ROOT_DIR}` inside `mktemp` call

Unquoted variable expansions and command substitutions break when paths contain whitespace.

Closes #8990
Closes #8992
Closes #9004