### PR TITLE
ci: add concurrency settings to cancel redundant workflow runs

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -8,6 +8,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   e2e-tests:

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -18,6 +18,10 @@ on:
   pull_request:
     branches: [ 'main', 'master' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   downstream-knative:


### PR DESCRIPTION
## Summary

- Adds a `concurrency` block to `kind-e2e.yaml` and `knative-downstream.yaml`
- New pushes to a PR cancel any in-progress run for the same ref, avoiding wasted runner-hours on the expensive 3-suite × 2-k8s-version KinD e2e matrix

## Test plan

- [ ] Verify that pushing a second commit to a PR cancels the in-progress run from the first commit in the GitHub Actions UI
