### PR TITLE
Add dependabot config for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      # Following actions aren't versioned
+      - dependency-name: "chainguard-dev/actions/*"
+      - dependency-name: "knative/actions/*"


### PR DESCRIPTION
Closes #9034

## Summary

- Adds `.github/dependabot.yml` to enable automatic weekly bumps of GitHub Actions versions
- Addresses the missing automation noted in #8998 — previously no dependabot config existed for `github-actions` ecosystem

## Test plan

- [ ] Verify dependabot opens PRs for outdated actions after merge