### PR TITLE
[WIP] Add configurable metric attributes deny list to config-observability

### DIFF
--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "0270bb17"
+    knative.dev/example-checksum: "1fdd6513"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -58,10 +58,10 @@ data:
     # If a zero or negative value is passed the default reporting OTel period is used (60 secs).
     metrics-export-interval: 60s
 
-    # metrics.attributes.deny is a comma-separated list of metric attribute keys to filter
+    # metrics-attributes-deny is a comma-separated list of metric attribute keys to filter
     # out from all metrics. This can help prevent OOM issues caused by unbounded
     # metric cardinality in production (e.g. cloudevents.type, messaging.destination.name).
-    metrics.attributes.deny: ""
+    metrics-attributes-deny: ""
 
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "6010dfc0"
+    knative.dev/example-checksum: "afa5507a"
 data:
   _example: |
     ################################
@@ -59,7 +59,7 @@ data:
     metrics-export-interval: 60s
 
     # metrics.attributes.deny is a comma-separated list of metric attribute keys to filter
-    # out from kn.eventing.* metrics. This can help prevent OOM issues caused by unbounded
+    # out from all metrics. This can help prevent OOM issues caused by unbounded
     # metric cardinality in production (e.g. cloudevents.type, messaging.destination.name).
     metrics.attributes.deny: ""
 

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -58,6 +58,11 @@ data:
     # If a zero or negative value is passed the default reporting OTel period is used (60 secs).
     metrics-export-interval: 60s
 
+    # metrics.high-cardinality.disable disables high-cardinality metric attributes such as
+    # cloudevents.type and messaging.destination.name. Enabling this can help prevent
+    # OOM issues caused by unbounded metric cardinality in production.
+    metrics.high-cardinality.disable: "false"
+
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.
     sink-event-error-reporting.enable: "false"

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "1fdd6513"
+    knative.dev/example-checksum: "6010dfc0"
 data:
   _example: |
     ################################
@@ -58,10 +58,10 @@ data:
     # If a zero or negative value is passed the default reporting OTel period is used (60 secs).
     metrics-export-interval: 60s
 
-    # metrics.high-cardinality.disable disables high-cardinality metric attributes such as
-    # cloudevents.type and messaging.destination.name. Enabling this can help prevent
-    # OOM issues caused by unbounded metric cardinality in production.
-    metrics.high-cardinality.disable: "false"
+    # metrics.attributes.deny is a comma-separated list of metric attribute keys to filter
+    # out from kn.eventing.* metrics. This can help prevent OOM issues caused by unbounded
+    # metric cardinality in production (e.g. cloudevents.type, messaging.destination.name).
+    metrics.attributes.deny: ""
 
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -32,6 +32,12 @@ const (
 	// DefaultEnableSinkEventErrorReporting is used to set the default sink event error reporting value
 	DefaultEnableSinkEventErrorReporting = false
 
+	// DisableHighCardinalityMetricsKey is the CM key to disable high-cardinality metric attributes
+	DisableHighCardinalityMetricsKey = "metrics.high-cardinality.disable"
+
+	// DefaultDisableHighCardinalityMetrics is the default value for disabling high-cardinality metrics
+	DefaultDisableHighCardinalityMetrics = false
+
 	// DefaultMetricsPort is the default port used for prometheus metrics if the prometheus protocol is used
 	DefaultMetricsPort = 9092
 )
@@ -50,12 +56,17 @@ type Config struct {
 	// EnableSinkEventErrorReporting specifies whether we should emit a k8s
 	// event when delivery to a sink fails
 	EnableSinkEventErrorReporting bool `json:"enableSinkEventErrorReporting"`
+
+	// DisableHighCardinalityMetrics specifies whether high-cardinality attributes
+	// (e.g. cloudevents.type, messaging.destination.name) are stripped from metrics
+	DisableHighCardinalityMetrics bool `json:"disableHighCardinalityMetrics"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
 		BaseConfig:                    *pkgo11y.DefaultConfig(),
 		EnableSinkEventErrorReporting: DefaultEnableSinkEventErrorReporting,
+		DisableHighCardinalityMetrics: DefaultDisableHighCardinalityMetrics,
 	}
 }
 
@@ -74,7 +85,10 @@ func NewFromMap(m map[string]string) (*Config, error) {
 		c.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
 	}
 
-	err := configmap.Parse(m, configmap.As(EnableSinkEventErrorReportingKey, &c.EnableSinkEventErrorReporting))
+	err := configmap.Parse(m,
+		configmap.As(EnableSinkEventErrorReportingKey, &c.EnableSinkEventErrorReporting),
+		configmap.As(DisableHighCardinalityMetricsKey, &c.DisableHighCardinalityMetrics),
+	)
 	if err != nil {
 		fmt.Printf("failed to parse enable-sink-error-reporting: %s\n", err.Error())
 		return c, err

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -19,7 +19,6 @@ package observability
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	configmap "knative.dev/pkg/configmap/parser"
 	pkgo11y "knative.dev/pkg/observability"
@@ -32,9 +31,6 @@ const (
 
 	// DefaultEnableSinkEventErrorReporting is used to set the default sink event error reporting value
 	DefaultEnableSinkEventErrorReporting = false
-
-	// MetricAttributesDenyListKey is the CM key for a comma-separated list of metric attribute keys to filter out
-	MetricAttributesDenyListKey = "metrics.attributes.deny"
 
 	// DefaultMetricsPort is the default port used for prometheus metrics if the prometheus protocol is used
 	DefaultMetricsPort = 9092
@@ -54,10 +50,6 @@ type Config struct {
 	// EnableSinkEventErrorReporting specifies whether we should emit a k8s
 	// event when delivery to a sink fails
 	EnableSinkEventErrorReporting bool `json:"enableSinkEventErrorReporting"`
-
-	// MetricAttributesDenyList is a list of metric attribute keys to filter out
-	// from all metrics (e.g. cloudevents.type, messaging.destination.name)
-	MetricAttributesDenyList []string `json:"metricAttributesDenyList,omitempty"`
 }
 
 func DefaultConfig() *Config {
@@ -80,16 +72,6 @@ func NewFromMap(m map[string]string) (*Config, error) {
 	// Force the port to the default queue user metrics port if it's not overridden
 	if c.BaseConfig.Metrics.Protocol == metrics.ProtocolPrometheus && c.BaseConfig.Metrics.Endpoint == "" {
 		c.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
-	}
-
-	if v, ok := m[MetricAttributesDenyListKey]; ok && v != "" {
-		parts := strings.Split(v, ",")
-		c.MetricAttributesDenyList = make([]string, 0, len(parts))
-		for _, p := range parts {
-			if t := strings.TrimSpace(p); t != "" {
-				c.MetricAttributesDenyList = append(c.MetricAttributesDenyList, t)
-			}
-		}
 	}
 
 	err := configmap.Parse(m,

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -19,6 +19,7 @@ package observability
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configmap "knative.dev/pkg/configmap/parser"
 	pkgo11y "knative.dev/pkg/observability"
@@ -32,11 +33,8 @@ const (
 	// DefaultEnableSinkEventErrorReporting is used to set the default sink event error reporting value
 	DefaultEnableSinkEventErrorReporting = false
 
-	// DisableHighCardinalityMetricsKey is the CM key to disable high-cardinality metric attributes
-	DisableHighCardinalityMetricsKey = "metrics.high-cardinality.disable"
-
-	// DefaultDisableHighCardinalityMetrics is the default value for disabling high-cardinality metrics
-	DefaultDisableHighCardinalityMetrics = false
+	// MetricAttributesDenyListKey is the CM key for a comma-separated list of metric attribute keys to filter out
+	MetricAttributesDenyListKey = "metrics.attributes.deny"
 
 	// DefaultMetricsPort is the default port used for prometheus metrics if the prometheus protocol is used
 	DefaultMetricsPort = 9092
@@ -57,16 +55,15 @@ type Config struct {
 	// event when delivery to a sink fails
 	EnableSinkEventErrorReporting bool `json:"enableSinkEventErrorReporting"`
 
-	// DisableHighCardinalityMetrics specifies whether high-cardinality attributes
-	// (e.g. cloudevents.type, messaging.destination.name) are stripped from metrics
-	DisableHighCardinalityMetrics bool `json:"disableHighCardinalityMetrics"`
+	// MetricAttributesDenyList is a list of metric attribute keys to filter out
+	// from kn.eventing.* metrics (e.g. cloudevents.type, messaging.destination.name)
+	MetricAttributesDenyList []string `json:"metricAttributesDenyList,omitempty"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
 		BaseConfig:                    *pkgo11y.DefaultConfig(),
 		EnableSinkEventErrorReporting: DefaultEnableSinkEventErrorReporting,
-		DisableHighCardinalityMetrics: DefaultDisableHighCardinalityMetrics,
 	}
 }
 
@@ -85,9 +82,18 @@ func NewFromMap(m map[string]string) (*Config, error) {
 		c.BaseConfig.Metrics.Endpoint = fmt.Sprintf(":%d", DefaultMetricsPort)
 	}
 
+	if v, ok := m[MetricAttributesDenyListKey]; ok && v != "" {
+		parts := strings.Split(v, ",")
+		c.MetricAttributesDenyList = make([]string, 0, len(parts))
+		for _, p := range parts {
+			if t := strings.TrimSpace(p); t != "" {
+				c.MetricAttributesDenyList = append(c.MetricAttributesDenyList, t)
+			}
+		}
+	}
+
 	err := configmap.Parse(m,
 		configmap.As(EnableSinkEventErrorReportingKey, &c.EnableSinkEventErrorReporting),
-		configmap.As(DisableHighCardinalityMetricsKey, &c.DisableHighCardinalityMetrics),
 	)
 	if err != nil {
 		fmt.Printf("failed to parse enable-sink-error-reporting: %s\n", err.Error())

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -56,7 +56,7 @@ type Config struct {
 	EnableSinkEventErrorReporting bool `json:"enableSinkEventErrorReporting"`
 
 	// MetricAttributesDenyList is a list of metric attribute keys to filter out
-	// from kn.eventing.* metrics (e.g. cloudevents.type, messaging.destination.name)
+	// from all metrics (e.g. cloudevents.type, messaging.destination.name)
 	MetricAttributesDenyList []string `json:"metricAttributesDenyList,omitempty"`
 }
 

--- a/pkg/observability/config_test.go
+++ b/pkg/observability/config_test.go
@@ -26,8 +26,8 @@ func TestNewFromMap(t *testing.T) {
 	configWithSinkEventErrorReporting := DefaultConfig()
 	configWithSinkEventErrorReporting.EnableSinkEventErrorReporting = true
 
-	configWithHighCardinalityDisabled := DefaultConfig()
-	configWithHighCardinalityDisabled.DisableHighCardinalityMetrics = true
+	configWithDenyList := DefaultConfig()
+	configWithDenyList.MetricAttributesDenyList = []string{"cloudevents.type", "messaging.destination.name"}
 
 	testCases := map[string]struct {
 		m                map[string]string
@@ -44,11 +44,11 @@ func TestNewFromMap(t *testing.T) {
 			},
 			want: configWithSinkEventErrorReporting,
 		},
-		"disable high cardinality metrics": {
+		"metric attributes deny list": {
 			m: map[string]string{
-				DisableHighCardinalityMetricsKey: "true",
+				MetricAttributesDenyListKey: "cloudevents.type, messaging.destination.name",
 			},
-			want: configWithHighCardinalityDisabled,
+			want: configWithDenyList,
 		},
 		"valid keys, invalid sink event error reporting value": {
 			m: map[string]string{

--- a/pkg/observability/config_test.go
+++ b/pkg/observability/config_test.go
@@ -23,8 +23,11 @@ import (
 )
 
 func TestNewFromMap(t *testing.T) {
-	configWithOverride := DefaultConfig()
-	configWithOverride.EnableSinkEventErrorReporting = true
+	configWithSinkEventErrorReporting := DefaultConfig()
+	configWithSinkEventErrorReporting.EnableSinkEventErrorReporting = true
+
+	configWithHighCardinalityDisabled := DefaultConfig()
+	configWithHighCardinalityDisabled.DisableHighCardinalityMetrics = true
 
 	testCases := map[string]struct {
 		m                map[string]string
@@ -39,7 +42,13 @@ func TestNewFromMap(t *testing.T) {
 			m: map[string]string{
 				EnableSinkEventErrorReportingKey: "true",
 			},
-			want: configWithOverride,
+			want: configWithSinkEventErrorReporting,
+		},
+		"disable high cardinality metrics": {
+			m: map[string]string{
+				DisableHighCardinalityMetricsKey: "true",
+			},
+			want: configWithHighCardinalityDisabled,
 		},
 		"valid keys, invalid sink event error reporting value": {
 			m: map[string]string{

--- a/pkg/observability/config_test.go
+++ b/pkg/observability/config_test.go
@@ -27,7 +27,7 @@ func TestNewFromMap(t *testing.T) {
 	configWithSinkEventErrorReporting.EnableSinkEventErrorReporting = true
 
 	configWithDenyList := DefaultConfig()
-	configWithDenyList.MetricAttributesDenyList = []string{"cloudevents.type", "messaging.destination.name"}
+	configWithDenyList.Metrics.AttributesDeny = "cloudevents.type, messaging.destination.name"
 
 	testCases := map[string]struct {
 		m                map[string]string
@@ -46,7 +46,7 @@ func TestNewFromMap(t *testing.T) {
 		},
 		"metric attributes deny list": {
 			m: map[string]string{
-				MetricAttributesDenyListKey: "cloudevents.type, messaging.destination.name",
+				"metrics-attributes-deny": "cloudevents.type, messaging.destination.name",
 			},
 			want: configWithDenyList,
 		},

--- a/pkg/observability/otel/otel.go
+++ b/pkg/observability/otel/otel.go
@@ -168,7 +168,7 @@ func metricAttributesDenyFilter(denyList []string) metric.View {
 		keys[i] = attribute.Key(k)
 	}
 	return metric.NewView(
-		metric.Instrument{Name: "kn.eventing.*"},
+		metric.Instrument{Name: "*"},
 		metric.Stream{
 			AttributeFilter: attribute.NewDenyKeysFilter(keys...),
 		},

--- a/pkg/observability/otel/otel.go
+++ b/pkg/observability/otel/otel.go
@@ -19,8 +19,10 @@ package otel
 import (
 	"context"
 
+	ceo11y "github.com/cloudevents/sdk-go/v2/observability"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -60,10 +62,15 @@ func SetupObservabilityOrDie(
 
 	otelResource := resource.Default(component)
 
+	meterOpts := []metric.Option{metric.WithResource(otelResource)}
+	if cfg.DisableHighCardinalityMetrics {
+		meterOpts = append(meterOpts, metric.WithView(highCardinalityFilter()))
+	}
+
 	meterProvider, err := metrics.NewMeterProvider(
 		ctx,
 		cfg.Metrics,
-		metric.WithResource(otelResource),
+		meterOpts...,
 	)
 	if err != nil {
 		logger.Fatalw("failed to set up meter provider", zap.Error(err))
@@ -154,4 +161,16 @@ func GetObservabilityConfig(ctx context.Context) (*observability.Config, error) 
 	}
 
 	return configmap.Parse(cm)
+}
+
+func highCardinalityFilter() metric.View {
+	return metric.NewView(
+		metric.Instrument{Name: "kn.eventing.*"},
+		metric.Stream{
+			AttributeFilter: attribute.NewDenyKeysFilter(
+				attribute.Key(ceo11y.TypeAttr),                        // "cloudevents.type"
+				attribute.Key(observability.MessagingDestinationName), // "messaging.destination.name"
+			),
+		},
+	)
 }

--- a/pkg/observability/otel/otel.go
+++ b/pkg/observability/otel/otel.go
@@ -19,7 +19,6 @@ package otel
 import (
 	"context"
 
-	ceo11y "github.com/cloudevents/sdk-go/v2/observability"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -63,8 +62,8 @@ func SetupObservabilityOrDie(
 	otelResource := resource.Default(component)
 
 	meterOpts := []metric.Option{metric.WithResource(otelResource)}
-	if cfg.DisableHighCardinalityMetrics {
-		meterOpts = append(meterOpts, metric.WithView(highCardinalityFilter()))
+	if len(cfg.MetricAttributesDenyList) > 0 {
+		meterOpts = append(meterOpts, metric.WithView(metricAttributesDenyFilter(cfg.MetricAttributesDenyList)))
 	}
 
 	meterProvider, err := metrics.NewMeterProvider(
@@ -163,14 +162,15 @@ func GetObservabilityConfig(ctx context.Context) (*observability.Config, error) 
 	return configmap.Parse(cm)
 }
 
-func highCardinalityFilter() metric.View {
+func metricAttributesDenyFilter(denyList []string) metric.View {
+	keys := make([]attribute.Key, len(denyList))
+	for i, k := range denyList {
+		keys[i] = attribute.Key(k)
+	}
 	return metric.NewView(
 		metric.Instrument{Name: "kn.eventing.*"},
 		metric.Stream{
-			AttributeFilter: attribute.NewDenyKeysFilter(
-				attribute.Key(ceo11y.TypeAttr),                        // "cloudevents.type"
-				attribute.Key(observability.MessagingDestinationName), // "messaging.destination.name"
-			),
+			AttributeFilter: attribute.NewDenyKeysFilter(keys...),
 		},
 	)
 }

--- a/pkg/observability/otel/otel.go
+++ b/pkg/observability/otel/otel.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -62,8 +61,8 @@ func SetupObservabilityOrDie(
 	otelResource := resource.Default(component)
 
 	meterOpts := []metric.Option{metric.WithResource(otelResource)}
-	if len(cfg.MetricAttributesDenyList) > 0 {
-		meterOpts = append(meterOpts, metric.WithView(metricAttributesDenyFilter(cfg.MetricAttributesDenyList)))
+	if denyList := cfg.Metrics.AttributesDenyList(); len(denyList) > 0 {
+		meterOpts = append(meterOpts, metric.WithView(metrics.MetricAttributesDenyFilter(denyList)))
 	}
 
 	meterProvider, err := metrics.NewMeterProvider(
@@ -160,17 +159,4 @@ func GetObservabilityConfig(ctx context.Context) (*observability.Config, error) 
 	}
 
 	return configmap.Parse(cm)
-}
-
-func metricAttributesDenyFilter(denyList []string) metric.View {
-	keys := make([]attribute.Key, len(denyList))
-	for i, k := range denyList {
-		keys[i] = attribute.Key(k)
-	}
-	return metric.NewView(
-		metric.Instrument{Name: "*"},
-		metric.Stream{
-			AttributeFilter: attribute.NewDenyKeysFilter(keys...),
-		},
-	)
 }

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -48,9 +48,10 @@ func TestMetricAttributesDenyFilter(t *testing.T) {
 	}
 }
 
-func TestMetricAttributesDenyFilterDoesNotMatchOtherInstruments(t *testing.T) {
+func TestMetricAttributesDenyFilterMatchesAllInstruments(t *testing.T) {
 	view := metricAttributesDenyFilter([]string{"cloudevents.type"})
 
-	_, ok := view(metric.Instrument{Name: "http.server.request.duration"})
-	assert.False(t, ok, "view should not match non kn.eventing.* instruments")
+	stream, ok := view(metric.Instrument{Name: "http.server.request.duration"})
+	assert.True(t, ok, "view should match all instruments")
+	assert.NotNil(t, stream.AttributeFilter)
 }

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -19,24 +19,21 @@ package otel
 import (
 	"testing"
 
-	ceo11y "github.com/cloudevents/sdk-go/v2/observability"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
-
-	"knative.dev/eventing/pkg/observability"
 )
 
-func TestHighCardinalityFilter(t *testing.T) {
-	view := highCardinalityFilter()
+func TestMetricAttributesDenyFilter(t *testing.T) {
+	view := metricAttributesDenyFilter([]string{"cloudevents.type", "messaging.destination.name"})
 
 	stream, ok := view(metric.Instrument{Name: "kn.eventing.dispatch.duration"})
 	assert.True(t, ok, "view should match kn.eventing.* instruments")
 	assert.NotNil(t, stream.AttributeFilter)
 
 	denied := []attribute.KeyValue{
-		attribute.String(ceo11y.TypeAttr, "com.example.event"),
-		attribute.String(string(observability.MessagingDestinationName), "my-destination"),
+		attribute.String("cloudevents.type", "com.example.event"),
+		attribute.String("messaging.destination.name", "my-destination"),
 	}
 	for _, kv := range denied {
 		assert.False(t, stream.AttributeFilter(kv), "attribute %s should be denied", kv.Key)
@@ -51,8 +48,8 @@ func TestHighCardinalityFilter(t *testing.T) {
 	}
 }
 
-func TestHighCardinalityFilterDoesNotMatchOtherInstruments(t *testing.T) {
-	view := highCardinalityFilter()
+func TestMetricAttributesDenyFilterDoesNotMatchOtherInstruments(t *testing.T) {
+	view := metricAttributesDenyFilter([]string{"cloudevents.type"})
 
 	_, ok := view(metric.Instrument{Name: "http.server.request.duration"})
 	assert.False(t, ok, "view should not match non kn.eventing.* instruments")

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
+
+	"knative.dev/pkg/observability/metrics"
 )
 
 func TestMetricAttributesDenyFilter(t *testing.T) {
-	view := metricAttributesDenyFilter([]string{"cloudevents.type", "messaging.destination.name"})
+	view := metrics.MetricAttributesDenyFilter([]string{"cloudevents.type", "messaging.destination.name"})
 
 	stream, ok := view(metric.Instrument{Name: "kn.eventing.dispatch.duration"})
 	assert.True(t, ok, "view should match kn.eventing.* instruments")
@@ -49,7 +51,7 @@ func TestMetricAttributesDenyFilter(t *testing.T) {
 }
 
 func TestMetricAttributesDenyFilterMatchesAllInstruments(t *testing.T) {
-	view := metricAttributesDenyFilter([]string{"cloudevents.type"})
+	view := metrics.MetricAttributesDenyFilter([]string{"cloudevents.type"})
 
 	stream, ok := view(metric.Instrument{Name: "http.server.request.duration"})
 	assert.True(t, ok, "view should match all instruments")

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package otel
 
 import (

--- a/pkg/observability/otel/otel_test.go
+++ b/pkg/observability/otel/otel_test.go
@@ -1,0 +1,43 @@
+package otel
+
+import (
+	"testing"
+
+	ceo11y "github.com/cloudevents/sdk-go/v2/observability"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	"knative.dev/eventing/pkg/observability"
+)
+
+func TestHighCardinalityFilter(t *testing.T) {
+	view := highCardinalityFilter()
+
+	stream, ok := view(metric.Instrument{Name: "kn.eventing.dispatch.duration"})
+	assert.True(t, ok, "view should match kn.eventing.* instruments")
+	assert.NotNil(t, stream.AttributeFilter)
+
+	denied := []attribute.KeyValue{
+		attribute.String(ceo11y.TypeAttr, "com.example.event"),
+		attribute.String(string(observability.MessagingDestinationName), "my-destination"),
+	}
+	for _, kv := range denied {
+		assert.False(t, stream.AttributeFilter(kv), "attribute %s should be denied", kv.Key)
+	}
+
+	allowed := []attribute.KeyValue{
+		attribute.String("messaging.system", "knative"),
+		attribute.Int("http.response.status_code", 200),
+	}
+	for _, kv := range allowed {
+		assert.True(t, stream.AttributeFilter(kv), "attribute %s should be allowed", kv.Key)
+	}
+}
+
+func TestHighCardinalityFilterDoesNotMatchOtherInstruments(t *testing.T) {
+	view := highCardinalityFilter()
+
+	_, ok := view(metric.Instrument{Name: "http.server.request.duration"})
+	assert.False(t, ok, "view should not match non kn.eventing.* instruments")
+}


### PR DESCRIPTION
## Proposed Changes

- :gift: Add a `metrics.attributes.deny` key to the `config-observability` ConfigMap that accepts a comma-separated list of metric attribute keys to filter out
  - When configured, an OTel View strips the specified attributes from all `kn.eventing.*` metrics at the SDK level
  - Default is empty (existing behavior preserved, no filtering)

Example usage to strip high-cardinality attributes:
```yaml
metrics.attributes.deny: "cloudevents.type,messaging.destination.name"
```

```release-note
Add `metrics.attributes.deny` option to config-observability ConfigMap to allow filtering out configurable metric attributes from kn.eventing.* metrics, helping prevent potential OOM issues caused by unbounded metric cardinality in production.
```