### PR TITLE
fix: restore `ARTIFACTS_TO_PUBLISH` in release.sh to fix nightly releases

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -66,10 +66,10 @@ function build_release() {
   local YAML_LIST="$(mktemp)"
   export TAG
   "$(dirname "$0")/generate-yamls.sh" "${REPO_ROOT_DIR}" "${YAML_LIST}"
-  mapfile -t artifacts < "${YAML_LIST}"
+  ARTIFACTS_TO_PUBLISH="$(cat "${YAML_LIST}" | tr '\n' ' ')"
   if (( ! PUBLISH_RELEASE )); then
     # Copy the generated YAML files to the repo root dir if not publishing.
-    cp "${artifacts[@]}" "${REPO_ROOT_DIR}"
+    cp ${ARTIFACTS_TO_PUBLISH} "${REPO_ROOT_DIR}"
   fi
 }
 


### PR DESCRIPTION
PR #9018 we replaced `ARTIFACTS_TO_PUBLISH` with a local `artifacts` array, but the vendored `knative.dev/hack/release.sh` relies on this global variable for image signing, checksums generation, and artifact publishing. With it unset, sign_release() had no files to process, breaking nightly release jobs.

This should help on the current nightly release failures: https://prow.knative.dev/view/gs/knative-prow/logs/nightly_eventing_main_periodic/2046879002605391872