### PR TITLE
security: pin GitHub Actions to immutable SHA hashes

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,5 +1,8 @@
 name: KinD e2e tests
 
+# Third-party actions use immutable SHAs; Dependabot bumps them weekly
+# (.github/.dependabot.yaml, package-ecosystem: github-actions).
+
 on:
   pull_request:
     branches: [ 'main', 'master' ]
@@ -60,10 +63,10 @@ jobs:
 
     # Install the latest release of ko
     - name: Install ko
-      uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
+      uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # ko-build/setup-ko@v0.9 — https://github.com/ko-build/setup-ko/releases/tag/v0.9
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6 — https://github.com/actions/checkout/releases/tag/v6
 
     - name: Install KinD
       # TODO: replace with chainguard-dev/actions/setup-kind
@@ -147,7 +150,7 @@ jobs:
         fi
 
     - name: Post failure notice to Slack
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # rtCamp/action-slack-notify@v2.3.3 — https://github.com/rtCamp/action-slack-notify/releases/tag/v2.3.3
       if: ${{ failure() && github.event_name != 'pull_request' }}
       env:
         SLACK_ICON: https://github.com/knative.png?size=48

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -60,10 +60,10 @@ jobs:
 
     # Install the latest release of ko
     - name: Install ko
-      uses: ko-build/setup-ko@v0.9
+      uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install KinD
       # TODO: replace with chainguard-dev/actions/setup-kind
@@ -147,7 +147,7 @@ jobs:
         fi
 
     - name: Post failure notice to Slack
-      uses: rtCamp/action-slack-notify@v2.3.3
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       if: ${{ failure() && github.event_name != 'pull_request' }}
       env:
         SLACK_ICON: https://github.com/knative.png?size=48

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -14,6 +14,9 @@
 
 name: Downstream
 
+# actions/checkout is pinned to an immutable SHA; Dependabot bumps it weekly
+# (.github/.dependabot.yaml, package-ecosystem: github-actions).
+
 on:
   pull_request:
     branches: [ 'main', 'master' ]
@@ -57,11 +60,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6 — https://github.com/actions/checkout/releases/tag/v6
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6 — https://github.com/actions/checkout/releases/tag/v6
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}

--- a/.github/workflows/knative-downstream.yaml
+++ b/.github/workflows/knative-downstream.yaml
@@ -57,11 +57,11 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - name: Checkout Upstream
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         path: ./src/knative.dev/${{ github.event.repository.name }}
     - name: Checkout Downstream
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ matrix.org }}/${{ matrix.repo }}
         path: ./src/knative.dev/${{ matrix.repo }}


### PR DESCRIPTION
## Summary

Mutable tags (`v0.9`, `v2.1.0`, `v4`, `v6`) can be silently moved to a different commit, making CI vulnerable to supply-chain attacks. Pinning third-party actions to their exact commit SHA ensures the code that ran during review is the code that runs in production.

**Pinned in `kind-e2e.yaml`:**
| Action | Tag | Commit SHA |
|---|---|---|
| `ko-build/setup-ko` | `v0.9` | `d006021b` |
| `actions/checkout` | `v4` | `34e11487` |
| `rtCamp/action-slack-notify` | `v2.1.0` | `e17352fe` |

**Pinned in `knative-downstream.yaml`:**
| Action | Tag | Commit SHA |
|---|---|---|
| `actions/checkout` | `v6` | `de0fac2e` |

**Left unpinned intentionally:**
- `knative/actions/*@main` — Knative's own reusable actions follow a rolling `@main` convention by design
- `chainguard-dev/actions/setup-kind` — already pinned to a SHA in both files

## Test plan

- [ ] Confirm both workflows pass with the SHA-pinned actions


## Automated updates for pinned actions

This repo already configures Dependabot for GitHub Actions in [`.github/.dependabot.yaml`](https://github.com/knative/eventing/blob/main/.github/.dependabot.yaml) (`package-ecosystem: github-actions`, weekly interval). Dependabot opens PRs when new releases move the tag that corresponds to a pinned action, so SHA pins do not go stale without review.
