### PR TITLE
docs: fix stale contribution and e2e debug instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -231,7 +231,7 @@ To run a single rekt test using the `e2e-debug.sh` script, follow these instruct
    ./hack/e2e-debug.sh TestPingSourceWithSinkRef ./test/rekt
    ```
 
-   This will run the specified rekt test (`TestMyRektScenario` in this case) from the provided directory (`test/rekt/scenarios`).
+   This will run the specified rekt test (`TestPingSourceWithSinkRef` in this case) from the provided directory (`./test/rekt`).
 
    **Note:** Ensure that you have the necessary dependencies and configurations set up before running the test.
 

--- a/hack/README.md
+++ b/hack/README.md
@@ -24,7 +24,7 @@ creating releases.
 
 1. Click the Branch dropdown.
 1. Type the desired `release-X.Y` branch name into the search box.
-1. Click the `Create branch: release-X.Y from 'master'` button. _You must have
+1. Click the `Create branch: release-X.Y from 'main'` button. _You must have
    write permissions to the repo to create a branch._
 
    Prow will detect the new release branch and run the `release.sh` script. If
@@ -43,10 +43,10 @@ creating releases.
     git fetch upstream
     ```
 
-1.  Create a `release-X.Y` branch from `upstream/master`.
+1.  Create a `release-X.Y` branch from `upstream/main`.
 
     ```sh
-    git branch --no-track release-X.Y upstream/master
+    git branch --no-track release-X.Y upstream/main
     ```
 
 1.  Push the branch to upstream.
@@ -80,10 +80,10 @@ The major version release job is currently called
 1.  Create a branch based on the desired `release-X.Y` branch.
 
     ```sh
-    git co -b my-backport-branch upstream/release-X.Y
+    git checkout -b my-backport-branch upstream/release-X.Y
     ```
 
-1.  Cherry-pick desired commits from master into the new branch.
+1.  Cherry-pick desired commits from main into the new branch.
 
     ```sh
     git cherry-pick <commitid>


### PR DESCRIPTION
A couple contributor docs are stale and trip people up a bit.

`hack/README.md` still points at `master` and uses `git co`, which fails on a normal git setup. `DEVELOPMENT.md` also points to `test/rekt/scenarios` and mentions `TestMyRektScenario`, but neither matches this repo.

How to repro
1. Run `git co -b my-backport-branch upstream/release-X.Y`
2. See `git: 'co' is not a git command`
3. Run `git symbolic-ref refs/remotes/origin/HEAD` and see `refs/remotes/origin/main`
4. Run `test -d test/rekt/scenarios || echo missing`
5. Run `rg 'TestPingSourceWithSinkRef|TestMyRektScenario' test/rekt test -S`

Fix is pretty small: use `main`, switch `git co` to `git checkout`, and align the `e2e-debug.sh` example with the real test and path. Tiny cleanup, but saves a weird faceplant