### PR TITLE
Fix jobsink status Location paths for slashy event metadata

### DIFF
--- a/cmd/jobsink/main.go
+++ b/cmd/jobsink/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -424,16 +425,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	logger := logging.FromContext(ctx)
-	parts := strings.Split(strings.TrimSuffix(r.RequestURI, "/"), "/")
-	if len(parts) != 9 {
+	ref, eventSource, eventID, err := parseLocation(r.RequestURI)
+	if err != nil {
 		logger.Info("Malformed uri", zap.String("URI", r.RequestURI))
 		w.WriteHeader(http.StatusBadRequest)
 		return
-	}
-
-	ref := types.NamespacedName{
-		Namespace: parts[2],
-		Name:      parts[4],
 	}
 
 	js, err := h.lister.JobSinks(ref.Namespace).Get(ref.Name)
@@ -450,10 +446,6 @@ func (h *Handler) handleGet(ctx context.Context, w http.ResponseWriter, r *http.
 		logger.Warn("Failed to verify AuthN and AuthZ.", zap.Error(err))
 		return
 	}
-
-	eventSource := parts[6]
-	eventID := parts[8]
-
 	jobName := toJobName(ref.Name, eventSource, eventID)
 
 	job, err := h.k8s.BatchV1().Jobs(ref.Namespace).Get(r.Context(), jobName, metav1.GetOptions{})
@@ -499,11 +491,43 @@ func getServerTLSConfig(ctx context.Context) (*tls.Config, error) {
 }
 
 func locationHeader(ref types.NamespacedName, source, id string) string {
-	return fmt.Sprintf("/namespaces/%s/name/%s/sources/%s/ids/%s", ref.Namespace, ref.Name, source, id)
+	return fmt.Sprintf(
+		"/namespaces/%s/name/%s/sources/%s/ids/%s",
+		url.PathEscape(ref.Namespace),
+		url.PathEscape(ref.Name),
+		url.PathEscape(source),
+		url.PathEscape(id),
+	)
 }
 
 func jobLabelSelector(ref types.NamespacedName, id string) string {
 	return fmt.Sprintf("%s=%s,%s=%s", sinks.JobSinkIDLabel, id, sinks.JobSinkNameLabel, ref.Name)
+}
+
+func parseLocation(requestURI string) (types.NamespacedName, string, string, error) {
+	parts := strings.Split(strings.TrimSuffix(requestURI, "/"), "/")
+	if len(parts) != 9 {
+		return types.NamespacedName{}, "", "", fmt.Errorf("unexpected path format")
+	}
+
+	namespace, err := url.PathUnescape(parts[2])
+	if err != nil {
+		return types.NamespacedName{}, "", "", fmt.Errorf("invalid namespace path segment: %w", err)
+	}
+	name, err := url.PathUnescape(parts[4])
+	if err != nil {
+		return types.NamespacedName{}, "", "", fmt.Errorf("invalid name path segment: %w", err)
+	}
+	source, err := url.PathUnescape(parts[6])
+	if err != nil {
+		return types.NamespacedName{}, "", "", fmt.Errorf("invalid source path segment: %w", err)
+	}
+	id, err := url.PathUnescape(parts[8])
+	if err != nil {
+		return types.NamespacedName{}, "", "", fmt.Errorf("invalid id path segment: %w", err)
+	}
+
+	return types.NamespacedName{Namespace: namespace, Name: name}, source, id, nil
 }
 
 func toJobName(js string, source, id string) string {

--- a/cmd/jobsink/main_test.go
+++ b/cmd/jobsink/main_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/eventing/pkg/utils"
 )
@@ -103,4 +104,57 @@ func FuzzToJobName(f *testing.F) {
 			t.Errorf("toJobName produced invalid name %q given %q, %q, %q: errors: %#v", name, js, source, id, errs)
 		}
 	})
+}
+
+func TestLocationHeaderRoundTrip(t *testing.T) {
+	testCases := map[string]struct {
+		ref    types.NamespacedName
+		source string
+		id     string
+	}{
+		"simple": {
+			ref: types.NamespacedName{
+				Namespace: "test-namespace",
+				Name:      "job-sink",
+			},
+			source: "mysource3",
+			id:     "2234-5678",
+		},
+		"slashes in source and id": {
+			ref: types.NamespacedName{
+				Namespace: "test-namespace",
+				Name:      "job-sink",
+			},
+			source: "https://example.com/sources/my/source",
+			id:     "event/id/with/slashes",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			location := locationHeader(tc.ref, tc.source, tc.id)
+
+			gotRef, gotSource, gotID, err := parseLocation(location)
+			if err != nil {
+				t.Fatal("unexpected error:", err)
+			}
+
+			if gotRef != tc.ref {
+				t.Fatalf("unexpected ref: got %#v want %#v", gotRef, tc.ref)
+			}
+			if gotSource != tc.source {
+				t.Fatalf("unexpected source: got %q want %q", gotSource, tc.source)
+			}
+			if gotID != tc.id {
+				t.Fatalf("unexpected id: got %q want %q", gotID, tc.id)
+			}
+		})
+	}
+}
+
+func TestParseLocationRejectsUnescapedSourceSlashes(t *testing.T) {
+	_, _, _, err := parseLocation("/namespaces/test-namespace/name/job-sink/sources/https://example.com/source/ids/event-id")
+	if err == nil {
+		t.Fatal("expected error for malformed location")
+	}
 }


### PR DESCRIPTION
## Proposed Changes

- escape `source` and `id` when `jobsink` builds the status `Location` header
- unescape them on GET, so the status URL round-trips again
- add unit tests for normal values and slash-heavy values

### Repro

1. Create a `JobSink`.
2. Send an event with `source=https://example.com/sources/my/source`.
3. Read the `Location` header from the `POST` response.
4. `GET` that URL.

Before this patch, the GET can return `400` because raw `/` in `source` turn into extra path segments. Pretty normal input, the status URL just goes sideways a bit.

### Pre-review Checklist

- [x] At least 80% unit test coverage
- [ ] E2E tests for any new behavior
- [ ] Docs PR for any user-facing impact
- [ ] Spec PR for any new API feature
- [ ] Conformance test for any change to the spec

Release Note

```release-note
Fixed `jobsink` status `Location` URLs for events whose CloudEvents `source` or `id` contain `/`.
```

Docs

knative/docs#6651