### PR TITLE
ci: add workflow_dispatch for manual reruns

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -3,6 +3,7 @@ name: KinD e2e tests
 on:
   pull_request:
     branches: [ 'main', 'master' ]
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -17,6 +17,7 @@ name: Downstream
 on:
   pull_request:
     branches: [ 'main', 'master' ]
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `kind-e2e.yaml` and `knative-downstream.yaml`
- Allows maintainers to re-trigger the KinD e2e and downstream unit test workflows directly from the GitHub Actions UI without needing a dummy commit, which is useful for investigating flakes

## Test plan

- [ ] Verify the "Run workflow" button appears in the GitHub Actions UI for both workflows after merge
