### PR TITLE
Remove unnecessary conversion webhook from RequestReply CRD

### DIFF
--- a/config/core/resources/requestreply.yaml
+++ b/config/core/resources/requestreply.yaml
@@ -207,10 +207,4 @@ spec:
       - eventing
   scope: Namespaced
   conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing
+    strategy: None


### PR DESCRIPTION
RequestReply only has a single version (`v1alpha1`) and was never registered in the conversion controller, so the webhook's CA bundle was never injected. This caused kube-apiserver to log x509 certificate errors when trying to reach the unconfigured webhook endpoint.