### PR TITLE
Fix goroutine/memory leak in SubjectAndFiltersPass

### DIFF
--- a/pkg/auth/event_policy.go
+++ b/pkg/auth/event_policy.go
@@ -227,7 +227,9 @@ func SubjectAndFiltersPass(ctx context.Context, sub string, allowedSubsWithFilte
 	for _, swf := range allowedSubsWithFilters {
 		for _, s := range swf.Subjects {
 			if strings.EqualFold(s, sub) || (strings.HasSuffix(s, "*") && strings.HasPrefix(sub, strings.TrimSuffix(s, "*"))) {
-				return subscriptionsapi.CreateSubscriptionsAPIFilters(logger.Desugar(), swf.Filters).Filter(ctx, *event) != eventfilter.FailFilter
+				filter := subscriptionsapi.CreateSubscriptionsAPIFilters(logger.Desugar(), swf.Filters)
+				defer filter.Cleanup()
+				return filter.Filter(ctx, *event) != eventfilter.FailFilter
 			}
 		}
 	}


### PR DESCRIPTION
`SubjectAndFiltersPass` creates filter objects via `CreateSubscriptionsAPIFilters` on every incoming request. The `anyFilter` and `allFilter` types each spawn a background goroutine (`optimizeLoop`) that only terminates when `Cleanup()` is called. Since the filter was used inline and discarded without calling `Cleanup()`, every request leaked goroutines, channels, and the filter object tree. Under sustained error traffic (e.g. dispatching to non-existing sinks), this accumulated millions of leaked goroutines and eventually caused the imc-dispatcher to OOM crash.

## Proposed Changes

- :bug: Extract the filter into a variable and `defer filter.Cleanup()` so the background goroutine is terminated after the filter result is returned

```release-note
Fixed a goroutine and memory leak in the IMC dispatcher that occurred when sending events to non-existing sinks. Filter objects were created per-request without calling Cleanup(), leaking goroutines until the dispatcher crashed with OOM.
```