### PR TITLE
test: add regression coverage for SinkBinding preserving existing volumes

### DIFF
--- a/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1/sinkbinding_lifecycle_test.go
@@ -589,6 +589,70 @@ func TestSinkBindingDo(t *testing.T) {
 			},
 		},
 	}, {
+		name: "preserves existing volumes and volumeMounts on subject",
+		in: &duckv1.WithPod{
+			Spec: duckv1.WithPodSpec{
+				Template: duckv1.PodSpecable{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{
+							Name: "user-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "user-config",
+									},
+								},
+							},
+						}},
+						Containers: []corev1.Container{{
+							Name:  "blah",
+							Image: "busybox",
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "user-volume",
+								MountPath: "/user-volume",
+							}},
+						}},
+					},
+				},
+			},
+		},
+		want: &duckv1.WithPod{
+			Spec: duckv1.WithPodSpec{
+				Template: duckv1.PodSpecable{
+					Spec: corev1.PodSpec{
+						Volumes: []corev1.Volume{{
+							Name: "user-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "user-config",
+									},
+								},
+							},
+						}},
+						Containers: []corev1.Container{{
+							Name:  "blah",
+							Image: "busybox",
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "user-volume",
+								MountPath: "/user-volume",
+							}},
+							Env: []corev1.EnvVar{{
+								Name:  "K_SINK",
+								Value: destination.URI.String(),
+							}, {
+								Name:  "K_CA_CERTS",
+								Value: caCert,
+							}, {
+								Name:  "K_CE_OVERRIDES",
+								Value: `{"extensions":{"foo":"bar"}}`,
+							}},
+						}},
+					},
+				},
+			},
+		},
+	}, {
 		name: "add trust bundles",
 		want: &duckv1.WithPod{
 			Spec: duckv1.WithPodSpec{


### PR DESCRIPTION
Motivation:
Issue #8261 reported that SinkBinding's mutation of a Deployment
subject (SinkBinding.Do in pkg/apis/sources/v1/sinkbinding_lifecycle.go)
eliminated pre-existing volumes/volumeMounts on the subject as soon as
K_SINK env vars were injected, filed against v1.14.0. A maintainer
later attempted to reproduce this on a newer release with a Deployment
carrying a custom ConfigMap volume and was unable to reproduce it, and
no further activity or linked fix followed.

Reviewing the current code, SinkBinding.Do only ever appends to
Volumes/VolumeMounts/Env (including the trust-bundle and OIDC token
volume injection paths), and the admission webhook applies the change
as a computed JSON patch diff rather than a wholesale object replace,
so there is no remaining code path that would drop unrelated volumes.
This change has no user-visible behavior impact today; the bug does
not currently reproduce.

Approach:
Add a regression test case to TestSinkBindingDo that starts from a
subject with a pre-existing user-defined Volume and a container
VolumeMount referencing it, and asserts both are still present after
Do() runs alongside the injected K_SINK/K_CA_CERTS/K_CE_OVERRIDES env
vars. This locks in the current correct behavior and will catch a
regression if this code path changes in the future.

Validation:
go build ./...
go test ./pkg/apis/sources/v1/... -run TestSinkBindingDo -v
(new subtest "preserves_existing_volumes_and_volumeMounts_on_subject"
passes, along with all sibling subtests)

/kind bug

```release-note
NONE
```

Fixes #8261

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>