### PR TITLE
feat(delivery): add maximum backoff duration

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -31,6 +31,11 @@ data:
   # For more details: https://github.com/knative/eventing/issues/5811
   delivery-retryafter: "disabled"
 
+  # ALPHA feature: The delivery-backoff-max flag allows DeliverySpec.backoffMax
+  # to cap the delay calculated from backoffDelay and backoffPolicy.
+  # For more details: https://github.com/knative/eventing/issues/9278
+  delivery-backoff-max: "disabled"
+
   # BETA feature: The delivery-timeout allows you to use the Timeout field in DeliverySpec.
   # For more details: https://github.com/knative/eventing/issues/5148
   delivery-timeout: "enabled"

--- a/docs/eventing-api.md
+++ b/docs/eventing-api.md
@@ -484,6 +484,27 @@ For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 </tr>
 <tr>
 <td>
+<code>backoffMax</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffMax is the maximum delay between normal delivery attempts. It caps
+the delay calculated from BackoffDelay and BackoffPolicy, but does not cap
+delays requested by a Retry-After response header. The value must be
+greater than zero.</p>
+<p>Note: This API is EXPERIMENTAL and might be changed at any time. Cluster
+operators must enable the delivery-backoff-max feature before users can set
+this field.</p>
+<p>More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
+</td>
+</tr>
+<tr>
+<td>
 <code>retryAfterMax</code><br/>
 <em>
 string

--- a/pkg/apis/duck/v1/delivery_types.go
+++ b/pkg/apis/duck/v1/delivery_types.go
@@ -62,6 +62,22 @@ type DeliverySpec struct {
 	// +optional
 	BackoffDelay *string `json:"backoffDelay,omitempty"`
 
+	// BackoffMax is the maximum delay between normal delivery attempts. It caps
+	// the delay calculated from BackoffDelay and BackoffPolicy, but does not cap
+	// delays requested by a Retry-After response header. The value must be
+	// greater than zero.
+	//
+	// Note: This API is EXPERIMENTAL and might be changed at any time. Cluster
+	// operators must enable the delivery-backoff-max feature before users can set
+	// this field.
+	//
+	// More information on Duration format:
+	//  - https://www.iso.org/iso-8601-date-and-time-format.html
+	//  - https://en.wikipedia.org/wiki/ISO_8601
+	//
+	// +optional
+	BackoffMax *string `json:"backoffMax,omitempty"`
+
 	// RetryAfterMax provides an optional upper bound on the duration specified in a "Retry-After" header
 	// when calculating backoff times for retrying 429 and 503 response codes.  Setting the value to
 	// zero ("PT0S") can be used to opt-out of respecting "Retry-After" header values altogether. This
@@ -128,6 +144,17 @@ func (ds *DeliverySpec) Validate(ctx context.Context) *apis.FieldError {
 		_, te := period.Parse(*ds.BackoffDelay)
 		if te != nil {
 			errs = errs.Also(apis.ErrInvalidValue(*ds.BackoffDelay, "backoffDelay"))
+		}
+	}
+
+	if ds.BackoffMax != nil {
+		if feature.FromContext(ctx).IsEnabled(feature.DeliveryBackoffMax) {
+			p, pe := period.Parse(*ds.BackoffMax)
+			if pe != nil || p.IsZero() || p.IsNegative() {
+				errs = errs.Also(apis.ErrInvalidValue(*ds.BackoffMax, "backoffMax"))
+			}
+		} else {
+			errs = errs.Also(apis.ErrDisallowedFields("backoffMax"))
 		}
 	}
 

--- a/pkg/apis/duck/v1/delivery_types_test.go
+++ b/pkg/apis/duck/v1/delivery_types_test.go
@@ -35,6 +35,9 @@ func TestDeliverySpecValidation(t *testing.T) {
 	deliveryRetryAfterEnabledCtx := feature.ToContext(context.TODO(), feature.Flags{
 		feature.DeliveryRetryAfter: feature.Enabled,
 	})
+	deliveryBackoffMaxEnabledCtx := feature.ToContext(context.TODO(), feature.Flags{
+		feature.DeliveryBackoffMax: feature.Enabled,
+	})
 
 	invalidString := "invalid time"
 	bop := BackoffPolicyExponential
@@ -142,6 +145,30 @@ func TestDeliverySpecValidation(t *testing.T) {
 		want: func() *apis.FieldError {
 			return apis.ErrDisallowedFields("retryAfterMax")
 		}(),
+	}, {
+		name: "valid backoffMax",
+		ctx:  deliveryBackoffMaxEnabledCtx,
+		spec: &DeliverySpec{BackoffMax: &validDuration},
+		want: nil,
+	}, {
+		name: "zero backoffMax",
+		ctx:  deliveryBackoffMaxEnabledCtx,
+		spec: &DeliverySpec{BackoffMax: pointer.String("PT0S")},
+		want: apis.ErrInvalidValue("PT0S", "backoffMax"),
+	}, {
+		name: "negative backoffMax",
+		ctx:  deliveryBackoffMaxEnabledCtx,
+		spec: &DeliverySpec{BackoffMax: pointer.String("-PT1S")},
+		want: apis.ErrInvalidValue("-PT1S", "backoffMax"),
+	}, {
+		name: "invalid backoffMax",
+		ctx:  deliveryBackoffMaxEnabledCtx,
+		spec: &DeliverySpec{BackoffMax: &invalidDuration},
+		want: apis.ErrInvalidValue(invalidDuration, "backoffMax"),
+	}, {
+		name: "disabled feature with backoffMax",
+		spec: &DeliverySpec{BackoffMax: &validDuration},
+		want: apis.ErrDisallowedFields("backoffMax"),
 	},
 		{
 			name: "valid format JSON",

--- a/pkg/apis/duck/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/duck/v1/zz_generated.deepcopy.go
@@ -196,6 +196,11 @@ func (in *DeliverySpec) DeepCopyInto(out *DeliverySpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BackoffMax != nil {
+		in, out := &in.BackoffMax, &out.BackoffMax
+		*out = new(string)
+		**out = **in
+	}
 	if in.RetryAfterMax != nil {
 		in, out := &in.RetryAfterMax, &out.RetryAfterMax
 		*out = new(string)

--- a/pkg/apis/feature/features.go
+++ b/pkg/apis/feature/features.go
@@ -81,6 +81,7 @@ func newDefaults() Flags {
 	return map[string]Flag{
 		KReferenceGroup:            Disabled,
 		DeliveryRetryAfter:         Disabled,
+		DeliveryBackoffMax:         Disabled,
 		DeliveryTimeout:            Enabled,
 		KReferenceMapping:          Disabled,
 		TransportEncryption:        Disabled,

--- a/pkg/apis/feature/flag_names.go
+++ b/pkg/apis/feature/flag_names.go
@@ -19,6 +19,7 @@ package feature
 const (
 	KReferenceGroup            = "kreference-group"
 	DeliveryRetryAfter         = "delivery-retryafter"
+	DeliveryBackoffMax         = "delivery-backoff-max"
 	DeliveryTimeout            = "delivery-timeout"
 	KReferenceMapping          = "kreference-mapping"
 	TransportEncryption        = "transport-encryption"

--- a/pkg/kncloudevents/retries.go
+++ b/pkg/kncloudevents/retries.go
@@ -19,7 +19,6 @@ package kncloudevents
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -58,11 +57,12 @@ type Backoff func(attemptNum int, resp *http.Response) time.Duration
 type RetryConfig struct {
 	// Maximum number of retries
 	RetryMax int
-	// These next two variables are just copied from the original DeliverySpec so
+	// These next three variables are just copied from the original DeliverySpec so
 	// we can detect if anything has changed. We can not do that with the CheckRetry
 	// Backoff (at least not easily).
 	BackoffDelay  *string
 	BackoffPolicy *v1.BackoffPolicyType
+	BackoffMax    *string
 
 	CheckRetry CheckRetry
 	Backoff    Backoff
@@ -92,6 +92,20 @@ func RetryConfigFromDeliverySpec(spec v1.DeliverySpec) (RetryConfig, error) {
 	}
 	retryConfig.BackoffPolicy = spec.BackoffPolicy
 	retryConfig.BackoffDelay = spec.BackoffDelay
+	retryConfig.BackoffMax = spec.BackoffMax
+
+	var backoffMaxDuration *time.Duration
+	if spec.BackoffMax != nil {
+		maxPeriod, err := period.Parse(*spec.BackoffMax)
+		if err != nil {
+			return retryConfig, fmt.Errorf("failed to parse Spec.BackoffMax: %w", err)
+		}
+		if maxPeriod.IsZero() || maxPeriod.IsNegative() {
+			return retryConfig, fmt.Errorf("Spec.BackoffMax must be greater than zero")
+		}
+		maxDelay := saturatingPeriodDuration(maxPeriod)
+		backoffMaxDuration = &maxDelay
+	}
 
 	if spec.BackoffPolicy != nil && spec.BackoffDelay != nil {
 
@@ -100,15 +114,15 @@ func RetryConfigFromDeliverySpec(spec v1.DeliverySpec) (RetryConfig, error) {
 			return retryConfig, fmt.Errorf("failed to parse Spec.BackoffDelay: %w", err)
 		}
 
-		delayDuration, _ := delay.Duration()
+		delayDuration := saturatingPeriodDuration(delay)
 		switch *spec.BackoffPolicy {
 		case v1.BackoffPolicyExponential:
 			retryConfig.Backoff = func(attemptNum int, resp *http.Response) time.Duration {
-				return delayDuration * time.Duration(math.Exp2(float64(attemptNum)))
+				return exponentialBackoff(delayDuration, attemptNum, backoffMaxDuration)
 			}
 		case v1.BackoffPolicyLinear:
 			retryConfig.Backoff = func(attemptNum int, resp *http.Response) time.Duration {
-				return delayDuration * time.Duration(attemptNum)
+				return linearBackoff(delayDuration, attemptNum, backoffMaxDuration)
 			}
 		}
 	}
@@ -131,6 +145,55 @@ func RetryConfigFromDeliverySpec(spec v1.DeliverySpec) (RetryConfig, error) {
 	}
 
 	return retryConfig, nil
+}
+
+const maxBackoffDuration = time.Duration(1<<63 - 1)
+
+func saturatingPeriodDuration(p period.Period) time.Duration {
+	if p.IsPositive() && p.TotalDaysApprox() > int(maxBackoffDuration/(24*time.Hour)) {
+		return maxBackoffDuration
+	}
+
+	d, _ := p.Duration()
+	if p.IsPositive() && d < 0 {
+		return maxBackoffDuration
+	}
+	return d
+}
+
+func linearBackoff(delay time.Duration, attemptNum int, configuredMax *time.Duration) time.Duration {
+	if attemptNum <= 0 || delay <= 0 {
+		return 0
+	}
+	limit := maxBackoffDuration
+	if configuredMax != nil {
+		limit = *configuredMax
+	}
+	if delay >= limit || time.Duration(attemptNum) > limit/delay {
+		return limit
+	}
+	return delay * time.Duration(attemptNum)
+}
+
+func exponentialBackoff(delay time.Duration, attemptNum int, configuredMax *time.Duration) time.Duration {
+	if attemptNum < 0 || delay <= 0 {
+		return 0
+	}
+	limit := maxBackoffDuration
+	if configuredMax != nil {
+		limit = *configuredMax
+	}
+	if delay >= limit {
+		return limit
+	}
+	result := delay
+	for range attemptNum {
+		if result > limit/2 {
+			return limit
+		}
+		result *= 2
+	}
+	return result
 }
 
 // SelectiveRetry is an alternative function to determine whether to retry based on response

--- a/pkg/kncloudevents/retries_test.go
+++ b/pkg/kncloudevents/retries_test.go
@@ -57,6 +57,158 @@ func TestNoRetries(t *testing.T) {
 	assert.Nil(t, retryConfig.RetryAfterMaxDuration)
 }
 
+func TestRetryConfigBackoffMax(t *testing.T) {
+	linear := v1.BackoffPolicyLinear
+	exponential := v1.BackoffPolicyExponential
+	tests := []struct {
+		name         string
+		policy       v1.BackoffPolicyType
+		delay        string
+		backoffMax   *string
+		attempts     []int
+		wantBackoffs []time.Duration
+		wantErr      bool
+	}{
+		{
+			name:       "linear capped",
+			policy:     linear,
+			delay:      "PT3S",
+			backoffMax: ptr.String("PT10S"),
+			attempts:   []int{1, 2, 3, 4, int(^uint(0) >> 1)},
+			wantBackoffs: []time.Duration{
+				3 * time.Second,
+				6 * time.Second,
+				9 * time.Second,
+				10 * time.Second,
+				10 * time.Second,
+			},
+		},
+		{
+			name:       "exponential capped",
+			policy:     exponential,
+			delay:      "PT1S",
+			backoffMax: ptr.String("PT10S"),
+			attempts:   []int{1, 2, 3, 4, int(^uint(0) >> 1)},
+			wantBackoffs: []time.Duration{
+				2 * time.Second,
+				4 * time.Second,
+				8 * time.Second,
+				10 * time.Second,
+				10 * time.Second,
+			},
+		},
+		{
+			name:         "uncapped exponential saturates",
+			policy:       exponential,
+			delay:        "PT1S",
+			attempts:     []int{1, int(^uint(0) >> 1)},
+			wantBackoffs: []time.Duration{2 * time.Second, maxBackoffDuration},
+		},
+		{
+			name:         "uncapped linear saturates",
+			policy:       linear,
+			delay:        "PT1S",
+			attempts:     []int{1, int(^uint(0) >> 1)},
+			wantBackoffs: []time.Duration{time.Second, maxBackoffDuration},
+		},
+		{
+			name:         "large linear delay saturates",
+			policy:       linear,
+			delay:        "P293Y",
+			attempts:     []int{1},
+			wantBackoffs: []time.Duration{maxBackoffDuration},
+		},
+		{
+			name:         "large exponential delay saturates",
+			policy:       exponential,
+			delay:        "P293Y",
+			attempts:     []int{0},
+			wantBackoffs: []time.Duration{maxBackoffDuration},
+		},
+		{
+			name:         "large linear maximum saturates",
+			policy:       linear,
+			delay:        "P292Y",
+			backoffMax:   ptr.String("P293Y"),
+			attempts:     []int{2},
+			wantBackoffs: []time.Duration{maxBackoffDuration},
+		},
+		{
+			name:         "large exponential maximum saturates",
+			policy:       exponential,
+			delay:        "P292Y",
+			backoffMax:   ptr.String("P293Y"),
+			attempts:     []int{1},
+			wantBackoffs: []time.Duration{maxBackoffDuration},
+		},
+		{
+			name:       "zero maximum rejected",
+			policy:     exponential,
+			delay:      "PT1S",
+			backoffMax: ptr.String("PT0S"),
+			wantErr:    true,
+		},
+		{
+			name:       "negative maximum rejected",
+			policy:     exponential,
+			delay:      "PT1S",
+			backoffMax: ptr.String("-PT1S"),
+			wantErr:    true,
+		},
+		{
+			name:       "invalid maximum rejected",
+			policy:     exponential,
+			delay:      "PT1S",
+			backoffMax: ptr.String("invalid"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := RetryConfigFromDeliverySpec(v1.DeliverySpec{
+				BackoffPolicy: &tt.policy,
+				BackoffDelay:  &tt.delay,
+				BackoffMax:    tt.backoffMax,
+			})
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.backoffMax, config.BackoffMax)
+			for i, attempt := range tt.attempts {
+				assert.Equal(t, tt.wantBackoffs[i], config.Backoff(attempt, nil))
+			}
+		})
+	}
+}
+
+func TestSaturatingPeriodDuration(t *testing.T) {
+	representable := period.MustParse("P292Y")
+	want, _ := representable.Duration()
+	assert.NotEqual(t, maxBackoffDuration, want)
+	assert.Equal(t, want, saturatingPeriodDuration(representable))
+	assert.Equal(t, maxBackoffDuration, saturatingPeriodDuration(period.MustParse("P293Y")))
+}
+
+func TestBackoffMaxDoesNotCapRetryAfter(t *testing.T) {
+	policy := v1.BackoffPolicyExponential
+	config, err := RetryConfigFromDeliverySpec(v1.DeliverySpec{
+		BackoffPolicy: &policy,
+		BackoffDelay:  ptr.String("PT1S"),
+		BackoffMax:    ptr.String("PT10S"),
+		RetryAfterMax: ptr.String("PT20S"),
+	})
+	assert.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"Retry-After": []string{"30"}},
+	}
+	assert.Equal(t, 20*time.Second, generateBackoffFn(&config)(0, 0, 20, resp))
+}
+
 // Test The RetryConfigFromDeliverySpec() Functionality
 func TestRetryConfigFromDeliverySpec(t *testing.T) {
 	const retry = 5

--- a/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
+++ b/pkg/reconciler/inmemorychannel/dispatcher/inmemorychannel_test.go
@@ -99,6 +99,18 @@ var (
 			BackoffPolicy: &linear,
 		},
 	}
+	subscriber1WithBackoffMax = eventingduckv1.SubscriberSpec{
+		UID:           subscriber1UID,
+		Generation:    subscriber1Generation,
+		SubscriberURI: apis.HTTP("call1"),
+		ReplyURI:      apis.HTTP("sink2"),
+		Delivery: &eventingduckv1.DeliverySpec{
+			Retry:         ptr.Int32(3),
+			BackoffPolicy: &linear,
+			BackoffDelay:  ptr.String("PT1S"),
+			BackoffMax:    ptr.String("PT10S"),
+		},
+	}
 
 	subscriber2 = eventingduckv1.SubscriberSpec{
 		UID:           subscriber2UID,
@@ -518,6 +530,47 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 					},
 					RetryConfig: &kncloudevents.RetryConfig{RetryMax: 3, BackoffPolicy: &linear}},
 			},
+		},
+		"with one subscriber, with only backoff max changed": {
+			imc: NewInMemoryChannel(imcName, testNS,
+				WithInitInMemoryChannelConditions,
+				WithInMemoryChannelDeploymentReady(),
+				WithInMemoryChannelServiceReady(),
+				WithInMemoryChannelEndpointsReady(),
+				WithInMemoryChannelChannelServiceReady(),
+				WithInMemoryChannelSubscribers([]eventingduckv1.SubscriberSpec{subscriber1WithBackoffMax}),
+				WithInMemoryChannelAddress(channelServiceAddress),
+				WithInMemoryChannelDLSUnknown(),
+				WithInMemoryChannelEventPoliciesReady()),
+			subs: []fanout.Subscription{{
+				Subscriber: duckv1.Addressable{
+					URL: apis.HTTP("call1"),
+				},
+				Reply: &duckv1.Addressable{
+					URL: apis.HTTP("sink2"),
+				},
+				RetryConfig: &kncloudevents.RetryConfig{
+					RetryMax:      3,
+					BackoffPolicy: &linear,
+					BackoffDelay:  ptr.String("PT1S"),
+					BackoffMax:    ptr.String("PT2S"),
+				},
+			}},
+			wantSubs: []fanout.Subscription{{
+				Namespace: testNS,
+				Subscriber: duckv1.Addressable{
+					URL: apis.HTTP("call1"),
+				},
+				Reply: &duckv1.Addressable{
+					URL: apis.HTTP("sink2"),
+				},
+				RetryConfig: &kncloudevents.RetryConfig{
+					RetryMax:      3,
+					BackoffPolicy: &linear,
+					BackoffDelay:  ptr.String("PT1S"),
+					BackoffMax:    ptr.String("PT10S"),
+				},
+			}},
 		},
 	}
 	for n, tc := range testCases {

--- a/pkg/reconciler/subscription/subscription.go
+++ b/pkg/reconciler/subscription/subscription.go
@@ -566,6 +566,7 @@ func deliverySpec(sub *v1.Subscription, channel *eventingduckv1.Channelable) (de
 		if channel.Spec.Delivery.BackoffDelay != nil ||
 			channel.Spec.Delivery.Retry != nil ||
 			channel.Spec.Delivery.BackoffPolicy != nil ||
+			channel.Spec.Delivery.BackoffMax != nil ||
 			channel.Spec.Delivery.Timeout != nil ||
 			channel.Spec.Delivery.RetryAfterMax != nil {
 			if delivery == nil {
@@ -574,6 +575,7 @@ func deliverySpec(sub *v1.Subscription, channel *eventingduckv1.Channelable) (de
 			delivery.BackoffPolicy = channel.Spec.Delivery.BackoffPolicy
 			delivery.Retry = channel.Spec.Delivery.Retry
 			delivery.BackoffDelay = channel.Spec.Delivery.BackoffDelay
+			delivery.BackoffMax = channel.Spec.Delivery.BackoffMax
 			delivery.Timeout = channel.Spec.Delivery.Timeout
 			delivery.RetryAfterMax = channel.Spec.Delivery.RetryAfterMax
 		}
@@ -592,6 +594,7 @@ func deliverySpec(sub *v1.Subscription, channel *eventingduckv1.Channelable) (de
 		(sub.Spec.Delivery.BackoffDelay != nil ||
 			sub.Spec.Delivery.Retry != nil ||
 			sub.Spec.Delivery.BackoffPolicy != nil ||
+			sub.Spec.Delivery.BackoffMax != nil ||
 			sub.Spec.Delivery.Timeout != nil ||
 			sub.Spec.Delivery.RetryAfterMax != nil) {
 		if delivery == nil {
@@ -600,6 +603,7 @@ func deliverySpec(sub *v1.Subscription, channel *eventingduckv1.Channelable) (de
 		delivery.BackoffPolicy = sub.Spec.Delivery.BackoffPolicy
 		delivery.Retry = sub.Spec.Delivery.Retry
 		delivery.BackoffDelay = sub.Spec.Delivery.BackoffDelay
+		delivery.BackoffMax = sub.Spec.Delivery.BackoffMax
 		delivery.Timeout = sub.Spec.Delivery.Timeout
 		delivery.RetryAfterMax = sub.Spec.Delivery.RetryAfterMax
 	}

--- a/pkg/reconciler/subscription/subscription_test.go
+++ b/pkg/reconciler/subscription/subscription_test.go
@@ -2023,6 +2023,7 @@ func TestAllCases(t *testing.T) {
 			Ctx: feature.ToContext(context.TODO(), feature.Flags{
 				feature.DeliveryTimeout:    feature.Enabled,
 				feature.DeliveryRetryAfter: feature.Enabled,
+				feature.DeliveryBackoffMax: feature.Enabled,
 			}),
 			Objects: []runtime.Object{
 				NewSubscription("a-"+subscriptionName, testNS,
@@ -2040,6 +2041,7 @@ func TestAllCases(t *testing.T) {
 					WithInMemoryChannelReadySubscriber("a-"+subscriptionUID),
 					WithInMemoryChannelDelivery(&eventingduck.DeliverySpec{
 						Timeout:       pointer.String("PT1S"),
+						BackoffMax:    pointer.String("PT10S"),
 						RetryAfterMax: pointer.String("PT2S"),
 					}),
 					WithInMemoryChannelStatusDLS(dlcStatus),
@@ -2072,6 +2074,7 @@ func TestAllCases(t *testing.T) {
 						SubscriberURI: serviceURI,
 						Delivery: &eventingduck.DeliverySpec{
 							Timeout:       pointer.String("PT1S"),
+							BackoffMax:    pointer.String("PT10S"),
 							RetryAfterMax: pointer.String("PT2S"),
 						},
 						Name: pointer.String("a-" + subscriptionName),

--- a/test/config/config-features.yaml
+++ b/test/config/config-features.yaml
@@ -27,6 +27,11 @@ data:
   # For more details: https://github.com/knative/eventing/issues/5811
   delivery-retryafter: "disabled"
 
+  # ALPHA feature: The delivery-backoff-max flag allows DeliverySpec.backoffMax
+  # to cap the delay calculated from backoffDelay and backoffPolicy.
+  # For more details: https://github.com/knative/eventing/issues/9278
+  delivery-backoff-max: "disabled"
+
   # BETA feature: The delivery-timeout allows you to use the Timeout field in DeliverySpec.
   # For more details: https://github.com/knative/eventing/issues/5148
   delivery-timeout: "enabled"

--- a/test/experimental/backoff_max_test.go
+++ b/test/experimental/backoff_max_test.go
@@ -1,0 +1,45 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing/test/experimental/features/backoff_max"
+)
+
+func TestBackoffMax(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithObservabilityConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, backoff_max.ChannelToSink())
+}

--- a/test/experimental/config/features.yaml
+++ b/test/experimental/config/features.yaml
@@ -23,5 +23,6 @@ metadata:
 data:
   kreference-group: "enabled"
   delivery-retryafter: "enabled"
+  delivery-backoff-max: "enabled"
   delivery-timeout: "enabled"
   eventtype-auto-create: "enabled"

--- a/test/experimental/features/backoff_max/channel.go
+++ b/test/experimental/features/backoff_max/channel.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff_max
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/eventshub/assert"
+	"knative.dev/reconciler-test/pkg/feature"
+
+	eventingduckv1 "knative.dev/eventing/pkg/apis/duck/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
+	eventingclient "knative.dev/eventing/pkg/client/injection/client"
+	"knative.dev/eventing/test/rekt/resources/channel"
+	"knative.dev/eventing/test/rekt/resources/subscription"
+)
+
+// ChannelToSink verifies that BackoffMax caps retries in the data plane.
+func ChannelToSink() *feature.Feature {
+	f := feature.NewFeatureNamed("Delivery backoff maximum")
+
+	channelName := feature.MakeRandomK8sName("backoff-max-channel")
+	subscriptionName := feature.MakeRandomK8sName("backoff-max-subscription")
+	receiverName := feature.MakeRandomK8sName("backoff-max-receiver")
+	senderName := feature.MakeRandomK8sName("backoff-max-sender")
+	event := cetest.FullEvent()
+
+	f.Setup("install receiver", eventshub.Install(
+		receiverName,
+		eventshub.StartReceiver,
+		eventshub.DropFirstN(4),
+		eventshub.DropEventsResponseCode(http.StatusServiceUnavailable),
+	))
+	f.Setup("install channel", channel.Install(channelName))
+	f.Setup("install subscription", installSubscription(channelName, subscriptionName, receiverName))
+	f.Requirement("channel is ready", channel.IsReady(channelName))
+	f.Requirement("subscription is ready", subscription.IsReady(subscriptionName))
+	f.Assert("send event", eventshub.Install(
+		senderName,
+		eventshub.StartSenderToResource(channel.GVR(), channelName),
+		eventshub.InputEvent(event),
+	))
+
+	f.Assert("receiver rejects the first four deliveries", assert.OnStore(receiverName).
+		MatchRejectedEvent(cetest.HasId(event.ID())).Exact(4))
+	f.Assert("receiver accepts the fifth delivery", assert.OnStore(receiverName).
+		MatchReceivedEvent(cetest.HasId(event.ID())).Exact(1))
+	f.Assert("retry delay stops growing at two seconds", assert.OnStore(receiverName).
+		Match(deliveriesFollowBackoff(event.ID(), []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second})).Exact(5))
+
+	return f
+}
+
+func installSubscription(channelName, subscriptionName, sinkName string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		namespace := environment.FromContext(ctx).Namespace()
+		channelAPIVersion, channelKind := channel.GVK().ToAPIVersionAndKind()
+		backoffPolicy := eventingduckv1.BackoffPolicyExponential
+		retry := int32(4)
+		_, err := eventingclient.Get(ctx).MessagingV1().Subscriptions(namespace).Create(ctx, &messagingv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      subscriptionName,
+				Namespace: namespace,
+			},
+			Spec: messagingv1.SubscriptionSpec{
+				Channel: duckv1.KReference{
+					APIVersion: channelAPIVersion,
+					Kind:       channelKind,
+					Name:       channelName,
+				},
+				Subscriber: &duckv1.Destination{Ref: &duckv1.KReference{
+					APIVersion: "v1",
+					Kind:       "Service",
+					Name:       sinkName,
+				}},
+				Delivery: &eventingduckv1.DeliverySpec{
+					Retry:         &retry,
+					BackoffPolicy: &backoffPolicy,
+					BackoffDelay:  pointer.String("PT1S"),
+					BackoffMax:    pointer.String("PT2S"),
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func deliveriesFollowBackoff(id string, expected []time.Duration) eventshub.EventInfoMatcher {
+	type deliveryKey struct {
+		kind     eventshub.EventKind
+		sequence uint64
+	}
+
+	var mu sync.Mutex
+	seen := make(map[deliveryKey]eventshub.EventInfo, len(expected)+1)
+
+	return func(info eventshub.EventInfo) error {
+		if info.Event == nil || info.Event.ID() != id {
+			return fmt.Errorf("received a different event")
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		seen[deliveryKey{kind: info.Kind, sequence: info.Sequence}] = info
+		if len(seen) < len(expected)+1 {
+			return nil
+		}
+
+		deliveries := make([]eventshub.EventInfo, 0, len(seen))
+		for _, delivery := range seen {
+			deliveries = append(deliveries, delivery)
+		}
+		sort.Slice(deliveries, func(i, j int) bool {
+			return deliveries[i].Time.Before(deliveries[j].Time)
+		})
+
+		for i, wait := range expected {
+			actual := deliveries[i+1].Time.Sub(deliveries[i].Time)
+			if actual < wait-500*time.Millisecond || actual > wait+3*time.Second {
+				return fmt.Errorf("delivery %d waited %s, expected %s", i+2, actual, wait)
+			}
+		}
+		return nil
+	}
+}

--- a/test/experimental/features/backoff_max/channel_test.go
+++ b/test/experimental/features/backoff_max/channel_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff_max
+
+import (
+	"testing"
+	"time"
+
+	cetest "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/stretchr/testify/require"
+	"knative.dev/reconciler-test/pkg/eventshub"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func TestChannelToSinkRunsSenderAfterReadiness(t *testing.T) {
+	timings := make(map[string]feature.Timing)
+	for _, step := range ChannelToSink().Steps {
+		timings[step.Name] = step.T
+	}
+
+	for _, name := range []string{"channel is ready", "subscription is ready"} {
+		timing, ok := timings[name]
+		require.Truef(t, ok, "step %q not found", name)
+		require.Equal(t, feature.Requirement, timing)
+	}
+
+	timing, ok := timings["send event"]
+	require.True(t, ok, "step %q not found", "send event")
+	require.Equal(t, feature.Assert, timing)
+}
+
+func TestDeliveriesFollowBackoff(t *testing.T) {
+	event := cetest.FullEvent()
+	expected := []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second}
+	tests := []struct {
+		name      string
+		intervals []time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "capped exponential backoff",
+			intervals: []time.Duration{time.Second, 2 * time.Second, 2 * time.Second, 2 * time.Second},
+		},
+		{
+			name:      "uncapped exponential backoff",
+			intervals: []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := deliveriesFollowBackoff(event.ID(), expected)
+			receivedAt := time.Unix(0, 0)
+			var gotErr error
+			for i := 0; i <= len(tt.intervals); i++ {
+				if i > 0 {
+					receivedAt = receivedAt.Add(tt.intervals[i-1])
+				}
+
+				kind := eventshub.EventRejected
+				sequence := uint64(i + 1)
+				if i == len(tt.intervals) {
+					kind = eventshub.EventReceived
+					sequence = 1
+				}
+				gotErr = matcher(eventshub.EventInfo{
+					Event:    &event,
+					Kind:     kind,
+					Time:     receivedAt,
+					Sequence: sequence,
+				})
+				if i < len(tt.intervals) {
+					require.NoError(t, gotErr)
+				}
+			}
+
+			if tt.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

This PR implements the Alpha stage of #9278.

<!-- Please include the 'why' behind your changes if no issue exists -->

**TL;DR:** New experimental feature allowing users to opt in to capping normal delivery retry intervals calculated from `backoffDelay` and `backoffPolicy`.

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Add the Alpha `delivery-backoff-max` feature flag, disabled by default.
- 🎁 Extend `DeliverySpec` with the optional `backoffMax` field.
- 🎁 Validate that `backoffMax` is a positive ISO 8601 duration and reject the field while the feature is disabled.
- 🎁 Propagate `backoffMax` through Subscription reconciliation and Channel delivery defaults.
- 🎁 Parse `backoffMax` in `RetryConfigFromDeliverySpec()` and apply it to linear and exponential backoff calculations.
- 🐛 Prevent linear and exponential backoff calculations from overflowing `time.Duration`, including when no explicit maximum is configured.
- 🎁 Keep delays requested through `Retry-After` independently controlled by `retryAfterMax`.
- 🎁 Add unit and experimental E2E coverage for capped delivery retries.
- 🎁 Update generated API documentation; user-facing documentation is tracked in knative/docs#6686.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [x] **Docs PR** for any user-facing impact
- [ ] **Spec PR** for any new API feature (Planned if the experimental feature graduates to Stable.)
- [ ] **Conformance test** for any change to the spec (To be evaluated when the feature graduates to Stable.)

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The new experimental `delivery-backoff-max` feature flag lets you set `DeliverySpec.backoffMax` to cap normal retry intervals calculated from `backoffDelay` and `backoffPolicy`. The feature is disabled by default.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

:book: https://github.com/knative/docs/pull/6686
