### PR TITLE
CI: replace deprecated git.io shortlink in vendored gen-crd (fixes #9047)

### DIFF
--- a/vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml
+++ b/vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-    script: curl -sL https://git.io/goreleaser | bash
+    script: curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | bash
   # use github release feature to upload dist/
   - provider: releases
     skip_cleanup: true


### PR DESCRIPTION
Fixes #9047

## Change
- `https://git.io/goreleaser` → `https://raw.githubusercontent.com/goreleaser/get/master/get` in `vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml`

