### PR TITLE
Wait in adapter for goroutines before returning in startFailFast

### DIFF
--- a/pkg/adapter/apiserver/adapter.go
+++ b/pkg/adapter/apiserver/adapter.go
@@ -182,11 +182,14 @@ func (a *apiServerAdapter) startFailFast(ctx context.Context, stopCh <-chan stru
 	select {
 	case err := <-errorChan:
 		if err != nil {
+			cancelWatchers()
+			wg.Wait()
 			a.logger.Errorf("ApiServerSource failed: %v", err)
 			return err
 		}
 	case <-stopCh:
 		cancelWatchers()
+		wg.Wait()
 		return nil
 	}
 


### PR DESCRIPTION
Fixes data race in `TestAdapter_FailFast` where spawned goroutines continued running after the function returned, attempting to log to a test context that was being cleaned up.

Race seen [here](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_eventing/9025/unit-tests_eventing_main/2045131256760373248) and [here](https://github.com/knative/eventing/actions/runs/24229007056/job/72075333061?pr=9015)