### PR TITLE
ci: add explicit timeout-minutes to prevent resource exhaustion

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -13,6 +13,7 @@ jobs:
   e2e-tests:
     name: e2e tests
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -40,6 +40,7 @@ jobs:
             org: knative-extensions
 
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       GOPATH: ${{ github.workspace }}
     steps:


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 120` to the `e2e-tests` job in `kind-e2e.yaml`
- Adds `timeout-minutes: 60` to the `downstream-knative` job in `knative-downstream.yaml`

Without a job-level wall-clock cap, a hung setup or install step can consume runner minutes indefinitely. `kind-e2e.yaml` already limits the test run itself to 90 m via `-timeout=90m` but had no job ceiling; the new cap gives 30 m of headroom for cluster setup and teardown. `knative-downstream.yaml` had no timeout at all.

## Test plan

- [ ] Confirm both workflows complete well within their new caps under normal conditions
