### PR TITLE
docs: fix KO_DEFAULTPLATFORMS example in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,7 +84,7 @@ export PATH="${PATH}:${GOPATH}/bin"
 export KO_DOCKER_REPO='gcr.io/my-gcloud-project-id'
 ```
 
-> :information_source: You can use the command `export KO_DEFAULTPLATFORMS=linux/amd64, arm64` to set the correct architecture according to your local machine.
+> :information_source: You can use the command `export KO_DEFAULTPLATFORMS=linux/amd64,linux/arm64` to set the correct architectures according to your local machine.
 
 ### Checkout your fork
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- fix the `KO_DEFAULTPLATFORMS` example in `DEVELOPMENT.md`
- use `linux/amd64,linux/arm64` instead of `linux/amd64, arm64`
- the old command is a bit busted, `ko` errors out with `no matching platforms in base image index`

### Repro

1. `export KO_DEFAULTPLATFORMS='linux/amd64, arm64'`
2. `KO_DOCKER_REPO=ko.local ko resolve -f config/tools/appender/`
3. see `no matching platforms in base image index`
4. `export KO_DEFAULTPLATFORMS='linux/amd64,linux/arm64'`
5. rerun the same `ko resolve` command
6. it works

### Pre-review Checklist

- [ ] At least 80% unit test coverage
- [ ] E2E tests for any new behavior
- [ ] Docs PR for any user-facing impact
- [ ] Spec PR for any new API feature
- [ ] Conformance test for any change to the spec

Release Note

```release-note
None
```

Docs

n/a, repo dev docs only