### PR TITLE
ci: add path filters to skip KinD e2e on unrelated changes

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ 'main', 'master' ]
     paths:
-      - '**.go'
+      - '**/*.go'
       - 'go.mod'
       - 'go.sum'
       - 'config/**'

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -9,6 +9,8 @@ on:
       - 'go.sum'
       - 'config/**'
       - 'test/**'
+      - 'hack/**'
+      - 'third_party/**'
       - '.github/workflows/kind-e2e.yaml'
 
 defaults:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -3,6 +3,13 @@ name: KinD e2e tests
 on:
   pull_request:
     branches: [ 'main', 'master' ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'config/**'
+      - 'test/**'
+      - '.github/workflows/kind-e2e.yaml'
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

- Adds `paths` filters to the `pull_request` trigger in `kind-e2e.yaml`
- The KinD e2e matrix (3 test suites × 2 k8s versions) currently fires on every PR regardless of what changed; restricting it to paths that can actually affect runtime behaviour avoids wasting ~6 parallel runner-hours on documentation or tooling-only PRs

Paths that trigger the workflow:
- `**/*.go` — any Go source change
- `go.mod` / `go.sum` — dependency changes
- `config/**` — Knative config YAMLs
- `test/**` — test helpers and fixtures
- `.github/workflows/kind-e2e.yaml` — the workflow file itself

**Note:** `e2e-tests` is not a required status check on this repo (Prow handles gating via `conformance-tests_eventing_main` etc.), so a skipped run on docs-only PRs does not block merging.

## Test plan

- [ ] Confirm e2e workflow is skipped for a docs-only PR
- [ ] Confirm e2e workflow runs for a PR touching `.go` files

