### PR TITLE
test: merge overlapping TLS and OIDC rekt e2e suites

### DIFF
--- a/test/rekt/container_source_test.go
+++ b/test/rekt/container_source_test.go
@@ -93,7 +93,7 @@ func TestContainerSourceWithArgs(t *testing.T) {
 	env.Test(ctx, t, containersource.SendsEventsWithArgs())
 }
 
-func TestContainerSourceWithTLS(t *testing.T) {
+func TestContainerSourceTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -105,23 +105,16 @@ func TestContainerSourceWithTLS(t *testing.T) {
 		eventshub.WithTLS(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
+	t.Cleanup(env.Finish)
 
-	env.ParallelTest(ctx, t, containersource.SendEventsWithTLSRecieverAsSink())
-	env.ParallelTest(ctx, t, containersource.SendEventsWithTLSRecieverAsSinkTrustBundle())
-}
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.ParallelTest(ctx, t, containersource.SendEventsWithTLSRecieverAsSink())
+		env.ParallelTest(ctx, t, containersource.SendEventsWithTLSRecieverAsSinkTrustBundle())
+	})
 
-func TestContainerSourceSendsEventsWithOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-		environment.WithPollTimings(5*time.Second, 4*time.Minute),
-	)
-
-	env.Test(ctx, t, containersource.SendsEventsWithSinkRefOIDC())
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, containersource.SendsEventsWithSinkRefOIDC())
+	})
 }

--- a/test/rekt/integrationsource_timer_test.go
+++ b/test/rekt/integrationsource_timer_test.go
@@ -49,7 +49,7 @@ func TestIntegrationSourceTimerWithSinkRef(t *testing.T) {
 	env.Test(ctx, t, integrationsource.SendsEventsWithSinkRef(integrationsourceresource.SourceTypeTimer))
 }
 
-func TestIntegrationSourceTimerWithTLS(t *testing.T) {
+func TestIntegrationSourceTimerTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -61,23 +61,16 @@ func TestIntegrationSourceTimerWithTLS(t *testing.T) {
 		eventshub.WithTLS(t),
 		environment.WithPollTimings(5*time.Second, 4*time.Minute),
 	)
+	t.Cleanup(env.Finish)
 
-	env.ParallelTest(ctx, t, integrationsource.SendEventsWithTLSReceiverAsSink(integrationsourceresource.SourceTypeTimer))
-	env.ParallelTest(ctx, t, integrationsource.SendEventsWithTLSReceiverAsSinkTrustBundle(integrationsourceresource.SourceTypeTimer))
-}
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.ParallelTest(ctx, t, integrationsource.SendEventsWithTLSReceiverAsSink(integrationsourceresource.SourceTypeTimer))
+		env.ParallelTest(ctx, t, integrationsource.SendEventsWithTLSReceiverAsSinkTrustBundle(integrationsourceresource.SourceTypeTimer))
+	})
 
-func TestIntegrationSourceTimerSendsEventsWithOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-		environment.WithPollTimings(5*time.Second, 4*time.Minute),
-	)
-
-	env.Test(ctx, t, integrationsource.SendsEventsWithSinkRefOIDC(integrationsourceresource.SourceTypeTimer))
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, integrationsource.SendsEventsWithSinkRefOIDC(integrationsourceresource.SourceTypeTimer))
+	})
 }

--- a/test/rekt/job_sink_test.go
+++ b/test/rekt/job_sink_test.go
@@ -65,7 +65,7 @@ func TestJobSinkDeleteJobCascadeSecretDeletion(t *testing.T) {
 	env.Test(ctx, t, jobsink.DeleteJobsCascadeSecretsDeletion(jobSinkName))
 }
 
-func TestJobSinkSuccessTLS(t *testing.T) {
+func TestJobSinkTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -76,23 +76,17 @@ func TestJobSinkSuccessTLS(t *testing.T) {
 		eventshub.WithTLS(t),
 		environment.Managed(t),
 	)
+	t.Cleanup(env.Finish)
 
-	env.Test(ctx, t, jobsink.SuccessTLS())
-}
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, jobsink.SuccessTLS())
+	})
 
-func TestJobSinkOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		eventshub.WithTLS(t),
-		environment.Managed(t),
-	)
-
-	env.Test(ctx, t, jobsink.OIDC())
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, jobsink.OIDC())
+	})
 }
 
 func TestJobSinkSupportsAuthZ(t *testing.T) {

--- a/test/rekt/parallel_test.go
+++ b/test/rekt/parallel_test.go
@@ -52,7 +52,7 @@ func TestParallel(t *testing.T) {
 	env.Test(ctx, t, parallel.ParallelWithTwoBranches(channel_template.ImmemoryChannelTemplate()))
 }
 
-func TestParallelTLS(t *testing.T) {
+func TestParallelTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -65,7 +65,17 @@ func TestParallelTLS(t *testing.T) {
 	)
 	t.Cleanup(env.Finish)
 
-	env.Test(ctx, t, parallel.ParallelWithTwoBranchesTLS(channel_template.ImmemoryChannelTemplate()))
+	// TLS and OIDC two-branch flows share the TLS environment; keep OIDC audience
+	// compliance (TestParallelSupportsOIDC) separate as it is OIDC-specific.
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, parallel.ParallelWithTwoBranchesTLS(channel_template.ImmemoryChannelTemplate()))
+	})
+
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, parallel.ParallelWithTwoBranchesOIDC(channel_template.ImmemoryChannelTemplate()))
+	})
 }
 
 func TestParallelSupportsOIDC(t *testing.T) {
@@ -87,21 +97,6 @@ func TestParallelSupportsOIDC(t *testing.T) {
 	})))
 
 	env.Test(ctx, t, parallel.ParallelHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
-}
-
-func TestParallelTwoBranchesWithOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
-
-	env.Test(ctx, t, parallel.ParallelWithTwoBranchesOIDC(channel_template.ImmemoryChannelTemplate()))
 }
 
 func TestParallelSupportsAuthZ(t *testing.T) {

--- a/test/rekt/pingsource_test.go
+++ b/test/rekt/pingsource_test.go
@@ -46,7 +46,7 @@ func TestPingSourceWithSinkRef(t *testing.T) {
 	env.Test(ctx, t, pingsource.SendsEventsWithSinkRef())
 }
 
-func TestPingSourceTLS(t *testing.T) {
+func TestPingSourceTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -59,9 +59,17 @@ func TestPingSourceTLS(t *testing.T) {
 	)
 	t.Cleanup(env.Finish)
 
-	env.ParallelTest(ctx, t, pingsource.SendsEventsTLS())
-	env.ParallelTest(ctx, t, pingsource.SendsEventsTLSTrustBundle())
-	env.ParallelTest(ctx, t, pingsource.SendsEventsTLSWithAdditionalTrustBundle())
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.ParallelTest(ctx, t, pingsource.SendsEventsTLS())
+		env.ParallelTest(ctx, t, pingsource.SendsEventsTLSTrustBundle())
+		env.ParallelTest(ctx, t, pingsource.SendsEventsTLSWithAdditionalTrustBundle())
+	})
+
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, pingsource.PingSourceSendEventOIDC())
+	})
 }
 
 func TestPingSourceWithSinkURI(t *testing.T) {
@@ -119,19 +127,4 @@ func TestPingSourceDataPlane_BrokerAsSinkTLS(t *testing.T) {
 	)
 
 	env.Test(ctx, t, pingsource.SendsEventsWithBrokerAsSinkTLS())
-}
-
-func TestPingSourceSendsEventsOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
-
-	env.Test(ctx, t, pingsource.PingSourceSendEventOIDC())
 }

--- a/test/rekt/sequence_test.go
+++ b/test/rekt/sequence_test.go
@@ -51,7 +51,7 @@ func TestSequence(t *testing.T) {
 	env.Test(ctx, t, sequence.SequenceTest(channel_template.ImmemoryChannelTemplate()))
 }
 
-func TestSequenceTLS(t *testing.T) {
+func TestSequenceTLSAndOIDC(t *testing.T) {
 	t.Parallel()
 
 	ctx, env := global.Environment(
@@ -62,8 +62,18 @@ func TestSequenceTLS(t *testing.T) {
 		environment.Managed(t),
 		eventshub.WithTLS(t),
 	)
+	t.Cleanup(env.Finish)
 
-	env.Test(ctx, t, sequence.SequenceTestTLS(channel_template.ImmemoryChannelTemplate()))
+	// Keep TestSequenceSupportsOIDC separate: audience/compliance only, no TLS path.
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		env.Test(ctx, t, sequence.SequenceTestTLS(channel_template.ImmemoryChannelTemplate()))
+	})
+
+	t.Run("OIDC", func(t *testing.T) {
+		t.Parallel()
+		env.TestSet(ctx, t, sequence.SequenceSendsEventWithOIDC())
+	})
 }
 
 func TestSequenceSupportsOIDC(t *testing.T) {
@@ -84,21 +94,6 @@ func TestSequenceSupportsOIDC(t *testing.T) {
 	})))
 
 	env.Test(ctx, t, sequence.SequenceHasAudienceOfInputChannel(name, env.Namespace(), channel_impl.GVR(), channel_impl.GVK().Kind))
-}
-
-func TestSequenceSendsEventsOIDC(t *testing.T) {
-	t.Parallel()
-
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithObservabilityConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-		eventshub.WithTLS(t),
-	)
-
-	env.TestSet(ctx, t, sequence.SequenceSendsEventWithOIDC())
 }
 
 func TestSequenceSupportsAuthZ(t *testing.T) {


### PR DESCRIPTION
Fixes #7638

## Proposed Changes

- :broom: Merge rekt e2e pairs that already share `eventshub.WithTLS` into single `TLSAndOIDC` tests with `TLS` / `OIDC` subtests
- Keep OIDC-only audience/compliance tests (`SupportsOIDC`) separate, matching the issue hint
- Resources covered in this PR: Parallel, PingSource, Sequence, ContainerSource, IntegrationSource (timer), JobSink

### Why this shape

For these suites the TLS and OIDC event-send paths already use the same TLS-enabled eventshub environment; the OIDC path mainly adds an audience. Running them under one environment setup avoids redundant setup without changing feature coverage.

Left alone on purpose:
- `Test*SupportsOIDC` (audience of input channel / compliance)
- Broker/Channel TLS rotate + SupportsOIDC style suites where the overlap is not a clear shared event path (can be follow-ups)

### Pre-review Checklist

- [x] **At least 80% unit test coverage** (n/a — rekt e2e organization only)
- [x] **E2E tests** reorganized; no new production behavior
- [ ] **Docs PR** (n/a — no user-facing impact)
- [ ] **Spec PR** (n/a)
- [ ] **Conformance test** (n/a)

**Release Note**

```release-note
NONE
```

**Docs**

n/a