### PR TITLE
ci: add top-level permissions for least-privilege security

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   e2e-tests:

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   downstream-knative:


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to `kind-e2e.yaml` and `knative-downstream.yaml`
- Neither workflow writes to the repo, posts PR comments, or needs a write-scoped `GITHUB_TOKEN`; restricting to read-only follows [GitHub's security hardening recommendations](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-permissions-for-the-github_token) and limits blast radius if a dependency is compromised

## Test plan

- [ ] Confirm both workflows still pass after the permissions change
