### PR TITLE
Add klog-verbosity flag to config-logging ConfigMap

### DIFF
--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -50,3 +50,8 @@ data:
   # For all components changes are be picked up immediately.
   loglevel.controller: "info"
   loglevel.webhook: "info"
+
+  # klog verbosity level for Kubernetes client-go internals (0-9).
+  # 0 = disabled (default). Higher values produce more verbose output.
+  # Changes are picked up immediately by adapters using ConfigMap-based logging.
+  klog-verbosity: "0"

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	k8s.io/apiserver v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/code-generator v0.35.4
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	knative.dev/hack v0.0.0-20260416140237-504af4d2178f
 	knative.dev/hack/schema v0.0.0-20260416140237-504af4d2178f
@@ -150,7 +151,7 @@ require (
 	k8s.io/gengo v0.0.0-20240404160639-a0386bf69313 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog v1.0.0 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
+
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,6 @@ require (
 	k8s.io/gengo v0.0.0-20240404160639-a0386bf69313 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog v1.0.0 // indirect
-
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -163,7 +163,7 @@ func (e *EnvConfig) GetLogger() *zap.SugaredLogger {
 
 		logger, _ := logging.NewLoggerFromConfig(loggingConfig, e.Component)
 
-		if err := pkgutils.SetKlogVerbosityFromConfigMap(map[string]string{
+		if _, err := pkgutils.SetKlogVerbosityFromConfigMap(map[string]string{
 			pkgutils.KlogVerbosityKey: e.KlogVerbosity,
 		}); err != nil {
 			logger.Warnw("Failed to set klog verbosity", zap.Error(err))

--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -163,9 +163,7 @@ func (e *EnvConfig) GetLogger() *zap.SugaredLogger {
 
 		logger, _ := logging.NewLoggerFromConfig(loggingConfig, e.Component)
 
-		if _, err := pkgutils.SetKlogVerbosityFromConfigMap(map[string]string{
-			pkgutils.KlogVerbosityKey: e.KlogVerbosity,
-		}); err != nil {
+		if _, err := pkgutils.SetKlogVerbosity(e.KlogVerbosity); err != nil {
 			logger.Warnw("Failed to set klog verbosity", zap.Error(err))
 		}
 

--- a/pkg/adapter/v2/config.go
+++ b/pkg/adapter/v2/config.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"knative.dev/eventing/pkg/observability"
+	pkgutils "knative.dev/eventing/pkg/utils"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	kle "knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
@@ -47,6 +48,7 @@ const (
 	EnvConfigObservabilityConfig  = "K_OBSERVABILITY_CONFIG"
 	EnvConfigLeaderElectionConfig = "K_LEADER_ELECTION_CONFIG"
 	EnvSinkTimeout                = "K_SINK_TIMEOUT"
+	EnvConfigKlogVerbosity        = "K_KLOG_VERBOSITY"
 )
 
 // EnvConfig is the minimal set of configuration parameters
@@ -85,6 +87,9 @@ type EnvConfig struct {
 	// This is used to configure the logging config, the config is stored in
 	// a config map inside the controllers namespace and copied here.
 	LoggingConfigJson string `envconfig:"K_LOGGING_CONFIG" default:"{}"`
+
+	// KlogVerbosity is the klog verbosity level (0-9). Injected from config-logging ConfigMap.
+	KlogVerbosity string `envconfig:"K_KLOG_VERBOSITY" default:"0"`
 
 	// ObservabilityConfigJson is a json string of observability.Config.
 	// This is used to configure the observability config, the config is stored in
@@ -157,6 +162,13 @@ func (e *EnvConfig) GetLogger() *zap.SugaredLogger {
 		}
 
 		logger, _ := logging.NewLoggerFromConfig(loggingConfig, e.Component)
+
+		if err := pkgutils.SetKlogVerbosityFromConfigMap(map[string]string{
+			pkgutils.KlogVerbosityKey: e.KlogVerbosity,
+		}); err != nil {
+			logger.Warnw("Failed to set klog verbosity", zap.Error(err))
+		}
+
 		e.logger = logger
 	}
 	return e.logger

--- a/pkg/adapter/v2/configurator_configmap.go
+++ b/pkg/adapter/v2/configurator_configmap.go
@@ -98,7 +98,7 @@ func (c *loggerConfiguratorFromConfigMap) CreateLogger(ctx context.Context) *zap
 	logger, atomicLevel := SetupLoggerFromConfig(lc, c.component)
 
 	if lcm != nil {
-		if err := utils.SetKlogVerbosityFromConfigMap(lcm.Data); err != nil {
+		if _, err := utils.SetKlogVerbosityFromConfigMap(lcm.Data); err != nil {
 			logger.Warnw("Failed to set initial klog verbosity", zap.Error(err))
 		}
 	}

--- a/pkg/adapter/v2/configurator_configmap.go
+++ b/pkg/adapter/v2/configurator_configmap.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/eventing/pkg/observability"
 	o11yconfigmap "knative.dev/eventing/pkg/observability/configmap"
 	"knative.dev/eventing/pkg/observability/otel"
+	"knative.dev/eventing/pkg/utils"
 )
 
 // loggerConfiguratorFromConfigMap dynamically
@@ -96,10 +97,17 @@ func (c *loggerConfiguratorFromConfigMap) CreateLogger(ctx context.Context) *zap
 
 	logger, atomicLevel := SetupLoggerFromConfig(lc, c.component)
 
+	if lcm != nil {
+		if err := utils.SetKlogVerbosityFromConfigMap(lcm.Data); err != nil {
+			logger.Warnw("Failed to set initial klog verbosity", zap.Error(err))
+		}
+	}
+
 	logger.Infof("Adding Watcher on ConfigMap %s for logs", c.configMapName)
 
 	cmw := ConfigWatcherFromContext(ctx)
 	cmw.Watch(c.configMapName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, c.component))
+	cmw.Watch(c.configMapName, utils.UpdateKlogVerbosityFromConfigMap(logger))
 
 	return logger
 }

--- a/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/apiserversource/resources/receive_adapter_test.go
@@ -176,6 +176,9 @@ O2dgzikq8iSy1BlRsVw=
 									Name:  source.EnvLoggingCfg,
 									Value: "",
 								}, {
+									Name:  source.EnvKlogVerbosity,
+									Value: "",
+								}, {
 									Name:  source.EnvObservabilityCfg,
 									Value: "",
 								},

--- a/pkg/reconciler/pingsource/resources/receive_adapter_test.go
+++ b/pkg/reconciler/pingsource/resources/receive_adapter_test.go
@@ -62,6 +62,9 @@ func TestMakePingAdapter(t *testing.T) {
 		Name:  "K_LOGGING_CONFIG",
 		Value: "",
 	}, {
+		Name:  "K_KLOG_VERBOSITY",
+		Value: "",
+	}, {
 		Name:  "K_OBSERVABILITY_CONFIG",
 		Value: "",
 	},

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -136,10 +136,6 @@ func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
 	cw.loggingCfg = loggingCfg
 	cw.klogVerbosity = cfg.Data[pkgutils.KlogVerbosityKey]
 
-	if _, err := pkgutils.SetKlogVerbosityFromConfigMap(cfg.Data); err != nil {
-		cw.logger.Warnw("failed to apply klog verbosity", zap.Error(err))
-	}
-
 	cw.logger.Debugw("Updated logging config from ConfigMap", zap.Any("ConfigMap", cfg))
 }
 

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -29,6 +29,7 @@ import (
 
 	"knative.dev/eventing/pkg/observability"
 	o11yconfigmap "knative.dev/eventing/pkg/observability/configmap"
+	pkgutils "knative.dev/eventing/pkg/utils"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 )
@@ -36,6 +37,7 @@ import (
 const (
 	EnvLoggingCfg       = "K_LOGGING_CONFIG"
 	EnvObservabilityCfg = "K_OBSERVABILITY_CONFIG"
+	EnvKlogVerbosity    = "K_KLOG_VERBOSITY"
 )
 
 type ConfigAccessor interface {
@@ -56,6 +58,8 @@ type ConfigWatcher struct {
 	// configurations remain nil if disabled
 	loggingCfg       *logging.Config
 	observabilityCfg *observability.Config
+
+	klogVerbosity string
 }
 
 // configWatcherOption is a function option for ConfigWatchers.
@@ -130,6 +134,7 @@ func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
 	}
 
 	cw.loggingCfg = loggingCfg
+	cw.klogVerbosity = cfg.Data[pkgutils.KlogVerbosityKey]
 
 	cw.logger.Debugw("Updated logging config from ConfigMap", zap.Any("ConfigMap", cfg))
 }
@@ -164,6 +169,7 @@ func (cw *ConfigWatcher) ToEnvVars() []corev1.EnvVar {
 	envs := make([]corev1.EnvVar, 0, 3)
 
 	envs = maybeAppendEnvVar(envs, cw.loggingConfigEnvVar(), cw.LoggingConfig() != nil)
+	envs = maybeAppendEnvVar(envs, cw.klogVerbosityEnvVar(), cw.LoggingConfig() != nil)
 	envs = maybeAppendEnvVar(envs, cw.observabilityConfigEnvVar(), cw.ObservabilityConfig() != nil)
 
 	return envs
@@ -203,6 +209,17 @@ func (cw *ConfigWatcher) loggingConfigEnvVar() corev1.EnvVar {
 	return corev1.EnvVar{
 		Name:  EnvLoggingCfg,
 		Value: cfg,
+	}
+}
+
+func (cw *ConfigWatcher) klogVerbosityEnvVar() corev1.EnvVar {
+	level := cw.klogVerbosity
+	if level == "" {
+		level = "0"
+	}
+	return corev1.EnvVar{
+		Name:  EnvKlogVerbosity,
+		Value: level,
 	}
 }
 
@@ -254,6 +271,7 @@ var _ ConfigAccessor = (*EmptyVarsGenerator)(nil)
 func (g *EmptyVarsGenerator) ToEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{Name: EnvLoggingCfg},
+		{Name: EnvKlogVerbosity},
 		{Name: EnvObservabilityCfg},
 	}
 }

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -136,6 +136,10 @@ func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
 	cw.loggingCfg = loggingCfg
 	cw.klogVerbosity = cfg.Data[pkgutils.KlogVerbosityKey]
 
+	if err := pkgutils.SetKlogVerbosityFromConfigMap(cfg.Data); err != nil {
+		cw.logger.Warnw("failed to apply klog verbosity", zap.Error(err))
+	}
+
 	cw.logger.Debugw("Updated logging config from ConfigMap", zap.Any("ConfigMap", cfg))
 }
 

--- a/pkg/reconciler/source/config_watcher.go
+++ b/pkg/reconciler/source/config_watcher.go
@@ -136,7 +136,7 @@ func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
 	cw.loggingCfg = loggingCfg
 	cw.klogVerbosity = cfg.Data[pkgutils.KlogVerbosityKey]
 
-	if err := pkgutils.SetKlogVerbosityFromConfigMap(cfg.Data); err != nil {
+	if _, err := pkgutils.SetKlogVerbosityFromConfigMap(cfg.Data); err != nil {
 		cw.logger.Warnw("failed to apply klog verbosity", zap.Error(err))
 	}
 

--- a/pkg/reconciler/source/config_watcher_test.go
+++ b/pkg/reconciler/source/config_watcher_test.go
@@ -62,12 +62,13 @@ func TestNewConfigWatcher_defaults(t *testing.T) {
 
 			envs := cw.ToEnvVars()
 
-			const expectEnvs = 2
+			const expectEnvs = 3
 			require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
 
 			assert.Equal(t, EnvLoggingCfg, envs[0].Name, "first env var is logging config")
 			assert.Contains(t, envs[0].Value, tc.expectLoggingContains)
-			assert.Contains(t, envs[1].Value, tc.expectObservabilityContains)
+			assert.Equal(t, EnvKlogVerbosity, envs[1].Name, "second env var is klog verbosity")
+			assert.Contains(t, envs[2].Value, tc.expectObservabilityContains)
 		})
 	}
 }
@@ -87,7 +88,7 @@ func TestLoggingConfigWithCustomLoggingLevel(t *testing.T) {
 func TestEmptyVarsGenerator(t *testing.T) {
 	g := &EmptyVarsGenerator{}
 	envs := g.ToEnvVars()
-	const expectEnvs = 2
+	const expectEnvs = 3
 	require.Lenf(t, envs, expectEnvs, "there should be %d env var(s)", expectEnvs)
 }
 

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -61,35 +61,38 @@ var (
 )
 
 // SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
-// applies it to klog. Missing or empty values are no-ops; "0" resets verbosity.
-// Valid range is 0–9.
-func SetKlogVerbosityFromConfigMap(data map[string]string) error {
+// applies it to klog. Missing, empty, or "0" values are no-ops and return
+// (false, nil). A level in the range 1–9 is applied and returns (true, nil).
+func SetKlogVerbosityFromConfigMap(data map[string]string) (bool, error) {
 	level, ok := data[KlogVerbosityKey]
-	if !ok || level == "" {
-		return nil
+	if !ok || level == "" || level == "0" {
+		return false, nil
 	}
 
 	n, err := strconv.Atoi(level)
 	if err != nil || n < 0 || n > 9 {
-		return fmt.Errorf("invalid %s value %q: must be an integer between 0 and 9", KlogVerbosityKey, level)
+		return false, fmt.Errorf("invalid %s value %q: must be an integer between 0 and 9", KlogVerbosityKey, level)
 	}
 
 	klogMu.Lock()
 	defer klogMu.Unlock()
-	return klogFlagSet.Set("v", level)
+	if err := klogFlagSet.Set("v", level); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // UpdateKlogVerbosityFromConfigMap returns a ConfigMap watch handler that updates
 // klog verbosity when the config-logging ConfigMap changes.
 func UpdateKlogVerbosityFromConfigMap(logger *zap.SugaredLogger) func(*corev1.ConfigMap) {
 	return func(cm *corev1.ConfigMap) {
-		level := cm.Data[KlogVerbosityKey]
-		if err := SetKlogVerbosityFromConfigMap(cm.Data); err != nil {
+		applied, err := SetKlogVerbosityFromConfigMap(cm.Data)
+		if err != nil {
 			logger.Warnw("Failed to update klog verbosity", zap.Error(err))
 			return
 		}
-		if level != "" && level != "0" {
-			logger.Infow("Updated klog verbosity", zap.String("level", level))
+		if applied {
+			logger.Infow("Updated klog verbosity", zap.String("level", cm.Data[KlogVerbosityKey]))
 		}
 	}
 }

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,18 +50,22 @@ func GetLoggingConfig(ctx context.Context, namespace, loggingConfigMapName strin
 }
 
 // klogFlagSet is initialized once at package load; reused on every verbosity update.
-var klogFlagSet = func() *flag.FlagSet {
-	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
-	klog.InitFlags(fs)
-	return fs
-}()
+// klogMu guards all writes to klogFlagSet — flag.FlagSet.Set is not goroutine-safe.
+var (
+	klogFlagSet = func() *flag.FlagSet {
+		fs := flag.NewFlagSet("klog", flag.ContinueOnError)
+		klog.InitFlags(fs)
+		return fs
+	}()
+	klogMu sync.Mutex
+)
 
 // SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
-// applies it to klog. Missing, empty, or "0" values are no-ops.
+// applies it to klog. Missing or empty values are no-ops; "0" resets verbosity.
 // Valid range is 0–9.
 func SetKlogVerbosityFromConfigMap(data map[string]string) error {
 	level, ok := data[KlogVerbosityKey]
-	if !ok || level == "0" || level == "" {
+	if !ok || level == "" {
 		return nil
 	}
 
@@ -69,6 +74,8 @@ func SetKlogVerbosityFromConfigMap(data map[string]string) error {
 		return fmt.Errorf("invalid %s value %q: must be an integer between 0 and 9", KlogVerbosityKey, level)
 	}
 
+	klogMu.Lock()
+	defer klogMu.Unlock()
 	return klogFlagSet.Set("v", level)
 }
 

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -18,13 +18,22 @@ package utils
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
+	"go.uber.org/zap"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 )
+
+// KlogVerbosityKey is the key in config-logging ConfigMap for klog verbosity level.
+const KlogVerbosityKey = "klog-verbosity"
 
 // GetLoggingConfig fetches the logging ConfigMap from the given namespace and
 // parses it into a *logging.Config. If the ConfigMap is not found, it returns
@@ -37,4 +46,35 @@ func GetLoggingConfig(ctx context.Context, namespace, loggingConfigMapName strin
 		return nil, err
 	}
 	return logging.NewConfigFromConfigMap(loggingConfigMap)
+}
+
+// SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
+// applies it to klog. Missing or "0" values are no-ops.
+func SetKlogVerbosityFromConfigMap(data map[string]string) error {
+	level, ok := data[KlogVerbosityKey]
+	if !ok || level == "0" || level == "" {
+		return nil
+	}
+
+	if _, err := strconv.Atoi(level); err != nil {
+		return fmt.Errorf("invalid %s value %q: must be an integer", KlogVerbosityKey, level)
+	}
+
+	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	return fs.Set("v", level)
+}
+
+// UpdateKlogVerbosityFromConfigMap returns a ConfigMap watch handler that updates
+// klog verbosity when the config-logging ConfigMap changes.
+func UpdateKlogVerbosityFromConfigMap(logger *zap.SugaredLogger) func(*corev1.ConfigMap) {
+	return func(cm *corev1.ConfigMap) {
+		if err := SetKlogVerbosityFromConfigMap(cm.Data); err != nil {
+			logger.Warnw("Failed to update klog verbosity", zap.Error(err))
+			return
+		}
+		if level, ok := cm.Data[KlogVerbosityKey]; ok {
+			logger.Infow("Updated klog verbosity", zap.String("level", level))
+		}
+	}
 }

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -48,32 +48,40 @@ func GetLoggingConfig(ctx context.Context, namespace, loggingConfigMapName strin
 	return logging.NewConfigFromConfigMap(loggingConfigMap)
 }
 
+// klogFlagSet is initialized once at package load; reused on every verbosity update.
+var klogFlagSet = func() *flag.FlagSet {
+	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	return fs
+}()
+
 // SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
-// applies it to klog. Missing or "0" values are no-ops.
+// applies it to klog. Missing, empty, or "0" values are no-ops.
+// Valid range is 0–9.
 func SetKlogVerbosityFromConfigMap(data map[string]string) error {
 	level, ok := data[KlogVerbosityKey]
 	if !ok || level == "0" || level == "" {
 		return nil
 	}
 
-	if _, err := strconv.Atoi(level); err != nil {
-		return fmt.Errorf("invalid %s value %q: must be an integer", KlogVerbosityKey, level)
+	n, err := strconv.Atoi(level)
+	if err != nil || n < 0 || n > 9 {
+		return fmt.Errorf("invalid %s value %q: must be an integer between 0 and 9", KlogVerbosityKey, level)
 	}
 
-	fs := flag.NewFlagSet("klog", flag.ContinueOnError)
-	klog.InitFlags(fs)
-	return fs.Set("v", level)
+	return klogFlagSet.Set("v", level)
 }
 
 // UpdateKlogVerbosityFromConfigMap returns a ConfigMap watch handler that updates
 // klog verbosity when the config-logging ConfigMap changes.
 func UpdateKlogVerbosityFromConfigMap(logger *zap.SugaredLogger) func(*corev1.ConfigMap) {
 	return func(cm *corev1.ConfigMap) {
+		level := cm.Data[KlogVerbosityKey]
 		if err := SetKlogVerbosityFromConfigMap(cm.Data); err != nil {
 			logger.Warnw("Failed to update klog verbosity", zap.Error(err))
 			return
 		}
-		if level, ok := cm.Data[KlogVerbosityKey]; ok {
+		if level != "" && level != "0" {
 			logger.Infow("Updated klog verbosity", zap.String("level", level))
 		}
 	}

--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -60,12 +60,11 @@ var (
 	klogMu sync.Mutex
 )
 
-// SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
-// applies it to klog. Missing, empty, or "0" values are no-ops and return
-// (false, nil). A level in the range 1–9 is applied and returns (true, nil).
-func SetKlogVerbosityFromConfigMap(data map[string]string) (bool, error) {
-	level, ok := data[KlogVerbosityKey]
-	if !ok || level == "" || level == "0" {
+// SetKlogVerbosity applies the given verbosity level string directly to klog.
+// An empty string is a no-op and returns (false, nil).
+// "0" resets verbosity and levels 1–9 raise it; both return (true, nil).
+func SetKlogVerbosity(level string) (bool, error) {
+	if level == "" {
 		return false, nil
 	}
 
@@ -80,6 +79,17 @@ func SetKlogVerbosityFromConfigMap(data map[string]string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// SetKlogVerbosityFromConfigMap reads klog-verbosity from the ConfigMap data and
+// applies it to klog. Missing or empty values are no-ops and return (false, nil).
+// "0" resets verbosity and levels 1–9 raise it; both return (true, nil).
+func SetKlogVerbosityFromConfigMap(data map[string]string) (bool, error) {
+	level, ok := data[KlogVerbosityKey]
+	if !ok || level == "" {
+		return false, nil
+	}
+	return SetKlogVerbosity(level)
 }
 
 // UpdateKlogVerbosityFromConfigMap returns a ConfigMap watch handler that updates

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -17,8 +17,53 @@ limitations under the License.
 package utils
 
 import (
+	"sync"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+// logCapture is a minimal zapcore.Core that records log entries for assertions.
+type logCapture struct {
+	mu      sync.Mutex
+	entries []zapcore.Entry
+}
+
+func (c *logCapture) Enabled(zapcore.Level) bool { return true }
+
+func (c *logCapture) With([]zapcore.Field) zapcore.Core { return c }
+
+func (c *logCapture) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(e, c)
+}
+
+func (c *logCapture) Write(e zapcore.Entry, _ []zapcore.Field) error {
+	c.mu.Lock()
+	c.entries = append(c.entries, e)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *logCapture) Sync() error { return nil }
+
+func (c *logCapture) countLevel(l zapcore.Level) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, e := range c.entries {
+		if e.Level == l {
+			n++
+		}
+	}
+	return n
+}
+
+func newCaptureLogger() (*zap.SugaredLogger, *logCapture) {
+	cap := &logCapture{}
+	return zap.New(cap).Sugar(), cap
+}
 
 func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
 	tests := []struct {
@@ -61,6 +106,16 @@ func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
 			data:    map[string]string{KlogVerbosityKey: "3.5"},
 			wantErr: true,
 		},
+		{
+			name:    "out of range level 10",
+			data:    map[string]string{KlogVerbosityKey: "10"},
+			wantErr: true,
+		},
+		{
+			name:    "negative level",
+			data:    map[string]string{KlogVerbosityKey: "-1"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +123,76 @@ func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
 			err := SetKlogVerbosityFromConfigMap(tt.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetKlogVerbosityFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateKlogVerbosityFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]string
+		wantWarn bool
+		wantInfo bool
+	}{
+		{
+			name:     "no key - no log",
+			data:     map[string]string{},
+			wantWarn: false,
+			wantInfo: false,
+		},
+		{
+			name:     "zero value - no log",
+			data:     map[string]string{KlogVerbosityKey: "0"},
+			wantWarn: false,
+			wantInfo: false,
+		},
+		{
+			name:     "empty value - no log",
+			data:     map[string]string{KlogVerbosityKey: ""},
+			wantWarn: false,
+			wantInfo: false,
+		},
+		{
+			name:     "valid level 5 - info logged",
+			data:     map[string]string{KlogVerbosityKey: "5"},
+			wantWarn: false,
+			wantInfo: true,
+		},
+		{
+			name:     "invalid value - warn logged",
+			data:     map[string]string{KlogVerbosityKey: "high"},
+			wantWarn: true,
+			wantInfo: false,
+		},
+		{
+			name:     "out of range - warn logged",
+			data:     map[string]string{KlogVerbosityKey: "10"},
+			wantWarn: true,
+			wantInfo: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, cap := newCaptureLogger()
+			cm := &corev1.ConfigMap{Data: tt.data}
+			UpdateKlogVerbosityFromConfigMap(logger)(cm)
+
+			warnCount := cap.countLevel(zapcore.WarnLevel)
+			infoCount := cap.countLevel(zapcore.InfoLevel)
+
+			if tt.wantWarn && warnCount == 0 {
+				t.Error("expected warn log, got none")
+			}
+			if !tt.wantWarn && warnCount > 0 {
+				t.Errorf("unexpected warn log")
+			}
+			if tt.wantInfo && infoCount == 0 {
+				t.Error("expected info log, got none")
+			}
+			if !tt.wantInfo && infoCount > 0 {
+				t.Errorf("unexpected info log")
 			}
 		})
 	}

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "key absent",
+			data:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name:    "zero value",
+			data:    map[string]string{KlogVerbosityKey: "0"},
+			wantErr: false,
+		},
+		{
+			name:    "empty value",
+			data:    map[string]string{KlogVerbosityKey: ""},
+			wantErr: false,
+		},
+		{
+			name:    "valid level 5",
+			data:    map[string]string{KlogVerbosityKey: "5"},
+			wantErr: false,
+		},
+		{
+			name:    "valid level 9",
+			data:    map[string]string{KlogVerbosityKey: "9"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid non-integer",
+			data:    map[string]string{KlogVerbosityKey: "high"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid float",
+			data:    map[string]string{KlogVerbosityKey: "3.5"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetKlogVerbosityFromConfigMap(tt.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetKlogVerbosityFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -67,62 +67,75 @@ func newCaptureLogger() (*zap.SugaredLogger, *logCapture) {
 
 func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
 	tests := []struct {
-		name    string
-		data    map[string]string
-		wantErr bool
+		name        string
+		data        map[string]string
+		wantApplied bool
+		wantErr     bool
 	}{
 		{
-			name:    "key absent",
-			data:    map[string]string{},
-			wantErr: false,
+			name:        "key absent",
+			data:        map[string]string{},
+			wantApplied: false,
+			wantErr:     false,
 		},
 		{
-			name:    "zero value",
-			data:    map[string]string{KlogVerbosityKey: "0"},
-			wantErr: false,
+			name:        "zero value",
+			data:        map[string]string{KlogVerbosityKey: "0"},
+			wantApplied: false,
+			wantErr:     false,
 		},
 		{
-			name:    "empty value",
-			data:    map[string]string{KlogVerbosityKey: ""},
-			wantErr: false,
+			name:        "empty value",
+			data:        map[string]string{KlogVerbosityKey: ""},
+			wantApplied: false,
+			wantErr:     false,
 		},
 		{
-			name:    "valid level 5",
-			data:    map[string]string{KlogVerbosityKey: "5"},
-			wantErr: false,
+			name:        "valid level 5",
+			data:        map[string]string{KlogVerbosityKey: "5"},
+			wantApplied: true,
+			wantErr:     false,
 		},
 		{
-			name:    "valid level 9",
-			data:    map[string]string{KlogVerbosityKey: "9"},
-			wantErr: false,
+			name:        "valid level 9",
+			data:        map[string]string{KlogVerbosityKey: "9"},
+			wantApplied: true,
+			wantErr:     false,
 		},
 		{
-			name:    "invalid non-integer",
-			data:    map[string]string{KlogVerbosityKey: "high"},
-			wantErr: true,
+			name:        "invalid non-integer",
+			data:        map[string]string{KlogVerbosityKey: "high"},
+			wantApplied: false,
+			wantErr:     true,
 		},
 		{
-			name:    "invalid float",
-			data:    map[string]string{KlogVerbosityKey: "3.5"},
-			wantErr: true,
+			name:        "invalid float",
+			data:        map[string]string{KlogVerbosityKey: "3.5"},
+			wantApplied: false,
+			wantErr:     true,
 		},
 		{
-			name:    "out of range level 10",
-			data:    map[string]string{KlogVerbosityKey: "10"},
-			wantErr: true,
+			name:        "out of range level 10",
+			data:        map[string]string{KlogVerbosityKey: "10"},
+			wantApplied: false,
+			wantErr:     true,
 		},
 		{
-			name:    "negative level",
-			data:    map[string]string{KlogVerbosityKey: "-1"},
-			wantErr: true,
+			name:        "negative level",
+			data:        map[string]string{KlogVerbosityKey: "-1"},
+			wantApplied: false,
+			wantErr:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := SetKlogVerbosityFromConfigMap(tt.data)
+			applied, err := SetKlogVerbosityFromConfigMap(tt.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SetKlogVerbosityFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if applied != tt.wantApplied {
+				t.Errorf("SetKlogVerbosityFromConfigMap() applied = %v, wantApplied %v", applied, tt.wantApplied)
 			}
 		})
 	}

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -81,7 +81,7 @@ func TestSetKlogVerbosityFromConfigMap(t *testing.T) {
 		{
 			name:        "zero value",
 			data:        map[string]string{KlogVerbosityKey: "0"},
-			wantApplied: false,
+			wantApplied: true,
 			wantErr:     false,
 		},
 		{
@@ -155,10 +155,10 @@ func TestUpdateKlogVerbosityFromConfigMap(t *testing.T) {
 			wantInfo: false,
 		},
 		{
-			name:     "zero value - no log",
+			name:     "zero value - info logged",
 			data:     map[string]string{KlogVerbosityKey: "0"},
 			wantWarn: false,
-			wantInfo: false,
+			wantInfo: true,
 		},
 		{
 			name:     "empty value - no log",

--- a/pkg/utils/logging_test.go
+++ b/pkg/utils/logging_test.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // logCapture is a minimal zapcore.Core that records log entries for assertions.

--- a/test/config/configmaps/logging.yaml
+++ b/test/config/configmaps/logging.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
 
 data:
+  klog-verbosity: "0"
   zap-logger-config: |
     {
       "level": "debug",


### PR DESCRIPTION
## Summary

Fixes #8706

- Adds `klog-verbosity` key to `config-logging` ConfigMap (default `"0"`) to control klog verbosity for Kubernetes client-go internals
- ConfigMap-based adapters (e.g. ApiServerSource) apply the level at startup and update it live via the existing ConfigMap watcher
- Env-based adapters read `K_KLOG_VERBOSITY` env var, which can be injected from the ConfigMap
- Parsing/validation logic lives in `pkg/utils/logging.go` with unit tests

## Test plan

- [ ] `go test ./pkg/utils/...` passes (7 new unit tests for valid/invalid/absent values)
- [ ] Deploy ApiServerSource, set `klog-verbosity: "5"` in `config-logging`, confirm klog output at verbosity 5 appears in adapter logs
- [ ] Update ConfigMap live, confirm verbosity changes without pod restart